### PR TITLE
[release-2.9] add watch logic for addondeployment (#1289)

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -326,7 +326,6 @@ func createManifestWorks(
 					container.Env[j].Value = strconv.FormatBool(installProm)
 				}
 			}
-
 			// If ProxyConfig is specified as part of addonConfig, set the proxy envs
 			if clusterName != localClusterName {
 				for i := range spec.Containers {

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -539,6 +539,9 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	clusterPred := getClusterPreds()
 
+	// Watch changes for AddonDeploymentConfig
+	AddonDeploymentPred := GetAddOnDeploymentPredicates()
+
 	obsAddonPred := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			return false
@@ -829,6 +832,20 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// secondary watch for alertmanager accessor serviceaccount
 		Watches(&source.Kind{Type: &corev1.ServiceAccount{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(amAccessorSAPred))
 
+	// watch for AddonDeploymentConfig
+	if _, err := r.RESTMapper.RESTMapping(schema.GroupKind{Group: addonv1alpha1.GroupVersion.Group, Kind: "AddOnDeploymentConfig"}, addonv1alpha1.GroupVersion.Version); err == nil {
+		ctrBuilder = ctrBuilder.Watches(
+			&source.Kind{Type: &addonv1alpha1.AddOnDeploymentConfig{}},
+			handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
+				return []reconcile.Request{
+					{NamespacedName: types.NamespacedName{
+						Name: config.AddonDeploymentConfigUpdateName,
+					}},
+				}
+			}),
+			builder.WithPredicates(AddonDeploymentPred),
+		)
+	}
 	manifestWorkGroupKind := schema.GroupKind{Group: workv1.GroupVersion.Group, Kind: "ManifestWork"}
 	if _, err := r.RESTMapper.RESTMapping(manifestWorkGroupKind, workv1.GroupVersion.Version); err == nil {
 		workPred := getManifestworkPred()
@@ -937,7 +954,8 @@ func StartPlacementController(mgr manager.Manager, crdMap map[string]bool) error
 func isReconcileRequired(request ctrl.Request, managedCluster string) bool {
 	if request.Name == config.MCOUpdatedRequestName ||
 		request.Name == config.MCHUpdatedRequestName ||
-		request.Name == config.ClusterManagementAddOnUpdateName {
+		request.Name == config.ClusterManagementAddOnUpdateName ||
+		request.Name == config.AddonDeploymentConfigUpdateName {
 		return true
 	}
 	if request.Namespace == config.GetDefaultNamespace() ||

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	ocinfrav1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -177,7 +179,7 @@ func TestObservabilityAddonController(t *testing.T) {
 		},
 	}
 	objs := []runtime.Object{mco, pull, newConsoleRoute(), newTestObsApiRoute(), newTestAlertmanagerRoute(), newTestIngressController(), newTestRouteCASecret(), newCASecret(), newCertSecret(mcoNamespace), NewMetricsAllowListCM(),
-		NewAmAccessorSA(), NewAmAccessorTokenSecret(), newManagedClusterAddon(), deprecatedRole, newClusterMgmtAddon(),
+		NewAmAccessorSA(), NewAmAccessorTokenSecret(), deprecatedRole, newClusterMgmtAddon(),
 		newAddonDeploymentConfig(defaultAddonConfigName, namespace), newAddonDeploymentConfig(addonConfigName, namespace)}
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 	r := &PlacementRuleReconciler{Client: c, Scheme: s, CRDMap: map[string]bool{config.IngressControllerCRD: true}}
@@ -232,6 +234,68 @@ func TestObservabilityAddonController(t *testing.T) {
 	_, err = r.Reconcile(context.TODO(), req)
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
+	}
+	foundAddonDeploymentConfig := &addonv1alpha1.AddOnDeploymentConfig{}
+	err = c.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: defaultAddonConfigName}, foundAddonDeploymentConfig)
+	if err != nil {
+		t.Fatalf("Failed to get addondeploymentconfig %s: (%v)", name, err)
+	}
+
+	//Change proxyconfig in addondeploymentconfig
+	foundAddonDeploymentConfig.Spec.ProxyConfig = addonv1alpha1.ProxyConfig{
+		HTTPProxy:  "http://test1.com",
+		HTTPSProxy: "https://test1.com",
+		NoProxy:    "test.com",
+	}
+
+	err = c.Update(context.TODO(), foundAddonDeploymentConfig)
+	if err != nil {
+		t.Fatalf("Failed to update addondeploymentconfig %s: (%v)", name, err)
+	}
+
+	req = ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name: config.AddonDeploymentConfigUpdateName,
+		},
+	}
+
+	_, err = r.Reconcile(context.TODO(), req)
+	if err != nil {
+		t.Fatalf("reconcile after updating addondeploymentconfig: (%v)", err)
+	}
+
+	foundManifestwork := &workv1.ManifestWork{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace + workNameSuffix, Namespace: namespace}, foundManifestwork)
+	if err != nil {
+		t.Fatalf("Failed to get manifestwork %s: (%v)", namespace, err)
+	}
+	for _, manifest := range foundManifestwork.Spec.Workload.Manifests {
+		obj, _ := util.GetObject(manifest.RawExtension)
+		if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+			//Check the proxy env variables
+			deployment := obj.(*appsv1.Deployment)
+			spec := deployment.Spec.Template.Spec
+			for _, c := range spec.Containers {
+				if c.Name == "endpoint-observability-operator" {
+					env := c.Env
+					for _, e := range env {
+						if e.Name == "HTTP_PROXY" {
+							if e.Value != "http://test1.com" {
+								t.Fatalf("HTTP_PROXY is not set correctly: expected %s, got %s", "http://test1.com", e.Value)
+							}
+						} else if e.Name == "HTTPS_PROXY" {
+							if e.Value != "https://test1.com" {
+								t.Fatalf("HTTPS_PROXY is not set correctly: expected %s, got %s", "https://test1.com", e.Value)
+							}
+						} else if e.Name == "NO_PROXY" {
+							if e.Value != "test.com" {
+								t.Fatalf("NO_PROXY is not set correctly: expected %s, got %s", "test.com", e.Value)
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 
 	err = c.Delete(context.TODO(), mco)
@@ -310,7 +374,7 @@ func TestObservabilityAddonController(t *testing.T) {
 	// test mco-disable-alerting annotation
 	// 1. Verify that alertmanager-endpoint in secret hub-info-secret in the ManifestWork is not null
 	t.Logf("check alertmanager endpoint is not null")
-	foundManifestwork := &workv1.ManifestWork{}
+	foundManifestwork = &workv1.ManifestWork{}
 	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace + workNameSuffix, Namespace: namespace}, foundManifestwork)
 	if err != nil {
 		t.Fatalf("Failed to get manifestwork %s: (%v)", namespace, err)
@@ -552,6 +616,11 @@ func newAddonDeploymentConfig(name, namespace string) *addonv1alpha1.AddOnDeploy
 				NodeSelector: map[string]string{
 					"kubernetes.io/os": "linux",
 				},
+			},
+			ProxyConfig: addonv1alpha1.ProxyConfig{
+				HTTPProxy:  "http://foo.com",
+				HTTPSProxy: "https://foo.com",
+				NoProxy:    "bar.com",
 			},
 		},
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
@@ -5,6 +5,9 @@
 package placementrule
 
 import (
+	"reflect"
+
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -71,5 +74,24 @@ func getClusterPreds() predicate.Funcs {
 		CreateFunc: createFunc,
 		UpdateFunc: updateFunc,
 		DeleteFunc: deleteFunc,
+	}
+}
+
+func GetAddOnDeploymentPredicates() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if !reflect.DeepEqual(e.ObjectNew.(*addonv1alpha1.AddOnDeploymentConfig).Spec.ProxyConfig,
+				e.ObjectOld.(*addonv1alpha1.AddOnDeploymentConfig).Spec.ProxyConfig) {
+				log.Info("AddonDeploymentConfig is updated", e.ObjectNew.GetName(), "name", e.ObjectNew.GetNamespace(), "namespace")
+				return true
+			}
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return true
+		},
 	}
 }

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -56,6 +56,7 @@ const (
 	MCHUpdatedRequestName               = "mch-updated-request"
 	MCOUpdatedRequestName               = "mco-updated-request"
 	ClusterManagementAddOnUpdateName    = "clustermgmtaddon-updated-request"
+	AddonDeploymentConfigUpdateName     = "addondc-updated-request"
 	MulticloudConsoleRouteName          = "multicloud-console"
 	ImageManifestConfigMapNamePrefix    = "mch-image-manifest-"
 	OCMManifestConfigMapTypeLabelKey    = "ocm-configmap-type"


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-8312

Back port  [PR 12890](https://github.com/stolostron/multicluster-observability-operator/pull/1289) to ACM 2.9 (cherry pick commit 7fb7465a8008f1ba0289a1d27f9f96ea36a8d15f)

* add watch logic for addondeployment
* make sonarcloud happy
* lint
* refactor predicate
* lint
* fix test case
* refactor
