### PR TITLE
Add Backup labels to observability resources.

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -586,6 +586,10 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		CreateFunc: func(e event.CreateEvent) bool {
 			if e.Object.GetName() == config.AllowlistCustomConfigMapName &&
 				e.Object.GetNamespace() == config.GetDefaultNamespace() {
+				err := util.AddBackupLabelToConfigMap(c, config.AllowlistCustomConfigMapName, config.GetDefaultNamespace())
+				if err != nil {
+					log.Error(err, "Failed to add backup label")
+				}
 				// generate the metrics allowlist configmap
 				log.Info("generate metric allow list configmap for custom configmap CREATE")
 				metricsAllowlistConfigMap, _ = generateMetricsListCM(c)
@@ -597,6 +601,10 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			if e.ObjectNew.GetName() == config.AllowlistCustomConfigMapName &&
 				e.ObjectNew.GetNamespace() == config.GetDefaultNamespace() &&
 				e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() {
+				err := util.AddBackupLabelToConfigMap(c, config.AllowlistCustomConfigMapName, config.GetDefaultNamespace())
+				if err != nil {
+					log.Error(err, "Failed to add backup label")
+				}
 				// regenerate the metrics allowlist configmap
 				log.Info("generate metric allow list configmap for custom configmap UPDATE")
 				metricsAllowlistConfigMap, _ = generateMetricsListCM(c)
@@ -694,6 +702,10 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			if e.Object.GetNamespace() == config.GetDefaultNamespace() &&
 				(e.Object.GetName() == config.AlertmanagerRouteBYOCAName ||
 					e.Object.GetName() == config.AlertmanagerRouteBYOCERTName) {
+				err := util.AddBackupLabelToSecret(c, e.Object.GetName(), config.GetDefaultNamespace())
+				if err != nil {
+					log.Error(err, "Failed to add backup label")
+				}
 				// generate the hubInfo secret
 				hubInfoSecret, _ = generateHubInfoSecret(
 					c,
@@ -710,6 +722,10 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() &&
 				(e.ObjectNew.GetName() == config.AlertmanagerRouteBYOCAName ||
 					e.ObjectNew.GetName() == config.AlertmanagerRouteBYOCERTName) {
+				err := util.AddBackupLabelToSecret(c, e.ObjectNew.GetName(), config.GetDefaultNamespace())
+				if err != nil {
+					log.Error(err, "Failed to add backup label")
+				}
 				// regenerate the hubInfo secret
 				hubInfoSecret, _ = generateHubInfoSecret(
 					c,

--- a/operators/multiclusterobservability/pkg/certificates/certificates.go
+++ b/operators/multiclusterobservability/pkg/certificates/certificates.go
@@ -214,6 +214,9 @@ func createCertSecret(c client.Client,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: config.GetDefaultNamespace(),
+					Labels: map[string]string{
+						config.BackupLabelName: config.BackupLabelValue,
+					},
 				},
 				Data: map[string][]byte{
 					"ca.crt":  caCertBytes,

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -98,6 +98,8 @@ const (
 
 	ValidatingWebhookConfigurationName = "multicluster-observability-operator"
 	WebhookServiceName                 = "multicluster-observability-webhook-service"
+	BackupLabelName                    = "cluster.open-cluster-management.io/backup"
+	BackupLabelValue                   = ""
 )
 
 const (
@@ -123,9 +125,10 @@ const (
 	MemcachedExporterKey     = "memcached_exporter"
 	MemcachedExporterImgTag  = "v0.9.0"
 
-	GrafanaImgKey              = "grafana"
-	GrafanaDashboardLoaderName = "grafana-dashboard-loader"
-	GrafanaDashboardLoaderKey  = "grafana_dashboard_loader"
+	GrafanaImgKey               = "grafana"
+	GrafanaDashboardLoaderName  = "grafana-dashboard-loader"
+	GrafanaDashboardLoaderKey   = "grafana_dashboard_loader"
+	GrafanaCustomDashboardLabel = "grafana-custom-dashboard"
 
 	AlertManagerImgName           = "prometheus-alertmanager"
 	AlertManagerImgKey            = "prometheus_alertmanager"
@@ -277,6 +280,8 @@ var (
 	MemoryLimitMB   = int32(1024)
 	ConnectionLimit = int32(1024)
 	MaxItemSize     = "1m"
+
+	ThanosObjectStore = "thanos-object-storage" // default name
 )
 
 func GetReplicas(component string, advanced *observabilityv1beta2.AdvancedConfig) *int32 {

--- a/operators/multiclusterobservability/pkg/util/backuputil.go
+++ b/operators/multiclusterobservability/pkg/util/backuputil.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package util
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+)
+
+func AddBackupLabelToConfigMap(c client.Client, name string, namespace string) error {
+	m := &corev1.ConfigMap{}
+	err := c.Get(context.TODO(), types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}, m)
+	if err != nil {
+		return err
+	}
+	if _, ok := m.ObjectMeta.Labels[config.BackupLabelName]; !ok {
+		m.ObjectMeta.Labels[config.BackupLabelName] = config.BackupLabelValue
+		err := c.Update(context.TODO(), m)
+		if err != nil {
+			return err
+		} else {
+			log.Info("Add backup label for configMap", "name", name)
+		}
+
+	}
+	return nil
+}
+
+func AddBackupLabelToSecret(c client.Client, name string, namespace string) error {
+	s := &corev1.Secret{}
+	err := c.Get(context.TODO(), types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}, s)
+	if err != nil {
+		return err
+	}
+	if _, ok := s.ObjectMeta.Labels[config.BackupLabelName]; !ok {
+		s.ObjectMeta.Labels[config.BackupLabelName] = config.BackupLabelValue
+		err := c.Update(context.TODO(), s)
+		if err != nil {
+			return err
+		} else {
+			log.Info("Add backup label for secret", "name", name)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
e2e testing diagnosis for https://github.com/stolostron/multicluster-observability-operator/pull/908
because only PR owner can execute into the e2e testing env.

Signed-off-by: morvencao <lcao@redhat.com>