### PR TITLE
[ACM-10809] Fix handling of updates on AddOnDeploymentConfig

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -36,16 +36,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
+
 	mcov1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/util"
 	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	commonutil "github.com/stolostron/multicluster-observability-operator/operators/pkg/util"
-	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
-	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
-	workv1 "open-cluster-management.io/api/work/v1"
 )
 
 const (
@@ -57,8 +58,7 @@ const (
 )
 
 var (
-	log = logf.Log.WithName("controller_placementrule")
-	//watchNamespace                  = config.GetDefaultNamespace()
+	log                           = logf.Log.WithName("controller_placementrule")
 	isCRoleCreated                = false
 	clusterAddon                  = &addonv1alpha1.ClusterManagementAddOn{}
 	defaultAddonDeploymentConfig  = &addonv1alpha1.AddOnDeploymentConfig{}
@@ -285,11 +285,21 @@ func createAllRelatedRes(
 		isCRoleCreated = true
 	}
 
-	//Get or create ClusterManagementAddon
+	// Get or create ClusterManagementAddon
 	clusterAddon, err = util.CreateClusterManagementAddon(c)
 	if err != nil {
 		return err
 	}
+
+	// Always start this loop with an empty addon deployment config.
+	// This simplifies the logic for the cases where:
+	// - There is nothing in `Spec.SupportedConfigs`.
+	// - There's something in `Spec.SupportedConfigs`, but none of them are for
+	//   the group and resource that we care about.
+	// - There is something in `Spec.SupportedConfigs`, the group and resource are correct,
+	//   but the default config is not present in the manifest or it is not found
+	//   (i.e. was deleted or there's a typo).
+	defaultAddonDeploymentConfig = &addonv1alpha1.AddOnDeploymentConfig{}
 	for _, config := range clusterAddon.Spec.SupportedConfigs {
 		if config.ConfigGroupResource.Group == util.AddonGroup &&
 			config.ConfigGroupResource.Resource == util.AddonDeploymentConfigResource {
@@ -415,7 +425,7 @@ func deleteGlobalResource(c client.Client) error {
 		return err
 	}
 	isCRoleCreated = false
-	//delete ClusterManagementAddon
+	// delete ClusterManagementAddon
 	err = util.DeleteClusterManagementAddon(c)
 	if err != nil {
 		return err
@@ -484,7 +494,6 @@ func createManagedClusterRes(
 }
 
 func deleteManagedClusterRes(c client.Client, namespace string) error {
-
 	managedclusteraddon := &addonv1alpha1.ManagedClusterAddOn{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      util.ManagedClusterAddonName,
@@ -540,7 +549,7 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	clusterPred := getClusterPreds()
 
 	// Watch changes for AddonDeploymentConfig
-	AddonDeploymentPred := GetAddOnDeploymentPredicates()
+	addOnDeploymentConfigPred := GetAddOnDeploymentConfigPredicates()
 
 	obsAddonPred := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
@@ -832,8 +841,9 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// secondary watch for alertmanager accessor serviceaccount
 		Watches(&source.Kind{Type: &corev1.ServiceAccount{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(amAccessorSAPred))
 
-	// watch for AddonDeploymentConfig
-	if _, err := r.RESTMapper.RESTMapping(schema.GroupKind{Group: addonv1alpha1.GroupVersion.Group, Kind: "AddOnDeploymentConfig"}, addonv1alpha1.GroupVersion.Version); err == nil {
+	// watch for AddOnDeploymentConfig
+	addOnDeploymentConfigGroupKind := schema.GroupKind{Group: addonv1alpha1.GroupVersion.Group, Kind: "AddOnDeploymentConfig"}
+	if _, err := r.RESTMapper.RESTMapping(addOnDeploymentConfigGroupKind, addonv1alpha1.GroupVersion.Version); err == nil {
 		ctrBuilder = ctrBuilder.Watches(
 			&source.Kind{Type: &addonv1alpha1.AddOnDeploymentConfig{}},
 			handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
@@ -843,7 +853,7 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					}},
 				}
 			}),
-			builder.WithPredicates(AddonDeploymentPred),
+			builder.WithPredicates(addOnDeploymentConfigPred),
 		)
 	}
 	manifestWorkGroupKind := schema.GroupKind{Group: workv1.GroupVersion.Group, Kind: "ManifestWork"}

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
@@ -77,18 +77,19 @@ func getClusterPreds() predicate.Funcs {
 	}
 }
 
-func GetAddOnDeploymentPredicates() predicate.Funcs {
+func GetAddOnDeploymentConfigPredicates() predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			return true
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			if !reflect.DeepEqual(e.ObjectNew.(*addonv1alpha1.AddOnDeploymentConfig).Spec.ProxyConfig,
-				e.ObjectOld.(*addonv1alpha1.AddOnDeploymentConfig).Spec.ProxyConfig) {
-				log.Info("AddonDeploymentConfig is updated", e.ObjectNew.GetName(), "name", e.ObjectNew.GetNamespace(), "namespace")
-				return true
+			newObj := e.ObjectNew.(*addonv1alpha1.AddOnDeploymentConfig)
+			oldObj := e.ObjectOld.(*addonv1alpha1.AddOnDeploymentConfig)
+			if reflect.DeepEqual(newObj.Spec, oldObj.Spec) {
+				return false
 			}
-			return false
+			log.Info("AddonDeploymentConfig is updated", e.ObjectNew.GetName(), "name", e.ObjectNew.GetNamespace(), "namespace")
+			return true
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return true

--- a/operators/multiclusterobservability/main.go
+++ b/operators/multiclusterobservability/main.go
@@ -35,6 +35,12 @@ import (
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 	migrationv1alpha1 "sigs.k8s.io/kube-storage-version-migrator/pkg/apis/migration/v1alpha1"
 
+	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+	observatoriumAPIs "github.com/stolostron/observatorium-operator/api/v1alpha1"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
+
 	observabilityv1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
 	observabilityv1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	mcoctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/multiclusterobservability"
@@ -42,11 +48,6 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/util"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/webhook"
 	operatorsutil "github.com/stolostron/multicluster-observability-operator/operators/pkg/util"
-	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
-	observatoriumAPIs "github.com/stolostron/observatorium-operator/api/v1alpha1"
-	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
-	workv1 "open-cluster-management.io/api/work/v1"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
This backports #1389 to the 2.9 release stream.

Fix in the addon deployment config predicate: we should not only compare the proxy config, but the whole spec, and trigger a reconciliation if anything has changed there.

Fix in the placement rule controller: whenever starting the loop for fetching a new default addon deployment config, reassign the result var to an empty config. We only change it from empty if we find any.