### PR TITLE
adding policy for centralized alert management

### DIFF
--- a/examples/policies/README.md
+++ b/examples/policies/README.md
@@ -1,0 +1,16 @@
+### Goal of the 3 policies
+If apply these policies to a managed cluster, it will configure the Prometheus of the managed cluster to forward all it alerts to the alertmanager on the ACM hub. It does so by configuring the cluster-monitoring-config configmap in openshift-monitoring namespace of the managed cluster. This cannot be applied to ACM hub unless [this feature](https://issues.redhat.com/browse/ACM-1756) is delivered.
+
+### Notes
+- When the policies are deleted, we do not delete the resources create by the policies. This is just to play it safe because we are dealing with cluster-monitoring-config configmap - a critical item in configuring OCP monitoring.
+- we cannot create policy set out of these because these policies need to be created in different namespaces as it accesses resources in those namespaces in the ACM Hub for hub side templating.
+- These polices will be supported on ACM 2.6; Not sure if ACM 2.5 will be able to support these levels of hub side and managed cluster side templates. However, it is not neccessary that these resources be delivered through policy either. As long as the right resources - configmap, secrets are delivered with correct content, the function will be served.
+
+### Description
+
+Policy | Description | Additional Info
+--- | --- | ---
+policy-hub-alert-routing.yaml| This needs to be created in openshift-ingress namespace. This takes the CA certs needed  to complete the router handshake and injects them into a secret in the openshift-monitoring namespace. | Needless to say, if custom certificates are used, appropriate changes need to be made to this policy.
+policy-cluster-monitoring-config.yaml| This needs to be created in open-cluster-management-observability namespace. This creates the real cluster-monitoring-config configmap in the openshift-monitoring namespace. This usese both hub side and managed cluster side templating. | The other 2 polices creates secrets referred to by this configmap. What happens if the "cluster" label is changed.
+policy-obs-alm-accessor.yaml|This needs to be created in open-cluster-management-observability namespace. This takes the bearer token required by the service account using which one can log into the ACM hub alertmanager and injects them into a secret in the openshift-monitoring namespace.|
+

--- a/examples/policies/centralized-alerting/policy-hub-alert-routing.yaml
+++ b/examples/policies/centralized-alerting/policy-hub-alert-routing.yaml
@@ -1,0 +1,64 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-hub-alertmanager-routing
+  namespace: openshift-ingress
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-hub-alertmanager-routing-define
+        spec:
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - default
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  service-ca.crt: '{{hub fromSecret "openshift-ingress" "router-certs-default" "tls.crt"  hub}}'
+                kind: Secret
+                metadata:
+                  name: hub-alertmanager-router-ca
+                  namespace: openshift-monitoring
+                type: Opaque                
+          remediationAction: enforce
+          severity: low
+  remediationAction: enforce
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: policy-create-hub-alertmanager-router-ca-placement
+  namespace: open-cluster-management-observability
+spec:
+  clusterConditions: []
+  clusterSelector:
+    matchExpressions:
+      - key: name
+        operator: In
+        values:
+          - "jb-sno-bb"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: policy-create-hub-alertmanager-router-ca-placement-binding
+  namespace: open-cluster-management-observability
+placementRef:
+  name: policy-create-hub-alertmanager-router-ca-placement
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+subjects:
+  - name: policy-hub-alertmanager-routing
+    apiGroup: policy.open-cluster-management.io
+    kind: Policy

--- a/examples/policies/centralized-alerting/policy-obs-alm-accessor.yaml
+++ b/examples/policies/centralized-alerting/policy-obs-alm-accessor.yaml
@@ -1,0 +1,67 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-obs-alm-accessor
+  namespace: open-cluster-management-observability
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-observability-alertmanager-accessor-define
+        spec:
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - default
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  # {{hub (lookup "v1" "ServiceAccount" "open-cluster-management-observability" "observability-alertmanager-accessor").secrets.name 1 hub}}
+                  #token: '{{hub fromSecret "open-cluster-management-observability" "observability-alertmanager-accessor-token-52r4l" "token"  hub}}'
+                  token: '{{hub fromSecret "open-cluster-management-observability" (printf "%s" (index (lookup "v1" "ServiceAccount" "open-cluster-management-observability" "observability-alertmanager-accessor") "secrets" 1 "name" )) "token"  hub}}'
+                kind: Secret
+                metadata:
+                  name: observability-alertmanager-accessor
+                  namespace: openshift-monitoring
+                type: Opaque
+          remediationAction: enforce
+          severity: low
+  remediationAction: enforce
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: policy-create-observability-alertmanager-accessor-placement
+  namespace: open-cluster-management-observability
+spec:
+  clusterConditions: []
+  clusterSelector:
+    matchExpressions:
+      - key: name
+        operator: In
+        values:
+          - "jb-sno-bb"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: policy-create-observability-alertmanager-accessor-placement-binding
+  namespace: open-cluster-management-observability
+placementRef:
+  name: policy-create-observability-alertmanager-accessor-placement
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+subjects:
+  - name: policy-obs-alm-accessor
+    apiGroup: policy.open-cluster-management.io
+    kind: Policy

--- a/examples/policies/policy-cluster-monitoring-config.yaml
+++ b/examples/policies/policy-cluster-monitoring-config.yaml
@@ -1,0 +1,81 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-cm-config
+  namespace: open-cluster-management-observability
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+spec:
+  disabled: false
+  policy-templates:           
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-cm-config-define
+        spec:
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - default
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: ConfigMap
+                apiVersion: v1
+                metadata:
+                  name: cluster-monitoring-config
+                  namespace: openshift-monitoring
+                data:
+                  config.yaml: |
+                    prometheusK8s:
+                        additionalAlertManagerConfigs:
+                        - apiVersion: v2
+                          bearerToken:
+                            key: token
+                            name: observability-alertmanager-accessor
+                          pathPrefix: /
+                          scheme: https
+                          staticConfigs:
+                          - {{hub (lookup "route.openshift.io/v1" "Route" "open-cluster-management-observability" "alertmanager").spec.host hub}}
+                          tlsConfig:
+                            ServerName: ""
+                            ca:
+                              key: service-ca.crt
+                              name: hub-alertmanager-router-ca
+                            insecureSkipVerify: false
+                        externalLabels:
+                          cluster: '{{ fromClusterClaim "id.openshift.io" }}'
+          remediationAction: enforce
+          severity: low
+  remediationAction: enforce
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: policy-create-cm-config-placement
+  namespace: open-cluster-management-observability
+spec:
+  clusterConditions: []
+  clusterSelector:
+    matchExpressions:
+      - key: name
+        operator: In
+        values:
+          - "jb-sno-bb"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: policy-create-cm-config-placement-binding
+  namespace: open-cluster-management-observability
+placementRef:
+  name: policy-create-cm-config-placement
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+subjects:
+  - name: policy-create-cm-config
+    apiGroup: policy.open-cluster-management.io
+    kind: Policy


### PR DESCRIPTION
Signed-off-by: Joydeep Banerjee <jbanerje@redhat.com>

Adding sample policies to configure centralized alert management. Attached are 3 policies with a README. Actually, as I have seen, this does `not` interfere even if ACM Observability is enabled. Please verify.