### PR TITLE
fix a metric query to use instant value

### DIFF
--- a/operators/multiclusterobservability/manifests/base/grafana/dash-acm-hcp-overview.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/dash-acm-hcp-overview.yaml
@@ -565,6 +565,7 @@ data:
                 "expr": "mce_hs_addon_qps_based_hcp_capacity_gauge{qps_rate=\"average\"}",
                 "hide": false,
                 "interval": "",
+                "instant": true,
                 "legendFormat": "est. Max. (avg QPS)",
                 "refId": "F"
               }


### PR DESCRIPTION
One of the queries needs to be fixed to use an instant time series value.