### PR TITLE
Change datasource timeout config for Grafana and add matching timeout…

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/grafana.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/grafana.go
@@ -55,9 +55,10 @@ type GrafanaDatasource struct {
 }
 
 type JsonData struct {
-	TLSAuth               bool   `yaml:"tlsAuth,omitempty"`
-	TLSAuthCA             bool   `yaml:"tlsAuthWithCACert,omitempty"`
-	QueryTimeout          string `yaml:"queryTimeout,omitempty"`
+	TLSAuth   bool `yaml:"tlsAuth,omitempty"`
+	TLSAuthCA bool `yaml:"tlsAuthWithCACert,omitempty"`
+	// Timeout is the request timeout in seconds for an HTTP datasource.
+	Timeout               string `yaml:"timeout,omitempty"`
 	HttpMethod            string `yaml:"httpMethod,omitempty"`
 	TimeInterval          string `yaml:"timeInterval,omitempty"`
 	CustomQueryParameters string `yaml:"customQueryParameters,omitempty"`
@@ -96,7 +97,7 @@ func GenerateGrafanaDataSource(
 					config.GetDefaultNamespace(),
 				),
 				JSONData: &JsonData{
-					QueryTimeout:          "300s",
+					Timeout:               "300",
 					CustomQueryParameters: "max_source_resolution=auto",
 					TimeInterval:          fmt.Sprintf("%ds", mco.Spec.ObservabilityAddonSpec.Interval),
 				},
@@ -112,7 +113,7 @@ func GenerateGrafanaDataSource(
 					config.GetDefaultNamespace(),
 				),
 				JSONData: &JsonData{
-					QueryTimeout:          "300s",
+					Timeout:               "300",
 					CustomQueryParameters: "max_source_resolution=auto",
 					TimeInterval:          fmt.Sprintf("%ds", DynamicTimeInterval),
 				},
@@ -192,6 +193,9 @@ func GenerateGrafanaRoute(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.GrafanaRouteName,
 			Namespace: config.GetDefaultNamespace(),
+			Annotations: map[string]string{
+				"haproxy.router.openshift.io/timeout": "300s",
+			},
 		},
 		Spec: routev1.RouteSpec{
 			Port: &routev1.RoutePort{


### PR DESCRIPTION
… annotation for Route

The previous configuration `queryTimeout` is not valid as per https://grafana.com/docs/grafana/v8.5/administration/provisioning/#json-data (it should be timeout defined as seconds).

The Route needs to have a corresponding annotation to avoid queries timing out after 30s, which is the default in OpenShifts HAProxy config