### PR TITLE
Kind version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ results.xml
 
 # build/tests artifacts
 registration-operator
+tmp

--- a/Makefile
+++ b/Makefile
@@ -54,12 +54,12 @@ unit-tests-collectors:
 	go test ${VERBOSE} `go list ./collectors/... | $(GREP) -v test`
 
 .PHONY: e2e-tests
-e2e-tests:
+e2e-tests: install-e2e-test-deps
 	@echo "Running e2e tests ..."
 	@./cicd-scripts/run-e2e-tests.sh
 
 .PHONY: e2e-tests-in-kind
-e2e-tests-in-kind:
+e2e-tests-in-kind: install-e2e-test-deps
 	@echo "Running e2e tests in KinD cluster..."
 ifeq ($(OPENSHIFT_CI),true)
 	@./cicd-scripts/run-e2e-in-kind-via-prow.sh
@@ -151,3 +151,7 @@ io/ioutil.{Discard,NopCloser,ReadAll,ReadDir,ReadFile,TempDir,TempFile,Writefile
 .PHONY: install-build-deps
 install-build-deps:
 	@./scripts/install-binaries.sh install_build_deps
+
+.PHONY: install-e2e-test-deps
+install-e2e-test-deps:
+	@./scripts/install-binaries.sh install_e2e_tests_deps

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ e2e-tests: install-e2e-test-deps
 e2e-tests-in-kind: install-e2e-test-deps
 	@echo "Running e2e tests in KinD cluster..."
 ifeq ($(OPENSHIFT_CI),true)
+    # Set up environment specific to OpenShift CI
 	@./cicd-scripts/run-e2e-in-kind-via-prow.sh
 else
 	@./tests/run-in-kind/run-e2e-in-kind.sh

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ include .bingo/Variables.mk
 FILES_TO_FMT ?= $(shell find . -path ./vendor -prune -o -name '*.deepcopy.go' -prune -o -name '*.go' -print)
 TMP_DIR := $(shell pwd)/tmp
 BIN_DIR ?= $(TMP_DIR)/bin
+export PATH := $(BIN_DIR):$(PATH)
 GIT ?= $(shell which git)
 
 XARGS ?= $(shell which gxargs 2>/dev/null || which xargs)
@@ -154,4 +155,5 @@ install-build-deps:
 
 .PHONY: install-e2e-test-deps
 install-e2e-test-deps:
-	@./scripts/install-binaries.sh install_e2e_tests_deps
+	@mkdir -p $(BIN_DIR)
+	@./scripts/install-binaries.sh install_e2e_tests_deps $(BIN_DIR)

--- a/cicd-scripts/customize-mco.sh
+++ b/cicd-scripts/customize-mco.sh
@@ -17,22 +17,8 @@ elif [[ "$(uname)" == "Darwin" ]]; then
   SED_COMMAND='sed -i '-e' -e'
 fi
 
-# Use snapshot for target release. Use latest one if no branch info detected, or not a release branch
-BRANCH=""
-LATEST_SNAPSHOT="2.10.0-SNAPSHOT-2024-02-22-17-32-31"
-if [[ ${PULL_BASE_REF} == "release-"* ]]; then
-  BRANCH=${PULL_BASE_REF#"release-"}
-  BRANCH=$(curl https://quay.io//api/v1/repository/stolostron/multicluster-observability-operator | jq '.tags|with_entries(select(.key|contains("'${BRANCH}'")))|keys[length-1]' | awk -F '-' '{print $1}')
-  BRANCH="${BRANCH#\"}"
-  LATEST_SNAPSHOT=$(curl https://quay.io//api/v1/repository/stolostron/multicluster-observability-operator | jq '.tags|with_entries(select(.key|contains("'${BRANCH}'-SNAPSHOT")))|keys[length-1]')
-fi
-if [[ ${LATEST_SNAPSHOT} == "null" ]] || [[ ${LATEST_SNAPSHOT} == "" ]]; then
-  LATEST_SNAPSHOT=$(curl https://quay.io/api/v1/repository/stolostron/multicluster-observability-operator | jq '.tags|with_entries(select((.key|contains("SNAPSHOT"))and(.key|contains("9.9.0")|not)))|keys[length-1]')
-fi
-
-# trim the leading and tailing quotes
-LATEST_SNAPSHOT="${LATEST_SNAPSHOT#\"}"
-LATEST_SNAPSHOT="${LATEST_SNAPSHOT%\"}"
+# Set the latest snapshot if it is not set
+LATEST_SNAPSHOT=${LATEST_SNAPSHOT:-$(get_latest_snapshot)}
 
 # list all components need to do test.
 CHANGED_COMPONENTS=""

--- a/cicd-scripts/run-e2e-in-kind-via-prow.sh
+++ b/cicd-scripts/run-e2e-in-kind-via-prow.sh
@@ -40,5 +40,10 @@ if [[ -n ${RBAC_QUERY_PROXY_IMAGE_REF} ]]; then
 fi
 
 ssh "${OPT[@]}" "$HOST" sudo yum install gcc git -y
+ssh "${OPT[@]}" "$HOST" sudo mkdir -p /home/ec2-user/bin
+ssh "${OPT[@]}" "$HOST" sudo chmod 777 /home/ec2-user/bin
 scp "${OPT[@]}" -r ../multicluster-observability-operator "$HOST:/tmp/multicluster-observability-operator"
+scp "${OPT[@]}" $(which kubectl) "$HOST:/home/ec2-user/bin"
+scp "${OPT[@]}" $(which kustomize) "$HOST:/home/ec2-user/bin"
+scp "${OPT[@]}" $(which jq) "$HOST:/home/ec2-user/bin"
 ssh "${OPT[@]}" "$HOST" "cd /tmp/multicluster-observability-operator/tests/run-in-kind && ./run-e2e-in-kind.sh" > >(tee "$ARTIFACT_DIR/run-e2e-in-kind.log") 2>&1

--- a/cicd-scripts/run-e2e-in-kind-via-prow.sh
+++ b/cicd-scripts/run-e2e-in-kind-via-prow.sh
@@ -15,6 +15,9 @@ OPT=(-q -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -i "${KE
 # support gnu sed only give that this script will be executed in prow env
 SED_COMMAND='sed -i-e -e'
 
+source ./scripts/test-utils.sh
+${SED_COMMAND} "$ a\export LATEST_SNAPSHOT=$(get_latest_snapshot)" ./tests/run-in-kind/env.sh
+
 if [ "${OPENSHIFT_CI}" == "true" ]; then
   ${SED_COMMAND} "$ a\export OPENSHIFT_CI=${OPENSHIFT_CI}" ./tests/run-in-kind/env.sh
 fi
@@ -45,5 +48,4 @@ ssh "${OPT[@]}" "$HOST" sudo chmod 777 /home/ec2-user/bin
 scp "${OPT[@]}" -r ../multicluster-observability-operator "$HOST:/tmp/multicluster-observability-operator"
 scp "${OPT[@]}" $(which kubectl) "$HOST:/home/ec2-user/bin"
 scp "${OPT[@]}" $(which kustomize) "$HOST:/home/ec2-user/bin"
-scp "${OPT[@]}" $(which jq) "$HOST:/home/ec2-user/bin"
 ssh "${OPT[@]}" "$HOST" "cd /tmp/multicluster-observability-operator/tests/run-in-kind && ./run-e2e-in-kind.sh" > >(tee "$ARTIFACT_DIR/run-e2e-in-kind.log") 2>&1

--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -29,20 +29,8 @@ if [[ "$(uname)" == "Darwin" ]]; then
   SED_COMMAND='sed -i '-e' -e'
 fi
 
-# Use snapshot for target release. Use latest one if no branch info detected, or not a release branch
-BRANCH=""
-LATEST_SNAPSHOT=""
-if [[ ${PULL_BASE_REF} == "release-"* ]]; then
-  BRANCH=${PULL_BASE_REF#"release-"}
-  LATEST_SNAPSHOT=$(curl https://quay.io//api/v1/repository/open-cluster-management/multicluster-observability-operator | jq '.tags|with_entries(select(.key|test("'${BRANCH}'.*-SNAPSHOT-*")))|keys[length-1]')
-fi
-if [[ ${LATEST_SNAPSHOT} == "null" ]] || [[ ${LATEST_SNAPSHOT} == "" ]]; then
-  LATEST_SNAPSHOT=$(curl https://quay.io/api/v1/repository/stolostron/multicluster-observability-operator | jq '.tags|with_entries(select((.key|contains("SNAPSHOT"))and(.key|contains("9.9.0")|not)))|keys[length-1]')
-fi
-
-# trim the leading and tailing quotes
-LATEST_SNAPSHOT="${LATEST_SNAPSHOT#\"}"
-LATEST_SNAPSHOT="${LATEST_SNAPSHOT%\"}"
+# Set the latest snapshot if it is not set
+LATEST_SNAPSHOT=${LATEST_SNAPSHOT:-$(get_latest_snapshot)}
 
 # deploy the hub and spoke core via OLM
 deploy_hub_spoke_core() {

--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -16,9 +16,6 @@ ROOTDIR="$(
   cd "$(dirname "$0")/.."
   pwd -P
 )"
-# Create bin directory and add it to PATH
-mkdir -p ${ROOTDIR}/bin
-export PATH=${PATH}:${ROOTDIR}/bin
 
 OCM_DEFAULT_NS="open-cluster-management"
 AGENT_NS="open-cluster-management-agent"

--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -32,16 +32,6 @@ if [[ "$(uname)" == "Darwin" ]]; then
   SED_COMMAND='sed -i '-e' -e'
 fi
 
-# install jq
-if ! command -v jq &>/dev/null; then
-  if [[ "$(uname)" == "Linux" ]]; then
-    curl -o jq -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
-  elif [[ "$(uname)" == "Darwin" ]]; then
-    curl -o jq -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64
-  fi
-  chmod +x ./jq && mv ./jq ${ROOTDIR}/bin/jq
-fi
-
 # Use snapshot for target release. Use latest one if no branch info detected, or not a release branch
 BRANCH=""
 LATEST_SNAPSHOT=""
@@ -56,29 +46,6 @@ fi
 # trim the leading and tailing quotes
 LATEST_SNAPSHOT="${LATEST_SNAPSHOT#\"}"
 LATEST_SNAPSHOT="${LATEST_SNAPSHOT%\"}"
-
-# install kubectl
-if ! command -v kubectl &>/dev/null; then
-  echo "This script will install kubectl (https://kubernetes.io/docs/tasks/tools/install-kubectl/) on your machine"
-  if [[ "$(uname)" == "Linux" ]]; then
-    curl -LO https://dl.k8s.io/release/v1.28.2/bin/linux/amd64/kubectl
-  elif [[ "$(uname)" == "Darwin" ]]; then
-    curl -LO curl -LO "https://dl.k8s.io/release/v1.28.2/bin/darwin/arm64/kubectl"
-  fi
-  chmod +x ./kubectl && mv ./kubectl ${ROOTDIR}/bin/kubectl
-fi
-
-# install kustomize
-if ! command -v kustomize &>/dev/null; then
-  echo "This script will install kustomize (sigs.k8s.io/kustomize/kustomize) on your machine"
-  if [[ "$(uname)" == "Linux" ]]; then
-    curl -o kustomize_v5.1.1.tar.gz -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.1.1/kustomize_v5.1.1_linux_amd64.tar.gz
-  elif [[ "$(uname)" == "Darwin" ]]; then
-    curl -o kustomize_v5.1.1.tar.gz -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.1.1/kustomize_v5.1.1_darwin_amd64.tar.gz
-  fi
-  tar xzvf kustomize_v5.1.1.tar.gz
-  chmod +x ./kustomize && mv ./kustomize ${ROOTDIR}/bin/kustomize
-fi
 
 # deploy the hub and spoke core via OLM
 deploy_hub_spoke_core() {

--- a/scripts/install-binaries.sh
+++ b/scripts/install-binaries.sh
@@ -12,6 +12,7 @@ OPERATOR_SDK_VERSION="${KUBECTL_VERSION:=v1.4.2}"
 KUBECTL_VERSION="${KUBECTL_VERSION:=v1.28.2}"
 KUSTOMIZE_VERSION="${KUSTOMIZE_VERSION:=v5.3.0}"
 JQ_VERSION="${JQ_VERSION:=1.6}"
+KIND_VERSION="${KIND_VERSION:=v0.22.0}"
 
 BIN_DIR="${BIN_DIR:=/usr/local/bin}"
 
@@ -59,6 +60,7 @@ install_kustomize() {
 install_jq() {
   bin_dir=${1:-${BIN_DIR}}
   if ! command -v jq &>/dev/null; then
+    echo "This script will install jq on your machine"
     if [[ "$(uname)" == "Linux" ]]; then
       curl -o jq -L "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64"
     elif [[ "$(uname)" == "Darwin" ]]; then
@@ -68,10 +70,31 @@ install_jq() {
   fi
 }
 
+install_kind() {
+  bin_dir=${1:-${BIN_DIR}}
+  if ! command -v kind &>/dev/null; then
+    echo "This script will install KinD on your machine"
+    if [[ "$(uname)" == "Linux" ]]; then
+      curl -o kind -L "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+    elif [[ "$(uname)" == "Darwin" ]]; then
+      curl -o kind -L "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-darwin-$(uname -m)"
+    fi
+    chmod +x ./kind && mv ./kind ${bin_dir}/kind
+  fi
+}
+
 install_build_deps() {
   bin_dir=${1:-${BIN_DIR}}
   install_operator_sdk ${bin_dir}
   # kustomize is required to build the bundle
+  install_kustomize ${bin_dir}
+}
+
+install_e2e_tests_deps() {
+  bin_dir=${1:-${BIN_DIR}}
+  install_kubectl ${bin_dir}
+  install_jq ${bin_dir}
+  install_kind ${bin_dir}
   install_kustomize ${bin_dir}
 }
 

--- a/scripts/test-utils.sh
+++ b/scripts/test-utils.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright (c) 2024 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+# Use snapshot for target release.
+# Use latest if no branch info detected, or not a release branch.
+get_latest_snapshot() {
+  BRANCH=""
+  LATEST_SNAPSHOT=""
+  if [[ ${PULL_BASE_REF} == "release-"* ]]; then
+    BRANCH=${PULL_BASE_REF#"release-"}
+    LATEST_SNAPSHOT=$(curl https://quay.io//api/v1/repository/open-cluster-management/multicluster-observability-operator | jq '.tags|with_entries(select(.key|test("'${BRANCH}'.*-SNAPSHOT-*")))|keys[length-1]')
+  fi
+  if [[ ${LATEST_SNAPSHOT} == "null" ]] || [[ ${LATEST_SNAPSHOT} == "" ]]; then
+    LATEST_SNAPSHOT=$(curl https://quay.io/api/v1/repository/stolostron/multicluster-observability-operator | jq '.tags|with_entries(select((.key|contains("SNAPSHOT"))and(.key|contains("9.9.0")|not)))|keys[length-1]')
+  fi
+
+  # trim the leading and tailing quotes
+  LATEST_SNAPSHOT="${LATEST_SNAPSHOT#\"}"
+  LATEST_SNAPSHOT="${LATEST_SNAPSHOT%\"}"
+  echo ${LATEST_SNAPSHOT}
+}

--- a/tests/run-in-kind/run-e2e-in-kind.sh
+++ b/tests/run-in-kind/run-e2e-in-kind.sh
@@ -13,26 +13,7 @@ export IS_KIND_ENV=true
 # shellcheck disable=SC1091
 source ${WORKDIR}/env.sh
 
-setup_kubectl_command() {
-  if ! command -v kubectl >/dev/null 2>&1; then
-    echo "This script will install kubectl (https://kubernetes.io/docs/tasks/tools/install-kubectl/) on your machine"
-    if [[ "$(uname)" == "Linux" ]]; then
-      curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
-    elif [[ "$(uname)" == "Darwin" ]]; then
-      curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/darwin/amd64/kubectl
-    fi
-    chmod +x ./kubectl
-    sudo mv ./kubectl /usr/local/bin/kubectl
-  fi
-}
-
 create_kind_cluster() {
-  if ! command -v kind >/dev/null 2>&1; then
-    echo "This script will install kind (https://kind.sigs.k8s.io/) on your machine."
-    curl -Lo ./kind-amd64 "https://kind.sigs.k8s.io/dl/v0.10.0/kind-$(uname)-amd64"
-    chmod +x ./kind-amd64
-    sudo mv ./kind-amd64 /usr/local/bin/kind
-  fi
   echo "Delete the KinD cluster if exists"
   kind delete cluster --name $1 || true
   rm -rf $HOME/.kube/kind-config-$1
@@ -69,7 +50,6 @@ run_e2e_test() {
 }
 
 run() {
-  setup_kubectl_command
   create_kind_cluster hub
   deploy_crds
   deploy_templates


### PR DESCRIPTION
Updates the KinD version and refactors some of the e2e test scripts to removing duplication.

We now fetch all test dependencies early and copy them into the ec2-users PATH.

Prior, we were duplicating the installs as the ec2-user post ssh so there was a potential to fail later in the test if those downloads failed. This change avoids that and allows us to fail the e2e tests early if the scp fails for any reason.