### PR TITLE
[release-2.8] add patch permission to mco role

### DIFF
--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -324,6 +324,7 @@ spec:
           - delete
           - get
           - list
+          - patch
         - apiGroups:
           - migration.k8s.io
           resources:

--- a/operators/multiclusterobservability/config/rbac/mco_role.yaml
+++ b/operators/multiclusterobservability/config/rbac/mco_role.yaml
@@ -243,6 +243,7 @@ rules:
   - delete
   - get
   - list
+  - patch
 - apiGroups:
   - migration.k8s.io
   resources:

--- a/operators/multiclusterobservability/controllers/placementrule/role.go
+++ b/operators/multiclusterobservability/controllers/placementrule/role.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2021 Red Hat, Inc.
-// Copyright Contributors to the Open Cluster Management project
+// Copyright (c) Red Hat, Inc.
+// Licensed under the Apache License 2.0
 
 package placementrule
 
@@ -184,12 +184,16 @@ func createResourceRole(c client.Client) error {
 				Resources: []string{
 					"managedclusteraddons",
 					"managedclusteraddons/status",
+					"managedclusteraddons/finalizers",
 				},
 				Verbs: []string{
 					"watch",
 					"list",
 					"get",
 					"update",
+					"patch",
+					"delete",
+					"create",
 				},
 				APIGroups: []string{
 					"addon.open-cluster-management.io",


### PR DESCRIPTION
`patch` permission is a prerequisite to upgrading add-on framework to new version in 2.8/2.7 service stream

CC: @dislbenn A new install PR similar to [PR 1169](https://github.com/stolostron/multiclusterhub-operator/pull/1169) would be required in service stream 