### PR TITLE
fix oauth-proxy image not found issue.

### DIFF
--- a/manifests/base/alertmanager/alertmanager-statefulset.yaml
+++ b/manifests/base/alertmanager/alertmanager-statefulset.yaml
@@ -112,7 +112,7 @@ spec:
         - --skip-provider-button=true
         - --openshift-ca=/etc/pki/tls/cert.pem
         - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        image: quay.io/open-cluster-management/origin-oauth-proxy:2.0.11-SNAPSHOT-2021-04-29-18-29-17
+        image: quay.io/stolostron/origin-oauth-proxy:4.5
         imagePullPolicy: IfNotPresent
         name: alertmanager-proxy
         ports:

--- a/manifests/base/alertmanager/alertmanager-statefulset.yaml
+++ b/manifests/base/alertmanager/alertmanager-statefulset.yaml
@@ -112,7 +112,7 @@ spec:
         - --skip-provider-button=true
         - --openshift-ca=/etc/pki/tls/cert.pem
         - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        image: quay.io/stolostron/origin-oauth-proxy:2.0.11-SNAPSHOT-2021-04-29-18-29-17
+        image: quay.io/open-cluster-management/origin-oauth-proxy:2.0.11-SNAPSHOT-2021-04-29-18-29-17
         imagePullPolicy: IfNotPresent
         name: alertmanager-proxy
         ports:

--- a/manifests/base/proxy/deployment.yaml
+++ b/manifests/base/proxy/deployment.yaml
@@ -88,7 +88,7 @@ spec:
         - --skip-provider-button=true
         - --openshift-ca=/etc/pki/tls/cert.pem
         - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        image: quay.io/stolostron/origin-oauth-proxy:2.0.11-SNAPSHOT-2021-04-29-18-29-17
+        image: quay.io/stolostron/origin-oauth-proxy:4.5
         imagePullPolicy: Always
         name: oauth-proxy
         ports:


### PR DESCRIPTION
the image `quay.io/stolostron/origin-oauth-proxy:2.0.11-SNAPSHOT-2021-04-29-18-29-17` doesn't exist, use the old to pass the e2e testings.

Signed-off-by: morvencao <lcao@redhat.com>