### PR TITLE
add the rule name as a label for hash

### DIFF
--- a/collectors/metrics/pkg/collectrule/evaluator.go
+++ b/collectors/metrics/pkg/collectrule/evaluator.go
@@ -267,6 +267,10 @@ func evaluateRule(logger log.Logger, r CollectRule, metrics []*clientmodel.Metri
 					Value: *l.Value,
 				})
 			}
+			ls = append(ls, labels.Label{
+				Name:  "rule_name",
+				Value: r.Name,
+			})
 			h := ls.Hash()
 			if (*firingRules[r.Name]).triggerTime[h] != nil {
 				delete(firings, h)

--- a/collectors/metrics/pkg/collectrule/evaluator_test.go
+++ b/collectors/metrics/pkg/collectrule/evaluator_test.go
@@ -27,6 +27,10 @@ func getHash(k string, v string) uint64 {
 		Name:  k,
 		Value: v,
 	})
+	ls = append(ls, labels.Label{
+		Name:  "rule_name",
+		Value: TEST_RULE_NAME,
+	})
 	return ls.Hash()
 }
 


### PR DESCRIPTION
add the rule name as a label for hash, to handle the case that different rule has same label set

Signed-off-by: Marco llan@redhat.com