### PR TITLE
Tests: Use CI images, and improve getting snapshot from Quay

### DIFF
--- a/cicd-scripts/customize-mco.sh
+++ b/cicd-scripts/customize-mco.sh
@@ -29,33 +29,26 @@ update_mco_cr() {
   if [ "${OPENSHIFT_CI}" == "true" ]; then
     # discard unstaged changes
     cd ${ROOTDIR} && git checkout -- .
-    for component_name in ${CHANGED_COMPONENTS}; do
-      component_anno_name=$(echo ${component_name} | sed 's/-/_/g')
-      get_image ${component_name}
-      ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-${component_anno_name}-image: ${IMAGE}" ${ROOTDIR}/examples/mco/e2e/v1beta1/observability.yaml
-      ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-${component_anno_name}-image: ${IMAGE}" ${ROOTDIR}/examples/mco/e2e/v1beta2/observability.yaml
-    done
-  else
-    if [[ -n ${RBAC_QUERY_PROXY_IMAGE_REF} ]]; then
-      ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-rbac_query_proxy-image: ${RBAC_QUERY_PROXY_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta1/observability.yaml
-      ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-rbac_query_proxy-image: ${RBAC_QUERY_PROXY_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta2/observability.yaml
-    fi
-    if [[ -n ${ENDPOINT_MONITORING_OPERATOR_IMAGE_REF} ]]; then
-      ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-endpoint_monitoring_operator-image: ${ENDPOINT_MONITORING_OPERATOR_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta1/observability.yaml
-      ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-endpoint_monitoring_operator-image: ${ENDPOINT_MONITORING_OPERATOR_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta2/observability.yaml
-    fi
-    if [[ -n ${GRAFANA_DASHBOARD_LOADER_IMAGE_REF} ]]; then
-      ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-grafana_dashboard_loader-image: ${GRAFANA_DASHBOARD_LOADER_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta1/observability.yaml
-      ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-grafana_dashboard_loader-image: ${GRAFANA_DASHBOARD_LOADER_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta2/observability.yaml
-    fi
-    if [[ -n ${METRICS_COLLECTOR_IMAGE_REF} ]]; then
-      ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-metrics_collector-image: ${METRICS_COLLECTOR_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta1/observability.yaml
-      ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-metrics_collector-image: ${METRICS_COLLECTOR_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta2/observability.yaml
-    fi
-    if [[ -n ${OBSERVATORIUM_OPERATOR_IMAGE_REF} ]]; then
-      ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-observatorium_operator-image: ${OBSERVATORIUM_OPERATOR_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta1/observability.yaml
-      ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-metrics_collector-image: ${OBSERVATORIUM_OPERATOR_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta2/observability.yaml
-    fi
+  fi
+  if [[ -n ${RBAC_QUERY_PROXY_IMAGE_REF} ]]; then
+    ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-rbac_query_proxy-image: ${RBAC_QUERY_PROXY_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta1/observability.yaml
+    ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-rbac_query_proxy-image: ${RBAC_QUERY_PROXY_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta2/observability.yaml
+  fi
+  if [[ -n ${ENDPOINT_MONITORING_OPERATOR_IMAGE_REF} ]]; then
+    ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-endpoint_monitoring_operator-image: ${ENDPOINT_MONITORING_OPERATOR_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta1/observability.yaml
+    ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-endpoint_monitoring_operator-image: ${ENDPOINT_MONITORING_OPERATOR_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta2/observability.yaml
+  fi
+  if [[ -n ${GRAFANA_DASHBOARD_LOADER_IMAGE_REF} ]]; then
+    ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-grafana_dashboard_loader-image: ${GRAFANA_DASHBOARD_LOADER_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta1/observability.yaml
+    ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-grafana_dashboard_loader-image: ${GRAFANA_DASHBOARD_LOADER_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta2/observability.yaml
+  fi
+  if [[ -n ${METRICS_COLLECTOR_IMAGE_REF} ]]; then
+    ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-metrics_collector-image: ${METRICS_COLLECTOR_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta1/observability.yaml
+    ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-metrics_collector-image: ${METRICS_COLLECTOR_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta2/observability.yaml
+  fi
+  if [[ -n ${OBSERVATORIUM_OPERATOR_IMAGE_REF} ]]; then
+    ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-observatorium_operator-image: ${OBSERVATORIUM_OPERATOR_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta1/observability.yaml
+    ${SED_COMMAND} "/annotations.*/a \ \ \ \ mco-metrics_collector-image: ${OBSERVATORIUM_OPERATOR_IMAGE_REF}" ${ROOTDIR}/examples/mco/e2e/v1beta2/observability.yaml
   fi
 
   # Add mco-imageTagSuffix annotation

--- a/scripts/test-utils.sh
+++ b/scripts/test-utils.sh
@@ -2,38 +2,29 @@
 # Copyright (c) 2024 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
-VERSION="2.11.0"
+WORKDIR="$(
+  cd "$(dirname "$0")" || exit
+  pwd -P
+)"
 
-# Use the PR mirror image for PRs against main branch.
-get_pr_image() {
-  BRANCH=""
-  LATEST_SNAPSHOT=""
+# Gets version from the component version without the z, i.e 2.11
+VERSION=$(awk -F '.' '{ print $1"."$2 }' <"$WORKDIR"/../COMPONENT_VERSION)
 
-  if [[ ${PULL_BASE_REF} == "main" ]]; then
-    LATEST_SNAPSHOT="${VERSION}-PR${PULL_NUMBER}-${PULL_PULL_SHA}"
-  fi
-
-  # trim the leading and tailing quotes
-  LATEST_SNAPSHOT="${LATEST_SNAPSHOT#\"}"
-  LATEST_SNAPSHOT="${LATEST_SNAPSHOT%\"}"
-  echo ${LATEST_SNAPSHOT}
-}
-
+# Tries to get the latest snapshot for the current release
+# Note if there are more than 100 snapshots per release
+# we might not get the latest as the quay API can only return
+# 100 results, and we only look at the first page.
 get_latest_snapshot() {
-  BRANCH=""
-  LATEST_SNAPSHOT=""
   SNAPSHOT_RELEASE=${SNAPSHOT_RELEASE:=$VERSION}
-  MATCH=$SNAPSHOT_RELEASE".*-SNAPSHOT"
-  if [[ ${PULL_BASE_REF} == "release-"* ]]; then
-    BRANCH=${PULL_BASE_REF#"release-"}
-    LATEST_SNAPSHOT=$(curl https://quay.io/api/v1/repository/open-cluster-management/multicluster-observability-operator | jq '.tags|with_entries(select(.key|test("'${BRANCH}'.*-SNAPSHOT-*")))|keys[length-1]')
-  fi
-  if [[ ${LATEST_SNAPSHOT} == "null" ]] || [[ ${LATEST_SNAPSHOT} == "" ]]; then
-    LATEST_SNAPSHOT=$(curl https://quay.io/api/v1/repository/stolostron/multicluster-observability-operator/tag/ | jq --arg MATCH "$MATCH" '.tags[] | select(.name | match($MATCH; "i")  ).name' | sort -r --version-sort | head -n 1)
-  fi
+  # matches:
+  # version number (i.e 2.11)
+  # z version 1-2 digits
+  # -SNAPSHOT
+  MATCH=$SNAPSHOT_RELEASE".\d{1,2}-SNAPSHOT"
+  LATEST_SNAPSHOT=$(curl "https://quay.io/api/v1/repository/stolostron/multicluster-observability-operator/tag/?filter_tag_name=like:$SNAPSHOT_RELEASE&limit=100" | jq --arg MATCH "$MATCH" '.tags[] | select(.name | match($MATCH; "i")  ).name' | sort -r --version-sort | head -n 1)
 
   # trim the leading and tailing quotes
   LATEST_SNAPSHOT="${LATEST_SNAPSHOT#\"}"
   LATEST_SNAPSHOT="${LATEST_SNAPSHOT%\"}"
-  echo ${LATEST_SNAPSHOT}
+  echo "${LATEST_SNAPSHOT}"
 }


### PR DESCRIPTION
- Always use the CI images we built during tests, don't rely on trying to get a resonable snapshot from quay
- Improve our chances of getting a resonable recent snapshot on quay for images we don't build as part of MCO (like grafana).

More details in individual commits