### PR TITLE
[ACM-10812]: retry status update on conflict

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -202,7 +202,9 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 				// ACM 8509: Special case for hub/local cluster metrics collection
 				// We do not report status for hub endpoint operator
 				if !isHubMetricsCollector {
-					util.ReportStatus(ctx, r.Client, util.NotSupportedStatus, obsAddon.Name, obsAddon.Namespace)
+					if err := util.ReportStatus(ctx, r.Client, util.NotSupportedStatus, obsAddon.Name, obsAddon.Namespace); err != nil {
+						log.Error(err, "Failed to report status")
+					}
 				}
 
 				return ctrl.Result{}, nil
@@ -301,12 +303,16 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 			forceRestart)
 		if err != nil {
 			if !isHubMetricsCollector {
-				util.ReportStatus(ctx, r.Client, util.DegradedStatus, obsAddon.Name, obsAddon.Namespace)
+				if err := util.ReportStatus(ctx, r.Client, util.DegradedStatus, obsAddon.Name, obsAddon.Namespace); err != nil {
+					log.Error(err, "Failed to report status")
+				}
 			}
 			return ctrl.Result{}, fmt.Errorf("failed to update metrics collectors: %w", err)
 		}
 		if created && !isHubMetricsCollector {
-			util.ReportStatus(ctx, r.Client, util.DeployedStatus, obsAddon.Name, obsAddon.Namespace)
+			if err := util.ReportStatus(ctx, r.Client, util.DeployedStatus, obsAddon.Name, obsAddon.Namespace); err != nil {
+				log.Error(err, "Failed to report status")
+			}
 		}
 	} else {
 		deleted, err := updateMetricsCollectors(ctx, r.Client, obsAddon.Spec, *hubInfo, clusterID, clusterType, 0, false)
@@ -314,7 +320,9 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, fmt.Errorf("failed to update metrics collectors: %w", err)
 		}
 		if deleted && !isHubMetricsCollector {
-			util.ReportStatus(ctx, r.Client, util.DisabledStatus, obsAddon.Name, obsAddon.Namespace)
+			if err := util.ReportStatus(ctx, r.Client, util.DisabledStatus, obsAddon.Name, obsAddon.Namespace); err != nil {
+				log.Error(err, "Failed to report status")
+			}
 		}
 	}
 

--- a/operators/endpointmetrics/pkg/util/status.go
+++ b/operators/endpointmetrics/pkg/util/status.go
@@ -54,7 +54,7 @@ var (
 	}
 )
 
-func ReportStatus(ctx context.Context, client client.Client, condition StatusConditionName, addonName, addonNs string) {
+func ReportStatus(ctx context.Context, client client.Client, condition StatusConditionName, addonName, addonNs string) error {
 	newCondition := conditions[condition].DeepCopy()
 	newCondition.LastTransitionTime = metav1.NewTime(time.Now())
 
@@ -79,8 +79,10 @@ func ReportStatus(ctx context.Context, client client.Client, condition StatusCon
 		return client.Status().Update(ctx, obsAddon)
 	})
 	if retryErr != nil {
-		log.Error(retryErr, "Failed to update status for observabilityaddon")
+		return retryErr
 	}
+
+	return nil
 }
 
 // shouldAppendCondition checks if the new condition should be appended to the status conditions

--- a/operators/endpointmetrics/pkg/util/status.go
+++ b/operators/endpointmetrics/pkg/util/status.go
@@ -6,6 +6,7 @@ package util
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	oav1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
@@ -91,6 +92,10 @@ func shouldAppendCondition(conditions []oav1beta1.StatusCondition, newCondition 
 	if len(conditions) == 0 {
 		return true
 	}
+
+	sort.Slice(conditions, func(i, j int) bool {
+		return conditions[i].LastTransitionTime.Before(&conditions[j].LastTransitionTime)
+	})
 
 	lastCondition := conditions[len(conditions)-1]
 

--- a/operators/endpointmetrics/pkg/util/status.go
+++ b/operators/endpointmetrics/pkg/util/status.go
@@ -18,10 +18,11 @@ import (
 type StatusConditionName string
 
 const (
-	DeployedStatus     StatusConditionName = "Deployed"
-	DisabledStatus     StatusConditionName = "Disabled"
-	DegradedStatus     StatusConditionName = "Degraded"
-	NotSupportedStatus StatusConditionName = "NotSupported"
+	DeployedStatus           StatusConditionName = "Deployed"
+	DisabledStatus           StatusConditionName = "Disabled"
+	DegradedStatus           StatusConditionName = "Degraded"
+	NotSupportedStatus       StatusConditionName = "NotSupported"
+	MaxStatusConditionsCount                     = 10
 )
 
 var (
@@ -70,6 +71,11 @@ func ReportStatus(ctx context.Context, client client.Client, condition StatusCon
 		}
 
 		obsAddon.Status.Conditions = append(obsAddon.Status.Conditions, *newCondition)
+
+		if len(obsAddon.Status.Conditions) > MaxStatusConditionsCount {
+			obsAddon.Status.Conditions = obsAddon.Status.Conditions[len(obsAddon.Status.Conditions)-MaxStatusConditionsCount:]
+		}
+
 		return client.Status().Update(ctx, obsAddon)
 	})
 	if retryErr != nil {

--- a/operators/endpointmetrics/pkg/util/status.go
+++ b/operators/endpointmetrics/pkg/util/status.go
@@ -10,45 +10,84 @@ import (
 
 	oav1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type StatusConditionName string
+
+const (
+	DeployedStatus     StatusConditionName = "Deployed"
+	DisabledStatus     StatusConditionName = "Disabled"
+	DegradedStatus     StatusConditionName = "Degraded"
+	NotSupportedStatus StatusConditionName = "NotSupported"
+)
+
 var (
-	conditions = map[string]map[string]string{
-		"Deployed": {
-			"type":    "Progressing",
-			"reason":  "Deployed",
-			"message": "Metrics collector deployed"},
-		"Disabled": {
-			"type":    "Disabled",
-			"reason":  "Disabled",
-			"message": "enableMetrics is set to False"},
-		"Degraded": {
-			"type":    "Degraded",
-			"reason":  "Degraded",
-			"message": "Metrics collector deployment not successful"},
-		"NotSupported": {
-			"type":    "NotSupported",
-			"reason":  "NotSupported",
-			"message": "No Prometheus service found in this cluster"},
+	conditions = map[StatusConditionName]*oav1beta1.StatusCondition{
+		DeployedStatus: {
+			Type:    "Progressing",
+			Reason:  "Deployed",
+			Message: "Metrics collector deployed",
+			Status:  metav1.ConditionTrue,
+		},
+		DisabledStatus: {
+			Type:    "Disabled",
+			Reason:  "Disabled",
+			Message: "enableMetrics is set to False",
+			Status:  metav1.ConditionTrue,
+		},
+		DegradedStatus: {
+			Type:    "Degraded",
+			Reason:  "Degraded",
+			Message: "Metrics collector deployment not successful",
+			Status:  metav1.ConditionTrue,
+		},
+		NotSupportedStatus: {
+			Type:    "NotSupported",
+			Reason:  "NotSupported",
+			Message: "No Prometheus service found in this cluster",
+			Status:  metav1.ConditionTrue,
+		},
 	}
 )
 
-func ReportStatus(ctx context.Context, client client.Client, i *oav1beta1.ObservabilityAddon, t string, reportStatus bool) {
-	if !reportStatus {
-		return
+func ReportStatus(ctx context.Context, client client.Client, condition StatusConditionName, addonName, addonNs string) {
+	newCondition := conditions[condition].DeepCopy()
+	newCondition.LastTransitionTime = metav1.NewTime(time.Now())
+
+	// Fetch the ObservabilityAddon instance in local cluster, and update the status
+	// Retry on conflict
+	obsAddon := &oav1beta1.ObservabilityAddon{}
+	retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := client.Get(ctx, types.NamespacedName{Name: addonName, Namespace: addonNs}, obsAddon); err != nil {
+			return err
+		}
+
+		if !shouldAppendCondition(obsAddon.Status.Conditions, newCondition) {
+			return nil
+		}
+
+		obsAddon.Status.Conditions = append(obsAddon.Status.Conditions, *newCondition)
+		return client.Status().Update(ctx, obsAddon)
+	})
+	if retryErr != nil {
+		log.Error(retryErr, "Failed to update status for observabilityaddon")
 	}
-	i.Status.Conditions = []oav1beta1.StatusCondition{
-		{
-			Type:               conditions[t]["type"],
-			Status:             metav1.ConditionTrue,
-			LastTransitionTime: metav1.NewTime(time.Now()),
-			Reason:             conditions[t]["reason"],
-			Message:            conditions[t]["message"],
-		},
+}
+
+// shouldAppendCondition checks if the new condition should be appended to the status conditions
+// based on the last condition in the slice.
+func shouldAppendCondition(conditions []oav1beta1.StatusCondition, newCondition *oav1beta1.StatusCondition) bool {
+	if len(conditions) == 0 {
+		return true
 	}
-	err := client.Status().Update(ctx, i)
-	if err != nil {
-		log.Error(err, "Failed to update status for observabilityaddon")
-	}
+
+	lastCondition := conditions[len(conditions)-1]
+
+	return lastCondition.Type != newCondition.Type ||
+		lastCondition.Status != newCondition.Status ||
+		lastCondition.Reason != newCondition.Reason ||
+		lastCondition.Message != newCondition.Message
 }


### PR DESCRIPTION
In some cases, while the metrics collector is well deployed in the spoke, the addon status remains in progressing state on the hub. After having modified the part that reflects the local observability addon state to the hub in https://github.com/stolostron/multicluster-observability-operator/pull/1420, this PR modifies the code that updates the local observability addon on the spoke:

- Adds retry logic in case of conflicts
- Avoids overriding the whole the status.Conditions list with the latest one
- Limits the number of status.Conditions to 10.

It also removes some weird stuff like the `reportStatus bool` function parameter in the reportStatus function 😅 