### PR TITLE
[ACM-8543] Tag Observatorium CR with a hash of all the config it uses

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -310,6 +310,14 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	clientCACerts := newTestCert(config.ClientCACerts, namespace)
 	grafanaCert := newTestCert(config.GrafanaCerts, namespace)
 	serverCert := newTestCert(config.ServerCerts, namespace)
+	obsAPICert := newTestCert(config.GetOperandNamePrefix()+config.ObservatoriumAPI, namespace)
+	obsAPIConfigMap := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: config.GetOperandNamePrefix() + "observatorium-api", Namespace: namespace},
+		Data: map[string]string{
+			"config.yaml": "test",
+		},
+	}
 	// byo case for proxy
 	proxyRouteBYOCACerts := newTestCert(config.ProxyRouteBYOCAName, namespace)
 	proxyRouteBYOCert := newTestCert(config.ProxyRouteBYOCERTName, namespace)
@@ -319,23 +327,7 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	clustermgmtAddon := newClusterManagementAddon()
 
 	objs := []runtime.Object{mco, svc, serverCACerts, clientCACerts, proxyRouteBYOCACerts, grafanaCert, serverCert,
-		testAmRouteBYOCaSecret, testAmRouteBYOCertSecret, proxyRouteBYOCert, clustermgmtAddon}
-	objs = append(objs, []runtime.Object{
-		&corev1.Secret{
-			TypeMeta:   metav1.TypeMeta{Kind: "Secret"},
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetOperandNamePrefix() + "observatorium-api", Namespace: namespace},
-			Data: map[string][]byte{
-				"tls.crt": []byte("test"),
-			},
-		},
-		&corev1.ConfigMap{
-			TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap"},
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetOperandNamePrefix() + "observatorium-api", Namespace: namespace},
-			Data: map[string]string{
-				"config.yaml": "test",
-			},
-		},
-	}...)
+		testAmRouteBYOCaSecret, testAmRouteBYOCertSecret, proxyRouteBYOCert, clustermgmtAddon, obsAPICert, obsAPIConfigMap}
 
 	// Create a fake client to mock API calls.
 	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
@@ -722,6 +714,14 @@ func TestImageReplaceForMCO(t *testing.T) {
 	clientCACerts := newTestCert(config.ClientCACerts, namespace)
 	grafanaCert := newTestCert(config.GrafanaCerts, namespace)
 	serverCert := newTestCert(config.ServerCerts, namespace)
+	obsAPICert := newTestCert(config.GetOperandNamePrefix()+config.ObservatoriumAPI, namespace)
+	obsAPIConfigMap := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: config.GetOperandNamePrefix() + "observatorium-api", Namespace: namespace},
+		Data: map[string]string{
+			"config.yaml": "test",
+		},
+	}
 	// create the image manifest configmap
 	testMCHInstance := newMCHInstanceWithVersion(config.GetMCONamespace(), version)
 	imageManifestsCM := newTestImageManifestsConfigMap(config.GetMCONamespace(), version)
@@ -731,7 +731,7 @@ func TestImageReplaceForMCO(t *testing.T) {
 	clustermgmtAddon := newClusterManagementAddon()
 
 	objs := []runtime.Object{mco, observatoriumAPIsvc, serverCACerts, clientCACerts, grafanaCert, serverCert,
-		testMCHInstance, imageManifestsCM, testAmRouteBYOCaSecret, testAmRouteBYOCertSecret, clustermgmtAddon}
+		testMCHInstance, imageManifestsCM, testAmRouteBYOCaSecret, testAmRouteBYOCertSecret, clustermgmtAddon, obsAPICert, obsAPIConfigMap}
 	// Create a fake client to mock API calls.
 	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -34,12 +34,13 @@ import (
 
 	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+
 	mcoshared "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/shared"
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/rendering/templates"
-	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 
 func init() {
@@ -58,7 +59,7 @@ func setupTest(t *testing.T) func() {
 	manifestsPath := path.Join(wd, "../../manifests")
 	os.Setenv("TEMPLATES_PATH", testManifestsPath)
 	templates.ResetTemplates()
-	//clean up the manifest path if left over from previous test
+	// clean up the manifest path if left over from previous test
 	if fi, err := os.Lstat(testManifestsPath); err == nil && fi.Mode()&os.ModeSymlink != 0 {
 		if err = os.Remove(testManifestsPath); err != nil {
 			t.Logf("Failed to delete symlink(%s) for the test manifests: (%v)", testManifestsPath, err)
@@ -309,7 +310,7 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	clientCACerts := newTestCert(config.ClientCACerts, namespace)
 	grafanaCert := newTestCert(config.GrafanaCerts, namespace)
 	serverCert := newTestCert(config.ServerCerts, namespace)
-	//byo case for proxy
+	// byo case for proxy
 	proxyRouteBYOCACerts := newTestCert(config.ProxyRouteBYOCAName, namespace)
 	proxyRouteBYOCert := newTestCert(config.ProxyRouteBYOCERTName, namespace)
 	// byo case for the alertmanager route
@@ -319,6 +320,23 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 
 	objs := []runtime.Object{mco, svc, serverCACerts, clientCACerts, proxyRouteBYOCACerts, grafanaCert, serverCert,
 		testAmRouteBYOCaSecret, testAmRouteBYOCertSecret, proxyRouteBYOCert, clustermgmtAddon}
+	objs = append(objs, []runtime.Object{
+		&corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: config.GetOperandNamePrefix() + "observatorium-api", Namespace: namespace},
+			Data: map[string][]byte{
+				"tls.crt": []byte("test"),
+			},
+		},
+		&corev1.ConfigMap{
+			TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap"},
+			ObjectMeta: metav1.ObjectMeta{Name: config.GetOperandNamePrefix() + "observatorium-api", Namespace: namespace},
+			Data: map[string]string{
+				"config.yaml": "test",
+			},
+		},
+	}...)
+
 	// Create a fake client to mock API calls.
 	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
@@ -339,10 +357,10 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
 	}
-	//wait for update status
+	// wait for update status
 	time.Sleep(1 * time.Second)
 
-	//verify openshiftcluster monitoring label is set to true in namespace
+	// verify openshiftcluster monitoring label is set to true in namespace
 	updatedNS := &corev1.Namespace{}
 	err = cl.Get(context.TODO(), types.NamespacedName{
 		Name: namespace,
@@ -398,7 +416,7 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
 	}
-	//wait for update status
+	// wait for update status
 	time.Sleep(1 * time.Second)
 
 	updatedObjectStoreSecret := &corev1.Secret{}
@@ -434,7 +452,7 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
 	}
-	//wait for update status
+	// wait for update status
 	time.Sleep(1 * time.Second)
 
 	updatedConfigmap := &corev1.ConfigMap{}
@@ -473,7 +491,7 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
 	}
-	//wait for update status
+	// wait for update status
 	time.Sleep(1 * time.Second)
 
 	updatedMCO = &mcov1beta2.MultiClusterObservability{}
@@ -509,7 +527,7 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 			t.Fatalf("reconcile: (%v)", err)
 		}
 	}
-	//wait for update status
+	// wait for update status
 	time.Sleep(1 * time.Second)
 
 	updatedMCO = &mcov1beta2.MultiClusterObservability{}
@@ -552,7 +570,7 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
 	}
-	//wait for update status
+	// wait for update status
 	time.Sleep(1 * time.Second)
 
 	updatedMCO = &mcov1beta2.MultiClusterObservability{}
@@ -586,7 +604,7 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
 	}
-	//wait for update status
+	// wait for update status
 	time.Sleep(1 * time.Second)
 
 	updatedMCO = &mcov1beta2.MultiClusterObservability{}
@@ -626,7 +644,7 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
 	}
-	//wait for update status
+	// wait for update status
 	time.Sleep(1 * time.Second)
 
 	updatedMCO = &mcov1beta2.MultiClusterObservability{}
@@ -640,7 +658,7 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 		t.Errorf("Failed to get correct MCO status, expect Ready")
 	}
 
-	//Test finalizer
+	// Test finalizer
 	mco.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 	mco.ObjectMeta.Finalizers = []string{resFinalizer, "test-finalizerr"}
 	mco.ObjectMeta.ResourceVersion = updatedMCO.ObjectMeta.ResourceVersion
@@ -738,7 +756,7 @@ func TestImageReplaceForMCO(t *testing.T) {
 		t.Fatalf("reconcile: (%v)", err)
 	}
 
-	//wait for update status
+	// wait for update status
 	time.Sleep(1 * time.Second)
 
 	expectedDeploymentNames := []string{
@@ -811,7 +829,7 @@ func TestImageReplaceForMCO(t *testing.T) {
 
 	// stop update status routine
 	stopStatusUpdate <- struct{}{}
-	//wait for update status
+	// wait for update status
 	time.Sleep(1 * time.Second)
 }
 
@@ -1013,7 +1031,7 @@ func TestPrometheusRulesRemovedFromOpenshiftMonitoringNamespace(t *testing.T) {
 			Name:      "acm-observability-alert-rules",
 			Namespace: "openshift-monitoring",
 		},
-		//Sample rules
+		// Sample rules
 		Spec: monitoringv1.PrometheusRuleSpec{
 			Groups: []monitoringv1.RuleGroup{
 				{

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -310,14 +310,6 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	clientCACerts := newTestCert(config.ClientCACerts, namespace)
 	grafanaCert := newTestCert(config.GrafanaCerts, namespace)
 	serverCert := newTestCert(config.ServerCerts, namespace)
-	obsAPICert := newTestCert(config.GetOperandNamePrefix()+config.ObservatoriumAPI, namespace)
-	obsAPIConfigMap := &corev1.ConfigMap{
-		TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap"},
-		ObjectMeta: metav1.ObjectMeta{Name: config.GetOperandNamePrefix() + "observatorium-api", Namespace: namespace},
-		Data: map[string]string{
-			"config.yaml": "test",
-		},
-	}
 	// byo case for proxy
 	proxyRouteBYOCACerts := newTestCert(config.ProxyRouteBYOCAName, namespace)
 	proxyRouteBYOCert := newTestCert(config.ProxyRouteBYOCERTName, namespace)
@@ -327,7 +319,7 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	clustermgmtAddon := newClusterManagementAddon()
 
 	objs := []runtime.Object{mco, svc, serverCACerts, clientCACerts, proxyRouteBYOCACerts, grafanaCert, serverCert,
-		testAmRouteBYOCaSecret, testAmRouteBYOCertSecret, proxyRouteBYOCert, clustermgmtAddon, obsAPICert, obsAPIConfigMap}
+		testAmRouteBYOCaSecret, testAmRouteBYOCertSecret, proxyRouteBYOCert, clustermgmtAddon}
 
 	// Create a fake client to mock API calls.
 	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
@@ -714,14 +706,6 @@ func TestImageReplaceForMCO(t *testing.T) {
 	clientCACerts := newTestCert(config.ClientCACerts, namespace)
 	grafanaCert := newTestCert(config.GrafanaCerts, namespace)
 	serverCert := newTestCert(config.ServerCerts, namespace)
-	obsAPICert := newTestCert(config.GetOperandNamePrefix()+config.ObservatoriumAPI, namespace)
-	obsAPIConfigMap := &corev1.ConfigMap{
-		TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap"},
-		ObjectMeta: metav1.ObjectMeta{Name: config.GetOperandNamePrefix() + "observatorium-api", Namespace: namespace},
-		Data: map[string]string{
-			"config.yaml": "test",
-		},
-	}
 	// create the image manifest configmap
 	testMCHInstance := newMCHInstanceWithVersion(config.GetMCONamespace(), version)
 	imageManifestsCM := newTestImageManifestsConfigMap(config.GetMCONamespace(), version)
@@ -731,7 +715,7 @@ func TestImageReplaceForMCO(t *testing.T) {
 	clustermgmtAddon := newClusterManagementAddon()
 
 	objs := []runtime.Object{mco, observatoriumAPIsvc, serverCACerts, clientCACerts, grafanaCert, serverCert,
-		testMCHInstance, imageManifestsCM, testAmRouteBYOCaSecret, testAmRouteBYOCertSecret, clustermgmtAddon, obsAPICert, obsAPIConfigMap}
+		testMCHInstance, imageManifestsCM, testAmRouteBYOCaSecret, testAmRouteBYOCertSecret, clustermgmtAddon}
 	// Create a fake client to mock API calls.
 	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -7,6 +7,7 @@ package multiclusterobservability
 import (
 	"bytes"
 	"context"
+
 	// The import of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
 	// changes and thus it's not a security issue.
 	// nolint:gosec

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -7,10 +7,9 @@ package multiclusterobservability
 import (
 	"bytes"
 	"context"
-
 	// The import of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
 	// changes and thus it's not a security issue.
-	// nolint:gosec
+	//nolint:gosec
 	"crypto/md5"
 	"encoding/hex"
 	"errors"
@@ -58,6 +57,7 @@ const (
 // Fetch contents of the secrets: observability-server-certs, observability-client-ca-certs, observability-observatorium-api.
 // Fetch contents of the configmap: observability-observatorium-api.
 // Concatenate all of the above and hash their contents.
+// If any of the secrets or configmaps aren't found, an empty struct of the respective type is used for the hash.
 func hashObservatoriumCRConfig(cl client.Client) (string, error) {
 	secretsToQuery := []metav1.ObjectMeta{
 		{Name: mcoconfig.ServerCerts, Namespace: mcoconfig.GetDefaultNamespace()},
@@ -70,7 +70,7 @@ func hashObservatoriumCRConfig(cl client.Client) (string, error) {
 
 	// The usage of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
 	// changes and thus it's not a security issue.
-	// nolint:gosec
+	//nolint:gosec
 	hasher := md5.New()
 	for _, secret := range secretsToQuery {
 		resultSecret := &v1.Secret{}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -7,6 +7,7 @@ package multiclusterobservability
 import (
 	"bytes"
 	"context"
+
 	// The import of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
 	// changes and thus it's not a security issue.
 	//nolint:gosec

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -11,7 +11,7 @@ import (
 	// The import of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
 	// changes and thus it's not a security issue.
 	// nolint:gosec
-	"crypto/md5" // #nosec G401
+	"crypto/md5" // #nosec G401 G501
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -73,7 +73,7 @@ func hashObservatoriumCRConfig(cl client.Client) (string, error) {
 	// The usage of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
 	// changes and thus it's not a security issue.
 	// nolint:gosec
-	hasher := md5.New() // #nosec G401
+	hasher := md5.New() // #nosec G401 G501
 	for _, secret := range secretsToQuery {
 		resultSecret := &v1.Secret{}
 		err := cl.Get(context.TODO(), types.NamespacedName{

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -7,6 +7,10 @@ package multiclusterobservability
 import (
 	"bytes"
 	"context"
+
+	// The import of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
+	// changes and thus it's not a security issue.
+	// nolint:gosec
 	"crypto/md5"
 	"encoding/hex"
 	"errors"
@@ -64,6 +68,9 @@ func hashObservatoriumCRConfig(cl client.Client) (string, error) {
 		Name: mcoconfig.GetOperandNamePrefix() + mcoconfig.ObservatoriumAPI, Namespace: mcoconfig.GetDefaultNamespace(),
 	}
 
+	// The usage of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
+	// changes and thus it's not a security issue.
+	// nolint:gosec
 	hasher := md5.New()
 	for _, secret := range secretsToQuery {
 		resultSecret := &v1.Secret{}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -10,7 +10,8 @@ import (
 
 	// The import of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
 	// changes and thus it's not a security issue.
-	"crypto/md5" // nolint:gosec
+	// nolint:gosec
+	"crypto/md5"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -54,7 +55,8 @@ const (
 	endpointsRestartLabel = "endpoints/time-restarted"
 )
 
-// Fetch contents of the secrets: observability-server-certs, observability-client-ca-certs, observability-observatorium-api.
+// Fetch contents of the secrets: observability-server-certs, observability-client-ca-certs,
+// observability-observatorium-api.
 // Fetch contents of the configmap: observability-observatorium-api.
 // Concatenate all of the above and hash their contents.
 // If any of the secrets or configmaps aren't found, an empty struct of the respective type is used for the hash.
@@ -70,10 +72,14 @@ func hashObservatoriumCRConfig(cl client.Client) (string, error) {
 
 	// The usage of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
 	// changes and thus it's not a security issue.
-	hasher := md5.New() // nolint:gosec
+	// nolint:gosec
+	hasher := md5.New()
 	for _, secret := range secretsToQuery {
 		resultSecret := &v1.Secret{}
-		err := cl.Get(context.TODO(), types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, resultSecret)
+		err := cl.Get(context.TODO(), types.NamespacedName{
+			Name:      secret.Name,
+			Namespace: secret.Namespace,
+		}, resultSecret)
 		if err != nil && !k8serrors.IsNotFound(err) {
 			return "", err
 		}
@@ -85,7 +91,10 @@ func hashObservatoriumCRConfig(cl client.Client) (string, error) {
 	}
 
 	resultConfigMap := &v1.ConfigMap{}
-	err := cl.Get(context.TODO(), types.NamespacedName{Name: configMapToQuery.Name, Namespace: configMapToQuery.Namespace}, resultConfigMap)
+	err := cl.Get(context.TODO(), types.NamespacedName{
+		Name:      configMapToQuery.Name,
+		Namespace: configMapToQuery.Namespace,
+	}, resultConfigMap)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return "", err
 	}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -11,7 +11,7 @@ import (
 	// The import of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
 	// changes and thus it's not a security issue.
 	// nolint:gosec
-	"crypto/md5"
+	"crypto/md5" // #nosec G401
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -73,7 +73,7 @@ func hashObservatoriumCRConfig(cl client.Client) (string, error) {
 	// The usage of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
 	// changes and thus it's not a security issue.
 	// nolint:gosec
-	hasher := md5.New()
+	hasher := md5.New() // #nosec G401
 	for _, secret := range secretsToQuery {
 		resultSecret := &v1.Secret{}
 		err := cl.Get(context.TODO(), types.NamespacedName{

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -7,7 +7,6 @@ package multiclusterobservability
 import (
 	"bytes"
 	"context"
-
 	// The import of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
 	// changes and thus it's not a security issue.
 	// nolint:gosec
@@ -75,7 +74,7 @@ func hashObservatoriumCRConfig(cl client.Client) (string, error) {
 	for _, secret := range secretsToQuery {
 		resultSecret := &v1.Secret{}
 		err := cl.Get(context.TODO(), types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, resultSecret)
-		if err != nil {
+		if err != nil && !k8serrors.IsNotFound(err) {
 			return "", err
 		}
 		secretData, err := yaml.Marshal(resultSecret.Data)
@@ -87,7 +86,7 @@ func hashObservatoriumCRConfig(cl client.Client) (string, error) {
 
 	resultConfigMap := &v1.ConfigMap{}
 	err := cl.Get(context.TODO(), types.NamespacedName{Name: configMapToQuery.Name, Namespace: configMapToQuery.Namespace}, resultConfigMap)
-	if err != nil {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		return "", err
 	}
 	configMapData, err := yaml.Marshal(resultConfigMap.Data)

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -10,8 +10,7 @@ import (
 
 	// The import of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
 	// changes and thus it's not a security issue.
-	//nolint:gosec
-	"crypto/md5"
+	"crypto/md5" // nolint:gosec
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -71,8 +70,7 @@ func hashObservatoriumCRConfig(cl client.Client) (string, error) {
 
 	// The usage of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
 	// changes and thus it's not a security issue.
-	//nolint:gosec
-	hasher := md5.New()
+	hasher := md5.New() // nolint:gosec
 	for _, secret := range secretsToQuery {
 		resultSecret := &v1.Secret{}
 		err := cl.Get(context.TODO(), types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, resultSecret)

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
@@ -192,14 +192,14 @@ func TestNoUpdateObservatoriumCR(t *testing.T) {
 		},
 		&corev1.Secret{
 			TypeMeta:   metav1.TypeMeta{Kind: "Secret"},
-			ObjectMeta: metav1.ObjectMeta{Name: mcoconfig.GetOperandNamePrefix() + "observatorium-api", Namespace: namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: mcoconfig.GetOperandNamePrefix() + mcoconfig.ObservatoriumAPI, Namespace: namespace},
 			Data: map[string][]byte{
 				"tls.crt": []byte("test"),
 			},
 		},
 		&corev1.ConfigMap{
 			TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap"},
-			ObjectMeta: metav1.ObjectMeta{Name: mcoconfig.GetOperandNamePrefix() + "observatorium-api", Namespace: namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: mcoconfig.GetOperandNamePrefix() + mcoconfig.ObservatoriumAPI, Namespace: namespace},
 			Data: map[string]string{
 				"config.yaml": "test",
 			},


### PR DESCRIPTION
This should make the CR's hash change. As the CR's hash is used to annotate the Observatorium API pods, these will be rolled out and pick up any new value from the configmaps or secrets.