### PR TITLE
ACM-10828: sort resources for microshift install

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -243,9 +243,12 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 			if !isHubMetricsCollector {
 				// For kind tests we need to deploy prometheus in hub but cannot set controller
 				// reference as there is no observabilityaddon
-				if err := controllerutil.SetControllerReference(obsAddon, res, r.Scheme); err != nil {
-					log.Info("Failed to set controller reference", "resource", res.GetName())
-					globalRes = append(globalRes, res)
+				// skip owner label for role and rolebinding
+				if res.GetKind() != "Role" && res.GetKind() != "RoleBinding" {
+					if err := controllerutil.SetControllerReference(obsAddon, res, r.Scheme); err != nil {
+						log.Info("Failed to set controller reference", "resource", res.GetName())
+						globalRes = append(globalRes, res)
+					}
 				}
 			}
 			if err := deployer.Deploy(res); err != nil {

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -394,6 +394,12 @@ func (r *ObservabilityAddonReconciler) ensureOpenShiftMonitoringLabelAndRole(ctx
 				Resources: []string{"services", "endpoints", "pods"},
 				Verbs:     []string{"get", "list", "watch"},
 			},
+			// add finalizers on observabilityaddon resource
+			{
+				APIGroups: []string{"observability.open-cluster-management.io"},
+				Resources: []string{"observabilityaddons/finalizers"},
+				Verbs:     []string{"*"},
+			},
 		},
 	}
 

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -243,14 +243,12 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 			if !isHubMetricsCollector {
 				// For kind tests we need to deploy prometheus in hub but cannot set controller
 				// reference as there is no observabilityaddon
-				// skip owner label for role and rolebinding
-				if res.GetKind() != "Role" && res.GetKind() != "RoleBinding" {
-					if err := controllerutil.SetControllerReference(obsAddon, res, r.Scheme); err != nil {
-						log.Info("Failed to set controller reference", "resource", res.GetName())
-						globalRes = append(globalRes, res)
-					}
+				if err := controllerutil.SetControllerReference(obsAddon, res, r.Scheme); err != nil {
+					log.Info("Failed to set controller reference", "resource", res.GetName(), "kind", res.GetKind(), "error", err)
+					globalRes = append(globalRes, res)
 				}
 			}
+
 			if err := deployer.Deploy(res); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to deploy %s %s/%s: %w", res.GetKind(), namespace, res.GetName(), err)
 			}
@@ -394,12 +392,6 @@ func (r *ObservabilityAddonReconciler) ensureOpenShiftMonitoringLabelAndRole(ctx
 				Resources: []string{"services", "endpoints", "pods"},
 				Verbs:     []string{"get", "list", "watch"},
 			},
-			// add finalizers on observabilityaddon resource
-			{
-				APIGroups: []string{"observability.open-cluster-management.io"},
-				Resources: []string{"observabilityaddons/finalizers"},
-				Verbs:     []string{"*"},
-			},
 		},
 	}
 
@@ -484,15 +476,20 @@ func (r *ObservabilityAddonReconciler) SetupWithManager(mgr ctrl.Manager) error 
 	if os.Getenv("NAMESPACE") != "" {
 		namespace = os.Getenv("NAMESPACE")
 	}
-	return ctrl.NewControllerManagedBy(mgr).
-		For(
-			&oav1beta1.ObservabilityAddon{},
-			builder.WithPredicates(getPred(obAddonName, namespace, true, true, true)),
-		).
-		Watches(
+
+	ctrlBuilder := ctrl.NewControllerManagedBy(mgr).For(
+		&oav1beta1.ObservabilityAddon{},
+		builder.WithPredicates(getPred(obAddonName, namespace, true, true, true)),
+	)
+
+	if isHubMetricsCollector {
+		ctrlBuilder = ctrlBuilder.Watches(
 			&source.Kind{Type: &oav1beta2.MultiClusterObservability{}},
 			&handler.EnqueueRequestForObject{},
-		).
+		)
+	}
+
+	return ctrlBuilder.
 		Watches(
 			&source.Kind{Type: &corev1.Secret{}},
 			&handler.EnqueueRequestForObject{},

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -240,6 +240,10 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 		deployer := deploying.NewDeployer(r.Client)
 		for _, res := range toDeploy {
+			if res.GetNamespace() != namespace {
+				globalRes = append(globalRes, res)
+			}
+
 			if !isHubMetricsCollector {
 				// For kind tests we need to deploy prometheus in hub but cannot set controller
 				// reference as there is no observabilityaddon
@@ -249,8 +253,7 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 				skipResources := []string{"Role", "RoleBinding", "ClusterRole", "ClusterRoleBinding"}
 				if !slices.Contains(skipResources, res.GetKind()) {
 					if err := controllerutil.SetControllerReference(obsAddon, res, r.Scheme); err != nil {
-						log.Info("Failed to set controller reference", "resource", res.GetName(), "kind", res.GetKind(), "error", err)
-						globalRes = append(globalRes, res)
+						log.Info("Failed to set controller reference", "resource", res.GetName(), "kind", res.GetKind(), "error", err.Error())
 					}
 				}
 			}

--- a/operators/endpointmetrics/main.go
+++ b/operators/endpointmetrics/main.go
@@ -99,9 +99,13 @@ func main() {
 		oav1beta1.GroupVersion.WithKind("ObservabilityAddon"): {
 			{FieldSelector: namespaceSelector},
 		},
-		oav1beta2.GroupVersion.WithKind("MultiClusterObservability"): {
+	}
+
+	// Only watch MCO CRs in the hub cluster to avoid noisy log messages
+	if os.Getenv("HUB_ENDPOINT_OPERATOR") == "true" {
+		gvkLabelMap[oav1beta2.GroupVersion.WithKind("MultiClusterObservability")] = []filteredcache.Selector{
 			{FieldSelector: "metadata.name!=null"},
-		},
+		}
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{

--- a/operators/endpointmetrics/manifests/prometheus/prometheus-operator-role.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/prometheus-operator-role.yaml
@@ -16,6 +16,7 @@ rules:
       - alertmanagerconfigs
       - prometheuses
       - prometheuses/finalizers
+      - prometheuses/status
       - thanosrulers
       - thanosrulers/finalizers
       - servicemonitors

--- a/operators/endpointmetrics/pkg/rendering/renderer.go
+++ b/operators/endpointmetrics/pkg/rendering/renderer.go
@@ -227,7 +227,7 @@ func Render(
 		}
 	}
 
-	// Ordering resources to ensure they are applied in correct order
+	// Ordering resources to ensure they are applied in the correct order
 	slices.SortFunc(resources, func(a, b *unstructured.Unstructured) bool {
 		return (resourcePriority(a) - resourcePriority(b)) < 0
 	})

--- a/operators/endpointmetrics/pkg/rendering/renderer.go
+++ b/operators/endpointmetrics/pkg/rendering/renderer.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"golang.org/x/exp/slices"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -226,7 +227,25 @@ func Render(
 		}
 	}
 
+	// Ordering resources to ensure they are applied in correct order
+	slices.SortFunc(resources, func(a, b *unstructured.Unstructured) bool {
+		return (resourcePriority(a) - resourcePriority(b)) < 0
+	})
+
 	return resources, nil
+}
+
+func resourcePriority(resource *unstructured.Unstructured) int {
+	switch resource.GetKind() {
+	case "Role", "ClusterRole":
+		return 1
+	case "RoleBinding", "ClusterRoleBinding":
+		return 2
+	case "CustomResourceDefinition":
+		return 3
+	default:
+		return 4
+	}
 }
 
 func getDisabledMetrics(c runtimeclient.Client) (string, error) {

--- a/operators/endpointmetrics/pkg/rendering/renderer_test.go
+++ b/operators/endpointmetrics/pkg/rendering/renderer_test.go
@@ -58,6 +58,14 @@ func TestRender(t *testing.T) {
 	}
 
 	printObjs(t, objs)
+
+	// ensure that objects are sorted
+	for i := 0; i < len(objs)-1; i++ {
+		if resourcePriority(objs[i]) > resourcePriority(objs[i+1]) {
+			t.Errorf("objects are not sorted")
+		}
+	}
+
 }
 
 func printObjs(t *testing.T, objs []*unstructured.Unstructured) {

--- a/operators/multiclusterobservability/manifests/endpoint-observability/role.yaml
+++ b/operators/multiclusterobservability/manifests/endpoint-observability/role.yaml
@@ -64,6 +64,12 @@ rules:
   - get
   - update
 - apiGroups:
+  - observability.open-cluster-management.io
+  resources:
+  - observabilityaddons/finalizers
+  verbs:
+  - update
+- apiGroups:
   - config.openshift.io
   resources:
   - clusterversions

--- a/operators/pkg/deploying/deployer.go
+++ b/operators/pkg/deploying/deployer.go
@@ -207,7 +207,7 @@ func (d *Deployer) updateSecret(desiredObj, runtimeObj *unstructured.Unstructure
 
 	if desiredSecret.Data == nil ||
 		!apiequality.Semantic.DeepDerivative(desiredSecret.Data, runtimeSecret.Data) {
-		log.Info("Update", "Kind", desiredObj.GroupVersionKind(), "Name", desiredObj.GetName())
+		logUpdateInfo(desiredObj)
 		return d.client.Update(context.TODO(), desiredSecret)
 	}
 	return nil
@@ -230,7 +230,7 @@ func (d *Deployer) updateClusterRole(desiredObj, runtimeObj *unstructured.Unstru
 
 	if !apiequality.Semantic.DeepDerivative(desiredClusterRole.Rules, runtimeClusterRole.Rules) ||
 		!apiequality.Semantic.DeepDerivative(desiredClusterRole.AggregationRule, runtimeClusterRole.AggregationRule) {
-		log.Info("Update", "Kind", desiredObj.GroupVersionKind(), "Name", desiredObj.GetName())
+		logUpdateInfo(desiredObj)
 		return d.client.Update(context.TODO(), desiredClusterRole)
 	}
 	return nil
@@ -253,7 +253,7 @@ func (d *Deployer) updateClusterRoleBinding(desiredObj, runtimeObj *unstructured
 
 	if !apiequality.Semantic.DeepDerivative(desiredClusterRoleBinding.Subjects, runtimeClusterRoleBinding.Subjects) ||
 		!apiequality.Semantic.DeepDerivative(desiredClusterRoleBinding.RoleRef, runtimeClusterRoleBinding.RoleRef) {
-		log.Info("Update", "Kind", desiredObj.GroupVersionKind(), "Name", desiredObj.GetName())
+		logUpdateInfo(desiredObj)
 		return d.client.Update(context.TODO(), desiredClusterRoleBinding)
 	}
 	return nil
@@ -383,5 +383,5 @@ func (d *Deployer) updateIngress(desiredObj, runtimeObj *unstructured.Unstructur
 }
 
 func logUpdateInfo(obj *unstructured.Unstructured) {
-	log.Info("Update", "kind", obj.GroupVersionKind().Kind, "kindVersion", obj.GroupVersionKind().Version, "name", obj.GetName(), "version", obj.GetResourceVersion())
+	log.Info("Update", "kind", obj.GroupVersionKind().Kind, "kindVersion", obj.GroupVersionKind().Version, "name", obj.GetName())
 }


### PR DESCRIPTION
Enables the endpoint operator to deploy resources on a microshift spoke.
Changes:

- Add necessary permissions for setting finalizers on deployed resources (needs finalizer updates perm on oba which is the referenced owner)
- Sort deployed resources so that needed permissions are deployed first, then needed CRDs, etc.
- Add some other missing perm for prometheus
- Remove noisy logs from the IBM filteredcache by only watching MCO resource when on the hub
- Clean some badly formatted logs in deploy