### PR TITLE
2 key csv metrics in newer ocp

### DIFF
--- a/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
+++ b/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
@@ -27,6 +27,8 @@ data:
       - coredns_dns_requests_total
       - coredns_dns_request_duration_seconds_sum
       - coredns_forward_responses_total
+      - csv_succeeded
+      - csv_abnormal
       - etcd_debugging_mvcc_db_total_size_in_bytes
       - etcd_mvcc_db_total_size_in_bytes
       - etcd_debugging_snap_save_total_duration_seconds_sum


### PR DESCRIPTION
Adding 2 key metrics for cluster service version aka operators that are added in the newer OCP. I did not check when they were added.
They are :
- csv_succeeded
- csv_abnormal. Well the number of failed can be derived from csv_succeeded, but reasons are not mentioned.
There are a few other which I did not choose. 
- csv_count can be derived from count(csv_succeeded)
- csv_upgrade_count : not sure how useful it is.
We are getting a lot of requests from customers about operator health. So makes sense to add them out of the box. Since they can be added to custom-allow-list anyway, did not work on back porting