### PR TITLE
Collect Configuration Policy controller saturation metrics

### DIFF
--- a/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
+++ b/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
@@ -130,6 +130,9 @@ data:
       - cluster:policy_governance_info:propagated_noncompliant_count
       - policy:policy_governance_info:propagated_count
       - policy:policy_governance_info:propagated_noncompliant_count
+      - config_policies_evaluation_duration_seconds_bucket
+      - config_policies_evaluation_duration_seconds_sum
+      - config_policies_evaluation_duration_seconds_count
     matches:
       - __name__="workqueue_queue_duration_seconds_bucket",job="apiserver"
       - __name__="workqueue_adds_total",job="apiserver"


### PR DESCRIPTION
This will allow users to set alerts when the Configuration Policy
controller is saturated. This will also allow them to determine if they
need to increase concurrency on the Configuration Policy controller.

Relates:
https://github.com/stolostron/backlog/issues/23547