### PR TITLE
add watch logic for addondeployment

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -324,6 +324,30 @@ func createManifestWorks(
 					container.Env[j].Value = strconv.FormatBool(installProm)
 				}
 			}
+			// If ProxyConfig is specified as part of addonConfig, set the proxy envs
+			if clusterName != localClusterName {
+				for i := range spec.Containers {
+					container := &spec.Containers[i]
+					if addonConfig.Spec.ProxyConfig.HTTPProxy != "" {
+						container.Env = append(container.Env, corev1.EnvVar{
+							Name:  "HTTP_PROXY",
+							Value: addonConfig.Spec.ProxyConfig.HTTPProxy,
+						})
+					}
+					if addonConfig.Spec.ProxyConfig.HTTPSProxy != "" {
+						container.Env = append(container.Env, corev1.EnvVar{
+							Name:  "HTTPS_PROXY",
+							Value: addonConfig.Spec.ProxyConfig.HTTPSProxy,
+						})
+					}
+					if addonConfig.Spec.ProxyConfig.NoProxy != "" {
+						container.Env = append(container.Env, corev1.EnvVar{
+							Name:  "NO_PROXY",
+							Value: addonConfig.Spec.ProxyConfig.NoProxy,
+						})
+					}
+				}
+			}
 
 			if hasCustomRegistry {
 				oldImage := container.Image
@@ -331,33 +355,6 @@ func createManifestWorks(
 				log.Info("Replace the endpoint operator image", "cluster", clusterName, "newImage", newImage)
 				if err == nil {
 					spec.Containers[i].Image = newImage
-				}
-			}
-		}
-	}
-	// If ProxyConfig is specified as part of addonConfig, set the proxy envs
-	for i := range spec.Containers {
-		if spec.Containers[i].Name == "endpoint-observability-operator" {
-			container := &spec.Containers[i]
-
-			if clusterName != localClusterName {
-				if addonConfig.Spec.ProxyConfig.HTTPProxy != "" {
-					container.Env = append(container.Env, corev1.EnvVar{
-						Name:  "HTTP_PROXY",
-						Value: addonConfig.Spec.ProxyConfig.HTTPProxy,
-					})
-				}
-				if addonConfig.Spec.ProxyConfig.HTTPSProxy != "" {
-					container.Env = append(container.Env, corev1.EnvVar{
-						Name:  "HTTPS_PROXY",
-						Value: addonConfig.Spec.ProxyConfig.HTTPSProxy,
-					})
-				}
-				if addonConfig.Spec.ProxyConfig.NoProxy != "" {
-					container.Env = append(container.Env, corev1.EnvVar{
-						Name:  "NO_PROXY",
-						Value: addonConfig.Spec.ProxyConfig.NoProxy,
-					})
 				}
 			}
 		}

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -325,37 +325,39 @@ func createManifestWorks(
 				}
 			}
 
-			// If ProxyConfig is specified as part of addonConfig, set the proxy envs
-			if clusterName != localClusterName {
-				for i := range spec.Containers {
-					container := &spec.Containers[i]
-					if addonConfig.Spec.ProxyConfig.HTTPProxy != "" {
-						container.Env = append(container.Env, corev1.EnvVar{
-							Name:  "HTTP_PROXY",
-							Value: addonConfig.Spec.ProxyConfig.HTTPProxy,
-						})
-					}
-					if addonConfig.Spec.ProxyConfig.HTTPSProxy != "" {
-						container.Env = append(container.Env, corev1.EnvVar{
-							Name:  "HTTPS_PROXY",
-							Value: addonConfig.Spec.ProxyConfig.HTTPSProxy,
-						})
-					}
-					if addonConfig.Spec.ProxyConfig.NoProxy != "" {
-						container.Env = append(container.Env, corev1.EnvVar{
-							Name:  "NO_PROXY",
-							Value: addonConfig.Spec.ProxyConfig.NoProxy,
-						})
-					}
-				}
-			}
-
 			if hasCustomRegistry {
 				oldImage := container.Image
 				newImage, err := imageRegistryClient.Cluster(clusterName).ImageOverride(oldImage)
 				log.Info("Replace the endpoint operator image", "cluster", clusterName, "newImage", newImage)
 				if err == nil {
 					spec.Containers[i].Image = newImage
+				}
+			}
+		}
+	}
+	// If ProxyConfig is specified as part of addonConfig, set the proxy envs
+	for i := range spec.Containers {
+		if spec.Containers[i].Name == "endpoint-observability-operator" {
+			container := &spec.Containers[i]
+
+			if clusterName != localClusterName {
+				if addonConfig.Spec.ProxyConfig.HTTPProxy != "" {
+					container.Env = append(container.Env, corev1.EnvVar{
+						Name:  "HTTP_PROXY",
+						Value: addonConfig.Spec.ProxyConfig.HTTPProxy,
+					})
+				}
+				if addonConfig.Spec.ProxyConfig.HTTPSProxy != "" {
+					container.Env = append(container.Env, corev1.EnvVar{
+						Name:  "HTTPS_PROXY",
+						Value: addonConfig.Spec.ProxyConfig.HTTPSProxy,
+					})
+				}
+				if addonConfig.Spec.ProxyConfig.NoProxy != "" {
+					container.Env = append(container.Env, corev1.EnvVar{
+						Name:  "NO_PROXY",
+						Value: addonConfig.Spec.ProxyConfig.NoProxy,
+					})
 				}
 			}
 		}

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -540,27 +540,7 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	clusterPred := getClusterPreds()
 
 	// Watch changes for AddonDeploymentConfig
-	AddonDeploymentPred := predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return true
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			if e.ObjectNew.GetName() == defaultAddonDeploymentConfig.Name &&
-				e.ObjectNew.GetNamespace() == defaultAddonDeploymentConfig.Namespace {
-				log.Info("default AddonDeploymentConfig is updated")
-				return true
-			}
-			return false
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			if e.Object.GetName() == defaultAddonDeploymentConfig.Name &&
-				e.Object.GetNamespace() == defaultAddonDeploymentConfig.Namespace {
-				log.Info("default AddonDeploymentConfig is deleted")
-				return true
-			}
-			return false
-		},
-	}
+	AddonDeploymentPred := GetAddOnDeploymentPredicates()
 
 	obsAddonPred := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	ocinfrav1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -177,7 +179,7 @@ func TestObservabilityAddonController(t *testing.T) {
 		},
 	}
 	objs := []runtime.Object{mco, pull, newConsoleRoute(), newTestObsApiRoute(), newTestAlertmanagerRoute(), newTestIngressController(), newTestRouteCASecret(), newCASecret(), newCertSecret(mcoNamespace), NewMetricsAllowListCM(),
-		NewAmAccessorSA(), NewAmAccessorTokenSecret(), newManagedClusterAddon(), deprecatedRole, newClusterMgmtAddon(),
+		NewAmAccessorSA(), NewAmAccessorTokenSecret(), deprecatedRole, newClusterMgmtAddon(),
 		newAddonDeploymentConfig(defaultAddonConfigName, namespace), newAddonDeploymentConfig(addonConfigName, namespace)}
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 	r := &PlacementRuleReconciler{Client: c, Scheme: s, CRDMap: map[string]bool{config.IngressControllerCRD: true}}
@@ -232,6 +234,68 @@ func TestObservabilityAddonController(t *testing.T) {
 	_, err = r.Reconcile(context.TODO(), req)
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
+	}
+	foundAddonDeploymentConfig := &addonv1alpha1.AddOnDeploymentConfig{}
+	err = c.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: defaultAddonConfigName}, foundAddonDeploymentConfig)
+	if err != nil {
+		t.Fatalf("Failed to get addondeploymentconfig %s: (%v)", name, err)
+	}
+
+	//Change proxyconfig in addondeploymentconfig
+	foundAddonDeploymentConfig.Spec.ProxyConfig = addonv1alpha1.ProxyConfig{
+		HTTPProxy:  "http://test1.com",
+		HTTPSProxy: "https://test1.com",
+		NoProxy:    "test.com",
+	}
+
+	err = c.Update(context.TODO(), foundAddonDeploymentConfig)
+	if err != nil {
+		t.Fatalf("Failed to update addondeploymentconfig %s: (%v)", name, err)
+	}
+
+	req = ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name: config.AddonDeploymentConfigUpdateName,
+		},
+	}
+
+	_, err = r.Reconcile(context.TODO(), req)
+	if err != nil {
+		t.Fatalf("reconcile after updating addondeploymentconfig: (%v)", err)
+	}
+
+	foundManifestwork := &workv1.ManifestWork{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace + workNameSuffix, Namespace: namespace}, foundManifestwork)
+	if err != nil {
+		t.Fatalf("Failed to get manifestwork %s: (%v)", namespace, err)
+	}
+	for _, manifest := range foundManifestwork.Spec.Workload.Manifests {
+		obj, _ := util.GetObject(manifest.RawExtension)
+		if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+			//Check the proxy env variables
+			deployment := obj.(*appsv1.Deployment)
+			spec := deployment.Spec.Template.Spec
+			for _, c := range spec.Containers {
+				if c.Name == "endpoint-observability-operator" {
+					env := c.Env
+					for _, e := range env {
+						if e.Name == "HTTP_PROXY" {
+							if e.Value != "http://test1.com" {
+								t.Fatalf("HTTP_PROXY is not set correctly: expected %s, got %s", "http://test1.com", e.Value)
+							}
+						} else if e.Name == "HTTPS_PROXY" {
+							if e.Value != "https://test1.com" {
+								t.Fatalf("HTTPS_PROXY is not set correctly: expected %s, got %s", "https://test1.com", e.Value)
+							}
+						} else if e.Name == "NO_PROXY" {
+							if e.Value != "test.com" {
+								t.Fatalf("NO_PROXY is not set correctly: expected %s, got %s", "test.com", e.Value)
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 
 	err = c.Delete(context.TODO(), mco)
@@ -310,7 +374,7 @@ func TestObservabilityAddonController(t *testing.T) {
 	// test mco-disable-alerting annotation
 	// 1. Verify that alertmanager-endpoint in secret hub-info-secret in the ManifestWork is not null
 	t.Logf("check alertmanager endpoint is not null")
-	foundManifestwork := &workv1.ManifestWork{}
+	foundManifestwork = &workv1.ManifestWork{}
 	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace + workNameSuffix, Namespace: namespace}, foundManifestwork)
 	if err != nil {
 		t.Fatalf("Failed to get manifestwork %s: (%v)", namespace, err)
@@ -552,6 +616,11 @@ func newAddonDeploymentConfig(name, namespace string) *addonv1alpha1.AddOnDeploy
 				NodeSelector: map[string]string{
 					"kubernetes.io/os": "linux",
 				},
+			},
+			ProxyConfig: addonv1alpha1.ProxyConfig{
+				HTTPProxy:  "http://foo.com",
+				HTTPSProxy: "https://foo.com",
+				NoProxy:    "bar.com",
 			},
 		},
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
@@ -5,6 +5,8 @@
 package placementrule
 
 import (
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -80,9 +82,9 @@ func GetAddOnDeploymentPredicates() predicate.Funcs {
 			return true
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			if e.ObjectNew.GetName() == defaultAddonDeploymentConfig.Name &&
-				e.ObjectNew.GetNamespace() == defaultAddonDeploymentConfig.Namespace {
-				log.Info("default AddonDeploymentConfig is updated")
+			if !reflect.DeepEqual(e.ObjectNew.(*addonv1alpha1.AddOnDeploymentConfig).Spec.ProxyConfig,
+				e.ObjectOld.(*addonv1alpha1.AddOnDeploymentConfig).Spec.ProxyConfig) {
+				log.Info("AddonDeploymentConfig is updated", e.ObjectNew.GetName(), "name", e.ObjectNew.GetNamespace(), "namespace")
 				return true
 			}
 			return false

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
@@ -73,3 +73,27 @@ func getClusterPreds() predicate.Funcs {
 		DeleteFunc: deleteFunc,
 	}
 }
+
+func GetAddOnDeploymentPredicates() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectNew.GetName() == defaultAddonDeploymentConfig.Name &&
+				e.ObjectNew.GetNamespace() == defaultAddonDeploymentConfig.Namespace {
+				log.Info("default AddonDeploymentConfig is updated")
+				return true
+			}
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			if e.Object.GetName() == defaultAddonDeploymentConfig.Name &&
+				e.Object.GetNamespace() == defaultAddonDeploymentConfig.Namespace {
+				log.Info("default AddonDeploymentConfig is deleted")
+				return true
+			}
+			return false
+		},
+	}
+}

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
@@ -5,8 +5,9 @@
 package placementrule
 
 import (
-	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	"reflect"
+
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
@@ -91,12 +91,7 @@ func GetAddOnDeploymentPredicates() predicate.Funcs {
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			if e.Object.GetName() == defaultAddonDeploymentConfig.Name &&
-				e.Object.GetNamespace() == defaultAddonDeploymentConfig.Namespace {
-				log.Info("default AddonDeploymentConfig is deleted")
-				return true
-			}
-			return false
+			return true
 		},
 	}
 }

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func_test.go
@@ -193,8 +193,11 @@ func TestAddonDeploymentPredicate(t *testing.T) {
 				}
 			}
 
+			newDefaultAddonDeploymentConfig := defaultAddonDeploymentConfig.DeepCopy()
+			newDefaultAddonDeploymentConfig.Spec.ProxyConfig.HTTPProxy = "http://bar1.com"
 			updateEvent := event.UpdateEvent{
-				ObjectNew: defaultAddonDeploymentConfig,
+				ObjectOld: defaultAddonDeploymentConfig,
+				ObjectNew: newDefaultAddonDeploymentConfig,
 			}
 			if c.expectedUpdate {
 				if !pred.UpdateFunc(updateEvent) {

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func_test.go
@@ -5,9 +5,10 @@
 package placementrule
 
 import (
-	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	"testing"
 	"time"
+
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -56,6 +56,7 @@ const (
 	MCHUpdatedRequestName               = "mch-updated-request"
 	MCOUpdatedRequestName               = "mco-updated-request"
 	ClusterManagementAddOnUpdateName    = "clustermgmtaddon-updated-request"
+	AddonDeploymentConfigUpdateName     = "addondc-updated-request"
 	MulticloudConsoleRouteName          = "multicloud-console"
 	ImageManifestConfigMapNamePrefix    = "mch-image-manifest-"
 	OCMManifestConfigMapTypeLabelKey    = "ocm-configmap-type"


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOBS-949
https://issues.redhat.com/browse/ACM-8312

From what I understand is that the placement controller has no logic to watch over the changes to addondeployment config. So any update to it will not be picked up by managerclusteraddon and clustermanagementaddon which are watched already but they only hold a ref to addondeploymentconfig and not the actual config.

The PR adds the watch logic in the placement controller to monitor changes in addondeployment config and sets up the request to reconcile and also apply change to all managed clusters