### PR TITLE
Add `cluster:node_cpu:ratio` to allowlist

### DIFF
--- a/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
+++ b/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
@@ -17,6 +17,7 @@ data:
       - cluster:cpu_usage_cores:sum
       - cluster:memory_usage:ratio
       - cluster:memory_usage_bytes:sum
+      - cluster:node_cpu:ratio
       - cluster:usage:resources:sum
       - cluster_infrastructure_provider
       - cluster_version


### PR DESCRIPTION
We add this metric to the allowlist as it will be used to optimize dashboard performance for the fleet wide CPU widgets.

The recording rule is already added to *ks clusters here: https://github.com/stolostron/multicluster-observability-operator/blob/7ed36704b0e67ec7b9ac9ea5213c51516475f04f/operators/endpointmetrics/manifests/prometheus/prometheusrules/kube-prometheus-node-recording.yaml#L24

The rule is slightly different from the the statistics we currently use in the dashboard. Before we counted everything except `idle` cpu as "cpu utilization", while this rule also excludes `iowait` and `streal`, this aligns with how i.e node-exporter handle things, more info in the commit message here: https://github.com/prometheus/node_exporter/commit/3e6f4ce627e588e9972e624f1f744c716e11b199