### PR TITLE
[ACM-10811] [2.10] Fix lack of reconciliation of hub's metrics collector 

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -290,7 +290,6 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
-	// TODO: UPDATE
 	return ctrl.Result{}, nil
 }
 
@@ -466,6 +465,10 @@ func (r *ObservabilityAddonReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		For(
 			&oav1beta1.ObservabilityAddon{},
 			builder.WithPredicates(getPred(obAddonName, namespace, true, true, true)),
+		).
+		Watches(
+			&source.Kind{Type: &oav1beta2.MultiClusterObservability{}},
+			&handler.EnqueueRequestForObject{},
 		).
 		Watches(
 			&source.Kind{Type: &corev1.Secret{}},

--- a/operators/endpointmetrics/main.go
+++ b/operators/endpointmetrics/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/util"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/version"
 	oav1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
+	oav1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	operatorsutil "github.com/stolostron/multicluster-observability-operator/operators/pkg/util"
 	// +kubebuilder:scaffold:imports
@@ -47,6 +48,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(oav1beta1.AddToScheme(scheme))
+	utilruntime.Must(oav1beta2.AddToScheme(scheme))
 	utilruntime.Must(ocinfrav1.AddToScheme(scheme))
 	utilruntime.Must(prometheusv1.AddToScheme(scheme))
 	utilruntime.Must(hyperv1.AddToScheme(scheme))
@@ -96,6 +98,9 @@ func main() {
 		},
 		oav1beta1.GroupVersion.WithKind("ObservabilityAddon"): {
 			{FieldSelector: namespaceSelector},
+		},
+		oav1beta2.GroupVersion.WithKind("MultiClusterObservability"): {
+			{FieldSelector: "metadata.name!=null"},
 		},
 	}
 


### PR DESCRIPTION
This backports #1391 into the 2.10 release stream.