### PR TITLE
correcting the temporary grafana access path

### DIFF
--- a/pkg/controller/multiclusterobservability/grafana.go
+++ b/pkg/controller/multiclusterobservability/grafana.go
@@ -58,7 +58,7 @@ func GenerateGrafanaDataSource(
 				//URL:    "http://" + mco.Name + obsPartoOfName + "-observatorium-api:8080/api/metrics/v1",
 				// TODO: need to use observatorium api here
 				// right now, bypass the observatorium api w/o authentication
-				URL: "http://" + mco.Name + "thanos-query-frontend.open-cluster-management-observability.svc.cluster.local",
+				URL: "http://" + mco.Name + "-observatorium-thanos-query-frontend.open-cluster-management-observability.svc.cluster.local:9090",
 			},
 		},
 	}, "", "    ")


### PR DESCRIPTION
I installed - 2.1.0-SNAPSHOT-2020-09-04-15-46-29 configuring with s3. Everything worked, including data being send from managed cluster to S3, but could not see data in grafana. Grafana datasource had a bug. The change needed was :
FROM
"url": "http://observabilitythanos-query-frontend.open-cluster-management-observability.svc.cluster.local",
TO
"url": "http://observability-observatorium-thanos-query-frontend.open-cluster-management-observability.svc.cluster.local:9090".