### PR TITLE
alert: make ACMRemoteWriteError less prone to flakes/flapping

### DIFF
--- a/operators/multiclusterobservability/manifests/base/alertmanager/prometheusrule.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/prometheusrule.yaml
@@ -13,7 +13,8 @@ spec:
           annotations:
             summary: "Error in remote write."
             description: "There are errors when sending requests to remote write endpoint: {{ $labels.name }}"
-          expr: increase(acm_remote_write_requests_total{code!~"2.*"}[5m]) > 10
+          expr: sum by (code)(rate(acm_remote_write_requests_total{code!~"2.*"}[5m])) > 10
+          for: 10m
           labels:
             severity: critical
     - name: acm-thanos-compact


### PR DESCRIPTION
This is a first pass at making this alert less noisy without introducing too much change on it initially.  
An alert should be actionable but in many cases here, the response codes can be in the 4xx unrecoverable range which means the alert can fire when essentially there is no data loss or the customer cannot intervene.

https://issues.redhat.com/browse/ACM-4820