### PR TITLE
Fix Test document

### DIFF
--- a/cicd-scripts/customize-mco.sh
+++ b/cicd-scripts/customize-mco.sh
@@ -17,6 +17,7 @@ elif [[ "$(uname)" == "Darwin" ]]; then
   SED_COMMAND='sed -i '-e' -e'
 fi
 
+source ./scripts/test-utils.sh
 # Set the latest snapshot if it is not set
 LATEST_SNAPSHOT=${LATEST_SNAPSHOT:-$(get_latest_snapshot)}
 

--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -29,6 +29,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
   SED_COMMAND='sed -i '-e' -e'
 fi
 
+source ./scripts/test-utils.sh
 # Set the latest snapshot if it is not set
 LATEST_SNAPSHOT=${LATEST_SNAPSHOT:-$(get_latest_snapshot)}
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,6 +24,8 @@ The tests can be running both locally and in [Openshift CI(based on Prow)](https
 
 The observability e2e testing can be running automatically in KinD cluster or OCP cluster.
 
+> _Note:_ We use ginkgo (1.16.5) for tests so that you need to download that version. You can run `go install github.com/onsi/ginkgo/ginkgo@latest` in `multicluster-observability-operator` folder to download that version.
+
 ### Run locally in KinD cluster
 
 1. clone this repository and enter its root directory:

--- a/tests/run-in-kind/kind/kind-hub.config.yaml
+++ b/tests/run-in-kind/kind/kind-hub.config.yaml
@@ -11,7 +11,7 @@ nodes:
     listenAddress: "0.0.0.0"
   - containerPort: 6443
     hostPort: 32806
-    listenAddress: "0.0.0.0"
+    listenAddress: "127.0.0.1"
   - containerPort: 31001
     hostPort: 31001
     listenAddress: "127.0.0.1"


### PR DESCRIPTION
Update document and some minor fixes to enable run the e2e tests in local

FYI @coleenquadros 

You can refer to this [document](https://github.com/clyang82/multicluster-observability-operator/blob/9c4deaafa7715226d5c031afad2c8fe5d15230e1/tests/README.md#run-locally-in-kind-cluster) to run the tests in your local KinD cluster. Please be aware that
- the `ginkgo` needs to be `1.16.5`
- need to specify the components images mentioned in step 2

If you want to run the tests in your local OCP cluster, please make sure you have ACM installed. Then follow this [document](https://github.com/clyang82/multicluster-observability-operator/blob/9c4deaafa7715226d5c031afad2c8fe5d15230e1/tests/README.md#run-locally-in-ocp-cluster)
