### PR TITLE
whitelist optimization

### DIFF
--- a/manifests/base/config/metrics_whitelist.yaml
+++ b/manifests/base/config/metrics_whitelist.yaml
@@ -7,9 +7,6 @@ data:
     names:
       - :node_memory_MemAvailable_bytes:sum
       - apiserver_request_count
-      - apiserver_request_duration_seconds_bucket
-      - apiserver_request_duration_seconds_count
-      - apiserver_request_duration_seconds_sum
       - apiserver_request_latencies_summary_count
       - apiserver_request_latencies_summary_sum
       - apiserver_request_total
@@ -31,10 +28,6 @@ data:
       - container_cpu_usage_seconds_total
       - container_fs_limit_bytes
       - container_fs_usage_bytes
-      - container_memory_cache
-      - container_memory_rss
-      - container_memory_swap
-      - container_memory_working_set_bytes
       - container_network_receive_bytes_total
       - container_network_receive_packets_dropped_total
       - container_network_receive_packets_total
@@ -67,8 +60,6 @@ data:
       - etcd_server_proposals_applied_total
       - etcd_server_quota_backend_bytes
       - go_goroutines
-      - grpc_server_started_total
-      - grpc_server_handled_total
       - haproxy_backend_connection_errors_total
       - haproxy_backend_connections_total
       - haproxy_backend_current_queue
@@ -102,14 +93,7 @@ data:
       - kube_pod_container_resource_limits_memory_bytes
       - kube_pod_container_resource_requests_cpu_cores
       - kube_pod_container_resource_requests_memory_bytes
-      - kube_pod_container_status_last_terminated_reason
-      - kube_pod_container_status_ready
-      - kube_pod_container_status_restarts_total
-      - kube_pod_container_status_terminated_reason
-      - kube_pod_container_status_waiting
       - kube_pod_info
-      - kube_pod_status_ready
-      - kube_pod_status_phase
       - kube_resourcequota
       - kubelet_running_container_count
       - kubelet_runtime_operations
@@ -135,9 +119,14 @@ data:
       - node_netstat_TcpExt_TCPSynRetrans
       - process_cpu_seconds_total
       - process_resident_memory_bytes
-      - rest_client_request_latency_seconds_bucket
       - rest_client_requests_total
       - up
       - workqueue_adds_total
       - workqueue_depth
-      - workqueue_queue_duration_seconds_bucket
+    matches:
+      - __name__="apiserver_request_duration_seconds_bucket",job="apiserver",verb!="WATCH"
+      - __name__="workqueue_queue_duration_seconds_bucket",job="apiserver"
+      - __name__="container_memory_cache",container!=""
+      - __name__="container_memory_rss",container!=""
+      - __name__="container_memory_swap",container!=""
+      - __name__="container_memory_working_set_bytes",container!=""


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/6383

removed metrics:
      - apiserver_request_duration_seconds_count
      - apiserver_request_duration_seconds_sum
      - grpc_server_started_total
      - grpc_server_handled_total
      - kube_pod_container_status_last_terminated_reason
      - kube_pod_container_status_ready
      - kube_pod_container_status_restarts_total
      - kube_pod_container_status_terminated_reason
      - kube_pod_container_status_waiting
      - kube_pod_status_ready
      - kube_pod_status_phase
      - rest_client_request_latency_seconds_bucket

metrics with additional label filter:
     - apiserver_request_duration_seconds_bucket
     - workqueue_queue_duration_seconds_bucket
     - container_memory_cache
     - container_memory_rss
     - container_memory_swap
     - container_memory_working_set_bytes

in my dev env, before this change, there are 61xxx time series each minute, and the number decrease to 29xxx after the change