### PR TITLE
enable alertforward case for e2e in kind.

### DIFF
--- a/cicd-scripts/customize-mco.sh
+++ b/cicd-scripts/customize-mco.sh
@@ -187,7 +187,7 @@ get_ginkgo_focus() {
 
     if [[ -n "${IS_KIND_ENV}" ]]; then
         # For KinD cluster, do not need to run all test cases
-        GINKGO_FOCUS=" --focus manifestwork/g0 --focus endpoint_preserve/g0 --focus grafana/g0 --focus metrics/g0 --focus addon/g0 --focus alert/g0 --focus dashboard/g0"
+        GINKGO_FOCUS=" --focus manifestwork/g0 --focus endpoint_preserve/g0 --focus grafana/g0 --focus metrics/g0 --focus addon/g0 --focus alert/g0 --focus alertforward/g0 --focus dashboard/g0"
     else
         GINKGO_FOCUS=$(echo "${GINKGO_FOCUS}" | xargs -n2 | sort -u | xargs)
     fi

--- a/tests/pkg/tests/observability_route_test.go
+++ b/tests/pkg/tests/observability_route_test.go
@@ -59,6 +59,10 @@ var _ = Describe("Observability:", func() {
 
 			client := &http.Client{}
 			if os.Getenv("IS_KIND_ENV") != "true" {
+				tr = &http.Transport{
+					// #nosec
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				}
 				client.Transport = tr
 				req.Header.Set("Authorization", "Bearer "+BearerToken)
 			}


### PR DESCRIPTION
enable alertforward case for e2e in kind, alertforward case  was added in https://github.com/stolostron/multicluster-observability-operator/pull/819
Signed-off-by: morvencao <lcao@redhat.com>