### PR TITLE
[ACM-10342]update metrics collector client cert when client CA is deleted

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -148,12 +148,11 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	// start to update mco status
 	StartStatusUpdate(r.Client, instance)
 
-	crdClient, err := operatorsutil.GetOrCreateCRDClient()
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
 	if _, ok := os.LookupEnv("UNIT_TEST"); !ok {
+		crdClient, err := operatorsutil.GetOrCreateCRDClient()
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 		mcghCrdExists, err := operatorsutil.CheckCRDExist(crdClient, config.MCGHCrdName)
 		if err != nil {
 			return ctrl.Result{}, err

--- a/operators/multiclusterobservability/pkg/certificates/certificates.go
+++ b/operators/multiclusterobservability/pkg/certificates/certificates.go
@@ -514,42 +514,41 @@ func CreateUpdateMtlsCertSecretForHubCollector(c client.Client, updateMtlsCert b
 	if signedClientCert == nil {
 		log.Error(nil, "failed to sign CSR")
 		return errors.NewBadRequest("failed to sign CSR")
-	} else {
-		if updateMtlsCert {
-			HubMtlsSecret := &corev1.Secret{}
-			err := c.Get(context.TODO(), types.NamespacedName{
-				Name:      operatorconfig.HubMetricsCollectorMtlsCert,
-				Namespace: config.GetDefaultNamespace(),
-			}, HubMtlsSecret)
-			if err != nil {
-				log.Error(err, "Failed to get secret", "name", operatorconfig.HubMetricsCollectorMtlsCert)
-				return err
-			}
-			HubMtlsSecret.Data["tls.crt"] = signedClientCert
-			HubMtlsSecret.Data["tls.key"] = privateKeyBytes
-			err = c.Update(context.TODO(), HubMtlsSecret)
-			if err != nil {
-				log.Error(err, "Failed to update secret", "name", operatorconfig.HubMetricsCollectorMtlsCert)
-				return err
-			}
-		} else {
-			//Create a secret
-			HubMtlsSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      operatorconfig.HubMetricsCollectorMtlsCert,
-					Namespace: config.GetDefaultNamespace(),
-				},
-				Data: map[string][]byte{
-					"tls.crt": signedClientCert,
-					"tls.key": privateKeyBytes,
-				},
-			}
-			err := c.Create(context.TODO(), HubMtlsSecret)
-			if err != nil && !errors.IsAlreadyExists(err) {
-				log.Error(err, "Failed to create secret", "name", operatorconfig.HubMetricsCollectorMtlsCert)
-				return err
-			}
-		}
 	}
+	//Create a secret
+	HubMtlsSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      operatorconfig.HubMetricsCollectorMtlsCert,
+			Namespace: config.GetDefaultNamespace(),
+		},
+		Data: map[string][]byte{
+			"tls.crt": signedClientCert,
+			"tls.key": privateKeyBytes,
+		},
+	}
+	err := c.Create(context.TODO(), HubMtlsSecret)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		log.Error(err, "Failed to create secret", "name", operatorconfig.HubMetricsCollectorMtlsCert)
+		return err
+	}
+	if errors.IsAlreadyExists(err) && updateMtlsCert {
+		err := c.Get(context.TODO(), types.NamespacedName{
+			Name:      operatorconfig.HubMetricsCollectorMtlsCert,
+			Namespace: config.GetDefaultNamespace(),
+		}, HubMtlsSecret)
+		if err != nil {
+			log.Error(err, "Failed to get secret", "name", operatorconfig.HubMetricsCollectorMtlsCert)
+			return err
+		}
+		HubMtlsSecret.Data["tls.crt"] = signedClientCert
+		HubMtlsSecret.Data["tls.key"] = privateKeyBytes
+		err = c.Update(context.TODO(), HubMtlsSecret)
+		if err != nil {
+			log.Error(err, "Failed to update secret", "name", operatorconfig.HubMetricsCollectorMtlsCert)
+			return err
+		}
+
+	}
+
 	return nil
 }

--- a/operators/multiclusterobservability/pkg/certificates/certificates.go
+++ b/operators/multiclusterobservability/pkg/certificates/certificates.go
@@ -502,7 +502,7 @@ func CreateCSR() ([]byte, []byte) {
 	return csr, privateKey
 }
 
-func CreateMtlsCertSecretForHubCollector(c client.Client) error {
+func CreateUpdateMtlsCertSecretForHubCollector(c client.Client, updateMtlsCert bool) error {
 	csrBytes, privateKeyBytes := CreateCSR()
 	csr := &certificatesv1.CertificateSigningRequest{
 		Spec: certificatesv1.CertificateSigningRequestSpec{
@@ -515,21 +515,40 @@ func CreateMtlsCertSecretForHubCollector(c client.Client) error {
 		log.Error(nil, "failed to sign CSR")
 		return errors.NewBadRequest("failed to sign CSR")
 	} else {
-		//Create a secret
-		HubMtlsSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
+		if updateMtlsCert {
+			HubMtlsSecret := &corev1.Secret{}
+			err := c.Get(context.TODO(), types.NamespacedName{
 				Name:      operatorconfig.HubMetricsCollectorMtlsCert,
 				Namespace: config.GetDefaultNamespace(),
-			},
-			Data: map[string][]byte{
-				"tls.crt": signedClientCert,
-				"tls.key": privateKeyBytes,
-			},
-		}
-		err := c.Create(context.TODO(), HubMtlsSecret)
-		if err != nil && !errors.IsAlreadyExists(err) {
-			log.Error(err, "Failed to create secret", "name", operatorconfig.HubMetricsCollectorMtlsCert)
-			return err
+			}, HubMtlsSecret)
+			if err != nil {
+				log.Error(err, "Failed to get secret", "name", operatorconfig.HubMetricsCollectorMtlsCert)
+				return err
+			}
+			HubMtlsSecret.Data["tls.crt"] = signedClientCert
+			HubMtlsSecret.Data["tls.key"] = privateKeyBytes
+			err = c.Update(context.TODO(), HubMtlsSecret)
+			if err != nil {
+				log.Error(err, "Failed to update secret", "name", operatorconfig.HubMetricsCollectorMtlsCert)
+				return err
+			}
+		} else {
+			//Create a secret
+			HubMtlsSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      operatorconfig.HubMetricsCollectorMtlsCert,
+					Namespace: config.GetDefaultNamespace(),
+				},
+				Data: map[string][]byte{
+					"tls.crt": signedClientCert,
+					"tls.key": privateKeyBytes,
+				},
+			}
+			err := c.Create(context.TODO(), HubMtlsSecret)
+			if err != nil && !errors.IsAlreadyExists(err) {
+				log.Error(err, "Failed to create secret", "name", operatorconfig.HubMetricsCollectorMtlsCert)
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-10342

ClientCACertificateCN is used to sign in the Certificate Signing Request to generate the Client cert (`observability-controller-open-cluster-management.io-observability-signer-client-cert`)  so when ClientCACertificateCN is deleted or updated we need to also update the client cert. 