### PR TITLE
Add servername for statefulset

### DIFF
--- a/manifests/base/alertmanager/alertmanager-statefulset.yaml
+++ b/manifests/base/alertmanager/alertmanager-statefulset.yaml
@@ -11,6 +11,7 @@ spec:
     matchLabels:
       app: multicluster-observability-alertmanager
       alertmanager: observability
+  serviceName: alertmanager-operated
   template:
     metadata:
       labels:


### PR DESCRIPTION
We use headless service to control the domain of each alertmanager pod. but forget to define the `serviceName` field on the StatefulSet to resolve `$(podname).$(governing service domain)` address.