### PR TITLE
Remove prom rules and Service Monitor  from openshift monitoring namespace

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -869,7 +869,6 @@ func (r *MultiClusterObservabilityReconciler) deleteSpecificPrometheusRule(ctx c
 	return nil
 }
 
-// Delete the ServiceMonitor in openshift-monitoring namespace
 func (r *MultiClusterObservabilityReconciler) deleteServiceMonitorInOpenshiftMonitoringNamespace(ctx context.Context) error {
 	serviceMonitorList := &monitoringv1.ServiceMonitorList{}
 	err := r.Client.List(ctx, serviceMonitorList, client.InNamespace("openshift-monitoring"))

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -71,6 +71,7 @@ var (
 	isRuleStorageSizeChanged         = false
 	isReceiveStorageSizeChanged      = false
 	isStoreStorageSizeChanged        = false
+	isLegacyResourceRemoved          = false
 )
 
 // MultiClusterObservabilityReconciler reconciles a MultiClusterObservability object
@@ -320,7 +321,8 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 		}
 	}
 
-	if os.Getenv("UNIT_TEST") != "true" {
+	if os.Getenv("UNIT_TEST") != "true" && !isLegacyResourceRemoved {
+		isLegacyResourceRemoved = true
 		// Delete PrometheusRule from openshift-monitoring namespace
 		if err := r.deleteSpecificPrometheusRule(ctx); err != nil {
 			reqLogger.Error(err, "Failed to delete the specific PrometheusRule in the openshift-monitoring namespace")

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -319,10 +319,12 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 		}
 	}
 
-	// Delete PrometheusRule from openshift-monitoring namespace
-	if err := r.deleteSpecificPrometheusRule(ctx); err != nil {
-		reqLogger.Error(err, "Failed to delete the specific PrometheusRule in the openshift-monitoring namespace")
-		return ctrl.Result{}, err
+	if os.Getenv("UNIT_TEST") != "true" {
+		// Delete PrometheusRule from openshift-monitoring namespace
+		if err := r.deleteSpecificPrometheusRule(ctx); err != nil {
+			reqLogger.Error(err, "Failed to delete the specific PrometheusRule in the openshift-monitoring namespace")
+			return ctrl.Result{}, err
+		}
 	}
 
 	//update status

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -844,7 +844,8 @@ func (r *MultiClusterObservabilityReconciler) ensureOpenShiftNamespaceLabel(ctx 
 
 func (r *MultiClusterObservabilityReconciler) deleteSpecificPrometheusRule(ctx context.Context) error {
 	promRule := &monitoringv1.PrometheusRule{}
-	err := r.Client.Get(ctx, client.ObjectKey{Name: "acm-observability-alert-rules", Namespace: "openshift-monitoring"}, promRule)
+	err := r.Client.Get(ctx, client.ObjectKey{Name: "acm-observability-alert-rules",
+		Namespace: "openshift-monitoring"}, promRule)
 	if err == nil {
 		err = r.Client.Delete(ctx, promRule)
 		if err != nil {

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -971,7 +971,6 @@ func createPersistentVolumeClaim(name, namespace, pvcName string) *corev1.Persis
 	}
 }
 
-<<<<<<< HEAD
 func newMultiClusterObservability() *mcov1beta2.MultiClusterObservability {
 	return &mcov1beta2.MultiClusterObservability{
 		TypeMeta:   metav1.TypeMeta{Kind: "MultiClusterObservability"},

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -1008,9 +1008,6 @@ func createAlertManagerConfigMap(name string) *corev1.ConfigMap {
 	}
 }
 
-// Test Prometheus Rules removed from open shift monitoring namespace
-=======
->>>>>>> ca1cbf5f (clean comments)
 func TestPrometheusRulesRemovedFromOpenshiftMonitoringNamespace(t *testing.T) {
 	promRule := &monitoringv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -6,12 +6,13 @@ package multiclusterobservability
 
 import (
 	"context"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"os"
 	"path"
 	"strings"
 	"testing"
 	"time"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	routev1 "github.com/openshift/api/route/v1"

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -971,6 +971,7 @@ func createPersistentVolumeClaim(name, namespace, pvcName string) *corev1.Persis
 	}
 }
 
+<<<<<<< HEAD
 func newMultiClusterObservability() *mcov1beta2.MultiClusterObservability {
 	return &mcov1beta2.MultiClusterObservability{
 		TypeMeta:   metav1.TypeMeta{Kind: "MultiClusterObservability"},
@@ -1008,6 +1009,8 @@ func createAlertManagerConfigMap(name string) *corev1.ConfigMap {
 }
 
 // Test Prometheus Rules removed from open shift monitoring namespace
+=======
+>>>>>>> ca1cbf5f (clean comments)
 func TestPrometheusRulesRemovedFromOpenshiftMonitoringNamespace(t *testing.T) {
 	promRule := &monitoringv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1039,7 +1042,6 @@ func TestPrometheusRulesRemovedFromOpenshiftMonitoringNamespace(t *testing.T) {
 	}
 }
 
-// Test Service Monitor removed from open shift monitoring namespace
 func TestServiceMonitorRemovedFromOpenshiftMonitoringNamespace(t *testing.T) {
 	sm := &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -6,6 +6,7 @@ package multiclusterobservability
 
 import (
 	"context"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"os"
 	"path"
 	"strings"
@@ -1002,5 +1003,63 @@ func createAlertManagerConfigMap(name string) *corev1.ConfigMap {
 			Name:      name,
 			Namespace: config.GetDefaultNamespace(),
 		},
+	}
+}
+
+// Test Prometheus Rules removed from open shift monitoring namespace
+func TestPrometheusRulesRemovedFromOpenshiftMonitoringNamespace(t *testing.T) {
+	promRule := &monitoringv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "acm-observability-alert-rules",
+			Namespace: "openshift-monitoring",
+		},
+		//Sample rules
+		Spec: monitoringv1.PrometheusRuleSpec{
+			Groups: []monitoringv1.RuleGroup{
+				{
+					Name: "test",
+					Rules: []monitoringv1.Rule{
+						{
+							Alert: "test",
+						},
+					},
+				},
+			},
+		},
+	}
+	s := scheme.Scheme
+	monitoringv1.AddToScheme(s)
+	objs := []runtime.Object{promRule}
+	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+	r := &MultiClusterObservabilityReconciler{Client: c, Scheme: s}
+	err := r.deleteSpecificPrometheusRule(context.TODO())
+	if err != nil {
+		t.Fatalf("Failed to delete PrometheusRule: (%v)", err)
+	}
+}
+
+// Test Service Monitor removed from open shift monitoring namespace
+func TestServiceMonitorRemovedFromOpenshiftMonitoringNamespace(t *testing.T) {
+	sm := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "observability-sm-test",
+			Namespace: "openshift-monitoring",
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Endpoints: []monitoringv1.Endpoint{
+				{
+					Port: "test",
+				},
+			},
+		},
+	}
+	s := scheme.Scheme
+	monitoringv1.AddToScheme(s)
+	objs := []runtime.Object{sm}
+	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+	r := &MultiClusterObservabilityReconciler{Client: c, Scheme: s}
+	err := r.deleteServiceMonitorInOpenshiftMonitoringNamespace(context.TODO())
+	if err != nil {
+		t.Fatalf("Failed to delete ServiceMonitor: (%v)", err)
 	}
 }

--- a/operators/multiclusterobservability/manifests/base/alertmanager/prometheusrule.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/prometheusrule.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     update-namespace: 'false'
   name: acm-observability-alert-rules
-  namespace: openshift-monitoring
+  namespace: open-cluster-management-observability
 spec:
   groups:
     - name: observability.rules

--- a/operators/multiclusterobservability/pkg/servicemonitor/sm_controller.go
+++ b/operators/multiclusterobservability/pkg/servicemonitor/sm_controller.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	ocpMonitoringNamespace = "openshift-monitoring"
+	ocpMonitoringNamespace = "open-cluster-management-observability"
 	metricsNamePrefix      = "acm_"
 )
 

--- a/operators/multiclusterobservability/pkg/servicemonitor/sm_controller.go
+++ b/operators/multiclusterobservability/pkg/servicemonitor/sm_controller.go
@@ -56,7 +56,6 @@ func Start() {
 		time.Minute*60,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    onAdd(promClient),
-			DeleteFunc: onDelete(promClient),
 			UpdateFunc: onUpdate(promClient),
 		},
 	)
@@ -70,22 +69,6 @@ func onAdd(promClient promclientset.Interface) func(obj interface{}) {
 		sm := obj.(*promv1.ServiceMonitor)
 		if sm.ObjectMeta.OwnerReferences != nil && sm.ObjectMeta.OwnerReferences[0].Kind == "Observatorium" {
 			updateServiceMonitor(promClient, sm)
-		}
-	}
-}
-
-func onDelete(promClient promclientset.Interface) func(obj interface{}) {
-	return func(obj interface{}) {
-		sm := obj.(*promv1.ServiceMonitor)
-		if sm.ObjectMeta.OwnerReferences != nil && sm.ObjectMeta.OwnerReferences[0].Kind == "Observatorium" {
-			err := promClient.MonitoringV1().
-				ServiceMonitors(ocpMonitoringNamespace).
-				Delete(context.TODO(), sm.Name, metav1.DeleteOptions{})
-			if err != nil {
-				log.Error(err, "Failed to delete ServiceMonitor", "namespace", ocpMonitoringNamespace, "name", sm.Name)
-			} else {
-				log.Info("ServiceMonitor Deleted", "namespace", ocpMonitoringNamespace, "name", sm.Name)
-			}
 		}
 	}
 }

--- a/operators/multiclusterobservability/pkg/servicemonitor/sm_controller.go
+++ b/operators/multiclusterobservability/pkg/servicemonitor/sm_controller.go
@@ -23,21 +23,21 @@ import (
 )
 
 const (
-	ocpMonitoringNamespace = "open-cluster-management-observability"
-	metricsNamePrefix      = "acm_"
+	metricsNamePrefix = "acm_"
 )
 
 var (
+	ocpMonitoringNamespace = config.GetDefaultNamespace()
 	log                    = logf.Log.WithName("sm_controller")
-	isSmControllerRunnning = false
+	isSmControllerRunning  = false
 )
 
 func Start() {
 
-	if isSmControllerRunnning {
+	if isSmControllerRunning {
 		return
 	}
-	isSmControllerRunnning = true
+	isSmControllerRunning = true
 
 	promClient, err := promclientset.NewForConfig(ctrl.GetConfigOrDie())
 	if err != nil {


### PR DESCRIPTION
- Remove Prometheus Rules from openshift-montioring namespace
- Remove Service Monitors from openshift-montioring namespace
- Change ns for the creation of service account

https://issues.redhat.com/browse/RHOBS-920