### PR TITLE
Fix unsupported chars for configmap name

### DIFF
--- a/tools/generate-dashboard-configmap-yaml.sh
+++ b/tools/generate-dashboard-configmap-yaml.sh
@@ -45,7 +45,7 @@ start() {
     savePath=$2
   fi
   org_dashboard_name=$1
-  dashboard_name=`echo ${1// /-} | tr '[:upper:]' '[:lower:]'`
+  dashboard_name=`echo ${1//[!(a-z\A-Z\0-9\-\.)]/-} | tr '[:upper:]' '[:lower:]'`
 
   while [[ $# -gt 0 ]]
   do


### PR DESCRIPTION
refer to: https://github.com/stolostron/backlog/issues/18480
Signed-off-by: clyang82 <chuyang@redhat.com>