### PR TITLE
add observabilityaddon spec nil check.

### DIFF
--- a/pkg/controller/placementrule/placementrule_controller.go
+++ b/pkg/controller/placementrule/placementrule_controller.go
@@ -236,7 +236,7 @@ func (r *ReconcilePlacementRule) Reconcile(request reconcile.Request) (reconcile
 		return reconcile.Result{}, nil
 	}
 
-	if !deleteAll && !mco.Spec.ObservabilityAddonSpec.EnableMetrics {
+	if !deleteAll && mco.Spec.ObservabilityAddonSpec != nil && !mco.Spec.ObservabilityAddonSpec.EnableMetrics {
 		reqLogger.Info("EnableMetrics is set to false. Delete Observability addons")
 		deleteAll = true
 	}


### PR DESCRIPTION
ref: https://github.com/stolostron/backlog/issues/20463

We didn't add default value for observabilityaddon spec in release-2.2, so it will be nil if user doesn't specific the value.
For release-2.3 and beyond, the observabilityaddon spec and default value for `EnableMetrics` is true, so it will not be a  problem.

Signed-off-by: morvencao <lcao@redhat.com>