### PR TITLE
Removed unneeded vendor for dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ version: 2
 updates:
   # Enable version updates for go modules
   - package-ecosystem: "gomod"
-    # Raise pull requests to update vendored dependencies that are checked in to the repository
-    vendor: true
     # Look for `go.mod` and `go.sum` files in the `root` directory
     directory: "/"
     # Check the go registry for updates every day (weekdays)


### PR DESCRIPTION
Github dependabot does not require the `vendor` path when updating the go mods. Removing the path will allow for the PRs to create properly.

Signed-off-by: dislbenn <lavontae.bennett@gmail.com>