### PR TITLE
[release-2.7] rename openshift configmap reloader key

### DIFF
--- a/examples/export/v1beta2/custom-certs/observability.yaml
+++ b/examples/export/v1beta2/custom-certs/observability.yaml
@@ -45,7 +45,7 @@ spec:
         limits:
           cpu: 1
           memory: 4Gi
-      replicas: 2
+      replicas: 3
       serviceAccountAnnotations:
         test.com/role-arn: 's3_role'
     rule:

--- a/examples/export/v1beta2/observability.yaml
+++ b/examples/export/v1beta2/observability.yaml
@@ -45,7 +45,7 @@ spec:
         limits:
           cpu: 1
           memory: 4Gi
-      replicas: 2
+      replicas: 3
       serviceAccountAnnotations:
         test.com/role-arn: 's3_role'
     rule:

--- a/examples/mco/e2e/v1beta2/custom-certs/observability.yaml
+++ b/examples/mco/e2e/v1beta2/custom-certs/observability.yaml
@@ -45,7 +45,7 @@ spec:
         limits:
           cpu: 1
           memory: 4Gi
-      replicas: 2
+      replicas: 3
       serviceAccountAnnotations:
         test.com/role-arn: 's3_role'
     rule:

--- a/examples/mco/e2e/v1beta2/observability.yaml
+++ b/examples/mco/e2e/v1beta2/observability.yaml
@@ -45,7 +45,7 @@ spec:
         limits:
           cpu: 1
           memory: 4Gi
-      replicas: 2
+      replicas: 3
       serviceAccountAnnotations:
         test.com/role-arn: 's3_role'
     rule:

--- a/examples/policy/resourceQuota.yaml
+++ b/examples/policy/resourceQuota.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   hard:
     cpu: "5.25"
-    memory: "12Gi"
+    memory: "16Gi"

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -68,7 +68,7 @@ var testImagemanifestsMap = map[string]string{
 	"observatorium":                "test.io/observatorium:test",
 	"observatorium_operator":       "test.io/observatorium-operator:test",
 	"prometheus_alertmanager":      "test.io/prometheus-alertmanager:test",
-	"prometheus-config-reloader":   "test.io/configmap-reloader:test",
+	"configmap_reloader":           "test.io/configmap-reloader:test",
 	"rbac_query_proxy":             "test.io/rbac-query-proxy:test",
 	"thanos":                       "test.io/thanos:test",
 	"thanos_receive_controller":    "test.io/thanos_receive_controller:test",
@@ -773,7 +773,7 @@ func TestImageReplaceForMCO(t *testing.T) {
 			case "grafana-proxy":
 				continue
 			case "config-reloader":
-				imageKey = "prometheus-config-reloader"
+				imageKey = "configmap_reloader"
 			}
 			imageValue, exists := testImagemanifestsMap[imageKey]
 			if !exists {
@@ -806,7 +806,7 @@ func TestImageReplaceForMCO(t *testing.T) {
 			case "alertmanager":
 				imageKey = "prometheus_alertmanager"
 			case "config-reloader":
-				imageKey = "prometheus-config-reloader"
+				imageKey = "configmap_reloader"
 			}
 			imageValue, exists := testImagemanifestsMap[imageKey]
 			if !exists {

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -145,7 +145,7 @@ const (
 	ConfigmapReloaderImgRepo      = "quay.io/openshift"
 	ConfigmapReloaderImgName      = "origin-configmap-reloader"
 	ConfigmapReloaderImgTagSuffix = "4.8.0"
-	ConfigmapReloaderKey          = "prometheus-config-reloader"
+	ConfigmapReloaderKey          = "configmap_reloader"
 
 	OauthProxyImgRepo      = "quay.io/stolostron"
 	OauthProxyImgName      = "origin-oauth-proxy"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=open-cluster-management_multicluster-observability-operator
 sonar.projectName=multicluster-observability-operator
 sonar.sources=.
-sonar.exclusions=**/main.go,**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**
+sonar.exclusions=**/main.go,**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**,**/tests/**
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 sonar.test.exclusions=**/*_generated*.go,**/*_generated/**,**/vendor/**

--- a/tests/pkg/tests/observability_addon_test.go
+++ b/tests/pkg/tests/observability_addon_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Observability:", func() {
 					MCO_ADDON_NAMESPACE,
 					"component=metrics-collector",
 				)
-				if len(podList.Items) == 1 && err == nil {
+				if len(podList.Items) >= 1 && err == nil {
 					return true
 				}
 				return false


### PR DESCRIPTION
1. backport [PR 519](https://github.com/stolostron/release/pull/519)  
2. Bump receives to 3 for e2e tests to ensure quorum on newer Thnaos versions
3. increase resource quota on `open-cluster-management-observability` from `12Gi` -> `16Gi` as receive pods are getting OOMKilled in e2e tests
4. Exclude `tests` folders from sonar scans

