### PR TITLE
[ACM-5782][release-2.7] Added resync for required managedcluster labels in allowlist

### DIFF
--- a/operators/multiclusterobservability/manifests/base/config/managed_cluster_label_allowlist.yaml
+++ b/operators/multiclusterobservability/manifests/base/config/managed_cluster_label_allowlist.yaml
@@ -8,7 +8,6 @@ data:
   managed_cluster.yaml: |
     ignore_labels:
       - clusterID
-      - cluster.open-cluster-management.io/clusterset
       - feature.open-cluster-management.io/addon-application-manager
       - feature.open-cluster-management.io/addon-cert-policy-controller
       - feature.open-cluster-management.io/addon-cluster-proxy
@@ -21,7 +20,6 @@ data:
       - installer.name
       - installer.namespace
       - local-cluster
-      - name
     labels:
       - cloud
       - vendor

--- a/operators/multiclusterobservability/manifests/base/grafana/dash-acm-clusters-overview.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/dash-acm-clusters-overview.yaml
@@ -1779,8 +1779,8 @@ data:
             "allValue": null,
             "current": {
               "selected": true,
-              "text": "cloud",
-              "value": "cloud"
+              "text": "name",
+              "value": "name"
             },
             "datasource": null,
             "definition": "label_values(acm_label_names, label_name)",

--- a/proxy/pkg/config/config.go
+++ b/proxy/pkg/config/config.go
@@ -26,6 +26,10 @@ var (
 	SyncLabelList    ManagedClusterLabelList
 )
 
+var (
+	requiredLabelList = []string{"name", "cluster.open-cluster-management.io/clusterset"}
+)
+
 // GetManagedClusterLabelAllowListConfigMapKey return the key name for the managedcluster labels
 func GetManagedClusterLabelAllowListConfigMapKey() string {
 	return ManagedClusterLabelAllowListConfigMapKey
@@ -39,6 +43,11 @@ func GetManagedClusterLabelAllowListConfigMapName() string {
 // GetManagedClusterLabelList will return the current cluster label list
 func GetManagedClusterLabelList() *ManagedClusterLabelList {
 	return &ManagedLabelList
+}
+
+// GetSyncLabelList will return the synced label list
+func GetRequiredLabelList() []string {
+	return requiredLabelList
 }
 
 // GetSyncLabelList will return the synced label list
@@ -65,7 +74,6 @@ func CreateManagedClusterLabelAllowListCM(namespace string) *v1.ConfigMap {
 
 ignore_labels:
 - clusterID
-- cluster.open-cluster-management.io/clusterset
 - feature.open-cluster-management.io/addon-application-manager
 - feature.open-cluster-management.io/addon-cert-policy-controller
 - feature.open-cluster-management.io/addon-cluster-proxy
@@ -78,7 +86,6 @@ ignore_labels:
 - installer.name
 - installer.namespace
 - local-cluster
-- name
 `}}
 }
 


### PR DESCRIPTION
Updated `rbac-query-proxy` resync to prevent adding the labels `name` and `cluster.open-cluster-management.io/clusterset ` to `managedcluster` label ignore list.