### PR TITLE
Update hub metrics collection resources when modified

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/metrics_collector.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/metrics_collector.go
@@ -182,10 +182,6 @@ func getCommands(params CollectorParams) []string {
 }
 
 func createDeployment(params CollectorParams) *appsv1.Deployment {
-	mtlsCaSecretName := mtlsCaName
-	if hubMetricsCollector {
-		mtlsCaSecretName = mtlsServerCaName
-	}
 	secretName := metricsCollector
 	if params.isUWL {
 		secretName = uwlMetricsCollector
@@ -203,7 +199,7 @@ func createDeployment(params CollectorParams) *appsv1.Deployment {
 			Name: "mtlsca",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: mtlsCaSecretName,
+					SecretName: mtlsCaName,
 				},
 			},
 		},

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -468,13 +468,6 @@ func createUpdateResourcesForHubMetricsCollection(c client.Client, manifests []w
 		return nil
 	}
 
-	HubMtlsSecret, err := cert_controller.CreateMtlsCertSecretForHubCollector()
-	if err != nil {
-		log.Error(err, "Failed to create mtls secret for hub metrics collector")
-		return err
-	}
-	manifests = injectIntoWork(manifests, HubMtlsSecret)
-
 	hubManifestCopy = make([]workv1.Manifest, len(manifests))
 	for i, manifest := range manifests {
 		obj := manifest.RawExtension.Object.DeepCopyObject()
@@ -567,6 +560,12 @@ func createUpdateResourcesForHubMetricsCollection(c client.Client, manifests []w
 				}
 			}
 		}
+	}
+
+	err := cert_controller.CreateMtlsCertSecretForHubCollector(c)
+	if err != nil {
+		log.Error(err, "Failed to create client cert secret for hub metrics collection")
+		return err
 	}
 	return nil
 }

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -520,7 +520,6 @@ func createUpdateResourcesForHubMetricsCollection(c client.Client, manifests []w
 		}
 
 		if k8serrors.IsNotFound(err) {
-			log.Info("Coleen creating resource", "kind", obj.GetObjectKind().GroupVersionKind().Kind, "name", obj.GetName())
 			err = c.Create(context.TODO(), obj)
 			if err != nil {
 				log.Error(err, "Failed to create resource", "kind", obj.GetObjectKind().GroupVersionKind().Kind)
@@ -528,7 +527,6 @@ func createUpdateResourcesForHubMetricsCollection(c client.Client, manifests []w
 			}
 		} else {
 			needsUpdate := false
-			log.Info("Coleen updating resource", "kind", obj.GetObjectKind().GroupVersionKind().Kind, "name", obj.GetName())
 			switch obj := obj.(type) {
 			case *appsv1.Deployment:
 				currentDeployment := currentObj.(*appsv1.Deployment)
@@ -552,7 +550,6 @@ func createUpdateResourcesForHubMetricsCollection(c client.Client, manifests []w
 			}
 
 			if needsUpdate {
-				log.Info("Coleen needs update updating resource", "kind", obj.GetObjectKind().GroupVersionKind().Kind, "name", obj.GetName())
 				err = c.Update(context.TODO(), obj)
 				if err != nil {
 					log.Error(err, "Failed to update resource", "kind", obj.GetObjectKind().GroupVersionKind().Kind)

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -480,12 +480,14 @@ func createUpdateResourcesForHubMetricsCollection(c client.Client, manifests []w
 		gvk := obj.GetObjectKind().GroupVersionKind()
 		switch gvk.Kind {
 		case "Namespace", "ObservabilityAddon":
-			// Skip these kinds
+			// ACM 8509: Special case for hub/local cluster metrics collection
+			// We don't need to create these resources for hub metrics collection
 			continue
 		case "ClusterRole", "ClusterRoleBinding", "CustomResourceDefinition":
 			// No namespace needed for these kinds
 		default:
-			// Set default namespace for other kinds
+			//ACM 8509: Special case for hub/local cluster metrics collection
+			// Set the default namespace for all the resources to open-cluster-management-observability
 			obj.SetNamespace(config.GetDefaultNamespace())
 		}
 

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -472,22 +472,18 @@ func createUpdateResourcesForHubMetricsCollection(c client.Client, manifests []w
 	for i, manifest := range manifests {
 		obj := manifest.RawExtension.Object.DeepCopyObject()
 		hubManifestCopy[i] = workv1.Manifest{RawExtension: runtime.RawExtension{Object: obj}}
-		hubManifestCopy[i] = workv1.Manifest{RawExtension: runtime.RawExtension{Object: obj}}
 	}
 
 	for _, manifest := range hubManifestCopy {
 		obj := manifest.RawExtension.Object.(client.Object)
-		var currentObj client.Object
 
 		gvk := obj.GetObjectKind().GroupVersionKind()
-		switch gvk.Kind {
-		case "Namespace", "ObservabilityAddon":
-			// Skip these kinds
+		if gvk.Kind == "Namespace" || gvk.Kind == "ObservabilityAddon" {
+			// ACM 8509: Special case for hub/local cluster metrics collection
+			// Skip creating/updating namespace and observabilityaddon for hub metrics collection
 			continue
-		case "ClusterRole", "ClusterRoleBinding", "CustomResourceDefinition":
-			// No namespace needed for these kinds
-		default:
-			// Set default namespace for other kinds
+		}
+		if gvk.Kind != "ClusterRole" || gvk.Kind != "ClusterRoleBinding" || gvk.Kind != "CustomResourceDefinition" {
 			obj.SetNamespace(config.GetDefaultNamespace())
 		}
 
@@ -497,17 +493,11 @@ func createUpdateResourcesForHubMetricsCollection(c client.Client, manifests []w
 				role.Subjects[0].Namespace = config.GetDefaultNamespace()
 			}
 		}
+	}
 
-		switch obj.GetObjectKind().GroupVersionKind().Kind {
-		case "Deployment":
-			currentObj = &appsv1.Deployment{}
-		case "Secret":
-			currentObj = &corev1.Secret{}
-		case "ConfigMap":
-			currentObj = &corev1.ConfigMap{}
-		default:
-			continue
-		}
+	for _, manifest := range hubManifestCopy {
+		obj := manifest.RawExtension.Object.(client.Object)
+		var currentObj client.Object
 
 		err := c.Get(context.TODO(), client.ObjectKey{
 			Namespace: obj.GetNamespace(),
@@ -525,38 +515,38 @@ func createUpdateResourcesForHubMetricsCollection(c client.Client, manifests []w
 				log.Error(err, "Failed to create resource", "kind", obj.GetObjectKind().GroupVersionKind().Kind)
 				return err
 			}
-		} else {
-			needsUpdate := false
-			switch obj := obj.(type) {
-			case *appsv1.Deployment:
-				currentDeployment := currentObj.(*appsv1.Deployment)
-				if !reflect.DeepEqual(obj.Spec, currentDeployment.Spec) {
-					needsUpdate = true
-				}
-			case *corev1.Secret:
-				currentSecret := currentObj.(*corev1.Secret)
-				if !reflect.DeepEqual(obj.Data, currentSecret.Data) {
-					needsUpdate = true
-				}
-			case *corev1.ConfigMap:
-				if obj.Name == operatorconfig.AllowlistConfigMapName || obj.Name == operatorconfig.AllowlistCustomConfigMapName {
-					// Skip the allowlist configmap as it is being watched by placementrule
-					continue
-				}
-				currentConfigMap := currentObj.(*corev1.ConfigMap)
-				if !reflect.DeepEqual(obj.Data, currentConfigMap.Data) {
-					needsUpdate = true
-				}
+		}
+		needsUpdate := false
+		switch obj := obj.(type) {
+		case *appsv1.Deployment:
+			currentDeployment := currentObj.(*appsv1.Deployment)
+			if !reflect.DeepEqual(obj.Spec, currentDeployment.Spec) {
+				needsUpdate = true
 			}
-
-			if needsUpdate {
-				err = c.Update(context.TODO(), obj)
-				if err != nil {
-					log.Error(err, "Failed to update resource", "kind", obj.GetObjectKind().GroupVersionKind().Kind)
-					return err
-				}
+		case *corev1.Secret:
+			currentSecret := currentObj.(*corev1.Secret)
+			if !reflect.DeepEqual(obj.Data, currentSecret.Data) {
+				needsUpdate = true
+			}
+		case *corev1.ConfigMap:
+			if obj.Name == operatorconfig.AllowlistConfigMapName || obj.Name == operatorconfig.AllowlistCustomConfigMapName {
+				// Skip the allowlist configmap as it is being watched by placementrule
+				continue
+			}
+			currentConfigMap := currentObj.(*corev1.ConfigMap)
+			if !reflect.DeepEqual(obj.Data, currentConfigMap.Data) {
+				needsUpdate = true
 			}
 		}
+
+		if needsUpdate {
+			err = c.Update(context.TODO(), obj)
+			if err != nil {
+				log.Error(err, "Failed to update resource", "kind", obj.GetObjectKind().GroupVersionKind().Kind)
+				return err
+			}
+		}
+
 	}
 
 	err := cert_controller.CreateMtlsCertSecretForHubCollector(c)

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -476,7 +476,6 @@ func createUpdateResourcesForHubMetricsCollection(c client.Client, manifests []w
 
 	for _, manifest := range hubManifestCopy {
 		obj := manifest.RawExtension.Object.(client.Object)
-		var currentObj client.Object
 
 		gvk := obj.GetObjectKind().GroupVersionKind()
 		switch gvk.Kind {
@@ -496,6 +495,11 @@ func createUpdateResourcesForHubMetricsCollection(c client.Client, manifests []w
 				role.Subjects[0].Namespace = config.GetDefaultNamespace()
 			}
 		}
+	}
+
+	for _, manifest := range hubManifestCopy {
+		var currentObj client.Object
+		obj := manifest.RawExtension.Object.(client.Object)
 
 		switch obj.GetObjectKind().GroupVersionKind().Kind {
 		case "Deployment":
@@ -507,7 +511,6 @@ func createUpdateResourcesForHubMetricsCollection(c client.Client, manifests []w
 		default:
 			continue
 		}
-
 		err := c.Get(context.TODO(), client.ObjectKey{
 			Namespace: obj.GetNamespace(),
 			Name:      obj.GetName(),

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
@@ -23,8 +23,12 @@ func getClusterPreds() predicate.Funcs {
 
 	createFunc := func(e event.CreateEvent) bool {
 		log.Info("CreateFunc", "managedCluster", e.Object.GetName())
+
+		//ACM 8509: Special case for local-cluster, we do not react changes to
+		//local-cluster as it is expected to be always present in the managed cluster list
+		//whether hubSelfManagement is enabled or not
 		if e.Object.GetName() == "local-cluster" {
-			delete(managedClusterList, "local-cluster")
+			return false
 		}
 
 		if isAutomaticAddonInstallationDisabled(e.Object) {
@@ -40,6 +44,10 @@ func getClusterPreds() predicate.Funcs {
 
 	updateFunc := func(e event.UpdateEvent) bool {
 		log.Info("UpdateFunc", "managedCluster", e.ObjectNew.GetName())
+
+		if e.ObjectNew.GetName() == "local-cluster" {
+			return false
+		}
 
 		if e.ObjectNew.GetResourceVersion() == e.ObjectOld.GetResourceVersion() {
 			return false
@@ -66,6 +74,10 @@ func getClusterPreds() predicate.Funcs {
 
 	deleteFunc := func(e event.DeleteEvent) bool {
 		log.Info("DeleteFunc", "managedCluster", e.Object.GetName())
+
+		if e.Object.GetName() == "local-cluster" {
+			return false
+		}
 
 		if isAutomaticAddonInstallationDisabled(e.Object) {
 			return false

--- a/operators/multiclusterobservability/pkg/certificates/certificates.go
+++ b/operators/multiclusterobservability/pkg/certificates/certificates.go
@@ -502,7 +502,7 @@ func CreateCSR() ([]byte, []byte) {
 	return csr, privateKey
 }
 
-func CreateMtlsCertSecretForHubCollector(c client.Client) error {
+func CreateMtlsCertSecretForHubCollector() (*corev1.Secret, error) {
 	csrBytes, privateKeyBytes := CreateCSR()
 	csr := &certificatesv1.CertificateSigningRequest{
 		Spec: certificatesv1.CertificateSigningRequestSpec{
@@ -513,10 +513,10 @@ func CreateMtlsCertSecretForHubCollector(c client.Client) error {
 	signedClientCert := Sign(csr)
 	if signedClientCert == nil {
 		log.Error(nil, "failed to sign CSR")
-		return errors.NewBadRequest("failed to sign CSR")
+		return nil, errors.NewBadRequest("failed to sign CSR")
 	} else {
 		//Create a secret
-		HubMtlsSecret := &corev1.Secret{
+		return &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      operatorconfig.HubMetricsCollectorMtlsCert,
 				Namespace: config.GetDefaultNamespace(),
@@ -525,12 +525,6 @@ func CreateMtlsCertSecretForHubCollector(c client.Client) error {
 				"tls.crt": signedClientCert,
 				"tls.key": privateKeyBytes,
 			},
-		}
-		err := c.Create(context.TODO(), HubMtlsSecret)
-		if err != nil && !errors.IsAlreadyExists(err) {
-			log.Error(err, "Failed to create secret", "name", operatorconfig.HubMetricsCollectorMtlsCert)
-			return err
-		}
+		}, nil
 	}
-	return nil
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-10153

- Toggling hubselfmanagement multiple times creates addon-observability namespace in hub cluster intermittently. This PR ensure we skip any reconcile in MCO touching local-cluster object
- Update hub metrics collections resources when modified