### PR TITLE
check the compact pod is restarted and ready

### DIFF
--- a/tests/pkg/tests/observability_observatorium_preserve_test.go
+++ b/tests/pkg/tests/observability_observatorium_preserve_test.go
@@ -5,7 +5,6 @@ package tests
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -29,8 +28,9 @@ var _ = Describe("Observability:", func() {
 
 	Context("[P1][Sev1][Observability] Should revert any manual changes on observatorium cr (observatorium_preserve/g0) -", func() {
 		It("[Stable] Updating observatorium cr (spec.thanos.compact.retentionResolution1h) should be automatically reverted", func() {
-			oldResourceVersion := ""
+			oldCRResourceVersion := ""
 			updateRetention := "10d"
+			oldCompactResourceVersion := ""
 			Eventually(func() error {
 				cr, err := dynClient.Resource(utils.NewMCOMObservatoriumGVR()).
 					Namespace(MCO_NAMESPACE).
@@ -38,8 +38,15 @@ var _ = Describe("Observability:", func() {
 				if err != nil {
 					return err
 				}
+				oldCRResourceVersion = cr.Object["metadata"].(map[string]interface{})["resourceVersion"].(string)
+
+				sts, err := utils.GetStatefulSetWithLabel(testOptions, true, THANOS_COMPACT_LABEL, MCO_NAMESPACE)
+				if err != nil {
+					return err
+				}
+				oldCompactResourceVersion = (*sts).Items[0].ResourceVersion
+
 				cr.Object["spec"].(map[string]interface{})["thanos"].(map[string]interface{})["compact"].(map[string]interface{})["retentionResolution1h"] = updateRetention
-				oldResourceVersion = cr.Object["metadata"].(map[string]interface{})["resourceVersion"].(string)
 				_, err = dynClient.Resource(utils.NewMCOMObservatoriumGVR()).
 					Namespace(MCO_NAMESPACE).
 					Update(context.TODO(), cr, metav1.UpdateOptions{})
@@ -53,7 +60,7 @@ var _ = Describe("Observability:", func() {
 				if err == nil {
 					replicasNewRetention := cr.Object["spec"].(map[string]interface{})["thanos"].(map[string]interface{})["compact"].(map[string]interface{})["retentionResolution1h"]
 					newResourceVersion := cr.Object["metadata"].(map[string]interface{})["resourceVersion"].(string)
-					if newResourceVersion != oldResourceVersion &&
+					if newResourceVersion != oldCRResourceVersion &&
 						replicasNewRetention != updateRetention {
 						return true
 					}
@@ -61,21 +68,35 @@ var _ = Describe("Observability:", func() {
 				return false
 			}, EventuallyTimeoutMinute*3, EventuallyIntervalSecond*1).Should(BeTrue())
 
-			// wait for pod restarting
-			time.Sleep(10 * time.Second)
+			// ensure the thanos compact is restarted
+			Eventually(func() bool {
+				sts, err := utils.GetStatefulSetWithLabel(testOptions, true, THANOS_COMPACT_LABEL, MCO_NAMESPACE)
+				if err == nil {
+					if (*sts).Items[0].ResourceVersion != oldCompactResourceVersion {
+						argList := (*sts).Items[0].Spec.Template.Spec.Containers[0].Args
+						for _, arg := range argList {
+							if arg != "--retention.resolution-raw="+updateRetention {
+								return true
+							}
+						}
+						return false
+					}
+				}
+				return false
+			}, EventuallyTimeoutMinute*10, EventuallyIntervalSecond*5).Should(BeTrue())
 
 			By("Wait for thanos compact pods are ready")
 			sts, err := utils.GetStatefulSetWithLabel(testOptions, true, THANOS_COMPACT_LABEL, MCO_NAMESPACE)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(sts.Items)).NotTo(Equal(0))
-			// ensure the thanos rule pods are restarted successfully before processing
+			// ensure the thanos rule pod is ready
 			Eventually(func() error {
 				err = utils.CheckStatefulSetPodReady(testOptions, (*sts).Items[0].Name)
 				if err != nil {
 					return err
 				}
 				return nil
-			}, EventuallyTimeoutMinute*10, EventuallyIntervalSecond*5).Should(Succeed())
+			}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
fixed: https://github.com/stolostron/backlog/issues/20231

the root cause is the compact pod is ready with the intermediate stage. and pass the test case `Should revert any manual changes on observatorium cr (observatorium_preserve/g0)`. But the pod will be restarted to reconcile the final state. 

 <pre>
manually modify the observatorium CR   ---> revert back by MCO operator
                 |                                    |
                 |                                    |
    observatorium operator reconcile        observatorium operator reconcile
            this intermediate state                 the final state
</pre>
Signed-off-by: clyang82 <chuyang@redhat.com>