### PR TITLE
update the default interval to 30 seconds for metrics scrape/push

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ spec:
   imagePullSecret: multiclusterhub-operator-pull-secret
   observabilityAddonSpec: # The ObservabilityAddonSpec defines the global settings for all managed clusters which have observability add-on enabled
     enableMetrics: true # EnableMetrics indicates the observability addon push metrics to hub server
-    interval: 60 # Interval for the observability addon push metrics to hub server
+    interval: 30 # Interval for the observability addon push metrics to hub server
   retentionResolution1h: 30d # How long to retain samples of 1 hour in bucket
   retentionResolution5m: 14d
   retentionResolutionRaw: 5d

--- a/deploy/crds/observability.open-cluster-management.io_multiclusterobservabilities_crd.yaml
+++ b/deploy/crds/observability.open-cluster-management.io_multiclusterobservabilities_crd.yaml
@@ -67,7 +67,7 @@ spec:
                   type: boolean
                 interval:
                   description: Interval for the observability addon push metrics to
-                    hub server. The default is 60 seconds
+                    hub server. The default is 30 seconds
                   format: int32
                   type: integer
                   minimum: 15

--- a/deploy/olm-catalog/multicluster-observability-operator/manifests/observability.open-cluster-management.io_multiclusterobservabilities_crd.yaml
+++ b/deploy/olm-catalog/multicluster-observability-operator/manifests/observability.open-cluster-management.io_multiclusterobservabilities_crd.yaml
@@ -67,7 +67,7 @@ spec:
                   type: boolean
                 interval:
                   description: Interval for the observability addon push metrics to
-                    hub server. The default is 60 seconds
+                    hub server. The default is 30 seconds
                   format: int32
                   type: integer
                   minimum: 15

--- a/deploy/olm-catalog/multicluster-observability-operator/manifests/observability.open-cluster-management.io_observabilityaddon_crd.yaml
+++ b/deploy/olm-catalog/multicluster-observability-operator/manifests/observability.open-cluster-management.io_observabilityaddon_crd.yaml
@@ -39,7 +39,7 @@ spec:
               type: boolean
             interval:
               description: Interval for the observability addon push metrics to hub
-                server. The default is 60 seconds
+                server. The default is 30 seconds
               format: int32
               type: integer
               minimum: 15

--- a/deploy/req_crds/observability.open-cluster-management.io_observabilityaddon_crd.yaml
+++ b/deploy/req_crds/observability.open-cluster-management.io_observabilityaddon_crd.yaml
@@ -39,7 +39,7 @@ spec:
               type: boolean
             interval:
               description: Interval for the observability addon push metrics to hub
-                server. The default is 60 seconds
+                server. The default is 30 seconds
               format: int32
               type: integer
               minimum: 15

--- a/pkg/apis/observability/v1beta1/multiclusterobservability_types.go
+++ b/pkg/apis/observability/v1beta1/multiclusterobservability_types.go
@@ -79,7 +79,7 @@ type ObservabilityAddonSpec struct {
 	EnableMetrics bool `json:"enableMetrics,omitempty"`
 
 	// Interval for the observability addon push metrics to hub server.
-	// The default is 60 seconds
+	// The default is 30 seconds
 	// +optional
 	Interval int32 `json:"interval,omitempty"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,7 +51,7 @@ const (
 	DefaultRetentionResolution5m  = "14d"
 	DefaultRetentionResolutionRaw = "5d"
 
-	DefaultAddonInterval = 60
+	DefaultAddonInterval = 30
 
 	ImageManifestConfigMapName = "mch-image-manifest-"
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -388,7 +388,7 @@ func TestGenerateMonitoringCR(t *testing.T) {
 func TestGenerateMonitoringCustomizedCR(t *testing.T) {
 	addonSpec := &mcov1beta1.ObservabilityAddonSpec{
 		EnableMetrics: true,
-		Interval:      60,
+		Interval:      30,
 	}
 
 	mco := &mcov1beta1.MultiClusterObservability{


### PR DESCRIPTION
to be align with OCP's setting

https://github.com/open-cluster-management/backlog/issues/8830