### PR TITLE
2.10: Bump MCO memory limit to 3Gi

### DIFF
--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -520,7 +520,7 @@ spec:
                 resources:
                   limits:
                     cpu: 600m
-                    memory: 1Gi
+                    memory: 3Gi
                   requests:
                     cpu: 100m
                     memory: 128Mi

--- a/operators/multiclusterobservability/config/manager/manager.yaml
+++ b/operators/multiclusterobservability/config/manager/manager.yaml
@@ -62,7 +62,7 @@ spec:
         resources:
           limits:
             cpu: 600m
-            memory: 1024Mi
+            memory: 3Gi
           requests:
             cpu: 100m
             memory: 128Mi


### PR DESCRIPTION
When the memory limit of MCO was bumped from 1Gi to 2Gi in c3e1e947854f3d711afaeccc814e0951a0158af6 it was updated only in the generated manifests, and not source used to generate said manifests. As a result, when we ran `make bundle` the limit was reverted. This was done in e97c825b579398bb68f76c114c62dbec60927ab1 (note this was later partially reverted in d74277862ebb83f14cdca85644aea486aa7b59a2 but the memory limit was not). The end result was the limit being lowered from 2Gi to 1Gi again causing problems on systems with a large number of managed clusters.

In this commit we raise the limit to 3Gi. 3Gi might seem like a high limit, however we occasionally saw OOMs with a 2Gi limit on large perfscale tests. Further, since 2.9 we no longer have any sensible ways to increase these limits on systems that need it, so it's better to have a large margin on the limit for now.