### PR TITLE
cutting out curl call during runtime

### DIFF
--- a/tools/simulator/metrics-collector/metrics-extractor/Dockerfile
+++ b/tools/simulator/metrics-collector/metrics-extractor/Dockerfile
@@ -23,6 +23,19 @@ RUN cp kubectl /usr/local/bin
 COPY --from=builder /usr/local/bin/gojsontoyaml /usr/local/bin/
 
 WORKDIR /metrics-extractor
+ARG METRICS_ALLOW_LIST_URL="https://raw.githubusercontent.com/stolostron/multicluster-observability-operator/main/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml"
+ARG METRICS_JSON_OUT=/metrics-extractor/metrics.json
+ARG RECORDINGRULES_JSON_OUT=/metrics-extractor/recordingrules.json
+ARG GOJSONTOYAML_BIN=/usr/local/bin/gojsontoyaml
+
+
+RUN export matches=$(curl -L $METRICS_ALLOW_LIST_URL | $GOJSONTOYAML_BIN --yamltojson | jq -r '.data."metrics_list.yaml"' | $GOJSONTOYAML_BIN --yamltojson | jq -r '.matches' | jq '"{" + .[] + "}"') && \
+    export names=$(curl -L $METRICS_ALLOW_LIST_URL | $GOJSONTOYAML_BIN --yamltojson | jq -r '.data."metrics_list.yaml"' | $GOJSONTOYAML_BIN --yamltojson | jq -r '.names' | jq '"{__name__=\"" + .[] + "\"}"') && \
+    echo $matches $names | jq -s . > $METRICS_JSON_OUT && \
+    export recordingrules=$(curl -L $METRICS_ALLOW_LIST_URL | $GOJSONTOYAML_BIN --yamltojson | jq -r '.data."metrics_list.yaml"' | $GOJSONTOYAML_BIN --yamltojson | jq '.recording_rules[]') && \
+	echo $recordingrules | jq -s . > ${RECORDINGRULES_JSON_OUT}
+
+
 
 COPY ./extract-metrics-data.sh /metrics-extractor/
 RUN chmod 777 /metrics-extractor

--- a/tools/simulator/metrics-collector/metrics-extractor/extract-metrics-data.sh
+++ b/tools/simulator/metrics-collector/metrics-extractor/extract-metrics-data.sh
@@ -18,30 +18,32 @@ mkdir -p ${WORKDIR}/../output
 
 # tmp output directory for metrics list
 TMP_OUT=$(mktemp -d /tmp/metrics.XXXXXXXXXX)
-METRICS_JSON_OUT=${TMP_OUT}/metrics.json
-RECORDINGRULES_JSON_OUT=${TMP_OUT}/recordingrules.json
+#METRICS_JSON_OUT=${TMP_OUT}/metrics.json
+#RECORDINGRULES_JSON_OUT=${TMP_OUT}/recordingrules.json
+METRICS_JSON_OUT=${WORKDIR}/metrics.json
+RECORDINGRULES_JSON_OUT=${WORKDIR}/recordingrules.json
 TIME_SERIES_OUT=${WORKDIR}/../output/timeseries.txt
 
 METRICS_ALLOW_LIST_URL=${METRICS_ALLOW_LIST_URL:-https://raw.githubusercontent.com/stolostron/multicluster-observability-operator/main/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml}
 
 
 
-function get_metrics_list() {
-	echo "getting metrics list..."
+# function get_metrics_list() {
+# 	echo "getting metrics list..."
 
-	matches=$(curl -L ${METRICS_ALLOW_LIST_URL} | ${GOJSONTOYAML_BIN} --yamltojson | jq -r '.data."metrics_list.yaml"' | ${GOJSONTOYAML_BIN} --yamltojson | jq -r '.matches' | jq '"{" + .[] + "}"')
-	names=$(curl -L ${METRICS_ALLOW_LIST_URL} | ${GOJSONTOYAML_BIN} --yamltojson | jq -r '.data."metrics_list.yaml"' | ${GOJSONTOYAML_BIN} --yamltojson | jq -r '.names' | jq '"{__name__=\"" + .[] + "\"}"')
-	echo $matches $names | jq -s . > ${METRICS_JSON_OUT}
+# 	matches=$(curl -L ${METRICS_ALLOW_LIST_URL} | ${GOJSONTOYAML_BIN} --yamltojson | jq -r '.data."metrics_list.yaml"' | ${GOJSONTOYAML_BIN} --yamltojson | jq -r '.matches' | jq '"{" + .[] + "}"')
+# 	names=$(curl -L ${METRICS_ALLOW_LIST_URL} | ${GOJSONTOYAML_BIN} --yamltojson | jq -r '.data."metrics_list.yaml"' | ${GOJSONTOYAML_BIN} --yamltojson | jq -r '.names' | jq '"{__name__=\"" + .[] + "\"}"')
+# 	echo $matches $names | jq -s . > ${METRICS_JSON_OUT}
 
-}
+# }
 
-function get_recordingrules_list() {
-	echo "getting recordingrules list..."
+# function get_recordingrules_list() {
+# 	echo "getting recordingrules list..."
 	
-	recordingrules=$(curl -L ${METRICS_ALLOW_LIST_URL} | ${GOJSONTOYAML_BIN} --yamltojson | jq -r '.data."metrics_list.yaml"' | ${GOJSONTOYAML_BIN} --yamltojson | jq '.recording_rules[]')
-	echo "$recordingrules" | jq -s . > ${RECORDINGRULES_JSON_OUT}
+# 	recordingrules=$(curl -L ${METRICS_ALLOW_LIST_URL} | ${GOJSONTOYAML_BIN} --yamltojson | jq -r '.data."metrics_list.yaml"' | ${GOJSONTOYAML_BIN} --yamltojson | jq '.recording_rules[]')
+# 	echo "$recordingrules" | jq -s . > ${RECORDINGRULES_JSON_OUT}
 
-}
+# }
 
 function generate_metrics() {
 	echo "generating metrics..."
@@ -89,7 +91,7 @@ function generate_timeseries() {
 }
 
 
-get_metrics_list
-get_recordingrules_list
+#get_metrics_list
+#get_recordingrules_list
 oc login ${OC_CLUSTER_URL} --token ${OC_TOKEN} --insecure-skip-tls-verify=true
 generate_timeseries


### PR DESCRIPTION
Customer complained that the docker container was making curl calls to the internet. So, this enhancement cuts out the dynamic call to the allow list caching it during the docker build tIme. This is needed because lot of our customers will run this from their bastion host which does not have any connection to the internet