### PR TITLE
[ACM-7594] Set prometheusRule resource version before calling update

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -244,7 +244,7 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 		}
 		if err := deployer.Deploy(res); err != nil {
 			reqLogger.Error(err, fmt.Sprintf("Failed to deploy %s %s/%s",
-				res.GetKind(), config.GetDefaultNamespace(), res.GetName()))
+				res.GetKind(), resNS, res.GetName()))
 			return ctrl.Result{}, err
 		}
 	}

--- a/operators/pkg/deploying/deployer.go
+++ b/operators/pkg/deploying/deployer.go
@@ -348,6 +348,10 @@ func (d *Deployer) updatePrometheusRule(desiredObj, runtimeObj *unstructured.Uns
 
 	if !apiequality.Semantic.DeepDerivative(desiredPrometheusRule.Spec, runtimePrometheusRule.Spec) {
 		log.Info("Update", "Kind:", runtimeObj.GroupVersionKind(), "Name:", runtimeObj.GetName())
+		if desiredPrometheusRule.ResourceVersion != runtimePrometheusRule.ResourceVersion {
+			desiredPrometheusRule.ResourceVersion = runtimePrometheusRule.ResourceVersion
+		}
+
 		return d.client.Update(context.TODO(), desiredPrometheusRule)
 	}
 	return nil


### PR DESCRIPTION
The update() call requires PrometheusRule object to have the same resourceVersion.