### PR TITLE
[release-2.9] Added resync for required managedcluster labels (#1207)

### DIFF
--- a/proxy/pkg/config/config.go
+++ b/proxy/pkg/config/config.go
@@ -26,6 +26,10 @@ var (
 	SyncLabelList    ManagedClusterLabelList
 )
 
+var (
+	requiredLabelList = []string{"name", "cluster.open-cluster-management.io/clusterset"}
+)
+
 // GetManagedClusterLabelAllowListConfigMapKey return the key name for the managedcluster labels
 func GetManagedClusterLabelAllowListConfigMapKey() string {
 	return ManagedClusterLabelAllowListConfigMapKey
@@ -39,6 +43,11 @@ func GetManagedClusterLabelAllowListConfigMapName() string {
 // GetManagedClusterLabelList will return the current cluster label list
 func GetManagedClusterLabelList() *ManagedClusterLabelList {
 	return &ManagedLabelList
+}
+
+// GetSyncLabelList will return the synced label list
+func GetRequiredLabelList() []string {
+	return requiredLabelList
 }
 
 // GetSyncLabelList will return the synced label list


### PR DESCRIPTION
This feature was implemented only in ACM 2.8; therefore, we need to bring it into this current release.