### PR TITLE
e2e testing changes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,11 +9,11 @@ This document describes the process for build, running and testing this applicat
 This project is built using [operator-sdk](https://github.com/operator-framework/operator-sdk).
 There is a hard dependency on version `1.4.2` at the time of writing.
 
-> [!NOTE]  
+> [!NOTE]
 > Due to this [controller-gen issue](https://github.com/kubernetes-sigs/controller-tools/issues/880)
 > the steps below cannot be built using Go 1.22.x.
 
-> [!NOTE]  
+> [!NOTE]
 > For macOS users on arm64 you may need to build the binary from source using the steps below.
 
 Firstly, remove any existing `operator-sdk` binary from your $PATH.
@@ -58,4 +58,48 @@ To build the image, which requires access to Red Hat CI registry, run:
 
 ```shell
 make docker-build
+```
+
+# E2E Testing
+
+> [!NOTE]
+> For macOS users, you will need to install `gsed` using `brew install gnu-sed`
+
+## Running in KinD
+
+Firstly, bring up the environment:
+
+```shell
+make mco-kind-env
+```
+
+This will create a cluster with MCO installed and the operator running.
+
+Then, run the tests:
+
+```shell
+make e2e-tests-in-kind
+```
+
+By default, if the tests fail, the ACM components will be removed.
+We can bypass this behaviour by running:
+
+```shell
+SKIP_UNINSTALL_STEP=true make e2e-tests-in-kind
+```
+
+Likewise, we can also bypass the environment setup by running:
+
+```shell
+SKIP_INSTALL_STEP=true make e2e-tests-in-kind
+```
+
+After running the tests, there will be some changes made to your environment.
+We can clean up the environment by running:
+
+```shell
+rm "examples/mco/e2e/v1beta1/observability.yaml-e" || true
+rm "examples/mco/e2e/v1beta2/observability.yaml-e" || true
+rm "operators/multiclusterobservability/manifests/base/grafana/deployment.yaml-e" || true
+git stash
 ```

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ BIN_DIR ?= $(TMP_DIR)/bin
 export PATH := $(BIN_DIR):$(PATH)
 GIT ?= $(shell which git)
 
+# Support gsed on OSX (installed via brew), falling back to sed. On Linux
+# systems gsed won't be installed, so will use sed as expected.
+export SED ?= $(shell which gsed 2>/dev/null || which sed)
+
 XARGS ?= $(shell which gxargs 2>/dev/null || which xargs)
 GREP ?= $(shell which ggrep 2>/dev/null || which grep)
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ GREP ?= $(shell which ggrep 2>/dev/null || which grep)
 
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/stolostron/multicluster-observability-operator:latest
+# KUSTOMIZE_VERSION is set here to allow it to be overridden by the caller
+# as it gets passed to the registration-operator Makefile and will fail on macOS if not set.
+# See https://github.com/stolostron/registration-operator/blob/release-2.4/Makefile#L184-L193
+KUSTOMIZE_VERSION ?= v5.3.0
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: 

--- a/cicd-scripts/customize-mco.sh
+++ b/cicd-scripts/customize-mco.sh
@@ -10,7 +10,6 @@ ROOTDIR="$(
   pwd -P
 )"
 
-
 SED_COMMAND=${SED}' -i-e -e'
 
 # Set the latest snapshot if it is not set

--- a/cicd-scripts/customize-mco.sh
+++ b/cicd-scripts/customize-mco.sh
@@ -9,15 +9,12 @@ ROOTDIR="$(
   cd "$(dirname "$0")/.."
   pwd -P
 )"
-export PATH=${PATH}:${ROOTDIR}/bin
 
-if [[ "$(uname)" == "Linux" ]]; then
-  SED_COMMAND='sed -i-e -e'
-elif [[ "$(uname)" == "Darwin" ]]; then
-  SED_COMMAND='sed -i '-e' -e'
-fi
+
+SED_COMMAND=${SED}' -i-e -e'
 
 # Set the latest snapshot if it is not set
+source ./scripts/test-utils.sh
 LATEST_SNAPSHOT=${LATEST_SNAPSHOT:-$(get_latest_snapshot)}
 
 # list all components need to do test.

--- a/cicd-scripts/run-e2e-in-kind-via-prow.sh
+++ b/cicd-scripts/run-e2e-in-kind-via-prow.sh
@@ -48,5 +48,6 @@ ssh "${OPT[@]}" "$HOST" sudo chmod 777 /home/ec2-user/bin
 scp "${OPT[@]}" -r ../multicluster-observability-operator "$HOST:/tmp/multicluster-observability-operator"
 scp "${OPT[@]}" $(which kubectl) "$HOST:/home/ec2-user/bin"
 scp "${OPT[@]}" $(which kustomize) "$HOST:/home/ec2-user/bin"
+scp "${OPT[@]}" $(which jq) "$HOST:/home/ec2-user/bin"
 ssh "${OPT[@]}" "$HOST" "cd /tmp/multicluster-observability-operator && make mco-kind-env"
 ssh "${OPT[@]}" "$HOST" "cd /tmp/multicluster-observability-operator && make e2e-tests-in-kind" > >(tee "$ARTIFACT_DIR/run-e2e-in-kind.log") 2>&1

--- a/cicd-scripts/run-e2e-in-kind-via-prow.sh
+++ b/cicd-scripts/run-e2e-in-kind-via-prow.sh
@@ -48,4 +48,5 @@ ssh "${OPT[@]}" "$HOST" sudo chmod 777 /home/ec2-user/bin
 scp "${OPT[@]}" -r ../multicluster-observability-operator "$HOST:/tmp/multicluster-observability-operator"
 scp "${OPT[@]}" $(which kubectl) "$HOST:/home/ec2-user/bin"
 scp "${OPT[@]}" $(which kustomize) "$HOST:/home/ec2-user/bin"
-ssh "${OPT[@]}" "$HOST" "cd /tmp/multicluster-observability-operator/tests/run-in-kind && ./run-e2e-in-kind.sh" > >(tee "$ARTIFACT_DIR/run-e2e-in-kind.log") 2>&1
+ssh "${OPT[@]}" "$HOST" "cd /tmp/multicluster-observability-operator && make mco-kind-env"
+ssh "${OPT[@]}" "$HOST" "cd /tmp/multicluster-observability-operator && make e2e-tests-in-kind" > >(tee "$ARTIFACT_DIR/run-e2e-in-kind.log") 2>&1

--- a/cicd-scripts/run-e2e-tests.sh
+++ b/cicd-scripts/run-e2e-tests.sh
@@ -12,7 +12,7 @@ ROOTDIR="$(
   pwd -P
 )"
 
-SED_COMMAND=${SED}' -i -e'
+SED_COMMAND=${SED}' -i-e -e'
 
 # customize the images for testing
 ${ROOTDIR}/cicd-scripts/customize-mco.sh

--- a/cicd-scripts/run-e2e-tests.sh
+++ b/cicd-scripts/run-e2e-tests.sh
@@ -12,10 +12,7 @@ ROOTDIR="$(
   pwd -P
 )"
 
-SED_COMMAND='sed -i -e'
-if [[ "$(uname)" == "Darwin" ]]; then
-  SED_COMMAND='sed -i '-e' -e'
-fi
+SED_COMMAND=${SED}' -i -e'
 
 # customize the images for testing
 ${ROOTDIR}/cicd-scripts/customize-mco.sh

--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -27,18 +27,19 @@ export MANAGED_CLUSTER="local-cluster" # registration-operator needs this
 SED_COMMAND=${SED}' -i-e -e'
 
 # Set the latest snapshot if it is not set
+source ./scripts/test-utils.sh
 LATEST_SNAPSHOT=${LATEST_SNAPSHOT:-$(get_latest_snapshot)}
 
 # deploy the hub and spoke core via OLM
 deploy_hub_spoke_core() {
   cd ${ROOTDIR}
-  if [[ -d "registration-operator" ]]; then
-    rm -rf registration-operator
+  # we are pinned here so no need to re-fetch if we have the project locally.
+  if [[ ! -d "registration-operator" ]]; then
+    git clone --depth 1 -b release-2.4 https://github.com/stolostron/registration-operator.git
   fi
-  git clone --depth 1 -b release-2.4 https://github.com/stolostron/registration-operator.git && cd registration-operator
+  cd registration-operator
   ${SED_COMMAND} "s~clusterName: cluster1$~clusterName: ${MANAGED_CLUSTER}~g" deploy/klusterlet/config/samples/operator_open-cluster-management_klusterlets.cr.yaml
   # deploy hub and spoke via OLM
-  #REGISTRATION_LATEST_SNAPSHOT=$(curl https://quay.io/api/v1/repository/stolostron/registration | jq '.tags|with_entries(select(.key|test("'2.4'.*-SNAPSHOT-*")))|keys[length-1]')
   REGISTRATION_LATEST_SNAPSHOT='2.4.9-SNAPSHOT-2022-11-17-20-19-31'
   make cluster-ip IMAGE_REGISTRY=quay.io/stolostron IMAGE_TAG=${REGISTRATION_LATEST_SNAPSHOT} WORK_TAG=${REGISTRATION_LATEST_SNAPSHOT} REGISTRATION_TAG=${REGISTRATION_LATEST_SNAPSHOT} PLACEMENT_TAG=${REGISTRATION_LATEST_SNAPSHOT}
   make deploy IMAGE_REGISTRY=quay.io/stolostron IMAGE_TAG=${REGISTRATION_LATEST_SNAPSHOT} WORK_TAG=${REGISTRATION_LATEST_SNAPSHOT} REGISTRATION_TAG=${REGISTRATION_LATEST_SNAPSHOT} PLACEMENT_TAG=${REGISTRATION_LATEST_SNAPSHOT}

--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -24,10 +24,7 @@ OBSERVABILITY_NS="open-cluster-management-observability"
 IMAGE_REPO="quay.io/stolostron"
 export MANAGED_CLUSTER="local-cluster" # registration-operator needs this
 
-SED_COMMAND='sed -i-e -e'
-if [[ "$(uname)" == "Darwin" ]]; then
-  SED_COMMAND='sed -i '-e' -e'
-fi
+SED_COMMAND=${SED}' -i-e -e'
 
 # Set the latest snapshot if it is not set
 LATEST_SNAPSHOT=${LATEST_SNAPSHOT:-$(get_latest_snapshot)}

--- a/operators/multiclusterobservability/Dockerfile.dev
+++ b/operators/multiclusterobservability/Dockerfile.dev
@@ -1,0 +1,61 @@
+# Copyright Contributors to the Open Cluster Management project
+
+FROM registry.access.redhat.com/ubi8/go-toolset@sha256:dbfd6fbe47b735360fbd674b125ec93f8bfdc41387b2c14163f2a137d28512af AS builder
+
+WORKDIR /workspace
+COPY go.sum go.mod ./
+COPY ./operators/multiclusterobservability ./operators/multiclusterobservability
+COPY ./operators/pkg ./operators/pkg
+
+RUN CGO_ENABLED=1 go build -a -installsuffix cgo -o bin/manager operators/multiclusterobservability/main.go
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ARG VCS_REF
+ARG VCS_URL
+ARG IMAGE_NAME
+ARG IMAGE_DESCRIPTION
+ARG IMAGE_DISPLAY_NAME
+ARG IMAGE_NAME_ARCH
+ARG IMAGE_MAINTAINER
+ARG IMAGE_VENDOR
+ARG IMAGE_VERSION
+ARG IMAGE_RELEASE
+ARG IMAGE_SUMMARY
+ARG IMAGE_OPENSHIFT_TAGS
+
+LABEL org.label-schema.vendor="Red Hat" \
+    org.label-schema.name="$IMAGE_NAME_ARCH" \
+    org.label-schema.description="$IMAGE_DESCRIPTION" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url=$VCS_URL \
+    org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+    org.label-schema.schema-version="1.0" \
+    name="$IMAGE_NAME" \
+    maintainer="$IMAGE_MAINTAINER" \
+    vendor="$IMAGE_VENDOR" \
+    version="$IMAGE_VERSION" \
+    release="$IMAGE_RELEASE" \
+    description="$IMAGE_DESCRIPTION" \
+    summary="$IMAGE_SUMMARY" \
+    io.k8s.display-name="$IMAGE_DISPLAY_NAME" \
+    io.k8s.description="$IMAGE_DESCRIPTION" \
+    io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
+
+ENV OPERATOR=/usr/local/bin/mco-operator \
+    USER_UID=1001 \
+    USER_NAME=mco
+
+RUN microdnf update -y && microdnf clean all
+
+# install templates
+COPY ./operators/multiclusterobservability/manifests /usr/local/manifests
+
+# install the prestop script
+COPY ./operators/multiclusterobservability/prestop.sh /usr/local/bin/prestop.sh
+
+# install operator binary
+COPY --from=builder /workspace/bin/manager ${OPERATOR}
+USER ${USER_UID}
+
+ENTRYPOINT ["/usr/local/bin/mco-operator"]

--- a/scripts/bootstrap-kind-env.sh
+++ b/scripts/bootstrap-kind-env.sh
@@ -7,11 +7,7 @@
 
 set -exo pipefail
 
-ROOTDIR="$(
-  cd "$(dirname "$0")../"
-  pwd -P
-)"
-
+ROOTDIR="$(pwd -P)"
 
 WORKDIR=${ROOTDIR}/tests/run-in-kind
 

--- a/scripts/bootstrap-kind-env.sh
+++ b/scripts/bootstrap-kind-env.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright (c) 2024 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+# This script bootstraps a KinD environment with the required
+# resources to run MulticlusterObservability components.
+
+set -exo pipefail
+
+ROOTDIR="$(
+  cd "$(dirname "$0")../"
+  pwd -P
+)"
+
+
+WORKDIR=${ROOTDIR}/tests/run-in-kind
+
+create_kind_cluster() {
+  echo "Delete the KinD cluster if exists"
+  kind delete cluster --name $1 || true
+  rm -rf $HOME/.kube/kind-config-$1
+
+  echo "Start KinD cluster with the default cluster name - $1"
+  kind create cluster --kubeconfig $HOME/.kube/kind-config-$1 --name $1 --config ${WORKDIR}/kind/kind-$1.config.yaml
+  export KUBECONFIG=$HOME/.kube/kind-config-$1
+}
+
+deploy_service_ca_operator() {
+  kubectl create ns openshift-config-managed
+  kubectl apply -f ${WORKDIR}/service-ca/
+}
+
+deploy_crds() {
+  kubectl apply -f ${WORKDIR}/req_crds/
+}
+
+deploy_templates() {
+  kubectl apply -f ${WORKDIR}/templates/
+}
+
+deploy_openshift_router() {
+  kubectl create ns openshift-ingress
+  kubectl apply -f ${WORKDIR}/router/
+}
+
+run() {
+  create_kind_cluster hub
+  deploy_crds
+  deploy_templates
+  deploy_service_ca_operator
+  deploy_openshift_router
+}
+
+run

--- a/scripts/test-utils.sh
+++ b/scripts/test-utils.sh
@@ -7,12 +7,14 @@
 get_latest_snapshot() {
   BRANCH=""
   LATEST_SNAPSHOT=""
+  SNAPSHOT_RELEASE=${SNAPSHOT_RELEASE:=2.10}
+  MATCH=$SNAPSHOT_RELEASE".*-SNAPSHOT"
   if [[ ${PULL_BASE_REF} == "release-"* ]]; then
     BRANCH=${PULL_BASE_REF#"release-"}
     LATEST_SNAPSHOT=$(curl https://quay.io//api/v1/repository/open-cluster-management/multicluster-observability-operator | jq '.tags|with_entries(select(.key|test("'${BRANCH}'.*-SNAPSHOT-*")))|keys[length-1]')
   fi
   if [[ ${LATEST_SNAPSHOT} == "null" ]] || [[ ${LATEST_SNAPSHOT} == "" ]]; then
-    LATEST_SNAPSHOT=$(curl https://quay.io/api/v1/repository/stolostron/multicluster-observability-operator | jq '.tags|with_entries(select((.key|contains("SNAPSHOT"))and(.key|contains("9.9.0")|not)))|keys[length-1]')
+    LATEST_SNAPSHOT=$(curl https://quay.io/api/v1/repository/stolostron/multicluster-observability-operator/tag/ | jq --arg MATCH "$MATCH" '.tags[] | select(.name | match($MATCH; "i")  ).name' | sort -r --version-sort | head -n 1)
   fi
 
   # trim the leading and tailing quotes

--- a/tests/pkg/tests/observability_install_test.go
+++ b/tests/pkg/tests/observability_install_test.go
@@ -242,9 +242,15 @@ func installMCO() {
 		return nil
 	}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*10).Should(Succeed())
 
-	BearerToken, err = utils.FetchBearerToken(testOptions)
-	if err != nil {
-		klog.Errorf("fetch bearer token error: %v", err)
-	}
-	Expect(BearerToken).NotTo(BeEmpty(), "failed to fetch `BearerToken`")
+	Eventually(func() error {
+		BearerToken, err = utils.FetchBearerToken(testOptions)
+		if err != nil {
+			klog.Errorf("fetch bearer token error: %v", err)
+		}
+		if BearerToken == "" {
+			return fmt.Errorf("failed to get bearer token: %w", err)
+		}
+		return nil
+
+	}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*10).Should(Succeed())
 }


### PR DESCRIPTION
The focus on this change which is a follow up to #1353 , #1359, #1360, #1361, #1362 is to allow running the KinD end-to-end tests in all environments and provide a sensible refactor to the underlying bash scripts.

It attempts to split the logic into the following:

1. Cluster bootstrap
2. ACM setup
3. Test run

as opposed to the previous target which setup and kicked off everything but was difficult to break down and assess during test runs.

It also adds an additional Dockerfile which does not require access to the Red Hat CI registry in order to develop on.

The following is out of scope here but will be added in follow up(s):

1. Docs explaining how to build and use local image in e2e tests
2. Targets, scripts and docs for developing the metrics collector
3. Clean up after test artifacts in automated fashion