### PR TITLE
(2.10) Tests: Better filtering on snapshot versions

### DIFF
--- a/scripts/test-utils.sh
+++ b/scripts/test-utils.sh
@@ -11,14 +11,14 @@ get_latest_snapshot() {
   MATCH=$SNAPSHOT_RELEASE".*-SNAPSHOT"
   if [[ ${PULL_BASE_REF} == "release-"* ]]; then
     BRANCH=${PULL_BASE_REF#"release-"}
-    LATEST_SNAPSHOT=$(curl https://quay.io//api/v1/repository/open-cluster-management/multicluster-observability-operator | jq '.tags|with_entries(select(.key|test("'${BRANCH}'.*-SNAPSHOT-*")))|keys[length-1]')
+    LATEST_SNAPSHOT=$(curl https://quay.io//api/v1/repository/open-cluster-management/multicluster-observability-operator | jq '.tags|with_entries(select(.key|test("'"${BRANCH}"'.*-SNAPSHOT-*")))|keys[length-1]')
   fi
   if [[ ${LATEST_SNAPSHOT} == "null" ]] || [[ ${LATEST_SNAPSHOT} == "" ]]; then
-    LATEST_SNAPSHOT=$(curl https://quay.io/api/v1/repository/stolostron/multicluster-observability-operator/tag/ | jq --arg MATCH "$MATCH" '.tags[] | select(.name | match($MATCH; "i")  ).name' | sort -r --version-sort | head -n 1)
+    LATEST_SNAPSHOT=$(curl "https://quay.io/api/v1/repository/stolostron/multicluster-observability-operator/tag/?filter_tag_name=like:$SNAPSHOT_RELEASE&limit=100" | jq --arg MATCH "$MATCH" '.tags[] | select(.name | match($MATCH; "i")  ).name' | sort -r --version-sort | head -n 1)
   fi
 
   # trim the leading and tailing quotes
   LATEST_SNAPSHOT="${LATEST_SNAPSHOT#\"}"
   LATEST_SNAPSHOT="${LATEST_SNAPSHOT%\"}"
-  echo ${LATEST_SNAPSHOT}
+  echo "${LATEST_SNAPSHOT}"
 }


### PR DESCRIPTION
Quay may return multiple pages of tags, causing us sometimes to grab a version which is very old. With this commit we tell quay to filter on the release and return more results (100 is the max) which at least should improve things a little. Not perfect though.