### PR TITLE
Set GOFLAGS to empty string for RHTAP builds

### DIFF
--- a/collectors/metrics/Containerfile.operator
+++ b/collectors/metrics/Containerfile.operator
@@ -8,7 +8,7 @@ COPY go.sum go.mod ./
 COPY ./collectors/metrics ./collectors/metrics
 COPY ./operators/pkg ./operators/pkg
 COPY ./operators/multiclusterobservability/api ./operators/multiclusterobservability/api
-RUN CGO_ENABLED=1 go build -a -installsuffix cgo -v -o metrics-collector ./collectors/metrics/cmd/metrics-collector/main.go
+RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -v -o metrics-collector ./collectors/metrics/cmd/metrics-collector/main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 

--- a/loaders/dashboards/Containerfile.operator
+++ b/loaders/dashboards/Containerfile.operator
@@ -7,7 +7,7 @@ WORKDIR /workspace
 COPY go.sum go.mod ./loaders/dashboards ./
 COPY ./loaders/dashboards ./loaders/dashboards
 
-RUN CGO_ENABLED=1 go build -a -installsuffix cgo -v -o main loaders/dashboards/cmd/main.go
+RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -v -o main loaders/dashboards/cmd/main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 

--- a/operators/endpointmetrics/Containerfile.operator
+++ b/operators/endpointmetrics/Containerfile.operator
@@ -8,7 +8,7 @@ COPY ./operators/endpointmetrics ./operators/endpointmetrics
 COPY ./operators/multiclusterobservability/api ./operators/multiclusterobservability/api
 COPY ./operators/pkg ./operators/pkg
 
-RUN CGO_ENABLED=1 go build -a -installsuffix cgo -o build/_output/bin/endpoint-monitoring-operator operators/endpointmetrics/main.go
+RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -o build/_output/bin/endpoint-monitoring-operator operators/endpointmetrics/main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 

--- a/operators/multiclusterobservability/Containerfile.operator
+++ b/operators/multiclusterobservability/Containerfile.operator
@@ -8,7 +8,7 @@ COPY go.sum go.mod ./
 COPY ./operators/multiclusterobservability ./operators/multiclusterobservability
 COPY ./operators/pkg ./operators/pkg
 
-RUN CGO_ENABLED=1 go build -a -installsuffix cgo -o bin/manager operators/multiclusterobservability/main.go
+RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -o bin/manager operators/multiclusterobservability/main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 

--- a/proxy/Containerfile.operator
+++ b/proxy/Containerfile.operator
@@ -6,7 +6,7 @@ WORKDIR /workspace
 COPY go.sum go.mod ./
 COPY ./proxy ./proxy
 
-RUN CGO_ENABLED=1 go build -a -installsuffix cgo -v -o main proxy/cmd/main.go
+RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -v -o main proxy/cmd/main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 

--- a/tools/simulator/alert-forward/Containerfile.operator
+++ b/tools/simulator/alert-forward/Containerfile.operator
@@ -7,7 +7,7 @@ WORKDIR /workspace
 COPY go.sum go.mod ./
 COPY tools/simulator/alert-forward/main.go tools/simulator/alert-forward/main.go
 
-RUN CGO_ENABLED=1 go build -a -installsuffix cgo -o bin/alert-forwarder tools/simulator/alert-forward/main.go
+RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -o bin/alert-forwarder tools/simulator/alert-forward/main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 


### PR DESCRIPTION
Required by [ACM-7181](https://issues.redhat.com/browse/ACM-7181)

The golang builder defaults to vendor. Need to set GOFLAGS to empty string for RHTAP builds.