### PR TITLE
change KubePersistentVolumeFillingUp severity to informational

### DIFF
--- a/operators/multiclusterobservability/manifests/base/alertmanager/alert_rules.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/alert_rules.yaml
@@ -18,7 +18,7 @@ data:
             cluster: "{{ $labels.cluster }}"
             clusterID: "{{ $labels.clusterID }}"
             PersistentVolumeClaim: "{{ $labels.persistentvolumeclaim }}"
-            severity: critical
+            severity: informational
         - alert: KubePersistentVolumeFillingUp
           annotations:
             summary: PersistentVolume is filling up and is predicted to run out of space in 6h.
@@ -30,7 +30,7 @@ data:
             cluster: "{{ $labels.cluster }}"
             clusterID: "{{ $labels.clusterID }}"
             PersistentVolumeClaim: "{{ $labels.persistentvolumeclaim }}"
-            severity: warning
+            severity: informational
       - name: policy-reports
         rules:
         - alert: ViolatedPolicyReport

--- a/operators/multiclusterobservability/manifests/base/alertmanager/alert_rules.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/alert_rules.yaml
@@ -18,7 +18,7 @@ data:
             cluster: "{{ $labels.cluster }}"
             clusterID: "{{ $labels.clusterID }}"
             PersistentVolumeClaim: "{{ $labels.persistentvolumeclaim }}"
-            severity: informational
+            severity: info
         - alert: KubePersistentVolumeFillingUp
           annotations:
             summary: PersistentVolume is filling up and is predicted to run out of space in 6h.
@@ -30,7 +30,7 @@ data:
             cluster: "{{ $labels.cluster }}"
             clusterID: "{{ $labels.clusterID }}"
             PersistentVolumeClaim: "{{ $labels.persistentvolumeclaim }}"
-            severity: informational
+            severity: info
       - name: policy-reports
         rules:
         - alert: ViolatedPolicyReport


### PR DESCRIPTION
When thanos-store persistent volumes get full, it does not affect the query. The alert KubePersistentVolumeFillingUp  and should be treated as informational only. 