### PR TITLE
Enable e2e tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ jobs:
         - |
           make
           make component/pull
+          make component/test/e2e
     - stage: release-ff
       name: "Push commits to current release branch"
       if: type = push AND branch =~ /^master$/


### PR DESCRIPTION
Observe that the KinD cluster cannot be setup due to cannot delete `cluster-manager` successfully. re-enable to observe it again.
```
NAMESPACE                               NAME                                                       READY   STATUS    RESTARTS   AGE
cert-manager                            cert-manager-999759bfc-fhtjw                               1/1     Running   0          9m
cert-manager                            cert-manager-cainjector-84958d7bc-d2ws4                    1/1     Running   0          9m
cert-manager                            cert-manager-webhook-5b9d955b74-8vzvg                      1/1     Running   0          9m1s
kube-system                             coredns-6955765f44-qlzf2                                   1/1     Running   0          9m1s
kube-system                             coredns-6955765f44-qtv54                                   1/1     Running   0          9m1s
kube-system                             etcd-hub-control-plane                                     1/1     Running   0          9m16s
kube-system                             kindnet-49wqz                                              1/1     Running   0          9m1s
kube-system                             kube-apiserver-hub-control-plane                           1/1     Running   0          9m16s
kube-system                             kube-controller-manager-hub-control-plane                  1/1     Running   0          9m16s
kube-system                             kube-proxy-v4g4k                                           1/1     Running   0          9m1s
kube-system                             kube-scheduler-hub-control-plane                           1/1     Running   0          9m16s
local-path-storage                      local-path-provisioner-7745554f7f-sfc7s                    1/1     Running   0          9m1s
open-cluster-management-hub             cluster-manager-registration-controller-655f87d949-7gvnx   1/1     Running   0          7m33s
open-cluster-management-hub             cluster-manager-registration-controller-655f87d949-g5p5d   1/1     Running   0          7m33s
open-cluster-management-hub             cluster-manager-registration-controller-655f87d949-vwzf4   1/1     Running   0          7m33s
open-cluster-management-hub             cluster-manager-registration-webhook-6c6b5c64b9-6qkvq      1/1     Running   0          7m33s
open-cluster-management-hub             cluster-manager-registration-webhook-6c6b5c64b9-hxp4n      0/1     Pending   0          7m33s
open-cluster-management-hub             cluster-manager-registration-webhook-6c6b5c64b9-pnk8g      0/1     Pending   0          7m33s
open-cluster-management-hub             cluster-manager-work-webhook-845bddc7d9-5lpqc              1/1     Running   0          7m32s
open-cluster-management-hub             cluster-manager-work-webhook-845bddc7d9-bjns2              0/1     Pending   0          7m32s
open-cluster-management-hub             cluster-manager-work-webhook-845bddc7d9-wq6w5              0/1     Pending   0          7m32s
open-cluster-management-observability   alertmanager-0                                             0/2     Pending   0          7m26s
open-cluster-management-observability   grafana-6cb4777dc9-krph4                                   2/2     Running   0          7m28s
open-cluster-management-observability   grafana-test-8b9bf576b-p4g84                               2/2     Running   0          7m27s
open-cluster-management-observability   minio-74fd45d45-wlbbn                                      1/1     Running   0          8m56s
open-cluster-management-observability   observatorium-operator-5cc8c5f98b-4mw65                    0/1     Pending   0          7m29s
open-cluster-management-observability   rbac-query-proxy-5dbb4785d8-8ch44                          1/1     Running   0          7m28s
open-cluster-management                 cluster-manager-7f758d8b49-hrkrr                           1/1     Running   0          8m45s
open-cluster-management                 multicluster-observability-operator-59ddf6f54-ftz5g        1/1     Running   0          8m49s
openshift-ingress                       ingress-router-55c6bfd649-dwzhf                            1/1     Running   0          9m1s
openshift-monitoring                    blackbox-exporter-78479b8994-dvd8s                         3/3     Running   0          9m
openshift-monitoring                    kube-state-metrics-78484c4fff-lw6xv                        3/3     Running   0          9m
openshift-monitoring                    node-exporter-f6x76                                        2/2     Running   0          9m1s
openshift-monitoring                    prometheus-adapter-6d5746b56-w8x9s                         1/1     Running   0          9m
openshift-monitoring                    prometheus-k8s-0                                           2/2     Running   1          7m55s
openshift-monitoring                    prometheus-operator-8559ff6d5d-n8tck                       2/2     Running   0          9m1s
```