### PR TITLE
ACM-9018: Add hosted control plane overview and resources dashboards

### DIFF
--- a/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
+++ b/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
@@ -98,6 +98,21 @@ data:
       - kube_persistentvolume_status_phase
       - machine_cpu_cores
       - machine_memory_bytes
+      - mce_hs_addon_request_based_hcp_capacity_gauge
+      - mce_hs_addon_low_qps_based_hcp_capacity_gauge
+      - mce_hs_addon_medium_qps_based_hcp_capacity_gauge
+      - mce_hs_addon_high_qps_based_hcp_capacity_gauge
+      - mce_hs_addon_average_qps_based_hcp_capacity_gauge
+      - mce_hs_addon_total_hosted_control_planes_gauge
+      - mce_hs_addon_available_hosted_control_planes_gauge
+      - mce_hs_addon_available_hosted_clusters_gauge
+      - mce_hs_addon_deleted_hosted_clusters_gauge
+      - mce_hs_addon_hypershift_operator_degraded_bool
+      - mce_hs_addon_hosted_control_planes_status_gauge
+      - mce_hs_addon_qps_based_hcp_capacity_gauge
+      - mce_hs_addon_worker_node_resource_capacities_gauge
+      - mce_hs_addon_qps_gauge
+      - mce_hs_addon_request_based_hcp_capacity_current_gauge
       - mixin_pod_workload
       - namespace:kube_pod_container_resource_requests_cpu_cores:sum
       - namespace_memory:kube_pod_container_resource_requests:sum

--- a/operators/multiclusterobservability/manifests/base/grafana/dash-acm-hcp-overview.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/dash-acm-hcp-overview.yaml
@@ -305,7 +305,7 @@ data:
           },
           {
             "datasource": "$datasource",
-            "description": "These API server loads are used for estimating the maximum number of hosted control planes that can be hosted. For example, the est. Max (low) in the panel below is the estimate maximum number of hosted control planes that can be hosted when all hosted control planes put low load on the API server.",
+            "description": "These API server loads are used for estimating the maximum number of hosted control planes that can be hosted. For example, the est. Max. (low QPS) in the panel below is the estimate maximum number of hosted control planes that can be hosted when all hosted control planes put low load on the API server.",
             "fieldConfig": {
               "defaults": {
                 "color": {

--- a/operators/multiclusterobservability/manifests/base/grafana/dash-acm-hcp-overview.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/dash-acm-hcp-overview.yaml
@@ -25,7 +25,7 @@ data:
         "gnetId": null,
         "graphTooltip": 0,
         "id": 33,
-        "iteration": 1707270564886,
+        "iteration": 1707320583517,
         "links": [],
         "panels": [
           {
@@ -60,6 +60,7 @@ data:
           },
           {
             "datasource": "$datasource",
+            "description": "These are the worker nodes that can run hosted control planes.",
             "fieldConfig": {
               "defaults": {
                 "color": {
@@ -162,6 +163,7 @@ data:
           },
           {
             "datasource": "$datasource",
+            "description": "This panel displays the current number of unavailable/failing and available hosted control planes. Based on the hosted control plane resource requirements, it also displays the estimated maximum number of hosted control planes that can be hosted in this cluster.",
             "fieldConfig": {
               "defaults": {
                 "color": {
@@ -303,6 +305,7 @@ data:
           },
           {
             "datasource": "$datasource",
+            "description": "These API server loads are used for estimating the maximum number of hosted control planes that can be hosted. For example, the est. Max (low) in the panel below is the estimate maximum number of hosted control planes that can be hosted when all hosted control planes put low load on the API server.",
             "fieldConfig": {
               "defaults": {
                 "color": {
@@ -395,6 +398,7 @@ data:
           },
           {
             "datasource": "$datasource",
+            "description": "This panel displays the current number of unavailable/failing and available hosted control planes. Based on various loads, it also displays the estimated maximum number of hosted control planes that can be hosted in this cluster.",
             "fieldConfig": {
               "defaults": {
                 "color": {
@@ -584,6 +588,7 @@ data:
           },
           {
             "datasource": "$datasource",
+            "description": "This is the list of all hosted control planes in this cluster. Click on the hosted control plane name to see its resource utilization.",
             "fieldConfig": {
               "defaults": {
                 "color": {
@@ -734,9 +739,7 @@ data:
         "refresh": "1m",
         "schemaVersion": 30,
         "style": "dark",
-        "tags": [
-          "ACM"
-        ],
+        "tags": ["ACM"],
         "templating": {
           "list": [
             {
@@ -812,6 +815,6 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    general-folder: 'true'
+    general-folder: "true"
   name: grafana-dashboard-acm-hcp-overview
   namespace: open-cluster-management-observability

--- a/operators/multiclusterobservability/manifests/base/grafana/dash-acm-hcp-overview.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/dash-acm-hcp-overview.yaml
@@ -1,0 +1,815 @@
+apiVersion: v1
+data:
+  acm-hcp-overview.json: |-
+    {
+        "annotations": {
+          "list": [
+            {
+              "builtIn": 1,
+              "datasource": "-- Grafana --",
+              "enable": true,
+              "hide": true,
+              "iconColor": "rgba(0, 211, 255, 1)",
+              "name": "Annotations & Alerts",
+              "target": {
+                "limit": 100,
+                "matchAny": false,
+                "tags": [],
+                "type": "dashboard"
+              },
+              "type": "dashboard"
+            }
+          ]
+        },
+        "editable": true,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "id": 33,
+        "iteration": 1707270564886,
+        "links": [],
+        "panels": [
+          {
+            "datasource": "$datasource",
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "id": 20,
+            "title": "Estimated capacity based on HCP resource requests",
+            "type": "row"
+          },
+          {
+            "datasource": "$datasource",
+            "description": "",
+            "gridPos": {
+              "h": 12,
+              "w": 12,
+              "x": 0,
+              "y": 1
+            },
+            "id": 18,
+            "options": {
+              "content": "## Request-based resource limit\n\nTo understand the request-based resource limit, consider the total request value of a hosted control plane. To calculate that value, add the request values of all highly available hosted control plane pods across the namespace. The estimates are calculated based on the following resource request samples:\n\n* 78 pods\n* Five vCPU requests for each highly available hosted control plane\n* 18 GiB memory requests for each highly available hosted control plane",
+              "mode": "markdown"
+            },
+            "pluginVersion": "8.5.20",
+            "title": " Resource Request-base Limit Estimation",
+            "type": "text"
+          },
+          {
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "custom": {
+                  "align": "auto",
+                  "displayMode": "auto"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 12,
+              "x": 12,
+              "y": 1
+            },
+            "id": 26,
+            "options": {
+              "showHeader": true
+            },
+            "pluginVersion": "8.5.20",
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "mce_hs_addon_worker_node_resource_capacities_gauge",
+                "format": "table",
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "A"
+              }
+            ],
+            "title": "Worker Nodes Capacities",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Time": true,
+                    "Value": true,
+                    "__name__": true,
+                    "cluster": true,
+                    "clusterID": true,
+                    "container": true,
+                    "endpoint": true,
+                    "instance": true,
+                    "job": true,
+                    "namespace": true,
+                    "pod": true,
+                    "receive": true,
+                    "service": true,
+                    "tenant_id": true
+                  },
+                  "indexByName": {
+                    "Time": 0,
+                    "Value": 17,
+                    "__name__": 1,
+                    "cluster": 2,
+                    "clusterID": 3,
+                    "container": 4,
+                    "cpu": 6,
+                    "endpoint": 8,
+                    "instance": 9,
+                    "job": 10,
+                    "maxPods": 11,
+                    "memory": 7,
+                    "namespace": 12,
+                    "node": 5,
+                    "pod": 13,
+                    "receive": 14,
+                    "service": 15,
+                    "tenant_id": 16
+                  },
+                  "renameByName": {
+                    "cpu": "CPU",
+                    "maxPods": "Pod Limit",
+                    "memory": "Memory (GiB)",
+                    "node": "Worker Node"
+                  }
+                }
+              }
+            ],
+            "type": "table"
+          },
+          {
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Currently Unavailable"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "est. Max"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 5,
+              "w": 12,
+              "x": 12,
+              "y": 8
+            },
+            "id": 12,
+            "options": {
+              "displayMode": "gradient",
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "text": {}
+            },
+            "pluginVersion": "8.5.20",
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum(mce_hs_addon_hosted_control_planes_status_gauge{ready=\"false\"})",
+                "format": "time_series",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "Currently Unavailable",
+                "refId": "B"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(mce_hs_addon_hosted_control_planes_status_gauge{ready=\"true\"})",
+                "format": "time_series",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "Currently Available",
+                "refId": "A"
+              },
+              {
+                "exemplar": true,
+                "expr": "mce_hs_addon_request_based_hcp_capacity_gauge",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "est. Max",
+                "refId": "C"
+              }
+            ],
+            "title": "Number of HCPs",
+            "transformations": [],
+            "type": "bargauge"
+          },
+          {
+            "collapsed": false,
+            "datasource": "$datasource",
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 13
+            },
+            "id": 11,
+            "panels": [],
+            "title": "Estimated capacity based on API server query (QPS)",
+            "type": "row"
+          },
+          {
+            "datasource": "$datasource",
+            "gridPos": {
+              "h": 14,
+              "w": 12,
+              "x": 0,
+              "y": 14
+            },
+            "id": 24,
+            "options": {
+              "content": "## Load-based limit\n\nRequest-based sizing provides a maximum number of hosted control planes that can run based on the minimum request totals for the `Burstable` class, which meet the average resource usage. For sizing guidance that is tuned to higher levels of hosted cluster load, the load-based approach demonstrates resource usage at increasing API rates. The load-based approach builds in resource capacity for each hosted control plane to handle higher API load points.\n\nResource utilization is measured as the workload increased to the total namespace count. This data provides an estimation factor to increase the compute resource capacity based on the expected API load. Exact utilization rates can vary based on the type and pace of the cluster workload. \n\n| **Hosted control plane resource utilization scaling** | **vCPUs** | **Memory (GiB)** |\n| --- | --- | --- |\n| Default requests | 5 | 18 |\n| Usage when idle | 2.9 | 11.1 |\n| Incremental usage per 1000 increase in API rate | 9.0 | 2.5 |\n\nBy using these examples, you can factor in a load-based limit that is based on the expected rate of stress on the API, which is measured as the aggregated QPS across the 3 hosted API servers. For general sizing purposes, consider a 1000 QPS API rate to be a medium hosted cluster load and a 2000 QPS API to be a heavy hosted cluster load.",
+              "mode": "markdown"
+            },
+            "pluginVersion": "8.5.20",
+            "title": "Load-based Limit Estimation",
+            "type": "text"
+          },
+          {
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "custom": {
+                  "align": "center",
+                  "displayMode": "auto"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 6,
+              "w": 12,
+              "x": 12,
+              "y": 14
+            },
+            "id": 28,
+            "options": {
+              "showHeader": true
+            },
+            "pluginVersion": "8.5.20",
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "mce_hs_addon_qps_gauge",
+                "format": "table",
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "A"
+              }
+            ],
+            "title": "QPS Settings",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Time": true,
+                    "__name__": true,
+                    "cluster": true,
+                    "clusterID": true,
+                    "container": true,
+                    "endpoint": true,
+                    "instance": true,
+                    "job": true,
+                    "namespace": true,
+                    "pod": true,
+                    "receive": true,
+                    "service": true,
+                    "tenant_id": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {
+                    "Value": "Query Rate (QPS)",
+                    "rate": "Load on API Server"
+                  }
+                }
+              },
+              {
+                "id": "sortBy",
+                "options": {
+                  "fields": {},
+                  "sort": [
+                    {
+                      "desc": false,
+                      "field": "Query Rate (QPS)"
+                    }
+                  ]
+                }
+              }
+            ],
+            "type": "table"
+          },
+          {
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Currently Unavailable"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "est. Max. (low QPS)"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "est. Max. (medium QPS)"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "est. Max. (high QPS)"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "est. Max. (avg QPS)"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 20
+            },
+            "id": 6,
+            "options": {
+              "displayMode": "gradient",
+              "orientation": "horizontal",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "text": {}
+            },
+            "pluginVersion": "8.5.20",
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum(mce_hs_addon_hosted_control_planes_status_gauge{ready=\"false\"})",
+                "format": "time_series",
+                "instant": true,
+                "interval": "",
+                "legendFormat": "Currently Unavailable",
+                "refId": "A"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(mce_hs_addon_hosted_control_planes_status_gauge{ready=\"true\"})",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "Currently Available",
+                "refId": "B"
+              },
+              {
+                "exemplar": true,
+                "expr": "mce_hs_addon_qps_based_hcp_capacity_gauge{qps_rate=\"low\"}",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "est. Max. (low QPS)",
+                "refId": "C"
+              },
+              {
+                "exemplar": true,
+                "expr": "mce_hs_addon_qps_based_hcp_capacity_gauge{qps_rate=\"medium\"}",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "est. Max. (medium QPS)",
+                "refId": "D"
+              },
+              {
+                "exemplar": true,
+                "expr": "mce_hs_addon_qps_based_hcp_capacity_gauge{qps_rate=\"high\"}",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "est. Max. (high QPS)",
+                "refId": "E"
+              },
+              {
+                "exemplar": true,
+                "expr": "mce_hs_addon_qps_based_hcp_capacity_gauge{qps_rate=\"average\"}",
+                "hide": false,
+                "interval": "",
+                "legendFormat": "est. Max. (avg QPS)",
+                "refId": "F"
+              }
+            ],
+            "title": "Number of HCPs ",
+            "type": "bargauge"
+          },
+          {
+            "collapsed": false,
+            "datasource": "$datasource",
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 28
+            },
+            "id": 22,
+            "panels": [],
+            "title": "Hosted Control Planes List",
+            "type": "row"
+          },
+          {
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "custom": {
+                  "align": "auto",
+                  "displayMode": "auto"
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "false": {
+                        "color": "orange",
+                        "index": 1,
+                        "text": "Not ready"
+                      },
+                      "true": {
+                        "index": 0,
+                        "text": "Ready"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": ""
+                    }
+                  ]
+                }
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "hcp_name"
+                  },
+                  "properties": [
+                    {
+                      "id": "links",
+                      "value": [
+                        {
+                          "title": "",
+                          "url": "d/ZGfrZUtIz/acm-resources-hosted-control-plane?${__url_time_range}&var-hcp_ns=${__data.fields.hcp_namespace}"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "ready"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "mode": "continuous-GrYlRd"
+                      }
+                    },
+                    {
+                      "id": "custom.displayMode",
+                      "value": "color-text"
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "HCP name"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": null
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 29
+            },
+            "id": 16,
+            "options": {
+              "showHeader": true,
+              "sortBy": []
+            },
+            "pluginVersion": "8.5.20",
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "mce_hs_addon_hosted_control_planes_status_gauge",
+                "format": "table",
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "A"
+              }
+            ],
+            "title": "Hosted Control Plane List",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Time": true,
+                    "Value": true,
+                    "Value #A": true,
+                    "__name__": true,
+                    "cluster": true,
+                    "clusterID": true,
+                    "container": true,
+                    "endpoint": true,
+                    "instance": true,
+                    "job": true,
+                    "namespace": true,
+                    "pod": true,
+                    "receive": true,
+                    "service": true,
+                    "tenant_id": true
+                  },
+                  "indexByName": {},
+                  "renameByName": {
+                    "hcp_name": "HCP name",
+                    "hcp_namespace": "HCP namespace",
+                    "ready": "Status",
+                    "version": "Version"
+                  }
+                }
+              }
+            ],
+            "type": "table"
+          }
+        ],
+        "refresh": "1m",
+        "schemaVersion": 30,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+          "list": [
+            {
+              "current": {
+                "selected": false,
+                "text": "Observatorium",
+                "value": "Observatorium"
+              },
+              "description": null,
+              "error": null,
+              "hide": 2,
+              "includeAll": false,
+              "label": null,
+              "multi": false,
+              "name": "datasource",
+              "options": [],
+              "query": "prometheus",
+              "refresh": 2,
+              "regex": "",
+              "skipUrlSync": false,
+              "type": "datasource"
+            },
+            {
+              "allValue": null,
+              "current": {
+                "isNone": true,
+                "selected": false,
+                "text": "None",
+                "value": ""
+              },
+              "datasource": "$datasource",
+              "definition": "mce_hs_addon_total_hosted_control_planes_gaug",
+              "description": null,
+              "error": null,
+              "hide": 2,
+              "includeAll": false,
+              "label": null,
+              "multi": false,
+              "name": "num_hcps",
+              "options": [],
+              "query": {
+                "query": "mce_hs_addon_total_hosted_control_planes_gaug",
+                "refId": "StandardVariableQuery"
+              },
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 0,
+              "type": "query"
+            }
+          ]
+        },
+        "time": {
+          "from": "now-3h",
+          "to": "now"
+        },
+        "timepicker": {
+          "refresh_intervals": [
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+          ]
+        },
+        "timezone": "browser",
+        "title": "ACM - Hosted Control Planes Overview",
+        "uid": "W8U46xpIk",
+        "version": 1
+      }
+kind: ConfigMap
+metadata:
+  labels:
+    general-folder: 'true'
+  name: grafana-dashboard-acm-hcp-overview
+  namespace: open-cluster-management-observability

--- a/operators/multiclusterobservability/manifests/base/grafana/dash-acm-hcp-overview.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/dash-acm-hcp-overview.yaml
@@ -734,7 +734,9 @@ data:
         "refresh": "1m",
         "schemaVersion": 30,
         "style": "dark",
-        "tags": [],
+        "tags": [
+          "ACM"
+        ],
         "templating": {
           "list": [
             {

--- a/operators/multiclusterobservability/manifests/base/grafana/dash-acm-resources-hcp.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/dash-acm-resources-hcp.yaml
@@ -641,7 +641,9 @@ data:
         ],
         "schemaVersion": 30,
         "style": "dark",
-        "tags": [],
+        "tags": [
+          "ACM"
+        ],
         "templating": {
           "list": [
             {

--- a/operators/multiclusterobservability/manifests/base/grafana/dash-acm-resources-hcp.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/dash-acm-resources-hcp.yaml
@@ -1,0 +1,721 @@
+apiVersion: v1
+data:
+  acm-hcp-resources.json: |-
+    {
+        "annotations": {
+          "list": [
+            {
+              "builtIn": 1,
+              "datasource": "-- Grafana --",
+              "enable": true,
+              "hide": true,
+              "iconColor": "rgba(0, 211, 255, 1)",
+              "name": "Annotations & Alerts",
+              "target": {
+                "limit": 100,
+                "matchAny": false,
+                "tags": [],
+                "type": "dashboard"
+              },
+              "type": "dashboard"
+            }
+          ]
+        },
+        "editable": true,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "id": 35,
+        "iteration": 1707272011958,
+        "links": [],
+        "panels": [
+          {
+            "datasource": null,
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 4,
+              "w": 3,
+              "x": 0,
+              "y": 0
+            },
+            "id": 12,
+            "options": {
+              "colorMode": "none",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "text": {},
+              "textMode": "auto"
+            },
+            "pluginVersion": "8.5.20",
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_owner{namespace=\"$hcp_ns\"})",
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "A"
+              }
+            ],
+            "title": "Number of pods",
+            "type": "stat"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 8,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 16,
+              "w": 21,
+              "x": 3,
+              "y": 0
+            },
+            "hiddenSeries": false,
+            "id": 2,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "nullPointMode": "null",
+            "options": {
+              "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "8.5.20",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=\"$hcp_ns\"}) by (pod)",
+                "interval": "",
+                "legendFormat": "{{pod}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CPU usage",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "datasource": null,
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 4,
+              "w": 3,
+              "x": 0,
+              "y": 4
+            },
+            "id": 6,
+            "options": {
+              "colorMode": "none",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "text": {},
+              "textMode": "auto"
+            },
+            "pluginVersion": "8.5.20",
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum{namespace=\"$hcp_ns\"}) by (namespace) / sum(kube_pod_container_resource_requests:sum{resource=\"cpu\",namespace=\"$hcp_ns\"}) by (namespace)",
+                "instant": false,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "A"
+              }
+            ],
+            "title": "CPU Requests %",
+            "type": "stat"
+          },
+          {
+            "datasource": null,
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 4,
+              "w": 3,
+              "x": 0,
+              "y": 8
+            },
+            "id": 10,
+            "options": {
+              "colorMode": "none",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "text": {},
+              "textMode": "auto"
+            },
+            "pluginVersion": "8.5.20",
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "kube_pod_container_resource_requests:sum{namespace=\"$hcp_ns\", resource=\"cpu\"}",
+                "instant": false,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "A"
+              }
+            ],
+            "title": "CPU Requests",
+            "type": "stat"
+          },
+          {
+            "datasource": null,
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 4,
+              "w": 3,
+              "x": 0,
+              "y": 12
+            },
+            "id": 8,
+            "options": {
+              "colorMode": "none",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "text": {},
+              "textMode": "auto"
+            },
+            "pluginVersion": "8.5.20",
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "node_namespace_pod_container:container_cpu_usage_seconds_total:sum{namespace=\"$hcp_ns\"}",
+                "instant": false,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "A"
+              }
+            ],
+            "title": "CPU Usage",
+            "type": "stat"
+          },
+          {
+            "datasource": null,
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 4,
+              "w": 3,
+              "x": 0,
+              "y": 16
+            },
+            "id": 14,
+            "options": {
+              "colorMode": "none",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "text": {},
+              "textMode": "auto"
+            },
+            "pluginVersion": "8.5.20",
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum(container_memory_rss:sum{namespace=\"$hcp_ns\", container!=\"\"}) by (namespace) / sum(kube_pod_container_resource_requests:sum{namespace=\"$hcp_ns\", resource=\"memory\"}) by (namespace)",
+                "instant": false,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "A"
+              }
+            ],
+            "title": "Memory Requests %",
+            "type": "stat"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fieldConfig": {
+              "defaults": {
+                "unit": "bytes"
+              },
+              "overrides": []
+            },
+            "fill": 8,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 14,
+              "w": 21,
+              "x": 3,
+              "y": 16
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "nullPointMode": "null",
+            "options": {
+              "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "8.5.20",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum(container_memory_rss{job=\"kubelet\",namespace=~\"$hcp_ns\"}) by (pod)",
+                "interval": "",
+                "legendFormat": "{{pod}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Memory Usage (w/o cache)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "bytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "datasource": null,
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "bytes"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 5,
+              "w": 3,
+              "x": 0,
+              "y": 20
+            },
+            "id": 18,
+            "options": {
+              "colorMode": "none",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "text": {},
+              "textMode": "auto"
+            },
+            "pluginVersion": "8.5.20",
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_requests:sum{namespace=\"$hcp_ns\", resource=\"memory\"})",
+                "instant": false,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "A"
+              }
+            ],
+            "title": "Memory Requests",
+            "type": "stat"
+          },
+          {
+            "datasource": null,
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                },
+                "unit": "decbytes"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 5,
+              "w": 3,
+              "x": 0,
+              "y": 25
+            },
+            "id": 16,
+            "options": {
+              "colorMode": "none",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "text": {},
+              "textMode": "auto"
+            },
+            "pluginVersion": "8.5.20",
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum(container_memory_rss:sum{namespace=\"$hcp_ns\", container!=\"\"})",
+                "instant": false,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "A"
+              }
+            ],
+            "title": "Memory Usage",
+            "type": "stat"
+          }
+        ],
+        "schemaVersion": 30,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+          "list": [
+            {
+              "current": {
+                "selected": false,
+                "text": "Observatorium",
+                "value": "Observatorium"
+              },
+              "description": null,
+              "error": null,
+              "hide": 2,
+              "includeAll": false,
+              "label": null,
+              "multi": false,
+              "name": "datasource",
+              "options": [],
+              "query": "prometheus",
+              "refresh": 2,
+              "regex": "",
+              "skipUrlSync": false,
+              "type": "datasource"
+            },
+            {
+              "allValue": null,
+              "current": {
+                "selected": true,
+                "text": "test-hcps-rj-0202a",
+                "value": "test-hcps-rj-0202a"
+              },
+              "datasource": "$datasource",
+              "definition": "label_values(mce_hs_addon_hosted_control_planes_status_gauge, hcp_namespace)",
+              "description": null,
+              "error": null,
+              "hide": 0,
+              "includeAll": false,
+              "label": "HCP Namespace",
+              "multi": false,
+              "name": "hcp_ns",
+              "options": [],
+              "query": {
+                "query": "label_values(mce_hs_addon_hosted_control_planes_status_gauge, hcp_namespace)",
+                "refId": "StandardVariableQuery"
+              },
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 0,
+              "type": "query"
+            }
+          ]
+        },
+        "time": {
+          "from": "now-3h",
+          "to": "now"
+        },
+        "timepicker": {
+          "refresh_intervals": [
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+          ]
+        },
+        "timezone": "browser",
+        "title": "ACM - Resources - Hosted Control Plane",
+        "uid": "ZGfrZUtIz",
+        "version": 1
+      }
+kind: ConfigMap
+metadata:
+  labels:
+    general-folder: "true"
+  name: grafana-dashboard-acm-resources-hcp
+  namespace: open-cluster-management-observability


### PR DESCRIPTION
This is for story https://issues.redhat.com/browse/ACM-9018 to add two new grafana dashboards.

- `ACM - Hosted Control Planes Overview` dashboard to show the cluster's capacity estimate for hosting hosted control planes and the related cluster resources.
- `ACM - Resources - Hosted Control Plan` dashboard that users can drill down from the overview page to see the resource utilizations of the selected hosted control plane.