### PR TITLE
[2.10] [ACM-10406] Fix handling of updates on AddOnDeploymentConfig 

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -42,6 +42,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+	observatoriumv1alpha1 "github.com/stolostron/observatorium-operator/api/v1alpha1"
+
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	placementctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/placementrule"
 	certctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/certificates"
@@ -52,8 +55,6 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/operators/pkg/deploying"
 	commonutil "github.com/stolostron/multicluster-observability-operator/operators/pkg/util"
 	operatorsutil "github.com/stolostron/multicluster-observability-operator/operators/pkg/util"
-	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
-	observatoriumv1alpha1 "github.com/stolostron/observatorium-operator/api/v1alpha1"
 )
 
 const (
@@ -241,14 +242,13 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 		return *result, err
 	}
 
-	//set operand names to cover the upgrade case since we have name changed in new release
+	// set operand names to cover the upgrade case since we have name changed in new release
 	err = config.SetOperandNames(r.Client)
 	if err != nil {
 		return *result, err
 	}
-	//instance.Namespace = config.GetDefaultNamespace()
 	instance.Spec.StorageConfig.StorageClass = storageClassSelected
-	//Render the templates with a specified CR
+	// Render the templates with a specified CR
 	renderer := rendering.NewMCORenderer(instance, r.Client)
 	toDeploy, err := renderer.Render()
 	if err != nil {
@@ -256,7 +256,7 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 		return ctrl.Result{}, err
 	}
 	deployer := deploying.NewDeployer(r.Client)
-	//Deploy the resources
+	// Deploy the resources
 	ns := &corev1.Namespace{}
 	for _, res := range toDeploy {
 		resNS := res.GetNamespace()
@@ -364,7 +364,7 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 		isLegacyResourceRemoved = true
 	}
 
-	//update status
+	// update status
 	requeueStatusUpdate <- struct{}{}
 
 	return ctrl.Result{}, nil

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
@@ -100,18 +100,19 @@ func getClusterPreds() predicate.Funcs {
 	}
 }
 
-func GetAddOnDeploymentPredicates() predicate.Funcs {
+func GetAddOnDeploymentConfigPredicates() predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			return true
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			if !reflect.DeepEqual(e.ObjectNew.(*addonv1alpha1.AddOnDeploymentConfig).Spec.ProxyConfig,
-				e.ObjectOld.(*addonv1alpha1.AddOnDeploymentConfig).Spec.ProxyConfig) {
-				log.Info("AddonDeploymentConfig is updated", e.ObjectNew.GetName(), "name", e.ObjectNew.GetNamespace(), "namespace")
-				return true
+			newObj := e.ObjectNew.(*addonv1alpha1.AddOnDeploymentConfig)
+			oldObj := e.ObjectOld.(*addonv1alpha1.AddOnDeploymentConfig)
+			if reflect.DeepEqual(newObj.Spec, oldObj.Spec) {
+				return false
 			}
-			return false
+			log.Info("AddonDeploymentConfig is updated", e.ObjectNew.GetName(), "name", e.ObjectNew.GetNamespace(), "namespace")
+			return true
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return true

--- a/operators/multiclusterobservability/main.go
+++ b/operators/multiclusterobservability/main.go
@@ -35,6 +35,12 @@ import (
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 	migrationv1alpha1 "sigs.k8s.io/kube-storage-version-migrator/pkg/apis/migration/v1alpha1"
 
+	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+	observatoriumAPIs "github.com/stolostron/observatorium-operator/api/v1alpha1"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
+
 	observabilityv1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
 	observabilityv1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	mcoctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/multiclusterobservability"
@@ -42,11 +48,6 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/util"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/webhook"
 	operatorsutil "github.com/stolostron/multicluster-observability-operator/operators/pkg/util"
-	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
-	observatoriumAPIs "github.com/stolostron/observatorium-operator/api/v1alpha1"
-	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
-	workv1 "open-cluster-management.io/api/work/v1"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
This cherry picks #1376 into the 2.10 release stream.

Fix in the addon deployment config predicate: we should not only compare the proxy config, but the whole spec, and trigger a reconciliation if anything has changed there.

Fix in the placement rule controller: whenever starting the loop for fetching a new default addon deployment config, reassign the result var to an empty config. We only change it from empty if we find any.