### PR TITLE
Ensure conflict status errors are surfaced in metrics-collector

### DIFF
--- a/collectors/metrics/pkg/metricsclient/metricsclient.go
+++ b/collectors/metrics/pkg/metricsclient/metricsclient.go
@@ -589,9 +589,8 @@ func (c *Client) sendRequest(serverURL string, body []byte) error {
 		bodyString := string(bodyBytes)
 		msg := fmt.Sprintf("response status code is %s, response body is %s", resp.Status, bodyString)
 		logger.Log(c.logger, logger.Warn, msg)
-		if resp.StatusCode != http.StatusConflict {
-			return errors.New(msg)
-		}
+		return errors.New(msg)
+
 	}
 	return nil
 }


### PR DESCRIPTION
While this is a 4xx statuscode, it is important to log errors, and not log "metrics pushed successfully", as the request did fail. 