### PR TITLE
[ACM-8543] Fix reconciliation on Observatorium CR for update scenario

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -7,6 +7,7 @@ package multiclusterobservability
 import (
 	"bytes"
 	"context"
+
 	// The import of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
 	// changes and thus it's not a security issue.
 	// nolint:gosec

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -7,7 +7,6 @@ package multiclusterobservability
 import (
 	"bytes"
 	"context"
-
 	// The import of crypto/md5 below is not for cryptographic use. It is used to hash the contents of files to track
 	// changes and thus it's not a security issue.
 	// nolint:gosec
@@ -178,11 +177,13 @@ func GenerateObservatoriumCR(
 		return &ctrl.Result{}, err
 	}
 
+	foundHash := observatoriumCRFound.Labels["config-hash"]
+
 	oldSpec := observatoriumCRFound.Spec
 	newSpec := observatoriumCR.Spec
 	oldSpecBytes, _ := yaml.Marshal(oldSpec)
 	newSpecBytes, _ := yaml.Marshal(newSpec)
-	if bytes.Equal(newSpecBytes, oldSpecBytes) {
+	if bytes.Equal(newSpecBytes, oldSpecBytes) && hash == foundHash {
 		return nil, nil
 	}
 

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -183,8 +183,8 @@ func GenerateObservatoriumCR(
 	newSpec := observatoriumCR.Spec
 	oldSpecBytes, _ := yaml.Marshal(oldSpec)
 	newSpecBytes, _ := yaml.Marshal(newSpec)
-	if bytes.Equal(newSpecBytes, oldSpecBytes) { // &&
-		// labels[obsCRConfigHashLabelName] == observatoriumCRFound.Labels[obsCRConfigHashLabelName] {
+	if bytes.Equal(newSpecBytes, oldSpecBytes) &&
+		labels[obsCRConfigHashLabelName] == observatoriumCRFound.Labels[obsCRConfigHashLabelName] {
 		return nil, nil
 	}
 

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -178,13 +178,11 @@ func GenerateObservatoriumCR(
 		return &ctrl.Result{}, err
 	}
 
-	foundHash := observatoriumCRFound.Labels["config-hash"]
-
 	oldSpec := observatoriumCRFound.Spec
 	newSpec := observatoriumCR.Spec
 	oldSpecBytes, _ := yaml.Marshal(oldSpec)
 	newSpecBytes, _ := yaml.Marshal(newSpec)
-	if bytes.Equal(newSpecBytes, oldSpecBytes) && hash == foundHash {
+	if bytes.Equal(newSpecBytes, oldSpecBytes) && hash == observatoriumCRFound.Labels["config-hash"] {
 		return nil, nil
 	}
 
@@ -201,6 +199,7 @@ func GenerateObservatoriumCR(
 
 	newObj := observatoriumCRFound.DeepCopy()
 	newObj.Spec = newSpec
+	newObj.Labels["config-hash"] = observatoriumCR.Labels["config-hash"]
 	err = cl.Update(context.TODO(), newObj)
 	if err != nil {
 		log.Error(err, "Failed to update observatorium CR %s", "name", observatoriumCR.Name)

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -178,23 +178,13 @@ func GenerateObservatoriumCR(
 	} else if err != nil {
 		return &ctrl.Result{}, err
 	}
-	log.Info(
-		"Observatorium CR already exists",
-		"config-hash",
-		observatoriumCRFound.Labels[obsCRConfigHashLabelName],
-	)
-	log.Info(
-		"Desired Observatorium CR config hash",
-		"config-hash",
-		observatoriumCR.Labels[obsCRConfigHashLabelName],
-	)
 
 	oldSpec := observatoriumCRFound.Spec
 	newSpec := observatoriumCR.Spec
 	oldSpecBytes, _ := yaml.Marshal(oldSpec)
 	newSpecBytes, _ := yaml.Marshal(newSpec)
-	if bytes.Equal(newSpecBytes, oldSpecBytes) &&
-		labels[obsCRConfigHashLabelName] == observatoriumCRFound.Labels[obsCRConfigHashLabelName] {
+	if bytes.Equal(newSpecBytes, oldSpecBytes) { // &&
+		// labels[obsCRConfigHashLabelName] == observatoriumCRFound.Labels[obsCRConfigHashLabelName] {
 		return nil, nil
 	}
 

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
@@ -171,28 +171,6 @@ func TestUpdateObservatoriumCR(t *testing.T) {
 
 	objs := []runtime.Object{mco}
 	objs = append(objs, []runtime.Object{
-		&corev1.Secret{
-			TypeMeta:   metav1.TypeMeta{Kind: "Secret"},
-			ObjectMeta: metav1.ObjectMeta{Name: mcoconfig.ServerCerts, Namespace: namespace},
-			Data: map[string][]byte{
-				"tls.crt": []byte("server-cert"),
-				"tls.key": []byte("server-key"),
-			},
-		},
-		&corev1.Secret{
-			TypeMeta:   metav1.TypeMeta{Kind: "Secret"},
-			ObjectMeta: metav1.ObjectMeta{Name: mcoconfig.ClientCACerts, Namespace: namespace},
-			Data: map[string][]byte{
-				"tls.crt": []byte("client-ca-cert"),
-			},
-		},
-		&corev1.Secret{
-			TypeMeta:   metav1.TypeMeta{Kind: "Secret"},
-			ObjectMeta: metav1.ObjectMeta{Name: mcoconfig.GetOperandNamePrefix() + mcoconfig.ObservatoriumAPI, Namespace: namespace},
-			Data: map[string][]byte{
-				"tls.crt": []byte("test"),
-			},
-		},
 		&corev1.ConfigMap{
 			TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap"},
 			ObjectMeta: metav1.ObjectMeta{Name: mcoconfig.GetOperandNamePrefix() + mcoconfig.ObservatoriumAPI, Namespace: namespace},
@@ -222,7 +200,7 @@ func TestUpdateObservatoriumCR(t *testing.T) {
 	if !configHashFound {
 		t.Errorf("config-hash label not found in Observatorium CR")
 	}
-	const observatoriumEmptyConfigHash = "1b7799225be7c98c78387c6aff5b0eed"
+	const observatoriumEmptyConfigHash = "8a80554c91d9fca8acb82f023de02f11"
 	if hash != observatoriumEmptyConfigHash {
 		t.Errorf("config-hash label contains unexpected hash. Want: '%s', got '%s'", observatoriumEmptyConfigHash, hash)
 	}
@@ -245,9 +223,10 @@ func TestUpdateObservatoriumCR(t *testing.T) {
 	if !updatedHashFound {
 		t.Errorf("config-hash label not found in Observatorium CR")
 	}
-	const expectedConfigHash = "06869d277adcef9eb22f81d61c964393"
+
+	const expectedConfigHash = "321c72e32663033537aa77c56d90834b"
 	if updatedHash != expectedConfigHash {
-		t.Errorf("config-hash label contains unexpected hash. Want: '%s', got '%s'", expectedConfigHash, hash)
+		t.Errorf("config-hash label contains unexpected hash. Want: '%s', got '%s'", expectedConfigHash, updatedHash)
 	}
 
 	createdSpecBytes, _ := yaml.Marshal(createdObservatoriumCR.Spec)
@@ -353,7 +332,7 @@ func TestNoUpdateObservatoriumCR(t *testing.T) {
 	if !configHashFound {
 		t.Errorf("config-hash label not found in Observatorium CR")
 	}
-	const expectedConfigHash = "06869d277adcef9eb22f81d61c964393"
+	const expectedConfigHash = "321c72e32663033537aa77c56d90834b"
 	if hash != expectedConfigHash {
 		t.Errorf("config-hash label contains unexpected hash. Want: '%s', got '%s'", expectedConfigHash, hash)
 	}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
@@ -362,30 +362,8 @@ func TestHashObservatoriumCRWithConfig(t *testing.T) {
 	}{
 		{
 			name:         "With Observatorium's secrets and configmap present",
-			expectedHash: "06869d277adcef9eb22f81d61c964393",
+			expectedHash: "321c72e32663033537aa77c56d90834b",
 			objs: []runtime.Object{
-				&corev1.Secret{
-					TypeMeta:   metav1.TypeMeta{Kind: "Secret"},
-					ObjectMeta: metav1.ObjectMeta{Name: mcoconfig.ServerCerts, Namespace: namespace},
-					Data: map[string][]byte{
-						"tls.crt": []byte("server-cert"),
-						"tls.key": []byte("server-key"),
-					},
-				},
-				&corev1.Secret{
-					TypeMeta:   metav1.TypeMeta{Kind: "Secret"},
-					ObjectMeta: metav1.ObjectMeta{Name: mcoconfig.ClientCACerts, Namespace: namespace},
-					Data: map[string][]byte{
-						"tls.crt": []byte("client-ca-cert"),
-					},
-				},
-				&corev1.Secret{
-					TypeMeta:   metav1.TypeMeta{Kind: "Secret"},
-					ObjectMeta: metav1.ObjectMeta{Name: mcoconfig.GetOperandNamePrefix() + mcoconfig.ObservatoriumAPI, Namespace: namespace},
-					Data: map[string][]byte{
-						"tls.crt": []byte("test"),
-					},
-				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap"},
 					ObjectMeta: metav1.ObjectMeta{Name: mcoconfig.GetOperandNamePrefix() + mcoconfig.ObservatoriumAPI, Namespace: namespace},
@@ -397,9 +375,9 @@ func TestHashObservatoriumCRWithConfig(t *testing.T) {
 		},
 		{
 			name: "Without Observatorium's secrets and configmap present",
-			// The hash is still calculated when the configmaps and secrets aren't presented, because the implementation
-			// is hashing an empty object for each one of them if they aren't found.
-			expectedHash: "1b7799225be7c98c78387c6aff5b0eed",
+			// The hash is still calculated when the configmap isn't present, because the implementation
+			// is hashing an empty object if it isn't found.
+			expectedHash: "8a80554c91d9fca8acb82f023de02f11",
 			objs:         []runtime.Object{},
 		},
 	}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
@@ -244,6 +244,7 @@ func TestUpdateObservatoriumCR(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to update observatorium due to %v", err)
 	}
+	objs = append(objs, []runtime.Object{createdObservatoriumCR}...)
 	updatedObservatorium := &observatoriumv1alpha1.Observatorium{}
 	cl.Get(
 		context.TODO(),

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
@@ -137,18 +137,13 @@ func TestNewDefaultObservatoriumSpec(t *testing.T) {
 }
 
 func TestUpdateObservatoriumCR(t *testing.T) {
-	var (
-		namespace = mcoconfig.GetDefaultNamespace()
-	)
+	namespace := mcoconfig.GetDefaultNamespace()
 
 	// A MultiClusterObservability object with metadata and spec.
 	mco := &mcov1beta2.MultiClusterObservability{
 		TypeMeta: metav1.TypeMeta{Kind: "MultiClusterObservability"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: mcoconfig.GetDefaultCRName(),
-			Annotations: map[string]string{
-				mcoconfig.AnnotationKeyImageTagSuffix: "tag",
-			},
 		},
 		Spec: mcov1beta2.MultiClusterObservabilitySpec{
 			StorageConfig: &mcov1beta2.StorageConfig{
@@ -219,14 +214,10 @@ func TestUpdateObservatoriumCR(t *testing.T) {
 
 	// Check if this Observatorium CR already exists
 	createdObservatoriumCR := &observatoriumv1alpha1.Observatorium{}
-	noConfigCl.Get(
-		context.TODO(),
-		types.NamespacedName{
-			Name:      mcoconfig.GetDefaultCRName(),
-			Namespace: namespace,
-		},
-		createdObservatoriumCR,
-	)
+	noConfigCl.Get(context.TODO(), types.NamespacedName{
+		Name:      mcoconfig.GetDefaultCRName(),
+		Namespace: namespace,
+	}, createdObservatoriumCR)
 	hash, configHashFound := createdObservatoriumCR.Labels[obsCRConfigHashLabelName]
 	if !configHashFound {
 		t.Errorf("config-hash label not found in Observatorium CR")
@@ -246,14 +237,10 @@ func TestUpdateObservatoriumCR(t *testing.T) {
 	}
 	objs = append(objs, []runtime.Object{createdObservatoriumCR}...)
 	updatedObservatorium := &observatoriumv1alpha1.Observatorium{}
-	cl.Get(
-		context.TODO(),
-		types.NamespacedName{
-			Name:      mcoconfig.GetDefaultCRName(),
-			Namespace: namespace,
-		},
-		updatedObservatorium,
-	)
+	cl.Get(context.TODO(), types.NamespacedName{
+		Name:      mcoconfig.GetDefaultCRName(),
+		Namespace: namespace,
+	}, updatedObservatorium)
 	updatedHash, updatedHashFound := updatedObservatorium.Labels[obsCRConfigHashLabelName]
 	if !updatedHashFound {
 		t.Errorf("config-hash label not found in Observatorium CR")
@@ -265,7 +252,6 @@ func TestUpdateObservatoriumCR(t *testing.T) {
 
 	createdSpecBytes, _ := yaml.Marshal(createdObservatoriumCR.Spec)
 	updatedSpecBytes, _ := yaml.Marshal(updatedObservatorium.Spec)
-
 	if res := bytes.Compare(updatedSpecBytes, createdSpecBytes); res != 0 {
 		t.Errorf("%v should be equal to %v", string(createdSpecBytes), string(updatedSpecBytes))
 	}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
@@ -228,7 +228,7 @@ func TestUpdateObservatoriumCR(t *testing.T) {
 	}
 
 	// Create a fake client to mock API calls.
-	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+	cl := fake.NewClientBuilder().WithRuntimeObjects(append(objs, createdObservatoriumCR)...).Build()
 	mcoconfig.SetOperandNames(cl)
 
 	_, err = GenerateObservatoriumCR(cl, s, mco)

--- a/operators/multiclusterobservability/pkg/certificates/cert_controller.go
+++ b/operators/multiclusterobservability/pkg/certificates/cert_controller.go
@@ -122,8 +122,9 @@ func updateDeployLabel(c client.Client, dName string, isUpdate bool) {
 		return
 	}
 	if isUpdate || dep.Status.ReadyReplicas != 0 {
-		dep.Spec.Template.ObjectMeta.Labels[restartLabel] = time.Now().Format("2006-1-2.1504")
-		err := c.Patch(context.TODO(), dep, client.StrategicMergeFrom(dep))
+		newDep := dep.DeepCopy()
+		newDep.Spec.Template.ObjectMeta.Labels[restartLabel] = time.Now().Format("2006-1-2.1504")
+		err := c.Patch(context.TODO(), newDep, client.StrategicMergeFrom(dep))
 		if err != nil {
 			log.Error(err, "Failed to update the deployment", "name", dName)
 		} else {

--- a/operators/multiclusterobservability/pkg/certificates/cert_controller.go
+++ b/operators/multiclusterobservability/pkg/certificates/cert_controller.go
@@ -24,9 +24,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"open-cluster-management.io/addon-framework/pkg/addonmanager"
+
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
-	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 )
 
 const (
@@ -122,7 +123,7 @@ func updateDeployLabel(c client.Client, dName string, isUpdate bool) {
 	}
 	if isUpdate || dep.Status.ReadyReplicas != 0 {
 		dep.Spec.Template.ObjectMeta.Labels[restartLabel] = time.Now().Format("2006-1-2.1504")
-		err = c.Update(context.TODO(), dep)
+		err := c.Patch(context.TODO(), dep, client.StrategicMergeFrom(dep))
 		if err != nil {
 			log.Error(err, "Failed to update the deployment", "name", dName)
 		} else {

--- a/tests/pkg/tests/observability_certrenew_test.go
+++ b/tests/pkg/tests/observability_certrenew_test.go
@@ -79,16 +79,6 @@ var _ = Describe("Observability:", func() {
 		err := utils.DeleteCertSecret(testOptions)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Waiting for secrets to be recreated")
-		Eventually(func() bool {
-			err := utils.EnsureCertSecretExists(testOptions)
-			if err != nil {
-				klog.V(1).Infof("Failed to ensure certificate secret exists: %v", err)
-				return false
-			}
-			return true
-		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(BeTrue())
-
 		By(fmt.Sprintf("Waiting for old pods removed: %v and new pods created", hubPodsName))
 		Eventually(func() bool {
 			err1, appPodList := utils.GetPodList(

--- a/tests/pkg/tests/observability_certrenew_test.go
+++ b/tests/pkg/tests/observability_certrenew_test.go
@@ -49,7 +49,6 @@ var _ = Describe("Observability:", func() {
 			if collectorPodName == "" {
 				return false
 			}
-			hubPodsName = []string{}
 			_, apiPodList := utils.GetPodList(
 				testOptions,
 				true,

--- a/tests/pkg/tests/observability_certrenew_test.go
+++ b/tests/pkg/tests/observability_certrenew_test.go
@@ -79,6 +79,16 @@ var _ = Describe("Observability:", func() {
 		err := utils.DeleteCertSecret(testOptions)
 		Expect(err).ToNot(HaveOccurred())
 
+		By("Waiting for secrets to be recreated")
+		Eventually(func() bool {
+			err := utils.EnsureCertSecretExists(testOptions)
+			if err != nil {
+				klog.V(1).Infof("Failed to ensure certificate secret exists: %v", err)
+				return false
+			}
+			return true
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(BeTrue())
+
 		By(fmt.Sprintf("Waiting for old pods removed: %v and new pods created", hubPodsName))
 		Eventually(func() bool {
 			err1, appPodList := utils.GetPodList(

--- a/tests/pkg/utils/mco_cert_secret.go
+++ b/tests/pkg/utils/mco_cert_secret.go
@@ -47,3 +47,37 @@ func DeleteCertSecret(opt TestOptions) error {
 	}
 	return err
 }
+
+func EnsureCertSecretExists(opt TestOptions) error {
+	clientKube := NewKubeClient(
+		opt.HubCluster.ClusterServerURL,
+		opt.KubeConfig,
+		opt.HubCluster.KubeContext)
+
+	klog.V(1).Infof("Ensure certificate secret exists")
+
+	_, err := clientKube.CoreV1().Secrets(MCO_NAMESPACE).Get(context.TODO(), ServerCACerts, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("Failed to get certificate secret %s due to %v", ServerCACerts, err)
+		return err
+	}
+
+	_, err = clientKube.CoreV1().Secrets(MCO_NAMESPACE).Get(context.TODO(), ClientCACerts, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("Failed to get certificate secret %s due to %v", ClientCACerts, err)
+		return err
+	}
+
+	_, err = clientKube.CoreV1().Secrets(MCO_NAMESPACE).Get(context.TODO(), ServerCerts, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("Failed to get certificate secret %s due to %v", ServerCerts, err)
+		return err
+	}
+
+	_, err = clientKube.CoreV1().Secrets(MCO_NAMESPACE).Get(context.TODO(), GrafanaCerts, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("Failed to get certificate secret %s due to %v", GrafanaCerts, err)
+		return err
+	}
+	return nil
+}

--- a/tests/pkg/utils/mco_cert_secret.go
+++ b/tests/pkg/utils/mco_cert_secret.go
@@ -47,37 +47,3 @@ func DeleteCertSecret(opt TestOptions) error {
 	}
 	return err
 }
-
-func EnsureCertSecretExists(opt TestOptions) error {
-	clientKube := NewKubeClient(
-		opt.HubCluster.ClusterServerURL,
-		opt.KubeConfig,
-		opt.HubCluster.KubeContext)
-
-	klog.V(1).Infof("Ensure certificate secret exists")
-
-	_, err := clientKube.CoreV1().Secrets(MCO_NAMESPACE).Get(context.TODO(), ServerCACerts, metav1.GetOptions{})
-	if err != nil {
-		klog.Errorf("Failed to get certificate secret %s due to %v", ServerCACerts, err)
-		return err
-	}
-
-	_, err = clientKube.CoreV1().Secrets(MCO_NAMESPACE).Get(context.TODO(), ClientCACerts, metav1.GetOptions{})
-	if err != nil {
-		klog.Errorf("Failed to get certificate secret %s due to %v", ClientCACerts, err)
-		return err
-	}
-
-	_, err = clientKube.CoreV1().Secrets(MCO_NAMESPACE).Get(context.TODO(), ServerCerts, metav1.GetOptions{})
-	if err != nil {
-		klog.Errorf("Failed to get certificate secret %s due to %v", ServerCerts, err)
-		return err
-	}
-
-	_, err = clientKube.CoreV1().Secrets(MCO_NAMESPACE).Get(context.TODO(), GrafanaCerts, metav1.GetOptions{})
-	if err != nil {
-		klog.Errorf("Failed to get certificate secret %s due to %v", GrafanaCerts, err)
-		return err
-	}
-	return nil
-}


### PR DESCRIPTION
Changes to the config hash approach:

* Gave up on hashing the secrets (mostly certs): they are already used by the embed `certcontroller` to add a label to the `observatorium-api` and its `kube-rbac-proxy` sidecar. I prefer to avoid the concurrency issue that comes with updating the Observatorium CR, which will also trigger the Observatorium pods to change. 
  Ideally this mechanism should live outside of the `certcontroller`. It's already watching for **all** secrets in the operator's namespace -- not only certificates. It could also be made to watch configmaps.
* I changed such mechanism above to use an `strategicMerge` **patch** instead of full update, as it only adds a label to a list. 