### PR TITLE
Tests: Don't check remote_write_requests on spokes 

### DIFF
--- a/examples/export/v1beta2/custom-certs/observability.yaml
+++ b/examples/export/v1beta2/custom-certs/observability.yaml
@@ -7,7 +7,6 @@ spec:
   advanced:
     retentionConfig:
       blockDuration: 3h
-      cleanupInterval: 6m
       deleteDelay: 50h
       retentionInLocal: 5d
       retentionResolution1h: 31d

--- a/examples/export/v1beta2/observability.yaml
+++ b/examples/export/v1beta2/observability.yaml
@@ -7,7 +7,6 @@ spec:
   advanced:
     retentionConfig:
       blockDuration: 3h
-      cleanupInterval: 6m
       deleteDelay: 50h
       retentionInLocal: 5d
       retentionResolution1h: 31d

--- a/examples/mco/e2e/v1beta2/custom-certs/observability.yaml
+++ b/examples/mco/e2e/v1beta2/custom-certs/observability.yaml
@@ -7,7 +7,6 @@ spec:
   advanced:
     retentionConfig:
       blockDuration: 3h
-      cleanupInterval: 6m
       deleteDelay: 50h
       retentionInLocal: 5d
       retentionResolution1h: 31d

--- a/examples/mco/e2e/v1beta2/observability.yaml
+++ b/examples/mco/e2e/v1beta2/observability.yaml
@@ -7,7 +7,6 @@ spec:
   advanced:
     retentionConfig:
       blockDuration: 3h
-      cleanupInterval: 6m
       deleteDelay: 50h
       retentionInLocal: 5d
       retentionResolution1h: 31d

--- a/tests/pkg/tests/observability_export_test.go
+++ b/tests/pkg/tests/observability_export_test.go
@@ -66,36 +66,42 @@ var _ = Describe("Observability:", func() {
 				yamlB,
 			)).NotTo(HaveOccurred())
 
+		// Get name of the hub cluster
+		hubClusterName := "local-cluster"
+		for _, cluster := range testOptions.ManagedClusters {
+			if cluster.BaseDomain == testOptions.HubCluster.BaseDomain {
+				hubClusterName = cluster.Name
+			}
+		}
+
 		By("Waiting for metrics acm_remote_write_requests_total on grafana console")
 		Eventually(func() error {
-			for _, cluster := range clusters {
-				query := fmt.Sprintf("acm_remote_write_requests_total{cluster=\"%s\"} offset 1m", cluster)
-				err, _ := utils.ContainManagedClusterMetric(
-					testOptions,
-					query,
-					[]string{`"__name__":"acm_remote_write_requests_total"`},
-				)
-				if err != nil {
-					return err
-				}
-				err, _ = utils.ContainManagedClusterMetric(
-					testOptions,
-					query,
-					[]string{`"__name__":"acm_remote_write_requests_total"`,
-						`"code":"200`, `"name":"thanos-receiver"`},
-				)
-				if err != nil {
-					return errors.New("metrics not forwarded to thanos-receiver")
-				}
-				err, _ = utils.ContainManagedClusterMetric(
-					testOptions,
-					query,
-					[]string{`"__name__":"acm_remote_write_requests_total"`,
-						`"code":"204`, `"name":"victoriametrics"`},
-				)
-				if err != nil {
-					return errors.New("metrics not forwarded to victoriametrics")
-				}
+			query := fmt.Sprintf("acm_remote_write_requests_total{cluster=\"%s\"} offset 1m", hubClusterName)
+			err, _ := utils.ContainManagedClusterMetric(
+				testOptions,
+				query,
+				[]string{`"__name__":"acm_remote_write_requests_total"`},
+			)
+			if err != nil {
+				return err
+			}
+			err, _ = utils.ContainManagedClusterMetric(
+				testOptions,
+				query,
+				[]string{`"__name__":"acm_remote_write_requests_total"`,
+					`"code":"200`, `"name":"thanos-receiver"`},
+			)
+			if err != nil {
+				return errors.New("metrics not forwarded to thanos-receiver")
+			}
+			err, _ = utils.ContainManagedClusterMetric(
+				testOptions,
+				query,
+				[]string{`"__name__":"acm_remote_write_requests_total"`,
+					`"code":"204`, `"name":"victoriametrics"`},
+			)
+			if err != nil {
+				return errors.New("metrics not forwarded to victoriametrics")
 			}
 			return nil
 		}, EventuallyTimeoutMinute*20, EventuallyIntervalSecond*5).Should(Succeed())


### PR DESCRIPTION
Previously the test "Should have acm_remote_write_requests_total metrics with correct labels/value" looked for the metric for both the hub cluster and any spokes. However, **per my understanding** the spokes isn't supposed to expose this metric, hence the test would always fail if any managed clusters were added to the test setup.