### PR TITLE
version bump to 2.1.1

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -314,7 +314,7 @@ func GenerateMonitoringCR(c client.Client,
 			mco.Annotations = map[string]string{}
 		}
 		mco.Annotations[AnnotationKeyImageRepository] = DefaultImgRepository
-		imageCMName := ImageManifestConfigmapName + "2.1.0"
+		imageCMName := ImageManifestConfigmapName + "2.1.1"
 		componentVersion, found := os.LookupEnv(ComponentVersion)
 		if found {
 			imageCMName = ImageManifestConfigmapName + componentVersion


### PR DESCRIPTION
use 2.1.1 image manifest configmap to get the images.
https://github.com/open-cluster-management/backlog/issues/4354