### PR TITLE
[ACM 10232, 10274] Keep managedclusteraddon for local-cluster 

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -149,14 +149,12 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 
 	crdClient, err := operatorsutil.GetOrCreateCRDClient()
 	if err != nil {
-		log.Error(err, "Failed to create the CRD client")
 		return ctrl.Result{}, err
 	}
 
 	if _, ok := os.LookupEnv("UNIT_TEST"); !ok {
 		mcghCrdExists, err := operatorsutil.CheckCRDExist(crdClient, config.MCGHCrdName)
 		if err != nil {
-			log.Error(err, "Failed to check the MCGH CRD")
 			return ctrl.Result{}, err
 		}
 		if mcghCrdExists {

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -51,6 +51,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/util"
 	"github.com/stolostron/multicluster-observability-operator/operators/pkg/deploying"
 	commonutil "github.com/stolostron/multicluster-observability-operator/operators/pkg/util"
+	operatorsutil "github.com/stolostron/multicluster-observability-operator/operators/pkg/util"
 	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	observatoriumv1alpha1 "github.com/stolostron/observatorium-operator/api/v1alpha1"
 )
@@ -146,10 +147,23 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	// start to update mco status
 	StartStatusUpdate(r.Client, instance)
 
-	if r.CRDMap[config.MCGHCrdName] {
-		// Do not start the MCO if the MCGH CRD exists
-		reqLogger.Info("MCGH CRD exists, Observability is not supported")
-		return ctrl.Result{}, nil
+	crdClient, err := operatorsutil.GetOrCreateCRDClient()
+	if err != nil {
+		log.Error(err, "Failed to create the CRD client")
+		return ctrl.Result{}, err
+	}
+
+	if _, ok := os.LookupEnv("UNIT_TEST"); !ok {
+		mcghCrdExists, err := operatorsutil.CheckCRDExist(crdClient, config.MCGHCrdName)
+		if err != nil {
+			log.Error(err, "Failed to check the MCGH CRD")
+			return ctrl.Result{}, err
+		}
+		if mcghCrdExists {
+			// Do not start the MCO if the MCGH CRD exists
+			reqLogger.Info("MCGH CRD exists, Observability is not supported")
+			return ctrl.Result{}, nil
+		}
 	}
 
 	ingressCtlCrdExists := r.CRDMap[config.IngressControllerCRD]

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -294,12 +294,10 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	if deleteAll {
-		if deleteAll {
-			// delete managedclusteraddon for local-cluster
-			err = deleteManagedClusterRes(r.Client, localClusterName)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
+		// delete managedclusteraddon for local-cluster
+		err = deleteManagedClusterRes(r.Client, localClusterName)
+		if err != nil {
+			return ctrl.Result{}, err
 		}
 
 		opts.Namespace = ""

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -242,6 +242,9 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 	for _, work := range workList.Items {
 		if work.Name != work.Namespace+workNameSuffix {
+			// ACM 8509: Special case for hub metrics collector
+			// In the upgrade case we want to clean up the obs add on and manifest work that was created
+			// for local-cluster before the upgrade that is why we check for the local-cluster namespace
 			reqLogger.Info("To delete invalid manifestwork", "name", work.Name, "namespace", work.Namespace)
 			err = deleteManifestWork(r.Client, work.Name, work.Namespace)
 			if err != nil {

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -196,10 +196,6 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			log.Error(err, "Failed to delete observabilityaddon")
 			return ctrl.Result{}, err
 		}
-		err = deleteManagedClusterRes(r.Client, localClusterName)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
 	}
 	if operatorconfig.IsMCOTerminating {
 		delete(managedClusterList, "local-cluster")
@@ -246,9 +242,6 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 	for _, work := range workList.Items {
 		if work.Name != work.Namespace+workNameSuffix {
-			// ACM 8509: Special case for hub metrics collector
-			// In the upgrade case we want to clean up the obs add on and manifest work that was created
-			// for local-cluster before the upgrade that is why we check for the local-cluster namespace
 			reqLogger.Info("To delete invalid manifestwork", "name", work.Name, "namespace", work.Namespace)
 			err = deleteManifestWork(r.Client, work.Name, work.Namespace)
 			if err != nil {
@@ -270,7 +263,7 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// but the managedclusteraddon for observability will not deleted by the cluster manager, so check against the
 	// managedclusteraddon list to remove the managedcluster resources after the managedcluster is detached.
 	for _, mcaddon := range managedclusteraddonList.Items {
-		if !slices.Contains(latestClusters, mcaddon.Namespace) {
+		if !slices.Contains(latestClusters, mcaddon.Namespace) && mcaddon.Namespace != config.GetDefaultNamespace() {
 			reqLogger.Info("To delete managedcluster resources", "namespace", mcaddon.Namespace)
 			err = deleteManagedClusterRes(r.Client, mcaddon.Namespace)
 			if err != nil {
@@ -298,6 +291,14 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	if deleteAll {
+		if deleteAll {
+			// delete managedclusteraddon for local-cluster
+			err = deleteManagedClusterRes(r.Client, localClusterName)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+
 		opts.Namespace = ""
 		err = r.Client.List(context.TODO(), workList, opts)
 		if err != nil {


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-10232
https://issues.redhat.com/browse/ACM-10274

- Do not delete managedcluster addon for local-cluster
- Make sure Observability stack is not deployed when global hub is enabled