### PR TITLE
[release-2.9] Relocate kubeconfig for non-root user access

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -11,12 +11,16 @@ RUN go install github.com/onsi/ginkgo/ginkgo@v1.14.2 && go mod vendor && ginkgo 
 # create new docker image to hold built artifacts
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
+# pre-create directories and set permissions
+RUN mkdir -p /resources /results && \
+    chown -R 1001:1001 /resources /results
+
 # run as non-root
 USER 1001:1001
 
 # expose env vars for runtime
-ENV KUBECONFIG "/opt/.kube/config"
-ENV IMPORT_KUBECONFIG "/opt/.kube/import-kubeconfig"
+ENV KUBECONFIG "/workspace/.kube/config"
+ENV IMPORT_KUBECONFIG "/workspace/.kube/import-kubeconfig"
 ENV OPTIONS "/resources/options.yaml"
 ENV REPORT_FILE "/results/results.xml"
 ENV GINKGO_DEFAULT_FLAGS "-slowSpecThreshold=120 -timeout 7200s"


### PR DESCRIPTION
The canary builds run e2e tests in a containerized env, and the user 1001 does not have access to /opt path.

Change kubeconfig path to /workspaces instead so user can access it.

Complimentary [PR 301](https://github.com/stolostron/canary-scripts/pull/301)  in canary-scripts repo that invokes the containerized image