### PR TITLE
[ACM-10511] Update hub collector with the whole obs addon spec

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/metrics_collector.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/metrics_collector.go
@@ -369,15 +369,12 @@ func createDeployment(params CollectorParams) *appsv1.Deployment {
 	}
 
 	if hubMetricsCollector {
-		//to avoid hub metrics collector from sending status
+		// to avoid hub metrics collector from sending status
 		metricsCollectorDep.Spec.Template.Spec.Containers[0].Env = append(metricsCollectorDep.Spec.Template.Spec.Containers[0].Env,
 			corev1.EnvVar{
 				Name:  "STANDALONE",
 				Value: "true",
 			})
-
-		//Since there is no obsAddOn for hub-metrics-collector, we need to set the resources here
-		metricsCollectorDep.Spec.Template.Spec.Containers[0].Resources = operatorconfig.HubMetricsCollectorResources
 	}
 
 	privileged := false

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -251,10 +251,7 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
-	forceRestart := false
-	if req.Name == mtlsCertName || req.Name == mtlsCaName || req.Name == caConfigmapName {
-		forceRestart = true
-	}
+	forceRestart := req.Name == mtlsCertName || req.Name == mtlsCaName || req.Name == caConfigmapName
 
 	if obsAddon.Spec.EnableMetrics || hubMetricsCollector {
 		if hubMetricsCollector {

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -190,7 +190,6 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				},
 			},
 		})
-		operatorconfig.HubObservabilityAddonSpec = mco.Spec.ObservabilityAddonSpec
 		err = deleteObsAddon(r.Client, localClusterName)
 		if err != nil {
 			log.Error(err, "Failed to delete observabilityaddon")

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -190,7 +190,7 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				},
 			},
 		})
-		operatorconfig.HubMetricsCollectorResources = *config.GetOBAResources(mco.Spec.ObservabilityAddonSpec)
+		operatorconfig.HubObservabilityAddonSpec = mco.Spec.ObservabilityAddonSpec
 		err = deleteObsAddon(r.Client, localClusterName)
 		if err != nil {
 			log.Error(err, "Failed to delete observabilityaddon")

--- a/operators/pkg/config/config.go
+++ b/operators/pkg/config/config.go
@@ -4,7 +4,9 @@
 
 package config
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	observabilityshared "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/shared"
+)
 
 const (
 	ClusterNameKey                  = "cluster-name"
@@ -61,18 +63,16 @@ const (
 	WorkloadPartitioningNSExpectedValue  = "management"
 )
 
-var (
-	ImageKeyNameMap = map[string]string{
-		PrometheusKey:                  PrometheusKey,
-		KubeStateMetricsKey:            KubeStateMetricsImgName,
-		NodeExporterKey:                NodeExporterImgName,
-		KubeRbacProxyKey:               KubeRbacProxyImgName,
-		MetricsCollectorKey:            MetricsCollectorImgName,
-		PrometheusConfigmapReloaderKey: PrometheusConfigmapReloaderImgName,
-	}
-)
+var ImageKeyNameMap = map[string]string{
+	PrometheusKey:                  PrometheusKey,
+	KubeStateMetricsKey:            KubeStateMetricsImgName,
+	NodeExporterKey:                NodeExporterImgName,
+	KubeRbacProxyKey:               KubeRbacProxyImgName,
+	MetricsCollectorKey:            MetricsCollectorImgName,
+	PrometheusConfigmapReloaderKey: PrometheusConfigmapReloaderImgName,
+}
 
 var (
-	HubMetricsCollectorResources = corev1.ResourceRequirements{}
-	IsMCOTerminating             = false
+	HubObservabilityAddonSpec = &observabilityshared.ObservabilityAddonSpec{}
+	IsMCOTerminating          = false
 )

--- a/operators/pkg/config/config.go
+++ b/operators/pkg/config/config.go
@@ -4,10 +4,6 @@
 
 package config
 
-import (
-	observabilityshared "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/shared"
-)
-
 const (
 	ClusterNameKey                  = "cluster-name"
 	HubInfoSecretName               = "hub-info-secret"
@@ -73,6 +69,5 @@ var ImageKeyNameMap = map[string]string{
 }
 
 var (
-	HubObservabilityAddonSpec = &observabilityshared.ObservabilityAddonSpec{}
-	IsMCOTerminating          = false
+	IsMCOTerminating = false
 )


### PR DESCRIPTION
There's no other way to fetch the observability addon spec from the metrics collector in the Hub besides querying the kube API for it. 

This fixes the synchronization of the MCO's observability addon spec to the hub's collector.

Important note: with these changes, the Hub's metrics collector will abide to the `metricsEnabled` setting of the `ObservabilityAddon` spec.