### PR TITLE
Create Containerfile.operator files in preparation to move to RHTAP

### DIFF
--- a/collectors/metrics/Containerfile.operator
+++ b/collectors/metrics/Containerfile.operator
@@ -1,0 +1,61 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
+
+WORKDIR /workspace
+COPY go.sum go.mod ./
+COPY ./collectors/metrics ./collectors/metrics
+COPY ./operators/pkg ./operators/pkg
+COPY ./operators/multiclusterobservability/api ./operators/multiclusterobservability/api
+RUN CGO_ENABLED=1 go build -a -installsuffix cgo -v -o metrics-collector ./collectors/metrics/cmd/metrics-collector/main.go
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ARG VCS_REF
+ARG VCS_URL
+ARG IMAGE_NAME
+ARG IMAGE_DESCRIPTION
+ARG IMAGE_DISPLAY_NAME
+ARG IMAGE_NAME_ARCH
+ARG IMAGE_MAINTAINER
+ARG IMAGE_VENDOR
+ARG IMAGE_VERSION
+ARG IMAGE_RELEASE
+ARG IMAGE_SUMMARY
+ARG IMAGE_OPENSHIFT_TAGS
+
+LABEL org.label-schema.vendor="Red Hat" \
+    org.label-schema.name="$IMAGE_NAME_ARCH" \
+    org.label-schema.description="$IMAGE_DESCRIPTION" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url=$VCS_URL \
+    org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+    org.label-schema.schema-version="1.0" \
+    name="$IMAGE_NAME" \
+    maintainer="$IMAGE_MAINTAINER" \
+    vendor="$IMAGE_VENDOR" \
+    version="$IMAGE_VERSION" \
+    release="$IMAGE_RELEASE" \
+    description="$IMAGE_DESCRIPTION" \
+    summary="$IMAGE_SUMMARY" \
+    io.k8s.display-name="$IMAGE_DISPLAY_NAME" \
+    io.k8s.description="$IMAGE_DESCRIPTION" \
+    io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
+
+RUN microdnf update &&\
+    microdnf install ca-certificates vi --nodocs &&\
+    mkdir /licenses &&\
+    microdnf clean all
+
+USER 1001:1001
+
+COPY --from=builder /workspace/metrics-collector /usr/bin/
+
+# standalone required parameters
+ENV FROM_CA_FILE="/from/service-ca.crt"
+ENV INTERVAL="60s"
+ENV MATCH_FILE="/metrics/match-file"
+ENV LIMIT_BYTES=1073741824
+
+CMD ["/bin/bash", "-c", "/usr/bin/metrics-collector --from ${FROM} --from-ca-file ${FROM_CA_FILE} --from-token ${FROM_TOKEN} --to-upload ${TO_UPLOAD} --id ${TENANT_ID} --label cluster=${CLUSTER_NAME} --label clusterID=${CLUSTER_ID} --match-file ${MATCH_FILE} --interval ${INTERVAL} --limit-bytes=${LIMIT_BYTES}"]

--- a/loaders/dashboards/Containerfile.operator
+++ b/loaders/dashboards/Containerfile.operator
@@ -1,0 +1,55 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
+
+WORKDIR /workspace
+COPY go.sum go.mod ./loaders/dashboards ./
+COPY ./loaders/dashboards ./loaders/dashboards
+
+RUN CGO_ENABLED=1 go build -a -installsuffix cgo -v -o main loaders/dashboards/cmd/main.go
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ARG VCS_REF
+ARG VCS_URL
+ARG IMAGE_NAME
+ARG IMAGE_DESCRIPTION
+ARG IMAGE_DISPLAY_NAME
+ARG IMAGE_NAME_ARCH
+ARG IMAGE_MAINTAINER
+ARG IMAGE_VENDOR
+ARG IMAGE_VERSION
+ARG IMAGE_RELEASE
+ARG IMAGE_SUMMARY
+ARG IMAGE_OPENSHIFT_TAGS
+
+LABEL org.label-schema.vendor="Red Hat" \
+    org.label-schema.name="$IMAGE_NAME_ARCH" \
+    org.label-schema.description="$IMAGE_DESCRIPTION" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url=$VCS_URL \
+    org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+    org.label-schema.schema-version="1.0" \
+    name="$IMAGE_NAME" \
+    maintainer="$IMAGE_MAINTAINER" \
+    vendor="$IMAGE_VENDOR" \
+    version="$IMAGE_VERSION" \
+    release="$IMAGE_RELEASE" \
+    description="$IMAGE_DESCRIPTION" \
+    summary="$IMAGE_SUMMARY" \
+    io.k8s.display-name="$IMAGE_DISPLAY_NAME" \
+    io.k8s.description="$IMAGE_DESCRIPTION" \
+    io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
+
+WORKDIR /
+
+RUN microdnf update -y && microdnf clean all
+
+USER 1001:1001
+
+COPY --from=builder /workspace/main grafana-dashboard-loader
+
+EXPOSE 3002
+
+ENTRYPOINT ["/grafana-dashboard-loader"]

--- a/operators/endpointmetrics/Containerfile.operator
+++ b/operators/endpointmetrics/Containerfile.operator
@@ -1,0 +1,58 @@
+# Copyright (c) 2021 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project.
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
+
+WORKDIR /workspace
+COPY go.sum go.mod ./
+COPY ./operators/endpointmetrics ./operators/endpointmetrics
+COPY ./operators/multiclusterobservability/api ./operators/multiclusterobservability/api
+COPY ./operators/pkg ./operators/pkg
+
+RUN CGO_ENABLED=1 go build -a -installsuffix cgo -o build/_output/bin/endpoint-monitoring-operator operators/endpointmetrics/main.go
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ARG VCS_REF
+ARG VCS_URL
+ARG IMAGE_NAME
+ARG IMAGE_DESCRIPTION
+ARG IMAGE_DISPLAY_NAME
+ARG IMAGE_NAME_ARCH
+ARG IMAGE_MAINTAINER
+ARG IMAGE_VENDOR
+ARG IMAGE_VERSION
+ARG IMAGE_RELEASE
+ARG IMAGE_SUMMARY
+ARG IMAGE_OPENSHIFT_TAGS
+
+LABEL org.label-schema.vendor="Red Hat" \
+    org.label-schema.name="$IMAGE_NAME_ARCH" \
+    org.label-schema.description="$IMAGE_DESCRIPTION" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url=$VCS_URL \
+    org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+    org.label-schema.schema-version="1.0" \
+    name="$IMAGE_NAME" \
+    maintainer="$IMAGE_MAINTAINER" \
+    vendor="$IMAGE_VENDOR" \
+    version="$IMAGE_VERSION" \
+    release="$IMAGE_RELEASE" \
+    description="$IMAGE_DESCRIPTION" \
+    summary="$IMAGE_SUMMARY" \
+    io.k8s.display-name="$IMAGE_DISPLAY_NAME" \
+    io.k8s.description="$IMAGE_DESCRIPTION" \
+    io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
+
+ENV OPERATOR=/usr/local/bin/endpoint-monitoring-operator \
+    USER_UID=1001 \
+    USER_NAME=endpoint-monitoring-operator
+
+RUN microdnf update -y && microdnf clean all
+
+COPY ./operators/endpointmetrics/manifests /usr/local/manifests
+
+# install operator binary
+COPY --from=builder /workspace/build/_output/bin/endpoint-monitoring-operator ${OPERATOR}
+USER ${USER_UID}
+
+ENTRYPOINT ["/usr/local/bin/endpoint-monitoring-operator"]

--- a/operators/multiclusterobservability/Containerfile.operator
+++ b/operators/multiclusterobservability/Containerfile.operator
@@ -1,0 +1,62 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
+
+WORKDIR /workspace
+COPY go.sum go.mod ./
+COPY ./operators/multiclusterobservability ./operators/multiclusterobservability
+COPY ./operators/pkg ./operators/pkg
+
+RUN CGO_ENABLED=1 go build -a -installsuffix cgo -o bin/manager operators/multiclusterobservability/main.go
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ARG VCS_REF
+ARG VCS_URL
+ARG IMAGE_NAME
+ARG IMAGE_DESCRIPTION
+ARG IMAGE_DISPLAY_NAME
+ARG IMAGE_NAME_ARCH
+ARG IMAGE_MAINTAINER
+ARG IMAGE_VENDOR
+ARG IMAGE_VERSION
+ARG IMAGE_RELEASE
+ARG IMAGE_SUMMARY
+ARG IMAGE_OPENSHIFT_TAGS
+
+LABEL org.label-schema.vendor="Red Hat" \
+    org.label-schema.name="$IMAGE_NAME_ARCH" \
+    org.label-schema.description="$IMAGE_DESCRIPTION" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url=$VCS_URL \
+    org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+    org.label-schema.schema-version="1.0" \
+    name="$IMAGE_NAME" \
+    maintainer="$IMAGE_MAINTAINER" \
+    vendor="$IMAGE_VENDOR" \
+    version="$IMAGE_VERSION" \
+    release="$IMAGE_RELEASE" \
+    description="$IMAGE_DESCRIPTION" \
+    summary="$IMAGE_SUMMARY" \
+    io.k8s.display-name="$IMAGE_DISPLAY_NAME" \
+    io.k8s.description="$IMAGE_DESCRIPTION" \
+    io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
+
+ENV OPERATOR=/usr/local/bin/mco-operator \
+    USER_UID=1001 \
+    USER_NAME=mco
+
+RUN microdnf update -y && microdnf clean all
+
+# install templates
+COPY ./operators/multiclusterobservability/manifests /usr/local/manifests
+
+# install the prestop script
+COPY ./operators/multiclusterobservability/prestop.sh /usr/local/bin/prestop.sh
+
+# install operator binary
+COPY --from=builder /workspace/bin/manager ${OPERATOR}
+USER ${USER_UID}
+
+ENTRYPOINT ["/usr/local/bin/mco-operator"]

--- a/proxy/Containerfile.operator
+++ b/proxy/Containerfile.operator
@@ -1,0 +1,52 @@
+# Copyright Contributors to the Open Cluster Management project
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
+
+WORKDIR /workspace
+COPY go.sum go.mod ./
+COPY ./proxy ./proxy
+
+RUN CGO_ENABLED=1 go build -a -installsuffix cgo -v -o main proxy/cmd/main.go
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ARG VCS_REF
+ARG VCS_URL
+ARG IMAGE_NAME
+ARG IMAGE_DESCRIPTION
+ARG IMAGE_DISPLAY_NAME
+ARG IMAGE_NAME_ARCH
+ARG IMAGE_MAINTAINER
+ARG IMAGE_VENDOR
+ARG IMAGE_VERSION
+ARG IMAGE_RELEASE
+ARG IMAGE_SUMMARY
+ARG IMAGE_OPENSHIFT_TAGS
+
+LABEL org.label-schema.vendor="Red Hat" \
+    org.label-schema.name="$IMAGE_NAME_ARCH" \
+    org.label-schema.description="$IMAGE_DESCRIPTION" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url=$VCS_URL \
+    org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+    org.label-schema.schema-version="1.0" \
+    name="$IMAGE_NAME" \
+    maintainer="$IMAGE_MAINTAINER" \
+    vendor="$IMAGE_VENDOR" \
+    version="$IMAGE_VERSION" \
+    release="$IMAGE_RELEASE" \
+    description="$IMAGE_DESCRIPTION" \
+    summary="$IMAGE_SUMMARY" \
+    io.k8s.display-name="$IMAGE_DISPLAY_NAME" \
+    io.k8s.description="$IMAGE_DESCRIPTION" \
+    io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
+
+WORKDIR /
+
+USER 1001:1001
+
+COPY --from=builder /workspace/main rbac-query-proxy
+
+EXPOSE 3002
+
+ENTRYPOINT ["/rbac-query-proxy"]

--- a/tests/Containerfile.operator
+++ b/tests/Containerfile.operator
@@ -1,0 +1,50 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
+
+WORKDIR /workspace
+# copy go tests into build image
+COPY go.sum go.mod ./
+COPY ./tests ./tests
+
+# compile go tests in build image
+RUN go install github.com/onsi/ginkgo/ginkgo@v1.14.2 && go mod vendor && ginkgo build ./tests/pkg/tests/
+
+# create new docker image to hold built artifacts
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+# run as non-root
+USER 1001:1001
+
+# expose env vars for runtime
+ENV KUBECONFIG "/opt/.kube/config"
+ENV IMPORT_KUBECONFIG "/opt/.kube/import-kubeconfig"
+ENV OPTIONS "/resources/options.yaml"
+ENV REPORT_FILE "/results/results.xml"
+ENV GINKGO_DEFAULT_FLAGS "-slowSpecThreshold=120 -timeout 7200s"
+ENV GINKGO_NODES "1"
+ENV GINKGO_FLAGS=""
+ENV GINKGO_FOCUS=""
+ENV GINKGO_SKIP="Integration"
+ENV SKIP_INTEGRATION_CASES="true"
+ENV IS_CANARY_ENV="true"
+
+# install ginkgo into built image
+COPY --from=builder /go/bin/ /usr/local/bin
+
+# oc exists in the base image. copy oc into built image
+COPY --from=builder /usr/local/bin/oc /usr/local/bin/oc
+RUN oc version
+
+WORKDIR /workspace/opt/tests/
+# copy compiled tests into built image
+COPY --from=builder /workspace/tests/pkg/tests/tests.test ./observability-e2e-test.test
+COPY ./examples /examples
+COPY --from=builder /workspace/tests/format-results.sh .
+
+VOLUME /results
+
+
+# execute compiled ginkgo tests
+CMD ["/bin/bash", "-c", "ginkgo --v --focus=${GINKGO_FOCUS} --skip=${GINKGO_SKIP} -nodes=${GINKGO_NODES} --reportFile=${REPORT_FILE} -x -debug -trace observability-e2e-test.test -- -v=3 ; ./format-results.sh ${REPORT_FILE}"]

--- a/tools/simulator/alert-forward/Containerfile.operator
+++ b/tools/simulator/alert-forward/Containerfile.operator
@@ -1,0 +1,25 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
+
+WORKDIR /workspace
+COPY go.sum go.mod ./
+COPY tools/simulator/alert-forward/main.go tools/simulator/alert-forward/main.go
+
+RUN CGO_ENABLED=1 go build -a -installsuffix cgo -o bin/alert-forwarder tools/simulator/alert-forward/main.go
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ENV MAIN_BINARY=/usr/local/bin/alert-forwarder \
+    USER_UID=1001 \
+    USER_NAME=alert-forwarder
+
+# install the binary
+COPY --from=builder /workspace/bin/alert-forwarder ${MAIN_BINARY} 
+COPY tools/simulator/alert-forward/alerts.json /tmp/
+
+USER ${USER_UID}
+
+ENTRYPOINT ["/usr/local/bin/alert-forwarder"]
+

--- a/tools/simulator/metrics-collector/metrics-extractor/Containerfile.operator
+++ b/tools/simulator/metrics-collector/metrics-extractor/Containerfile.operator
@@ -1,0 +1,48 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
+
+RUN GOBIN=/usr/local/bin go install github.com/brancz/gojsontoyaml@latest
+
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+RUN mkdir /metrics-extractor
+RUN mkdir /ocp-tools
+RUN microdnf install wget -y \
+    && microdnf clean all
+RUN microdnf install tar gzip jq bc -y\
+    && microdnf clean all
+
+USER 1001:1001
+
+RUN wget https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.13/openshift-client-linux.tar.gz -P /ocp-tools
+WORKDIR /ocp-tools
+RUN chmod 644 /ocp-tools
+RUN tar xvf openshift-client-linux.tar.gz oc kubectl
+RUN rm openshift-client-linux.tar.gz
+RUN cp oc /usr/local/bin
+RUN cp kubectl /usr/local/bin
+
+COPY --from=builder /usr/local/bin/gojsontoyaml /usr/local/bin/
+
+WORKDIR /metrics-extractor
+ARG METRICS_ALLOW_LIST_URL="https://raw.githubusercontent.com/stolostron/multicluster-observability-operator/main/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml"
+ARG METRICS_JSON_OUT=/metrics-extractor/metrics.json
+ARG RECORDINGRULES_JSON_OUT=/metrics-extractor/recordingrules.json
+ARG GOJSONTOYAML_BIN=/usr/local/bin/gojsontoyaml
+
+
+RUN export matches=$(curl -L $METRICS_ALLOW_LIST_URL | $GOJSONTOYAML_BIN --yamltojson | jq -r '.data."metrics_list.yaml"' | $GOJSONTOYAML_BIN --yamltojson | jq -r '.matches' | jq '"{" + .[] + "}"') && \
+    export names=$(curl -L $METRICS_ALLOW_LIST_URL | $GOJSONTOYAML_BIN --yamltojson | jq -r '.data."metrics_list.yaml"' | $GOJSONTOYAML_BIN --yamltojson | jq -r '.names' | jq '"{__name__=\"" + .[] + "\"}"') && \
+    echo $matches $names | jq -s . > $METRICS_JSON_OUT && \
+    export recordingrules=$(curl -L $METRICS_ALLOW_LIST_URL | $GOJSONTOYAML_BIN --yamltojson | jq -r '.data."metrics_list.yaml"' | $GOJSONTOYAML_BIN --yamltojson | jq '.recording_rules[]') && \
+	echo $recordingrules | jq -s . > ${RECORDINGRULES_JSON_OUT}
+
+
+
+COPY ./extract-metrics-data.sh /metrics-extractor/
+RUN chmod 744 /metrics-extractor
+
+
+CMD [ "/bin/bash", "/metrics-extractor/extract-metrics-data.sh" ]


### PR DESCRIPTION
Required by [ACM-7181](https://issues.redhat.com/browse/ACM-7181)

change builder image to: brew.registry.redhat.io//rh-osbs/openshift-golang-builder:rhel_8_1.20