### PR TITLE
[release-2.8] fix test cases causing intermittent failures

### DIFF
--- a/tests/pkg/tests/observability_export_test.go
+++ b/tests/pkg/tests/observability_export_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Observability:", func() {
 				}
 			}
 			return nil
-		}, EventuallyTimeoutMinute*10, EventuallyIntervalSecond*5).Should(Succeed())
+		}, EventuallyTimeoutMinute*20, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	JustAfterEach(func() {

--- a/tests/pkg/utils/mco_oba.go
+++ b/tests/pkg/utils/mco_oba.go
@@ -80,11 +80,16 @@ func CheckAllOBAsEnabled(opt TestOptions) error {
 			return err
 		}
 
-		klog.V(1).Infof("Check managedcluster addon status for cluster <%v>", cluster)
-		err = CheckManagedClusterAddonsStatus(opt, cluster, ManagedClusterAddOnEnabledMessage)
-		if err != nil {
-			return err
-		}
+		// NOTE: Managed cluster add-on status gets set to "Cluster metrics sent successfully"
+		// for a very brief period of time, but it quickly gets overwritten with
+		// "observability-controller add-on is available" when managed cluster addon's lease is updated
+		// Disabling this check as it is not reliable.
+		//
+		// klog.V(1).Infof("Check managedcluster addon status for cluster <%v>", cluster)
+		// err = CheckManagedClusterAddonsStatus(opt, cluster, ManagedClusterAddOnEnabledMessage)
+		// if err != nil {
+		// 	return err
+		// }
 	}
 	return nil
 }


### PR DESCRIPTION
1. Disable ManagedCluster status message check as it is not reliable
2. Increase wait time for acm_remote_write_requests_total tests from 10 min. to 20 min. 