### PR TITLE
Precreate and set permissions for /workspace/.kube directory

### DIFF
--- a/tests/Containerfile.operator
+++ b/tests/Containerfile.operator
@@ -15,8 +15,8 @@ RUN go install github.com/onsi/ginkgo/ginkgo@v1.14.2 && go mod vendor && ginkgo 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 # pre-create directories and set permissions
-RUN mkdir -p /resources /results && \
-    chown -R 1001:1001 /resources /results
+RUN mkdir -p /resources /results /workspace/.kube && \
+    chown -R 1001:1001 /resources /results /workspace/.kube
 
 # run as non-root
 USER 1001:1001

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -12,8 +12,8 @@ RUN go install github.com/onsi/ginkgo/ginkgo@v1.14.2 && go mod vendor && ginkgo 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 # pre-create directories and set permissions
-RUN mkdir -p /resources /results && \
-    chown -R 1001:1001 /resources /results
+RUN mkdir -p /resources /results /workspace/.kube && \
+    chown -R 1001:1001 /resources /results /workspace/.kube
 
 # run as non-root
 USER 1001:1001


### PR DESCRIPTION
Address the canary failure

Status: Downloaded newer image for quay.io/stolostron/observability-e2e-test:2.11.0-SNAPSHOT-2024-05-17-08-37-07
--- FAIL: TestObservabilityE2E (0.01s)
panic: error loading config file "/workspace/.kube/config": open /workspace/.kube/config: permission denied [recovered]
	panic: error loading config file "/workspace/.kube/config": open /workspace/.kube/config: permission denied