### PR TITLE
Rebuild image to fix `gosec` scan results in SonarCloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,4 +186,4 @@ kubectl -n open-cluster-management-observability delete -k examples/minio
 kubectl delete ns open-cluster-management-observability
 ```
 
-Rebuild Image: Wed Jan 25 15:08:26 EST 2023
+Rebuild Image: Thu Nov  2 17:15:25 CET 2023

--- a/REMEDIATE.md
+++ b/REMEDIATE.md
@@ -34,3 +34,7 @@
 ### Wed Jan 25 15:08:26 EST 2023
 
 - <https://issues.redhat.com/browse/ACM-2750>
+
+### Thu Nov  2 17:15:25 CET 2023
+
+- <https://issues.redhat.com/browse/ACM-6937>


### PR DESCRIPTION
This should pick up a newer version of the image-builder, with an updated `gosec`. With this new version it should properly skip a false-positive that previous versions don't ignore.