### PR TITLE
[ACM-10706] Add support for custom observability hub URL

### DIFF
--- a/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
+++ b/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
@@ -13,6 +13,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// URL is kubebuilder type that validates the containing string is an URL.
+// +kubebuilder:validation:Pattern=`^https?:\/\/`
+// +kubebuilder:validation:MaxLength=2083
+type URL string
+
 // ObservabilityAddonSpec is the spec of observability addon.
 type ObservabilityAddonSpec struct {
 	// EnableMetrics indicates the observability addon push metrics to hub server.

--- a/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
+++ b/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
@@ -9,6 +9,8 @@
 package shared
 
 import (
+	"net/url"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -17,6 +19,11 @@ import (
 // +kubebuilder:validation:Pattern=`^https?:\/\/`
 // +kubebuilder:validation:MaxLength=2083
 type URL string
+
+func (u URL) Validate() error {
+	_, err := url.Parse(string(u))
+	return err
+}
 
 // ObservabilityAddonSpec is the spec of observability addon.
 type ObservabilityAddonSpec struct {

--- a/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
+++ b/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
@@ -42,6 +42,11 @@ type MultiClusterObservabilitySpec struct {
 }
 
 type AdvancedConfig struct {
+	// CustomObservabilityHubURL overrides the endpoint used by the metrics-collector to send
+	// metrics to the hub server.
+	// For the metrics-collector that runs in the hub this setting has no effect.
+	// +optional
+	CustomObservabilityHubURL observabilityshared.URL `json:"customObservabilityHubURL,omitempty"`
 	// The spec of the data retention configurations
 	// +optional
 	RetentionConfig *RetentionConfig `json:"retentionConfig,omitempty"`

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -1148,6 +1148,11 @@ spec:
                         description: Annotations is an unstructured key value map stored with a service account
                         type: object
                     type: object
+                  customObservabilityHubURL:
+                    description: CustomObservabilityHubURL overrides the endpoint used by the metrics-collector to send metrics to the hub server. For the metrics-collector that runs in the hub this setting has no effect.
+                    maxLength: 2083
+                    pattern: ^https?:\/\/
+                    type: string
                   grafana:
                     description: The spec of grafana
                     properties:

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -1761,6 +1761,14 @@ spec:
                           stored with a service account
                         type: object
                     type: object
+                  customObservabilityHubURL:
+                    description: CustomObservabilityHubURL overrides the endpoint
+                      used by the metrics-collector to send metrics to the hub server.
+                      For the metrics-collector that runs in the hub this setting
+                      has no effect.
+                    maxLength: 2083
+                    pattern: ^https?:\/\/
+                    type: string
                   grafana:
                     description: The spec of grafana
                     properties:

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -481,7 +481,6 @@ func GetDefaultTenantName() string {
 }
 
 // GetObsAPIHost is used to get the URL for observartium api gateway.
-// TODO: grab custom Obs API host from somewhere?
 func GetObsAPIHost(client client.Client, namespace string) (string, error) {
 	mco := &observabilityv1beta2.MultiClusterObservability{}
 	err := client.Get(context.TODO(),

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -492,6 +492,10 @@ func GetObsAPIHost(client client.Client, namespace string) (string, error) {
 	}
 	advancedConfig := mco.Spec.AdvancedConfig
 	if advancedConfig != nil && advancedConfig.CustomObservabilityHubURL != "" {
+		err := advancedConfig.CustomObservabilityHubURL.Validate()
+		if err != nil {
+			return "", err
+		}
 		return string(advancedConfig.CustomObservabilityHubURL), nil
 	}
 	return GetRouteHost(client, obsAPIGateway, namespace)

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -481,7 +481,20 @@ func GetDefaultTenantName() string {
 }
 
 // GetObsAPIHost is used to get the URL for observartium api gateway.
+// TODO: grab custom Obs API host from somewhere?
 func GetObsAPIHost(client client.Client, namespace string) (string, error) {
+	mco := &observabilityv1beta2.MultiClusterObservability{}
+	err := client.Get(context.TODO(),
+		types.NamespacedName{
+			Name: GetMonitoringCRName(),
+		}, mco)
+	if err != nil && !errors.IsNotFound(err) {
+		return "", err
+	}
+	advancedConfig := mco.Spec.AdvancedConfig
+	if advancedConfig != nil && advancedConfig.CustomObservabilityHubURL != "" {
+		return string(advancedConfig.CustomObservabilityHubURL), nil
+	}
 	return GetRouteHost(client, obsAPIGateway, namespace)
 }
 

--- a/operators/multiclusterobservability/pkg/config/config_test.go
+++ b/operators/multiclusterobservability/pkg/config/config_test.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -264,14 +263,30 @@ func TestGetObsAPIHost(t *testing.T) {
 	}
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypes(routev1.GroupVersion, route)
+	scheme.AddKnownTypes(mcov1beta2.GroupVersion, &mcov1beta2.MultiClusterObservability{})
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(route).Build()
 
 	host, _ := GetObsAPIHost(client, "default")
 	if host == apiServerURL {
 		t.Errorf("Should not get route host in default namespace")
 	}
+
 	host, _ = GetObsAPIHost(client, "test")
 	if host != apiServerURL {
+		t.Errorf("Observatorium api (%v) is not the expected (%v)", host, apiServerURL)
+	}
+
+	customBaseURL := "https://custom.base/url"
+	mco := &mcov1beta2.MultiClusterObservability{
+		Spec: mcov1beta2.MultiClusterObservabilitySpec{
+			AdvancedConfig: &mcov1beta2.AdvancedConfig{
+				CustomObservabilityHubURL: mcoshared.URL(customBaseURL),
+			},
+		},
+	}
+	client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(route, mco).Build()
+	host, _ = GetObsAPIHost(client, "test")
+	if host != customBaseURL {
 		t.Errorf("Observatorium api (%v) is not the expected (%v)", host, apiServerURL)
 	}
 }
@@ -325,7 +340,7 @@ func TestIsPaused(t *testing.T) {
 
 func NewFakeClient(mco *mcov1beta2.MultiClusterObservability,
 	obs *observatoriumv1alpha1.Observatorium) client.Client {
-	s := scheme.Scheme
+	s := runtime.NewScheme()
 	s.AddKnownTypes(mcov1beta2.GroupVersion, mco)
 	s.AddKnownTypes(observatoriumv1alpha1.GroupVersion, obs)
 	objs := []runtime.Object{mco, obs}
@@ -446,7 +461,7 @@ func TestReadImageManifestConfigMap(t *testing.T) {
 }
 
 func Test_checkIsIBMCloud(t *testing.T) {
-	s := scheme.Scheme
+	s := runtime.NewScheme()
 	nodeIBM := &corev1.Node{
 		Spec: corev1.NodeSpec{
 			ProviderID: "ibm",
@@ -891,7 +906,7 @@ func TestGetOperandName(t *testing.T) {
 			name:          "Have Observatorium CR without ownerreference",
 			componentName: Alertmanager,
 			prepare: func() {
-				//clean the operandNames map
+				// clean the operandNames map
 				CleanUpOperandNames()
 				mco := &mcov1beta2.MultiClusterObservability{
 					TypeMeta: metav1.TypeMeta{Kind: "MultiClusterObservability"},
@@ -916,7 +931,7 @@ func TestGetOperandName(t *testing.T) {
 				}
 
 				// Register operator types with the runtime scheme.
-				s := scheme.Scheme
+				s := runtime.NewScheme()
 				mcov1beta2.SchemeBuilder.AddToScheme(s)
 				observatoriumv1alpha1.AddToScheme(s)
 				client := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mco, observatorium).Build()
@@ -933,7 +948,7 @@ func TestGetOperandName(t *testing.T) {
 			name:          "Have Observatorium CR (observability-observatorium) with ownerreference",
 			componentName: Alertmanager,
 			prepare: func() {
-				//clean the operandNames map
+				// clean the operandNames map
 				CleanUpOperandNames()
 				mco := &mcov1beta2.MultiClusterObservability{
 					TypeMeta: metav1.TypeMeta{Kind: "MultiClusterObservability"},
@@ -964,7 +979,7 @@ func TestGetOperandName(t *testing.T) {
 				}
 
 				// Register operator types with the runtime scheme.
-				s := scheme.Scheme
+				s := runtime.NewScheme()
 				mcov1beta2.SchemeBuilder.AddToScheme(s)
 				observatoriumv1alpha1.AddToScheme(s)
 				client := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mco, observatorium).Build()
@@ -982,7 +997,7 @@ func TestGetOperandName(t *testing.T) {
 			name:          "Have Observatorium CR (observability) with ownerreference",
 			componentName: Alertmanager,
 			prepare: func() {
-				//clean the operandNames map
+				// clean the operandNames map
 				CleanUpOperandNames()
 				mco := &mcov1beta2.MultiClusterObservability{
 					TypeMeta: metav1.TypeMeta{Kind: "MultiClusterObservability"},
@@ -1013,7 +1028,7 @@ func TestGetOperandName(t *testing.T) {
 				}
 
 				// Register operator types with the runtime scheme.
-				s := scheme.Scheme
+				s := runtime.NewScheme()
 				mcov1beta2.SchemeBuilder.AddToScheme(s)
 				observatoriumv1alpha1.AddToScheme(s)
 				client := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mco, observatorium).Build()

--- a/operators/multiclusterobservability/pkg/config/config_test.go
+++ b/operators/multiclusterobservability/pkg/config/config_test.go
@@ -278,6 +278,9 @@ func TestGetObsAPIHost(t *testing.T) {
 
 	customBaseURL := "https://custom.base/url"
 	mco := &mcov1beta2.MultiClusterObservability{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: GetMonitoringCRName(),
+		},
 		Spec: mcov1beta2.MultiClusterObservabilitySpec{
 			AdvancedConfig: &mcov1beta2.AdvancedConfig{
 				CustomObservabilityHubURL: mcoshared.URL(customBaseURL),
@@ -287,7 +290,7 @@ func TestGetObsAPIHost(t *testing.T) {
 	client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(route, mco).Build()
 	host, _ = GetObsAPIHost(client, "test")
 	if host != customBaseURL {
-		t.Errorf("Observatorium api (%v) is not the expected (%v)", host, apiServerURL)
+		t.Errorf("Observatorium api (%v) is not the expected (%v)", host, customBaseURL)
 	}
 }
 

--- a/operators/multiclusterobservability/pkg/config/config_test.go
+++ b/operators/multiclusterobservability/pkg/config/config_test.go
@@ -465,6 +465,8 @@ func TestReadImageManifestConfigMap(t *testing.T) {
 
 func Test_checkIsIBMCloud(t *testing.T) {
 	s := runtime.NewScheme()
+	s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Node{})
+	s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.NodeList{})
 	nodeIBM := &corev1.Node{
 		Spec: corev1.NodeSpec{
 			ProviderID: "ibm",

--- a/operators/multiclusterobservability/pkg/config/config_test.go
+++ b/operators/multiclusterobservability/pkg/config/config_test.go
@@ -292,6 +292,14 @@ func TestGetObsAPIHost(t *testing.T) {
 	if host != customBaseURL {
 		t.Errorf("Observatorium api (%v) is not the expected (%v)", host, customBaseURL)
 	}
+
+	mco.Spec.AdvancedConfig.CustomObservabilityHubURL = "httpa://foob ar.c"
+	client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(route, mco).Build()
+	_, err := GetObsAPIHost(client, "test")
+	if err == nil {
+		t.Errorf("expected error when parsing URL '%v', but got none", mco.Spec.AdvancedConfig.CustomObservabilityHubURL)
+	}
+
 }
 
 func TestIsPaused(t *testing.T) {


### PR DESCRIPTION
This is supposed to cover cases where there is some sort of intermediate component, like but not limited to a reverse proxy, between the spokes and the Observatorium API Route in the hub.

I decided to add a new field to the MCO CR's advanced config instead of using AddOnDeploymentConfig's custom variables because that's how we customize other things in the MCO. This way the configuration stays all in one place, avoiding any possible user confusion or extra cognitive load.