### PR TITLE
Fix git credentials issue

### DIFF
--- a/cicd-scripts/run-e2e-tests.sh
+++ b/cicd-scripts/run-e2e-tests.sh
@@ -3,6 +3,8 @@
 
 echo "<repo>/<component>:<tag> : $1"
 
+git config --global url."https://$GITHUB_TOKEN@github.com/open-cluster-management".insteadOf  "https://github.com/open-cluster-management"
+
 ./tests/e2e/setup.sh $1
 if [ $? -ne 0 ]; then
     echo "Cannot setup environment successfully."

--- a/cicd-scripts/run-unit-tests.sh
+++ b/cicd-scripts/run-unit-tests.sh
@@ -2,4 +2,6 @@ echo "UNIT TESTS GO HERE!"
 
 echo "<repo>/<component>:<tag> : $1"
 
+git config --global url."https://$GITHUB_TOKEN@github.com/open-cluster-management".insteadOf "https://github.com/open-cluster-management"
+
 go test ./...


### PR DESCRIPTION
it is possible either an ssh key was revoked or had its permissions restricted, or someone changed a github-side security setting so that cannot download private repo during weekend.