### PR TITLE
Adding default rule for kubeapi server latency

### DIFF
--- a/manifests/base/alertmanager/alert_rules.yaml
+++ b/manifests/base/alertmanager/alert_rules.yaml
@@ -3,4 +3,19 @@ apiVersion: v1
 metadata:
   name: thanos-ruler-default-rules
 data:
-  default_rules.yaml: ""
+  default_rules.yaml: |
+    groups:
+      - name: control-plane-health
+        rules:
+        - alert: KubeAPIServerLatency
+          annotations:
+            summary: Fires when Kube API Server 99th percentile latency exceeds the threshold.
+            description: "The Kube API Server has a high 99th percentile Latency: {{ $value }} seconds for cluster: {{ $labels.cluster }} clusterid: {{ $labels.clusterID }}."  
+          expr: |
+            max(histogram_quantile(0.99,sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver", verb!="WATCH"}[5m])) by (verb,le,cluster,clusterID))) by (cluster,clusterID) >1
+          for: 3m
+          labels:
+            cluster: "{{ $labels.cluster }}"
+            clusterID: "{{ $labels.clusterID }}"
+            severity: critical
+


### PR DESCRIPTION
Adding a **default rule** to monitor Kube Api server 