### PR TITLE
check readiness of the server certificate for managedcluster before generating manifestwork.

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -373,7 +373,6 @@ func generateObservabilityServerCACerts(client client.Client) (*corev1.Secret, e
 	err := client.Get(context.TODO(), types.NamespacedName{Name: config.ServerCACerts,
 		Namespace: config.GetDefaultNamespace()}, ca)
 	if err != nil {
-		log.Error(err, "Failed to get ca cert secret", "name", config.ServerCACerts)
 		return nil, err
 	}
 

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -120,6 +120,16 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
+	// check if the server certificate for managedcluster
+	if managedClusterObsCert == nil {
+		var err error
+		managedClusterObsCert, err = generateObservabilityServerCACerts(r.Client)
+		if err != nil && k8serrors.IsNotFound(err) {
+			// if the servser certificate for managedcluster is not ready, then requeue the request after 10s to avoid useless reconcile loop.
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+	}
+
 	opts := &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(map[string]string{ownerLabelKey: ownerLabelValue}),
 	}


### PR DESCRIPTION
this is a followup PR for: https://github.com/open-cluster-management/multicluster-observability-operator/pull/712

Sometimes, the certificate controller is starting slower than the placementrule controller, so the server **certificate** for the managedclusters will be not ready, this results in the error when generating **manifestwork**, although the error will be gone after the certificate is ready, but we should proactively prevent the useless reconcile loop in such case.

```
# grep error -i mco.log
2021-08-26T10:36:14.761Z	ERROR	controller_placementrule	Failed to get ca cert secret	{"name": "observability-server-ca-certs", "error": "secrets \"observability-server-ca-certs\" not found"}
2021-08-26T10:36:14.761Z	ERROR	controller-runtime.manager.controller.managedcluster	Reconciler error	{"reconciler group": "cluster.open-cluster-management.io", "reconciler kind": "ManagedCluster", "name": "local-cluster", "namespace": "", "error": "secrets \"observability-server-ca-certs\" not found"}
2021-08-26T10:36:14.768Z	ERROR	controller_placementrule	Failed to get ca cert secret	{"name": "observability-server-ca-certs", "error": "secrets \"observability-server-ca-certs\" not found"}
2021-08-26T10:36:14.768Z	ERROR	controller-runtime.manager.controller.managedcluster	Reconciler error	{"reconciler group": "cluster.open-cluster-management.io", "reconciler kind": "ManagedCluster", "name": "mch-updated-request", "namespace": "open-cluster-management", "error": "secrets \"observability-server-ca-certs\" not found"}
2021-08-26T10:36:14.775Z	ERROR	controller_placementrule	Failed to get ca cert secret	{"name": "observability-server-ca-certs", "error": "secrets \"observability-server-ca-certs\" not found"}
2021-08-26T10:36:14.775Z	ERROR	controller-runtime.manager.controller.managedcluster	Reconciler error	{"reconciler group": "cluster.open-cluster-management.io", "reconciler kind": "ManagedCluster", "name": "observability", "namespace": "", "error": "secrets \"observability-server-ca-certs\" not found"}
```

Signed-off-by: morvencao <lcao@redhat.com>