### PR TITLE
[ACM-8232] call  addonMgr.start asynchronously

### DIFF
--- a/operators/multiclusterobservability/pkg/certificates/cert_controller.go
+++ b/operators/multiclusterobservability/pkg/certificates/cert_controller.go
@@ -58,11 +58,15 @@ func Start(c client.Client, ingressCtlCrdExists bool) {
 		os.Exit(1)
 	}
 
-	err = addonMgr.Start(context.TODO())
-	if err != nil {
-		log.Error(err, "Failed to start addon manager")
-		os.Exit(1)
-	}
+	go func() {
+		ctx := context.TODO()
+		err = addonMgr.Start(ctx)
+		if err != nil {
+			log.Error(err, "Failed to start addon manager")
+			os.Exit(1)
+		}
+		<-ctx.Done()
+	}()
 
 	kubeClient, err := kubernetes.NewForConfig(ctrl.GetConfigOrDie())
 	if err != nil {


### PR DESCRIPTION
A workaround suggested by @elgnay  is to call `addonMgr.start()` asynchronously.
Together with  fix https://github.com/stolostron/multiclusterhub-operator/pull/1169/ should resolve the issue.

I have verified that this works in my local env.
