### PR TITLE
remove blank line

### DIFF
--- a/deploy/olm-catalog/multicluster-observability-operator/manifests/core.observatorium.io_observatoria.yaml
+++ b/deploy/olm-catalog/multicluster-observability-operator/manifests/core.observatorium.io_observatoria.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/deploy/req_crds/core.observatorium.io_observatoria.yaml
+++ b/deploy/req_crds/core.observatorium.io_observatoria.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition


### PR DESCRIPTION
@schmidtd reported that there is error in ACM bundle
```
error checking provided apis in bundle multicluster-hub.v2.2.0: couldn't find core.observatorium.io/v1alpha1/Observatorium (observatoria) in bundle. found: map[observability.open-cluster-management.io/v1beta1/MultiClusterObservability (multiclusterobservabilities):{} observability.open-cluster-management.io/v1beta1/ObservabilityAddon (observabilityaddons):{} operator.open-cluster-management.io/v1/ClusterManager (clustermanagers):{} operator.open-cluster-management.io/v1/MultiClusterHub (multiclusterhubs):{} submarineraddon.open-cluster-management.io/v1alpha1/SubmarinerConfig (submarinerconfigs):{}]
```

Just remove the blank line to see if it works or not.