### PR TITLE
fix pull secret nil error

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -337,7 +337,7 @@ func createManifestWorks(c client.Client, restMapper meta.RESTMapper,
 		if err == nil && customPullSecret != nil {
 			customPullSecret.ResourceVersion = ""
 			customPullSecret.Name = config.GetImagePullSecret(mco.Spec)
-			customPullSecret.Namespace = config.GetDefaultNamespace()
+			customPullSecret.Namespace = spokeNameSpace
 			manifests = injectIntoWork(manifests, customPullSecret)
 		}
 


### PR DESCRIPTION
if pull secret is nil, we will have the following error:

```
panic: runtime error: invalid memory address or nil pointer dereference
```
Signed-off-by: Song Song Li <ssli@redhat.com>