### PR TITLE
Rename OpenShift configmap reloader key to configmap_reloader

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -68,7 +68,7 @@ var testImagemanifestsMap = map[string]string{
 	"observatorium":                "test.io/observatorium:test",
 	"observatorium_operator":       "test.io/observatorium-operator:test",
 	"prometheus_alertmanager":      "test.io/prometheus-alertmanager:test",
-	"prometheus-config-reloader":   "test.io/configmap-reloader:test",
+	"configmap_reloader":           "test.io/configmap-reloader:test",
 	"rbac_query_proxy":             "test.io/rbac-query-proxy:test",
 	"thanos":                       "test.io/thanos:test",
 	"thanos_receive_controller":    "test.io/thanos_receive_controller:test",
@@ -773,7 +773,7 @@ func TestImageReplaceForMCO(t *testing.T) {
 			case "grafana-proxy":
 				continue
 			case "config-reloader":
-				imageKey = "prometheus-config-reloader"
+				imageKey = "configmap_reloader"
 			}
 			imageValue, exists := testImagemanifestsMap[imageKey]
 			if !exists {
@@ -806,7 +806,7 @@ func TestImageReplaceForMCO(t *testing.T) {
 			case "alertmanager":
 				imageKey = "prometheus_alertmanager"
 			case "config-reloader":
-				imageKey = "prometheus-config-reloader"
+				imageKey = "configmap_reloader"
 			}
 			imageValue, exists := testImagemanifestsMap[imageKey]
 			if !exists {

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -145,7 +145,7 @@ const (
 	ConfigmapReloaderImgRepo      = "quay.io/openshift"
 	ConfigmapReloaderImgName      = "origin-configmap-reloader"
 	ConfigmapReloaderImgTagSuffix = "4.8.0"
-	ConfigmapReloaderKey          = "prometheus-config-reloader"
+	ConfigmapReloaderKey          = "configmap_reloader"
 
 	OauthProxyImgRepo      = "quay.io/stolostron"
 	OauthProxyImgName      = "origin-oauth-proxy"


### PR DESCRIPTION
PRs https://github.com/stolostron/release/pull/508, https://github.com/stolostron/release/pull/509 and https://github.com/stolostron/release/pull/510 which were done to eliminate seeming dulicatoin/overlap were in error, and removed needed keys. This probably came about because of the close naming of the prometheus_config_reloader and prometheus-config-reloader keys, which suggested they were two entries for the same image, but they were not.

1. `prometheus_config_reloader` is a key that points to an ACM-built image for a Prometneus-specific image that triggers reloading on changes to Prometheus config info.
2. `configmap_reloader` is a key that points to an external (from Openshift) image that is not specific to Prometheus and causes containers to be restarted on changes to ConfigMaps or Secrets. This image also happens to be used by Observability pods (Stateful sets), but since its not Prometheus specific, we're dripping that prefix from its name.)

Observability operator code will be updated to use the new key `configmap_reloader` instead of the old `promethues-configmap-reload` across all releases.