### PR TITLE
modifying the metrics extraction process

### DIFF
--- a/tools/simulator/metrics-collector/README.md
+++ b/tools/simulator/metrics-collector/README.md
@@ -47,13 +47,8 @@ export SIMULATED_MANAGED_CLUSTER_NAME=simulated-sno-1
 export SIMULATED_MANAGED_CLUSTER_ID=2b4bfc20-110e-4c4e-aa42-d97ac608c5e8
 ```
 
-5. Retrieve the simulated metrics by executing the script `generate-metrics-data.sh`. For example, log into an SNO cluster and execute the following command to get the metrics for SNO cluster:
-
-```bash
-IS_TIMESERIES_ONLY=true ./generate-metrics-data.sh
-```
-
-> _Note:_ we should find a file named `timeseries.txt` in current directory after running the command above that contains the metrics, you can generate simulated metrics in any connected OCP cluster.
+5. Retrieve the simulated metrics by following the instructions in [README here](metrics-extractor/README.md) .
+ The script used for this earlier - `generate-metrics-data.sh` - is deprecated.
 
 6. Run the metrics-collector to remotely write simulated SNO metrics to the ACM hub by running the following command:
 

--- a/tools/simulator/metrics-collector/metrics-extractor/.dockerignore
+++ b/tools/simulator/metrics-collector/metrics-extractor/.dockerignore
@@ -1,0 +1,2 @@
+.git
+**/*.DS_Store

--- a/tools/simulator/metrics-collector/metrics-extractor/Dockerfile
+++ b/tools/simulator/metrics-collector/metrics-extractor/Dockerfile
@@ -1,0 +1,31 @@
+FROM registry.ci.openshift.org/stolostron/builder:go1.20-linux AS builder
+
+RUN GOBIN=/usr/local/bin go install github.com/brancz/gojsontoyaml@latest
+
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+RUN mkdir /metrics-extractor
+RUN mkdir /ocp-tools
+RUN microdnf install wget -y \
+    && microdnf clean all
+RUN microdnf install tar gzip jq bc -y\
+    && microdnf clean all
+
+
+RUN wget https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.13/openshift-client-linux.tar.gz -P /ocp-tools
+WORKDIR /ocp-tools
+RUN chmod 777 /ocp-tools
+RUN tar xvf openshift-client-linux.tar.gz oc kubectl
+RUN rm openshift-client-linux.tar.gz
+RUN cp oc /usr/local/bin
+RUN cp kubectl /usr/local/bin
+
+COPY --from=builder /usr/local/bin/gojsontoyaml /usr/local/bin/
+
+WORKDIR /metrics-extractor
+
+COPY ./extract-metrics-data.sh /metrics-extractor/
+RUN chmod 777 /metrics-extractor
+
+
+CMD [ "/bin/bash", "/metrics-extractor/extract-metrics-data.sh" ]

--- a/tools/simulator/metrics-collector/metrics-extractor/README.md
+++ b/tools/simulator/metrics-collector/metrics-extractor/README.md
@@ -1,0 +1,16 @@
+# Note
+This container captures the details of the timeseries data, a cluster will send to ACM Hub if it was brought under ACM's management. It does not matter if the cluster is really under ACM maagement as well. The data gathered is useful either way.
+
+1. A docker image has been created for this container and is publicly available. It is at `quay.io/bjoydeep/metrics-extractor:latest`.
+1. You are free to use it or build your own.
+1. In the `docker run` command given below, a file called `timeseries.txt` will be created in the `/tmp` directory(mounted). This is the output or extract of the timeseries, the cluster would send to ACM Hub, if it was brought under ACM's management.
+1. This output will help the ACM team to run simulation with `a certain` number of these clusters to figure out performance or just do a calculation without running any load.
+
+### To build the docker image
+docker build -t metrics-extractor .
+
+### To use the docker image in quay.io
+docker run -e OC_CLUSTER_URL=https://api.xyz.com:6443 -e OC_TOKEN=sha256~elK -v /tmp:/output quay.io/bjoydeep/metrics-extractor:latest
+
+### To get into the image and debug
+docker run -it metrics-extractor /bin/bash

--- a/tools/simulator/metrics-collector/metrics-extractor/extract-metrics-data.sh
+++ b/tools/simulator/metrics-collector/metrics-extractor/extract-metrics-data.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Copyright (c) 2021 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+# Copyright Contributors to the Open Cluster Management project
+
+set -eo pipefail
+#set -x
+
+IS_TIMESERIES_ONLY=true
+# expectig  gojsontoyaml to be installed here
+GOJSONTOYAML_BIN=/usr/local/bin/gojsontoyaml
+WORKDIR="$(cd "$(dirname "$0")" ; pwd -P)"
+# Create bin directory and add it to PATH
+mkdir -p ${WORKDIR}/bin
+export PATH={WORKDIR}/bin:${PATH}
+mkdir -p ${WORKDIR}/../output
+
+# tmp output directory for metrics list
+TMP_OUT=$(mktemp -d /tmp/metrics.XXXXXXXXXX)
+METRICS_JSON_OUT=${TMP_OUT}/metrics.json
+RECORDINGRULES_JSON_OUT=${TMP_OUT}/recordingrules.json
+TIME_SERIES_OUT=${WORKDIR}/../output/timeseries.txt
+
+METRICS_ALLOW_LIST_URL=${METRICS_ALLOW_LIST_URL:-https://raw.githubusercontent.com/stolostron/multicluster-observability-operator/main/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml}
+
+
+
+function get_metrics_list() {
+	echo "getting metrics list..."
+
+	matches=$(curl -L ${METRICS_ALLOW_LIST_URL} | ${GOJSONTOYAML_BIN} --yamltojson | jq -r '.data."metrics_list.yaml"' | ${GOJSONTOYAML_BIN} --yamltojson | jq -r '.matches' | jq '"{" + .[] + "}"')
+	names=$(curl -L ${METRICS_ALLOW_LIST_URL} | ${GOJSONTOYAML_BIN} --yamltojson | jq -r '.data."metrics_list.yaml"' | ${GOJSONTOYAML_BIN} --yamltojson | jq -r '.names' | jq '"{__name__=\"" + .[] + "\"}"')
+	echo $matches $names | jq -s . > ${METRICS_JSON_OUT}
+
+}
+
+function get_recordingrules_list() {
+	echo "getting recordingrules list..."
+	
+	recordingrules=$(curl -L ${METRICS_ALLOW_LIST_URL} | ${GOJSONTOYAML_BIN} --yamltojson | jq -r '.data."metrics_list.yaml"' | ${GOJSONTOYAML_BIN} --yamltojson | jq '.recording_rules[]')
+	echo "$recordingrules" | jq -s . > ${RECORDINGRULES_JSON_OUT}
+
+}
+
+function generate_metrics() {
+	echo "generating metrics..."
+    federate="curl --fail --silent -G http://localhost:9090/federate"
+	for rule in $(cat ${METRICS_JSON_OUT} | jq -r '.[]');
+    do
+        federate="${federate} $(printf -- "--data-urlencode match[]=%s" ${rule})"
+    done
+    echo '# Beggining for metrics' > ${TIME_SERIES_OUT}
+    ${federate} >> ${TIME_SERIES_OUT}
+}
+
+function generate_recordingrules() {
+    echo "generating recordingrules..."
+        query="curl --fail --silent -G http://localhost:9090/api/v1/query"
+        cat ${RECORDINGRULES_JSON_OUT} | jq -cr '.[]' | while read item;
+        do
+                record=$(jq -r '.record' <<< "$item")
+                expr=$(jq -r '.expr' <<< "$item")
+                #expr=${expr//\"/\\\"}
+                expr=$(echo "${expr}" | tr -d " ")
+                querycmd="${query} $(printf -- "--data-urlencode query=%s" ${expr})"
+                echo -e "\n# TYPE ${record} untyped" >> ${TIME_SERIES_OUT}
+                ${querycmd} | jq -r '.data.result' | jq -cr '.[]' | while read result;
+                do
+                        vec="${record}"
+                        metric=$(jq -r '.metric | to_entries | map("\(.key)=\"\(.value | tostring)\"") | .[]' <<< "$result")
+                        metric=$(echo "${metric}" | sed ':a;N;$!ba;s/\n/,/g')
+                        vec="${vec}{${metric}}"
+                        timestamp=$(jq -r '.value[0]' <<< "$result")
+                        value=$(jq -r '.value[1]' <<< "$result")
+                        timestamp=$(echo "${timestamp} * 1000" | bc)
+                        timestamp=${timestamp%.*}
+                        echo "${vec} ${value} ${timestamp}" >> ${TIME_SERIES_OUT}
+                done
+        done
+}
+
+function generate_timeseries() {
+    kubectl port-forward -n openshift-monitoring prometheus-k8s-0 9090 > /dev/null &
+	sleep 10
+    generate_metrics
+    generate_recordingrules
+    jobs -p | xargs -r kill
+}
+
+
+get_metrics_list
+get_recordingrules_list
+oc login ${OC_CLUSTER_URL} --token ${OC_TOKEN} --insecure-skip-tls-verify=true
+generate_timeseries


### PR DESCRIPTION
We need customers to be able to run this process on their bastion hosts. That by nature should be considered a:
- disconnected env with no internet access
- an immutable machine where we are not allowed to install anything
- but it can run a docker container. The docker container can be copied over to the customer's internal repo/artifactory.

The changes just allows that. And uses a simpler version of the old script that was created. 