### PR TITLE
Fix Compare method to enable installing in OCP 4.5

### DIFF
--- a/pkg/controller/multiclusterobservability/observatorium_test.go
+++ b/pkg/controller/multiclusterobservability/observatorium_test.go
@@ -3,12 +3,20 @@
 package multiclusterobservability
 
 import (
+	"bytes"
+	"context"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
 
+	observatoriumv1alpha1 "github.com/observatorium/deployments/operator/api/v1alpha1"
 	mcov1beta1 "github.com/open-cluster-management/multicluster-monitoring-operator/pkg/apis/observability/v1beta1"
 	mcoconfig "github.com/open-cluster-management/multicluster-monitoring-operator/pkg/config"
 	"github.com/open-cluster-management/multicluster-monitoring-operator/pkg/util"
@@ -103,5 +111,53 @@ func TestMergeVolumeClaimTemplate(t *testing.T) {
 	mergeVolumeClaimTemplate(vct1, vct3)
 	if vct1.Spec.Resources.Requests[v1.ResourceStorage] != resource.MustParse("3Gi") {
 		t.Errorf("Failed to merge %v to %v", vct3, vct1)
+	}
+}
+
+func TestNoUpdateObservatoriumCR(t *testing.T) {
+	var (
+		name      = "monitoring"
+		namespace = mcoconfig.GetDefaultNamespace()
+	)
+
+	// A MultiClusterObservability object with metadata and spec.
+	mco := &mcov1beta1.MultiClusterObservability{
+		TypeMeta:   metav1.TypeMeta{Kind: "MultiClusterObservability"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec:       mcov1beta1.MultiClusterObservabilitySpec{},
+	}
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	mcov1beta1.SchemeBuilder.AddToScheme(s)
+	observatoriumv1alpha1.AddToScheme(s)
+
+	objs := []runtime.Object{mco}
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClient(objs...)
+
+	if _, err := GenerateMonitoringCR(cl, mco); err != nil {
+		t.Errorf("Failed to generate monitoring CR: %v", err)
+	}
+
+	GenerateObservatoriumCR(cl, s, mco)
+
+	// Check if this Observatorium CR already exists
+	observatoriumCRFound := &observatoriumv1alpha1.Observatorium{}
+	cl.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      name + obsPartoOfName,
+			Namespace: namespace,
+		},
+		observatoriumCRFound,
+	)
+
+	oldSpec := observatoriumCRFound.Spec
+	newSpec := newDefaultObservatoriumSpec(mco)
+	oldSpecBytes, _ := yaml.Marshal(oldSpec)
+	newSpecBytes, _ := yaml.Marshal(newSpec)
+
+	if res := bytes.Compare(newSpecBytes, oldSpecBytes); res != 0 {
+		t.Errorf("%v should be equal to %v", string(oldSpecBytes), string(newSpecBytes))
 	}
 }


### PR DESCRIPTION
Fix cannot install in OCP 4.5 issue - https://github.com/open-cluster-management/backlog/issues/4978
the reason is MCO operator and observatorium operator both update the observatorium CR. It conflicts.
The fix is to correct the compare method to ensure reconcile if there is a real change.