### PR TITLE
[ACM-7015] [release-2.6] reset endpoint deployment node selectors and tolerations

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/metrics_collector.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/metrics_collector.go
@@ -265,6 +265,11 @@ func updateMetricsCollector(ctx context.Context, client client.Client, obsAddonS
 		return false, err
 	}
 	endpointDeployment := getEndpointDeployment(ctx, client)
+	log.Info(fmt.Sprintf("endpoint operator [version: %+v, UID: %+v]",
+		endpointDeployment.ResourceVersion,
+		endpointDeployment.UID))
+	log.Info(fmt.Sprintf("node selectors: %+v", endpointDeployment.Spec.Template.Spec.NodeSelector))
+	log.Info(fmt.Sprintf("tolerations: %+v", endpointDeployment.Spec.Template.Spec.Tolerations))
 	deployment := createDeployment(
 		clusterID,
 		clusterType,

--- a/operators/multiclusterobservability/controllers/placementrule/obsaddon_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/obsaddon_test.go
@@ -45,9 +45,7 @@ func TestObsAddonCR(t *testing.T) {
 		t.Fatalf("Failed to get observabilityaddon: (%v)", err)
 	}
 	// inject the testing observabilityAddon
-	if testObservabilityAddon != nil {
-		testManifests = injectIntoWork(testManifests, testObservabilityAddon)
-	}
+	testManifests = injectIntoWork(testManifests, testObservabilityAddon)
 	testWork.Spec.Workload.Manifests = testManifests
 
 	err = c.Create(context.TODO(), testWork)


### PR DESCRIPTION
When MCO CR defines `NodeSelectors` and `Tolerations` they should only be applied on the hub observability components. However, the code that generates endpoint operator deployment in the ManifestWork is reused across multiple managed clusters, and is inheriting settings from `local-cluser` and applying them to  managed clusters.

The fix addresses it by resetting NodeSelectors and Tolerations in the template before evaluating they should be set.
