### PR TITLE
Updated slack config api url

### DIFF
--- a/tests/pkg/utils/mco_deploy.go
+++ b/tests/pkg/utils/mco_deploy.go
@@ -886,7 +886,7 @@ route:
 receivers:
   - name: default-receiver
     slack_configs:
-    - api_url: https://hooks.slack.com/services/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
+    - api_url: https://hooks.slack.com/services/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
       channel: team-observability-test
       footer: |
         {{ .CommonLabels.cluster }}


### PR DESCRIPTION
This PR will replace the slack config webhook URL with the latest webhook URL created.

Signed-off-by: dislbenn <dbennett@redhat.com>