### PR TITLE
Update observatorium operator

### DIFF
--- a/manifests/base/observatorium/operator.yaml
+++ b/manifests/base/observatorium/operator.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
       - args:
         - --log-level=debug
-        image: quay.io/observatorium/observatorium-operator:master-2020-09-23-55feecd
+        image: quay.io/observatorium/observatorium-operator:master-2020-10-09-ecc37fc
         imagePullPolicy: "{{MULTICLUSTEROBSERVABILITY_IMAGE_PULL_POLICY}}"
         name: observatorium-operator
         resources:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,7 +72,7 @@ const (
 	ObservatoriumAPIImgName        = "observatorium"
 	ObservatoriumAPIImgTag         = "latest"
 	ObservatoriumOperatorImgName   = "observatorium_operator"
-	ObservatoriumOperatorImgTag    = "master-2020-09-23-55feecd"
+	ObservatoriumOperatorImgTag    = "master-2020-10-09-ecc37fc"
 	ThanosReceiveControllerImgName = "thanos-receive-controller"
 	//ThanosReceiveControllerKey is used to get from mch-image-manifest.xxx configmap
 	ThanosReceiveControllerKey    = "thanos_receive_controller"


### PR DESCRIPTION
update to use the latest observatorium operator to adopt:
1. The required components of observatorium operator can be able to ready around 1 min. we have a defect that change the CR field, it takes effect after 10 mins. After adopting the latest operator, it takes effect at once.
2. Fix the issue - the observatorium operator cannot do reconciling if one of apiservice is not ready - https://github.com/observatorium/deployments/issues/319 
