### PR TITLE
e2e kind tests

### DIFF
--- a/cicd-scripts/customize-mco.sh
+++ b/cicd-scripts/customize-mco.sh
@@ -14,7 +14,7 @@ SED_COMMAND=${SED}' -i-e -e'
 
 # Set the latest snapshot if it is not set
 source ./scripts/test-utils.sh
-LATEST_SNAPSHOT=${LATEST_SNAPSHOT:-$(get_latest_snapshot)}
+LATEST_SNAPSHOT=${LATEST_SNAPSHOT:-$(get_container_image)}
 
 # list all components need to do test.
 CHANGED_COMPONENTS=""

--- a/cicd-scripts/customize-mco.sh
+++ b/cicd-scripts/customize-mco.sh
@@ -16,6 +16,11 @@ SED_COMMAND=${SED}' -i-e -e'
 source ./scripts/test-utils.sh
 LATEST_SNAPSHOT=${LATEST_SNAPSHOT:-$(get_container_image)}
 
+# need to add this annotation due to KinD cluster resources are insufficient
+if [[ -n ${IS_KIND_ENV} ]]; then
+  source ../tests/run-in-kind/env.sh
+fi
+
 # list all components need to do test.
 CHANGED_COMPONENTS=""
 GINKGO_FOCUS=""

--- a/cicd-scripts/customize-mco.sh
+++ b/cicd-scripts/customize-mco.sh
@@ -18,7 +18,7 @@ LATEST_SNAPSHOT=${LATEST_SNAPSHOT:-$(get_container_image)}
 
 # need to add this annotation due to KinD cluster resources are insufficient
 if [[ -n ${IS_KIND_ENV} ]]; then
-  source ../tests/run-in-kind/env.sh
+  source ./tests/run-in-kind/env.sh
 fi
 
 # list all components need to do test.

--- a/cicd-scripts/run-e2e-in-kind-via-prow.sh
+++ b/cicd-scripts/run-e2e-in-kind-via-prow.sh
@@ -16,7 +16,7 @@ OPT=(-q -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -i "${KE
 SED_COMMAND='sed -i-e -e'
 
 source ./scripts/test-utils.sh
-${SED_COMMAND} "$ a\export LATEST_SNAPSHOT=$(get_latest_snapshot)" ./tests/run-in-kind/env.sh
+${SED_COMMAND} "$ a\export LATEST_SNAPSHOT=$(get_container_image)" ./tests/run-in-kind/env.sh
 
 if [ "${OPENSHIFT_CI}" == "true" ]; then
   ${SED_COMMAND} "$ a\export OPENSHIFT_CI=${OPENSHIFT_CI}" ./tests/run-in-kind/env.sh

--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -28,7 +28,7 @@ SED_COMMAND=${SED}' -i-e -e'
 
 # Set the latest snapshot if it is not set
 source ./scripts/test-utils.sh
-LATEST_SNAPSHOT=${LATEST_SNAPSHOT:-$(get_latest_snapshot)}
+LATEST_SNAPSHOT=${LATEST_SNAPSHOT:-$(get_container_image)}
 
 # deploy the hub and spoke core via OLM
 deploy_hub_spoke_core() {

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -232,6 +232,7 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, fmt.Errorf("failed to create CA configmap: %w", err)
 		}
 	} else {
+		log.Info("Coleen installing prometheus")
 		if isHubMetricsCollector && installPrometheus {
 			//This case runs only in kind tests in the hub cluster
 			hubInfo.ClusterName = hubInfo.ClusterName + "-kind"

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -232,6 +232,10 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, fmt.Errorf("failed to create CA configmap: %w", err)
 		}
 	} else {
+		if isHubMetricsCollector && installPrometheus {
+			//This case runs only in kind tests in the hub cluster
+			hubInfo.ClusterName = hubInfo.ClusterName + "-kind"
+		}
 		// Render the prometheus templates
 		renderer := rendererutil.NewRenderer()
 		toDeploy, err := rendering.Render(renderer, r.Client, hubInfo)

--- a/operators/endpointmetrics/pkg/rendering/renderer.go
+++ b/operators/endpointmetrics/pkg/rendering/renderer.go
@@ -73,6 +73,7 @@ func Render(
 		return nil, err
 	}
 	for idx := range resources {
+		log.Info("Coleen for loop resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
 		//if resources kind is clusterrolebinding or rolebinding change the subjects namespace to "open-cluster-management-obserbability"
 		if isKindTest {
 			if resources[idx].GetKind() == "ClusterRoleBinding" || resources[idx].GetKind() == "RoleBinding" {

--- a/operators/endpointmetrics/pkg/rendering/renderer.go
+++ b/operators/endpointmetrics/pkg/rendering/renderer.go
@@ -73,6 +73,7 @@ func Render(
 		return nil, err
 	}
 	for idx := range resources {
+		log.Info("Coleen resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
 		//if resources kind is clusterrolebinding or rolebinding change the subjects namespace to "open-cluster-management-obserbability"
 		if isKindTest {
 			if resources[idx].GetKind() == "ClusterRoleBinding" || resources[idx].GetKind() == "RoleBinding" {
@@ -209,7 +210,7 @@ func Render(
 				//replace all occurrences of open-cluster-management-addon-observability with open-cluster-management-observability in the scrape-targets.yaml
 				s.StringData["scrape-targets.yaml"] = strings.ReplaceAll(s.StringData["scrape-targets.yaml"], "open-cluster-management-addon-observability", "open-cluster-management-observability")
 				// print scrape-targets.yaml
-				log.Info("scrape-targets.yaml", "scrape-targets.yaml", s.StringData["scrape-targets.yaml"])
+				log.Info("Coleen scrape-targets.yaml", "scrape-targets.yaml", s.StringData["scrape-targets.yaml"])
 			}
 
 			// replace the disabled metrics

--- a/operators/endpointmetrics/pkg/rendering/renderer.go
+++ b/operators/endpointmetrics/pkg/rendering/renderer.go
@@ -58,6 +58,7 @@ func Render(
 
 	isKindTest := false
 	if strings.Contains(hubInfo.ClusterName, "kind") {
+		log.Info("Coleen Running in kind test")
 		//remove -kind from the cluster name
 		hubInfo.ClusterName = strings.Replace(hubInfo.ClusterName, "-kind", "", 1)
 		isKindTest = true
@@ -188,6 +189,7 @@ func Render(
 			resources[idx].Object = unstructuredObj
 		}
 		if resources[idx].GetKind() == "Secret" && resources[idx].GetName() == "prometheus-scrape-targets " {
+			log.Info("Coleen scrape Running in kind test 1")
 			obj := util.GetK8sObj(resources[idx].GetKind())
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(resources[idx].Object, obj)
 			if err != nil {
@@ -203,6 +205,7 @@ func Render(
 				)
 			}
 			if isKindTest {
+				log.Info("Coleen scrape Running in kind test 2")
 				//replace all occurrences of open-cluster-management-addon-observability with open-cluster-management-observability in the scrape-targets.yaml
 				s.StringData["scrape-targets.yaml"] = strings.ReplaceAll(s.StringData["scrape-targets.yaml"], "open-cluster-management-addon-observability", "open-cluster-management-observability")
 				// print scrape-targets.yaml

--- a/operators/endpointmetrics/pkg/rendering/renderer.go
+++ b/operators/endpointmetrics/pkg/rendering/renderer.go
@@ -202,6 +202,10 @@ func Render(
 					s.GetName(),
 				)
 			}
+			if isKindTest {
+				//replace all occurrences of open-cluster-management-addon-observability with open-cluster-management-observability in the scrape-targets.yaml
+				s.StringData["scrape-targets.yaml"] = strings.ReplaceAll(s.StringData["scrape-targets.yaml"], "open-cluster-management-addon-observability", "open-cluster-management-observability")
+			}
 
 			// replace the disabled metrics
 			disabledMetricsSt, err := getDisabledMetrics(c)
@@ -210,10 +214,6 @@ func Render(
 			}
 			if disabledMetricsSt != "" {
 				s.StringData["scrape-targets.yaml"] = strings.ReplaceAll(promConfig, "_DISABLED_METRICS_", disabledMetricsSt)
-			}
-			if isKindTest {
-				//replace all occurences of open-cluster-management-addon-observability with open-cluster-management-observability in the scrape-targets.yaml
-				s.StringData["scrape-targets.yaml"] = strings.ReplaceAll(s.StringData["scrape-targets.yaml"], "open-cluster-management-addon-observability", "open-cluster-management-observability")
 			}
 			unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 			if err != nil {

--- a/operators/endpointmetrics/pkg/rendering/renderer.go
+++ b/operators/endpointmetrics/pkg/rendering/renderer.go
@@ -58,7 +58,6 @@ func Render(
 
 	isKindTest := false
 	if strings.Contains(hubInfo.ClusterName, "kind") {
-		log.Info("Coleen Running in kind test")
 		//remove -kind from the cluster name
 		hubInfo.ClusterName = strings.Replace(hubInfo.ClusterName, "-kind", "", 1)
 		isKindTest = true
@@ -73,7 +72,6 @@ func Render(
 		return nil, err
 	}
 	for idx := range resources {
-		log.Info("Coleen for loop resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
 		//if resources kind is clusterrolebinding or rolebinding change the subjects namespace to "open-cluster-management-obserbability"
 		if isKindTest {
 			if resources[idx].GetKind() == "ClusterRoleBinding" || resources[idx].GetKind() == "RoleBinding" {
@@ -88,7 +86,6 @@ func Render(
 			}
 		}
 		if resources[idx].GetKind() == "Deployment" && resources[idx].GetName() == "kube-state-metrics" {
-			log.Info("Coleen resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
 			obj := util.GetK8sObj(resources[idx].GetKind())
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(resources[idx].Object, obj)
 			if err != nil {
@@ -110,7 +107,6 @@ func Render(
 			resources[idx].Object = unstructuredObj
 		}
 		if resources[idx].GetKind() == "Deployment" && resources[idx].GetName() == "prometheus-operator" {
-			log.Info("Coleen resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
 			obj := util.GetK8sObj(resources[idx].GetKind())
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(resources[idx].Object, obj)
 			if err != nil {
@@ -136,7 +132,6 @@ func Render(
 			resources[idx].Object = unstructuredObj
 		}
 		if resources[idx].GetKind() == "Prometheus" && resources[idx].GetName() == "k8s" {
-			log.Info("Coleen resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
 			obj := util.GetK8sObj(resources[idx].GetKind())
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(resources[idx].Object, obj)
 			if err != nil {
@@ -173,7 +168,6 @@ func Render(
 			resources[idx].Object = unstructuredObj
 		}
 		if resources[idx].GetKind() == "DaemonSet" && resources[idx].GetName() == "node-exporter" {
-			log.Info("Coleen resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
 			obj := util.GetK8sObj(resources[idx].GetKind())
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(resources[idx].Object, obj)
 			if err != nil {
@@ -194,8 +188,6 @@ func Render(
 			resources[idx].Object = unstructuredObj
 		}
 		if resources[idx].GetKind() == "Secret" && resources[idx].GetName() == "prometheus-scrape-targets" {
-			log.Info("Coleen resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
-			log.Info("Coleen scrape Running in kind test 1")
 			obj := util.GetK8sObj(resources[idx].GetKind())
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(resources[idx].Object, obj)
 			if err != nil {
@@ -221,11 +213,7 @@ func Render(
 			}
 
 			if isKindTest {
-				log.Info("Coleen scrape Running in kind test new")
-				//replace all occurrences of open-cluster-management-addon-observability with open-cluster-management-observability in the scrape-targets.yaml
 				s.StringData["scrape-targets.yaml"] = strings.ReplaceAll(promConfig, "open-cluster-management-addon-observability", "open-cluster-management-observability")
-				// print scrape-targets.yaml
-				log.Info("Coleen scrape-targets.yaml", "scrape-targets.yaml", s.StringData["scrape-targets.yaml"])
 			}
 			unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 			if err != nil {
@@ -234,7 +222,6 @@ func Render(
 			resources[idx].Object = unstructuredObj
 		}
 		if resources[idx].GetKind() == "Secret" && resources[idx].GetName() == "prometheus-alertmanager" {
-			log.Info("Coleen resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
 			obj := util.GetK8sObj(resources[idx].GetKind())
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(resources[idx].Object, obj)
 			if err != nil {

--- a/operators/endpointmetrics/pkg/rendering/renderer.go
+++ b/operators/endpointmetrics/pkg/rendering/renderer.go
@@ -205,6 +205,8 @@ func Render(
 			if isKindTest {
 				//replace all occurrences of open-cluster-management-addon-observability with open-cluster-management-observability in the scrape-targets.yaml
 				s.StringData["scrape-targets.yaml"] = strings.ReplaceAll(s.StringData["scrape-targets.yaml"], "open-cluster-management-addon-observability", "open-cluster-management-observability")
+				// print scrape-targets.yaml
+				log.Info("scrape-targets.yaml", "scrape-targets.yaml", s.StringData["scrape-targets.yaml"])
 			}
 
 			// replace the disabled metrics

--- a/operators/endpointmetrics/pkg/rendering/renderer.go
+++ b/operators/endpointmetrics/pkg/rendering/renderer.go
@@ -73,7 +73,6 @@ func Render(
 		return nil, err
 	}
 	for idx := range resources {
-		log.Info("Coleen resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
 		//if resources kind is clusterrolebinding or rolebinding change the subjects namespace to "open-cluster-management-obserbability"
 		if isKindTest {
 			if resources[idx].GetKind() == "ClusterRoleBinding" || resources[idx].GetKind() == "RoleBinding" {
@@ -88,6 +87,7 @@ func Render(
 			}
 		}
 		if resources[idx].GetKind() == "Deployment" && resources[idx].GetName() == "kube-state-metrics" {
+			log.Info("Coleen resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
 			obj := util.GetK8sObj(resources[idx].GetKind())
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(resources[idx].Object, obj)
 			if err != nil {
@@ -109,6 +109,7 @@ func Render(
 			resources[idx].Object = unstructuredObj
 		}
 		if resources[idx].GetKind() == "Deployment" && resources[idx].GetName() == "prometheus-operator" {
+			log.Info("Coleen resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
 			obj := util.GetK8sObj(resources[idx].GetKind())
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(resources[idx].Object, obj)
 			if err != nil {
@@ -134,6 +135,7 @@ func Render(
 			resources[idx].Object = unstructuredObj
 		}
 		if resources[idx].GetKind() == "Prometheus" && resources[idx].GetName() == "k8s" {
+			log.Info("Coleen resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
 			obj := util.GetK8sObj(resources[idx].GetKind())
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(resources[idx].Object, obj)
 			if err != nil {
@@ -170,6 +172,7 @@ func Render(
 			resources[idx].Object = unstructuredObj
 		}
 		if resources[idx].GetKind() == "DaemonSet" && resources[idx].GetName() == "node-exporter" {
+			log.Info("Coleen resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
 			obj := util.GetK8sObj(resources[idx].GetKind())
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(resources[idx].Object, obj)
 			if err != nil {
@@ -190,6 +193,7 @@ func Render(
 			resources[idx].Object = unstructuredObj
 		}
 		if resources[idx].GetKind() == "Secret" && resources[idx].GetName() == "prometheus-scrape-targets " {
+			log.Info("Coleen resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
 			log.Info("Coleen scrape Running in kind test 1")
 			obj := util.GetK8sObj(resources[idx].GetKind())
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(resources[idx].Object, obj)
@@ -228,6 +232,7 @@ func Render(
 			resources[idx].Object = unstructuredObj
 		}
 		if resources[idx].GetKind() == "Secret" && resources[idx].GetName() == "prometheus-alertmanager" {
+			log.Info("Coleen resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
 			obj := util.GetK8sObj(resources[idx].GetKind())
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(resources[idx].Object, obj)
 			if err != nil {

--- a/operators/endpointmetrics/pkg/rendering/renderer.go
+++ b/operators/endpointmetrics/pkg/rendering/renderer.go
@@ -210,13 +210,6 @@ func Render(
 					s.GetName(),
 				)
 			}
-			if isKindTest {
-				log.Info("Coleen scrape Running in kind test 2")
-				//replace all occurrences of open-cluster-management-addon-observability with open-cluster-management-observability in the scrape-targets.yaml
-				s.StringData["scrape-targets.yaml"] = strings.ReplaceAll(s.StringData["scrape-targets.yaml"], "open-cluster-management-addon-observability", "open-cluster-management-observability")
-				// print scrape-targets.yaml
-				log.Info("Coleen scrape-targets.yaml", "scrape-targets.yaml", s.StringData["scrape-targets.yaml"])
-			}
 
 			// replace the disabled metrics
 			disabledMetricsSt, err := getDisabledMetrics(c)
@@ -225,6 +218,14 @@ func Render(
 			}
 			if disabledMetricsSt != "" {
 				s.StringData["scrape-targets.yaml"] = strings.ReplaceAll(promConfig, "_DISABLED_METRICS_", disabledMetricsSt)
+			}
+
+			if isKindTest {
+				log.Info("Coleen scrape Running in kind test new")
+				//replace all occurrences of open-cluster-management-addon-observability with open-cluster-management-observability in the scrape-targets.yaml
+				s.StringData["scrape-targets.yaml"] = strings.ReplaceAll(promConfig, "open-cluster-management-addon-observability", "open-cluster-management-observability")
+				// print scrape-targets.yaml
+				log.Info("Coleen scrape-targets.yaml", "scrape-targets.yaml", s.StringData["scrape-targets.yaml"])
 			}
 			unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 			if err != nil {

--- a/operators/endpointmetrics/pkg/rendering/renderer.go
+++ b/operators/endpointmetrics/pkg/rendering/renderer.go
@@ -193,7 +193,7 @@ func Render(
 			}
 			resources[idx].Object = unstructuredObj
 		}
-		if resources[idx].GetKind() == "Secret" && resources[idx].GetName() == "prometheus-scrape-targets " {
+		if resources[idx].GetKind() == "Secret" && resources[idx].GetName() == "prometheus-scrape-targets" {
 			log.Info("Coleen resource type and name", "resource type", resources[idx].GetName(), "resource kind", resources[idx].GetKind())
 			log.Info("Coleen scrape Running in kind test 1")
 			obj := util.GetK8sObj(resources[idx].GetKind())

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -424,6 +424,7 @@ func createAllRelatedRes(
 				if mco.Annotations["test-env"] == "kind-test" {
 					installProm = true
 				}
+				log.Info("Coleen installProm", "installProm", installProm)
 				// Create copy of hub-info-secret for local-cluster since hubInfo is global variable
 				hubInfoSecretCopy := hubInfoSecret.DeepCopy()
 				err = createManagedClusterRes(c, mco,
@@ -507,6 +508,7 @@ func createManagedClusterRes(
 	hubInfo *corev1.Secret,
 	installProm bool,
 ) error {
+	log.Info("Coleen inStALL", "installProm", installProm)
 	err := createObsAddon(c, namespace)
 	if err != nil {
 		log.Error(err, "Failed to create observabilityaddon")

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -1034,6 +1034,11 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&source.Kind{Type: &corev1.Secret{}},
 			&handler.EnqueueRequestForObject{},
 			builder.WithPredicates(getPred(config.AlertmanagerAccessorSecretName, config.GetDefaultNamespace(), false, false, true)),
+		).
+		Watches(
+			&source.Kind{Type: &corev1.ServiceAccount{}},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(getPred(config.HubEndpointSaName, config.GetDefaultNamespace(), false, false, true)),
 		)
 	// create and return a new controller
 	return ctrBuilder.Complete(r)

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -265,6 +265,7 @@ const (
 	HubMetricsCollectorName    = "metrics-collector-deployment"
 	HubUwlMetricsCollectorName = "uwl-metrics-collector-deployment"
 	HubUwlMetricsCollectorNs   = "openshift-user-workload-monitoring"
+	HubEndpointSaName          = "endpoint-observability-operator-sa"
 )
 
 // ObjectStorgeConf is used to Unmarshal from bytes to do validation.

--- a/scripts/test-utils.sh
+++ b/scripts/test-utils.sh
@@ -7,7 +7,7 @@
 get_latest_snapshot() {
   BRANCH=""
   LATEST_SNAPSHOT=""
-  SNAPSHOT_RELEASE=${SNAPSHOT_RELEASE:=2.10}
+  SNAPSHOT_RELEASE=${SNAPSHOT_RELEASE:=2.11}
   MATCH=$SNAPSHOT_RELEASE".*-SNAPSHOT"
   if [[ ${PULL_BASE_REF} == "release-"* ]]; then
     BRANCH=${PULL_BASE_REF#"release-"}

--- a/scripts/test-utils.sh
+++ b/scripts/test-utils.sh
@@ -32,7 +32,8 @@ get_latest_snapshot() {
   MATCH=$SNAPSHOT_RELEASE".*-SNAPSHOT"
   if [[ ${PULL_BASE_REF} == "release-"* ]]; then
     BRANCH=${PULL_BASE_REF#"release-"}
-    LATEST_SNAPSHOT=$(curl https://quay.io/api/v1/repository/open-cluster-management/multicluster-observability-operator | jq '.tags|with_entries(select(.key|test("'${BRANCH}'.*-SNAPSHOT-*")))|keys[length-1]') fi
+    LATEST_SNAPSHOT=$(curl https://quay.io/api/v1/repository/open-cluster-management/multicluster-observability-operator | jq '.tags|with_entries(select(.key|test("'${BRANCH}'.*-SNAPSHOT-*")))|keys[length-1]')
+  fi
   if [[ ${LATEST_SNAPSHOT} == "null" ]] || [[ ${LATEST_SNAPSHOT} == "" ]]; then
     LATEST_SNAPSHOT=$(curl https://quay.io/api/v1/repository/stolostron/multicluster-observability-operator/tag/ | jq --arg MATCH "$MATCH" '.tags[] | select(.name | match($MATCH; "i")  ).name' | sort -r --version-sort | head -n 1)
   fi

--- a/scripts/test-utils.sh
+++ b/scripts/test-utils.sh
@@ -28,12 +28,11 @@ get_container_image() {
 get_latest_snapshot() {
   BRANCH=""
   LATEST_SNAPSHOT=""
-  SNAPSHOT_RELEASE=${SNAPSHOT_RELEASE:=2.11}
+  SNAPSHOT_RELEASE=${SNAPSHOT_RELEASE:=$VERSION}
   MATCH=$SNAPSHOT_RELEASE".*-SNAPSHOT"
   if [[ ${PULL_BASE_REF} == "release-"* ]]; then
     BRANCH=${PULL_BASE_REF#"release-"}
-    LATEST_SNAPSHOT=$(curl https://quay.io//api/v1/repository/open-cluster-management/multicluster-observability-operator | jq '.tags|with_entries(select(.key|test("'${BRANCH}'.*-SNAPSHOT-*")))|keys[length-1]')
-  fi
+    LATEST_SNAPSHOT=$(curl https://quay.io/api/v1/repository/open-cluster-management/multicluster-observability-operator | jq '.tags|with_entries(select(.key|test("'${BRANCH}'.*-SNAPSHOT-*")))|keys[length-1]') fi
   if [[ ${LATEST_SNAPSHOT} == "null" ]] || [[ ${LATEST_SNAPSHOT} == "" ]]; then
     LATEST_SNAPSHOT=$(curl https://quay.io/api/v1/repository/stolostron/multicluster-observability-operator/tag/ | jq --arg MATCH "$MATCH" '.tags[] | select(.name | match($MATCH; "i")  ).name' | sort -r --version-sort | head -n 1)
   fi

--- a/scripts/test-utils.sh
+++ b/scripts/test-utils.sh
@@ -4,6 +4,27 @@
 
 # Use snapshot for target release.
 # Use latest if no branch info detected, or not a release branch.
+VERSION="2.11"
+
+# Determine, based on the branch, which image to use for the test.
+# If the branch is main, then assume that an image for the PR has been built and pushed to quay.io.
+# If the branch is a release branch, then use the latest snapshot image for that release.
+get_container_image() {
+  BRANCH=""
+  LATEST_SNAPSHOT=""
+
+  if [[ ${PULL_BASE_REF} == "main" ]]; then
+    LATEST_SNAPSHOT="${VERSION}-PR${PULL_NUMBER}-${PULL_PULL_SHA}"
+  else
+    LATEST_SNAPSHOT=$(get_latest_snapshot)
+  fi
+
+  # trim the leading and tailing quotes
+  LATEST_SNAPSHOT="${LATEST_SNAPSHOT#\"}"
+  LATEST_SNAPSHOT="${LATEST_SNAPSHOT%\"}"
+  echo ${LATEST_SNAPSHOT}
+}
+
 get_latest_snapshot() {
   BRANCH=""
   LATEST_SNAPSHOT=""

--- a/tests/pkg/tests/observability_endpoint_preserve_test.go
+++ b/tests/pkg/tests/observability_endpoint_preserve_test.go
@@ -122,6 +122,9 @@ var _ = Describe("Observability:", func() {
 	})
 
 	It("[P2][Sev2][observability][Stable] Should revert any manual changes on metrics-collector-view clusterolebinding (endpoint_preserve/g0)", func() {
+		if os.Getenv("IS_KIND_ENV") == trueStr {
+			Skip("Skip the case due to run in KinD")
+		}
 		By("Deleting metrics-collector-view clusterolebinding")
 		err, crb := utils.GetCRB(testOptions, false, "metrics-collector-view")
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/pkg/tests/observability_endpoint_preserve_test.go
+++ b/tests/pkg/tests/observability_endpoint_preserve_test.go
@@ -81,9 +81,6 @@ var _ = Describe("Observability:", func() {
 			}, EventuallyTimeoutMinute*1, EventuallyIntervalSecond*1).Should(BeTrue())
 		})
 		It("[Stable] Updating metrics-collector deployment", func() {
-			if os.Getenv("IS_KIND_ENV") == trueStr {
-				Skip("Skip the case due to run in KinD")
-			}
 			updateSaName := "test-serviceaccount"
 			Eventually(func() error {
 				newDep, err = utils.GetDeployment(
@@ -125,10 +122,6 @@ var _ = Describe("Observability:", func() {
 	})
 
 	It("[P2][Sev2][observability][Stable] Should revert any manual changes on metrics-collector-view clusterolebinding (endpoint_preserve/g0)", func() {
-		if os.Getenv("IS_KIND_ENV") == trueStr {
-			Skip("Skip the case due to run in KinD")
-		}
-
 		By("Deleting metrics-collector-view clusterolebinding")
 		err, crb := utils.GetCRB(testOptions, false, "metrics-collector-view")
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/pkg/tests/observability_endpoint_preserve_test.go
+++ b/tests/pkg/tests/observability_endpoint_preserve_test.go
@@ -38,9 +38,6 @@ var _ = Describe("Observability:", func() {
 	Context("[P2][Sev2][observability] Should revert any manual changes on metrics-collector deployment (endpoint_preserve/g0) -", func() {
 		newDep := &appv1.Deployment{}
 		It("[Stable] Deleting metrics-collector deployment for cluster", func() {
-			if os.Getenv("IS_KIND_ENV") == trueStr {
-				Skip("Skip the case due to run in KinD")
-			}
 			var (
 				err error
 				dep *appv1.Deployment

--- a/tests/pkg/utils/mco_clusterrolebinding.go
+++ b/tests/pkg/utils/mco_clusterrolebinding.go
@@ -25,7 +25,7 @@ func GetCRB(opt TestOptions, isHub bool, name string) (error, *rbacv1.ClusterRol
 func DeleteCRB(opt TestOptions, isHub bool, name string) error {
 	clientKube := getKubeClient(opt, isHub)
 	err := clientKube.RbacV1().ClusterRoleBindings().Delete(context.TODO(), name, metav1.DeleteOptions{})
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		klog.Errorf("Failed to delete cluster rolebinding %s due to %v", name, err)
 	}
 	return err


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-10473

For kind tests the following changes were made

- Since kind needs prometheus installed, an annotation is added to MCO to enable the `installPrometheus` flag. This allows the code path to take the installPrometheus flags route to install the necessary resources while running on kind. 
- We need to also ensure that the prometheus resources are installed in the correct namespace i.e. the `open-cluster-management-observability`. Even the clusterrolebindings should refer to the correct namespace. The scrape-targets has been modified in place to ensure the jobs in the correct namespace are picked.

Annotations logic was merged with e2e tests PR - https://github.com/stolostron/multicluster-observability-operator/pull/1400/files
