### PR TITLE
Update Grafana ClusterRole and ClusterRoleBinding

### DIFF
--- a/manifests/base/grafana/cluster-role-binding.yaml
+++ b/manifests/base/grafana/cluster-role-binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: grafana
+  name: open-cluster-management:grafana
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: grafana
+  name: open-cluster-management:grafana
 subjects:
 - kind: ServiceAccount
   name: grafana

--- a/manifests/base/grafana/cluster-role.yaml
+++ b/manifests/base/grafana/cluster-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: grafana
+  name: open-cluster-management:grafana
 rules:
 - apiGroups:
   - authentication.k8s.io


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/7621
This fix is to use the separated clusterrole and clusterrolebinding for ACM Grafana ServiceAccount.