### PR TITLE
[ACM-4384] defer unsafe Close vulnerability

### DIFF
--- a/collectors/metrics/pkg/metricfamily/hypershift_transformer.go
+++ b/collectors/metrics/pkg/metricfamily/hypershift_transformer.go
@@ -44,7 +44,7 @@ func NewHypershiftTransformer(l log.Logger, c client.Client, labels map[string]s
 	//clusters := map[string]string{}
 	hClient := c
 	if hClient == nil {
-		if os.Getenv("UNIT_TEST") != "true" {
+		if _, ok := os.LookupEnv("UNIT_TEST"); !ok {
 			config, err := clientcmd.BuildConfigFromFlags("", "")
 			if err != nil {
 				return nil, errors.New("failed to create the kube config")

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -468,7 +468,7 @@ func newAPISpec(c client.Client, mco *mcov1beta2.MultiClusterObservability) (obs
 				data, ok := storageSecret.Data[storageConfig.Key]
 				if !ok {
 					log.Error(err, "Invalid key in secret", "name", storageConfig.Name, "key", storageConfig.Key)
-					return apiSpec, fmt.Errorf("Invalid key %s in secret %s", storageConfig.Key, storageConfig.Name)
+					return apiSpec, fmt.Errorf("invalid key %s in secret %s", storageConfig.Key, storageConfig.Name)
 				}
 				ep := &mcoutil.RemoteWriteEndpointWithSecret{}
 				err = yaml.Unmarshal(data, ep)

--- a/proxy/pkg/util/util.go
+++ b/proxy/pkg/util/util.go
@@ -427,7 +427,13 @@ func FetchUserProjectList(token string, url string) []string {
 		writeError(fmt.Sprintf("failed to send http request: %v", err))
 		return []string{}
 	}
-	defer resp.Body.Close()
+
+	defer func() {
+		err := resp.Body.Close()
+		if err != nil {
+			klog.Errorf("failed to close response body: %v", err)
+		}
+	}()
 
 	var projects projectv1.ProjectList
 	err = json.NewDecoder(resp.Body).Decode(&projects)
@@ -451,9 +457,15 @@ func GetUserName(token string, url string) string {
 		writeError(fmt.Sprintf("failed to send http request: %v", err))
 		return ""
 	}
-	defer resp.Body.Close()
 
 	user := userv1.User{}
+	defer func() {
+		err := resp.Body.Close()
+		if err != nil {
+			klog.Errorf("failed to close response body: %v", err)
+		}
+	}()
+
 	err = json.NewDecoder(resp.Body).Decode(&user)
 	if err != nil {
 		klog.Errorf("failed to decode response json body: %v", err)

--- a/tests/pkg/utils/mco_pods.go
+++ b/tests/pkg/utils/mco_pods.go
@@ -65,7 +65,14 @@ func GetPodLogs(
 		klog.Errorf("Failed to get logs for %s/%s in namespace %s due to %v", podName, containerName, namespace, err)
 		return "", err
 	}
-	defer podLogs.Close()
+
+	defer func() {
+		err := podLogs.Close()
+		if err != nil {
+			klog.Errorf("Failed to close pod logs due to %v", err)
+		}
+	}()
+
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, podLogs)
 	if err != nil {

--- a/tests/pkg/utils/utils.go
+++ b/tests/pkg/utils/utils.go
@@ -191,7 +191,7 @@ func FetchBearerToken(opt TestOptions) (string, error) {
 	}
 	for _, secret := range secretList.Items {
 		// nolint:staticcheck
-		if secret.GetObjectMeta() != nil && len(secret.GetObjectMeta().GetAnnotations()) > 0 {
+		if len(secret.GetObjectMeta().GetAnnotations()) > 0 {
 			annos := secret.GetObjectMeta().GetAnnotations()
 			sa, saExists := annos["kubernetes.io/service-account.name"]
 			//_, createByExists := annos["kubernetes.io/created-by"]


### PR DESCRIPTION
This PR addresses the following issues
1. [ACM-4384](https://issues.redhat.com/browse/ACM-4384) - defer unsafe close vulnerability
2. Adds a diagnostic message when MCO reconcile is skipped waiting for MCH CR to be ready (upgrade)
3. Miscellaneous warnings

CC: @bjoydeep @berenss - (2) should help diagnose MCO reconcile wasn't working as we saw in in ROSA HCP env