### PR TITLE
Fixed syntax error in managed-cluster-label-allowlist configmap yaml

### DIFF
--- a/operators/multiclusterobservability/manifests/base/config/managed_cluster_label_allowlist.yaml
+++ b/operators/multiclusterobservability/manifests/base/config/managed_cluster_label_allowlist.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: observability-managed-cluster-label-allowlist
   annotations:
-    skip-creation-if-exist: “true”
+    skip-creation-if-exist: "true"
 data:
   managed_cluster.yaml: |
     ignore_labels:

--- a/proxy/pkg/util/util.go
+++ b/proxy/pkg/util/util.go
@@ -549,26 +549,21 @@ func resyncManagedClusterLabelAllowList(kubeClient kubernetes.Interface) error {
 		klog.Infof("resyncing required for managedcluster label allowlist: %v",
 			proxyconfig.GetManagedClusterLabelAllowListConfigMapName())
 
-		if ok := reflect.DeepEqual(syncLabelList.IgnoreList, managedLabelList.IgnoreList); !ok {
-			managedLabelList.IgnoreList = syncLabelList.IgnoreList
-			ignoreManagedClusterLabelNames(managedLabelList)
-		}
+		managedLabelList.IgnoreList = syncLabelList.IgnoreList
+		ignoreManagedClusterLabelNames(managedLabelList)
 
-		if ok := reflect.DeepEqual(syncLabelList.LabelList, managedLabelList.LabelList); !ok {
-			*syncLabelList = *managedLabelList
+		*syncLabelList = *managedLabelList
+		_ = marshalLabelListToConfigMap(found,
+			proxyconfig.GetManagedClusterLabelAllowListConfigMapKey(), syncLabelList)
 
-			_ = marshalLabelListToConfigMap(found,
-				proxyconfig.GetManagedClusterLabelAllowListConfigMapKey(), syncLabelList)
-
-			_, err := kubeClient.CoreV1().ConfigMaps(proxyconfig.ManagedClusterLabelAllowListNamespace).Update(
-				context.TODO(),
-				found,
-				metav1.UpdateOptions{},
-			)
-			if err != nil {
-				klog.Errorf("failed to update managedcluster label allowlist configmap: %v", err)
-				return err
-			}
+		_, err := kubeClient.CoreV1().ConfigMaps(proxyconfig.ManagedClusterLabelAllowListNamespace).Update(
+			context.TODO(),
+			found,
+			metav1.UpdateOptions{},
+		)
+		if err != nil {
+			klog.Errorf("failed to update managedcluster label allowlist configmap: %v", err)
+			return err
 		}
 	}
 


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/ACM-2319
Signed-off-by: dislbenn <dbennett@redhat.com>