### PR TITLE
[ACM-6774] [release-2.8] reset endpoint deployment node selectors and tolerations

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -304,6 +304,10 @@ func createManifestWorks(c client.Client, restMapper meta.RESTMapper,
 	} else if clusterName == localClusterName {
 		spec.NodeSelector = mco.Spec.NodeSelector
 		spec.Tolerations = mco.Spec.Tolerations
+	} else {
+		// reset NodeSelector and Tolerations
+		spec.NodeSelector = map[string]string{}
+		spec.Tolerations = []corev1.Toleration{}
 	}
 	for i, container := range spec.Containers {
 		if container.Name == "endpoint-observability-operator" {
@@ -326,6 +330,8 @@ func createManifestWorks(c client.Client, restMapper meta.RESTMapper,
 			}
 		}
 	}
+	log.Info(fmt.Sprintf("Cluster: %+v, Spec.NodeSelector (after): %+v", clusterName, spec.NodeSelector))
+	log.Info(fmt.Sprintf("Cluster: %+v, Spec.Tolerations (after): %+v", clusterName, spec.Tolerations))
 	dep.Spec.Template.Spec = spec
 	manifests = injectIntoWork(manifests, dep)
 	// replace the pull secret and addon components image


### PR DESCRIPTION
When MCO CR defines NodeSelectors and Tolerations they should only be applied on the hub observability components. However, the code that generates endpoint operator deployment in the ManifestWork is reused across multiple managed clusters, and is inheriting settings from local-cluser and applying them to managed clusters.

The fix addresses it by resetting NodeSelectors and Tolerations in the template before evaluating they should be set.