### PR TITLE
Upgrade to use 0.8.0 memcached

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,7 +93,7 @@ const (
 	MemcachedExporterImgRepo = "prom"
 	MemcachedExporterImgName = "memcached-exporter"
 	MemcachedExporterKey     = "memcached_exporter"
-	MemcachedExporterImgTag  = "v0.6.0"
+	MemcachedExporterImgTag  = "v0.8.0"
 
 	GrafanaImgRepo            = "grafana"
 	GrafanaImgName            = "grafana"


### PR DESCRIPTION
upgrade to use memcached 0.8.0 to keep align with https://code.engineering.redhat.com/gerrit/#/c/226949/