### PR TITLE
Use custom certs for kubeconfig

### DIFF
--- a/pkg/controller/placementrule/kubeconfig_test.go
+++ b/pkg/controller/placementrule/kubeconfig_test.go
@@ -34,7 +34,7 @@ func TestCreateKubeSecret(t *testing.T) {
 	objs := []runtime.Object{newSATokenSecret(), newTestSA(), newTestInfra()}
 	c := fake.NewFakeClient(objs...)
 
-	kubeconfig, err := createKubeSecret(c, namespace)
+	kubeconfig, err := createKubeSecret(c, nil, namespace)
 	if err != nil {
 		t.Fatalf("Failed to create kubeconfig secret: (%v)", err)
 	}
@@ -108,7 +108,7 @@ func TestGetKubeAPIServerSecretName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getKubeAPIServerSecretName(tt.args.client, tt.args.name)
+			got, err := getKubeAPIServerSecretName(tt.args.client, nil, tt.args.name)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getKubeAPIServerSecretName() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/placementrule/manifestwork.go
+++ b/pkg/controller/placementrule/manifestwork.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -62,8 +63,8 @@ func injectIntoWork(works []workv1.Manifest, obj runtime.Object) []workv1.Manife
 	return works
 }
 
-func createManifestWork(client client.Client, clusterNamespace string,
-	clusterName string,
+func createManifestWork(client client.Client, restMapper meta.RESTMapper,
+	clusterNamespace string, clusterName string,
 	mco *mcov1beta1.MultiClusterObservability,
 	imagePullSecret *corev1.Secret) error {
 
@@ -105,7 +106,7 @@ func createManifestWork(client client.Client, clusterNamespace string,
 	manifests = injectIntoWork(manifests, createNameSpace())
 
 	// inject kube secret
-	secret, err := createKubeSecret(client, clusterNamespace)
+	secret, err := createKubeSecret(client, restMapper, clusterNamespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/placementrule/manifestwork_test.go
+++ b/pkg/controller/placementrule/manifestwork_test.go
@@ -123,7 +123,7 @@ func TestManifestWork(t *testing.T) {
 	}
 	templatePath = path.Join(wd, "../../../manifests/endpoint-observability")
 
-	err = createManifestWork(c, namespace, clusterName, newTestMCO(), newTestPullSecret())
+	err = createManifestWork(c, nil, namespace, clusterName, newTestMCO(), newTestPullSecret())
 	if err != nil {
 		t.Fatalf("Failed to create manifestwork: (%v)", err)
 	}
@@ -136,7 +136,7 @@ func TestManifestWork(t *testing.T) {
 		t.Fatal("Wrong size of manifests in the mainfestwork")
 	}
 
-	err = createManifestWork(c, namespace, clusterName, newTestMCO(), nil)
+	err = createManifestWork(c, nil, namespace, clusterName, newTestMCO(), nil)
 	if err != nil {
 		t.Fatalf("Failed to create manifestwork: (%v)", err)
 	}
@@ -149,7 +149,7 @@ func TestManifestWork(t *testing.T) {
 	}
 
 	spokeNameSpace = "spoke-ns"
-	err = createManifestWork(c, namespace, clusterName, newTestMCO(), newTestPullSecret())
+	err = createManifestWork(c, nil, namespace, clusterName, newTestMCO(), newTestPullSecret())
 	if err != nil {
 		t.Fatalf("Failed to create manifestwork with updated namespace: (%v)", err)
 	}

--- a/pkg/controller/placementrule/placementrule_controller.go
+++ b/pkg/controller/placementrule/placementrule_controller.go
@@ -306,7 +306,7 @@ func (r *ReconcilePlacementRule) Reconcile(request reconcile.Request) (reconcile
 		for _, decision := range instance.Status.Decisions {
 			reqLogger.Info("Monitoring operator should be installed in cluster", "cluster_name", decision.ClusterName)
 			currentClusters = util.Remove(currentClusters, decision.ClusterNamespace)
-			err = createManagedClusterRes(r.client, mco, imagePullSecret,
+			err = createManagedClusterRes(r.client, r.restMapper, mco, imagePullSecret,
 				decision.ClusterName, decision.ClusterNamespace)
 			if err != nil {
 				return reconcile.Result{}, err
@@ -371,7 +371,7 @@ func (r *ReconcilePlacementRule) Reconcile(request reconcile.Request) (reconcile
 	return reconcile.Result{}, nil
 }
 
-func createManagedClusterRes(client client.Client,
+func createManagedClusterRes(client client.Client, restMapper meta.RESTMapper,
 	mco *mcov1beta1.MultiClusterObservability, imagePullSecret *corev1.Secret,
 	name string, namespace string) error {
 	org := multiclusterobservability.GetManagedClusterOrg()
@@ -396,7 +396,7 @@ func createManagedClusterRes(client client.Client,
 		return err
 	}
 
-	err = createManifestWork(client, namespace, name, mco, imagePullSecret)
+	err = createManifestWork(client, restMapper, namespace, name, mco, imagePullSecret)
 	if err != nil {
 		log.Error(err, "Failed to create manifestwork")
 		return err


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/7682

1. if apiserver has custom certs, create `kubeconfig` to use the custom certs. otherwise, use certs from sa.
2. watch `APIServer` changes to recreate the manifestwork.