### PR TITLE
fix testcase: observability-controller managedclusteraddon status

### DIFF
--- a/tests/pkg/utils/mco_oba.go
+++ b/tests/pkg/utils/mco_oba.go
@@ -81,15 +81,15 @@ func CheckAllOBAsEnabled(opt TestOptions) error {
 			return err
 		}
 
-		klog.V(1).Infof("Check managedcluster addon status for cluster <%v>", cluster)
-		// NOTE: Managed cluster add-on status gets set to "Cluster metrics sent successfully"
-		// for a very brief period of time, but it quickly gets overwritten with
-		// "observability-controller add-on is available" when managed cluster addon's lease gets updated.
-		// Updating the test case to only check for the later more persistent message.
-		err = CheckManagedClusterAddonsStatus(opt, cluster, ManagedClusterAddOnEnabledMessage)
-		if err != nil {
-			return err
-		}
+		// klog.V(1).Infof("Check managedcluster addon status for cluster <%v>", cluster)
+		// // NOTE: Managed cluster add-on status gets set to "Cluster metrics sent successfully"
+		// // for a very brief period of time, but it quickly gets overwritten with
+		// // "observability-controller add-on is available" when managed cluster addon's lease gets updated.
+		// // Updating the test case to only check for the later more persistent message.
+		// err = CheckManagedClusterAddonsStatus(opt, cluster, ManagedClusterAddOnEnabledMessage)
+		// if err != nil {
+		// 	return err
+		// }
 	}
 	return nil
 }

--- a/tests/pkg/utils/mco_oba.go
+++ b/tests/pkg/utils/mco_oba.go
@@ -12,7 +12,8 @@ import (
 
 const (
 	ManagedClusterAddOnDisabledMessage = "enableMetrics is set to False"
-	ManagedClusterAddOnEnabledMessage  = "Cluster metrics sent successfully"
+	OBMAddonEnabledMessage             = "Cluster metrics sent successfully"
+	ManagedClusterAddOnEnabledMessage  = "observability-controller add-on is available"
 )
 
 func CheckOBAStatus(opt TestOptions, namespace, status string) error {
@@ -75,12 +76,16 @@ func CheckAllOBAsEnabled(opt TestOptions) error {
 
 	for _, cluster := range clusters {
 		klog.V(1).Infof("Check OBA status for cluster <%v>", cluster)
-		err = CheckOBAStatus(opt, cluster, ManagedClusterAddOnEnabledMessage)
+		err = CheckOBAStatus(opt, cluster, OBMAddonEnabledMessage)
 		if err != nil {
 			return err
 		}
 
 		klog.V(1).Infof("Check managedcluster addon status for cluster <%v>", cluster)
+		// NOTE: Managed cluster add-on status gets set to "Cluster metrics sent successfully"
+		// for a very brief period of time, but it quickly gets overwritten with
+		// "observability-controller add-on is available" when managed cluster addon's lease gets updated.
+		// Updating the test case to only check for the later more persistent message.
 		err = CheckManagedClusterAddonsStatus(opt, cluster, ManagedClusterAddOnEnabledMessage)
 		if err != nil {
 			return err


### PR DESCRIPTION
The test case was looking for a status string "Cluster metrics sent successfully". 

```
oc get managedclusteraddons observability-controller -n smeduri-m1 -o json | jq .status.conditions
[
  ...
  {
    "lastTransitionTime": "2023-08-16T16:59:28Z",
    "message": "Cluster metrics sent successfully",
    "reason": "Available",
    "status": "True",
    "type": "Available"
  }
```

However, I found in my experiments that it gets set to that value for a very brief period, and quickly gets overwritten by another update when managed cluster lease is renewed as shown below.  

```
oc get managedclusteraddons observability-controller -n smeduri-m1 -o json | jq .status.conditions
[
  ...
  {
    "lastTransitionTime": "2023-08-16T14:52:41Z",
    "message": "observability-controller add-on is available.",
    "reason": "ManagedClusterAddOnLeaseUpdated",
    "status": "True",
  }
```

This is causing intermittent timing failures in e2e tests. 

Since managedclusteraddon status message could vary between releases, and observability components cannot rely on it,  the test case is updated so it checks for only: ObservabilityAddon Status has message `"message": "Cluster metrics sent successfully",`

