### PR TITLE
Owners: Add full MultiCluster Observability Team

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,10 @@ approvers:
 - saswatamcode
 - philipgough
 - douglascamata
+- coleenquadros
+- thibaultmg
+- moadz
+- jacobbaungard
 reviewers:
 - clyang82
 - haoqing0110


### PR DESCRIPTION
This commit adds everyone in the team as approvers in the owners file.