### PR TITLE
[ACM-11722] Add support for alertmanager path prefix and validate URL

### DIFF
--- a/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
+++ b/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
@@ -15,8 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// URL is kubebuilder type that validates the containing string is an URL.
-// +kubebuilder:validation:Pattern=`^https?:\/\/`
+// URL is kubebuilder type that validates the containing string is an HTTPS URL.
+// +kubebuilder:validation:Pattern=`^https:\/\/`
 // +kubebuilder:validation:MaxLength=2083
 type URL string
 

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -1151,12 +1151,12 @@ spec:
                   customAlertmanagerHubURL:
                     description: CustomAlertmanagerHubURL overrides the alertmanager URL to send alerts from the spoke to the hub server. For the alertmanager that runs in the hub this setting has no effect.
                     maxLength: 2083
-                    pattern: ^https?:\/\/
+                    pattern: ^https:\/\/
                     type: string
                   customObservabilityHubURL:
                     description: CustomObservabilityHubURL overrides the endpoint used by the metrics-collector to send metrics to the hub server. For the metrics-collector that runs in the hub this setting has no effect.
                     maxLength: 2083
-                    pattern: ^https?:\/\/
+                    pattern: ^https:\/\/
                     type: string
                   grafana:
                     description: The spec of grafana

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -1766,7 +1766,7 @@ spec:
                       URL to send alerts from the spoke to the hub server. For the
                       alertmanager that runs in the hub this setting has no effect.
                     maxLength: 2083
-                    pattern: ^https?:\/\/
+                    pattern: ^https:\/\/
                     type: string
                   customObservabilityHubURL:
                     description: CustomObservabilityHubURL overrides the endpoint
@@ -1774,7 +1774,7 @@ spec:
                       For the metrics-collector that runs in the hub this setting
                       has no effect.
                     maxLength: 2083
-                    pattern: ^https?:\/\/
+                    pattern: ^https:\/\/
                     type: string
                   grafana:
                     description: The spec of grafana

--- a/operators/multiclusterobservability/controllers/placementrule/hub_info_secret.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_info_secret.go
@@ -7,6 +7,7 @@ package placementrule
 import (
 	"context"
 	"net/url"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
@@ -37,6 +38,10 @@ func generateHubInfoSecret(client client.Client, obsNamespace string,
 		// if alerting is disabled, do not set alertmanagerEndpoint
 		if !config.IsAlertingDisabled() {
 			alertmanagerEndpoint, err = config.GetAlertmanagerEndpoint(context.TODO(), client, obsNamespace)
+			if !strings.HasPrefix(alertmanagerEndpoint, "https://") {
+				alertmanagerEndpoint = "https://" + alertmanagerEndpoint
+			}
+
 			if err != nil {
 				log.Error(err, "Failed to get alertmanager endpoint")
 				return nil, err

--- a/operators/multiclusterobservability/controllers/placementrule/hub_info_secret_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_info_secret_test.go
@@ -135,7 +135,7 @@ func TestNewSecret(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to unmarshal data in hub info secret (%v)", err)
 	}
-	if !strings.HasPrefix(hub.ObservatoriumAPIEndpoint, "https://test-host") || hub.AlertmanagerEndpoint != routeHost || hub.AlertmanagerRouterCA != routerCA {
+	if !strings.HasPrefix(hub.ObservatoriumAPIEndpoint, "https://test-host") || hub.AlertmanagerEndpoint != "https://"+routeHost || hub.AlertmanagerRouterCA != routerCA {
 		t.Fatalf("Wrong content in hub info secret: \ngot: "+hub.ObservatoriumAPIEndpoint+" "+hub.AlertmanagerEndpoint+" "+hub.AlertmanagerRouterCA, clusterName+" "+"https://test-host"+" "+"test-host"+" "+routerCA)
 	}
 }
@@ -155,7 +155,7 @@ func TestNewBYOSecret(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to unmarshal data in hub info secret (%v)", err)
 	}
-	if !strings.HasPrefix(hub.ObservatoriumAPIEndpoint, "https://test-host") || hub.AlertmanagerEndpoint != routeHost || hub.AlertmanagerRouterCA != routerBYOCA {
+	if !strings.HasPrefix(hub.ObservatoriumAPIEndpoint, "https://test-host") || hub.AlertmanagerEndpoint != "https://"+routeHost || hub.AlertmanagerRouterCA != routerBYOCA {
 		t.Fatalf("Wrong content in hub info secret: \ngot: "+hub.ObservatoriumAPIEndpoint+" "+hub.AlertmanagerEndpoint+" "+hub.AlertmanagerRouterCA, clusterName+" "+"https://test-host"+" "+"test-host"+" "+routerBYOCA)
 	}
 }


### PR DESCRIPTION
Previously the URL's path was being ignored in the code that built the additional cluster monitoring configuration. 

I also made the code handle URLs without protocol as being `https://` by default. This has been the only supported protocol anyway as it was previously prepended to all the hosts when the protocol was omitted. 