### PR TITLE
[ACM-11543] Check if URL already contains remote write path before appending it

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/hub_info_secret.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_info_secret.go
@@ -69,9 +69,13 @@ func generateHubInfoSecret(client client.Client, obsNamespace string,
 		}
 	}
 
-	obsApiURL := url.URL{
-		Host: obsAPIHost,
-		Path: operatorconfig.ObservatoriumAPIRemoteWritePath,
+	if !strings.HasSuffix(obsAPIHost, operatorconfig.ObservatoriumAPIRemoteWritePath) {
+		obsAPIHost += operatorconfig.ObservatoriumAPIRemoteWritePath
+	}
+
+	obsApiURL, err := url.Parse(obsAPIHost)
+	if err != nil {
+		return nil, err
 	}
 	if !obsApiURL.IsAbs() {
 		obsApiURL.Scheme = "https"

--- a/operators/multiclusterobservability/controllers/placementrule/hub_info_secret.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_info_secret.go
@@ -69,6 +69,11 @@ func generateHubInfoSecret(client client.Client, obsNamespace string,
 		}
 	}
 
+	// Due to ambiguities in URL parsing when the scheme is not present, we preprend it here.
+	if !strings.HasPrefix(obsAPIHost, "https://") {
+		obsAPIHost = "https://" + obsAPIHost
+	}
+
 	obsApiURL, err := url.Parse(obsAPIHost)
 	if err != nil {
 		return nil, err
@@ -79,10 +84,6 @@ func generateHubInfoSecret(client client.Client, obsNamespace string,
 	// or load balancers).
 	if !strings.HasSuffix(obsApiURL.Path, operatorconfig.ObservatoriumAPIRemoteWritePath) {
 		obsApiURL = obsApiURL.JoinPath(obsAPIHost, operatorconfig.ObservatoriumAPIRemoteWritePath)
-	}
-
-	if !obsApiURL.IsAbs() {
-		obsApiURL.Scheme = "https"
 	}
 
 	hubInfo := &operatorconfig.HubInfo{

--- a/operators/multiclusterobservability/controllers/placementrule/hub_info_secret.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_info_secret.go
@@ -69,7 +69,7 @@ func generateHubInfoSecret(client client.Client, obsNamespace string,
 		}
 	}
 
-	// Due to ambiguities in URL parsing when the scheme is not present, we preprend it here.
+	// Due to ambiguities in URL parsing when the scheme is not present, we prepend it here.
 	if !strings.HasPrefix(obsAPIHost, "https://") {
 		obsAPIHost = "https://" + obsAPIHost
 	}
@@ -83,7 +83,7 @@ func generateHubInfoSecret(client client.Client, obsNamespace string,
 	// a custom sub-path required by intermediate components running between spokes and the hub (i.e. reverse proxies
 	// or load balancers).
 	if !strings.HasSuffix(obsApiURL.Path, operatorconfig.ObservatoriumAPIRemoteWritePath) {
-		obsApiURL = obsApiURL.JoinPath(obsAPIHost, operatorconfig.ObservatoriumAPIRemoteWritePath)
+		obsApiURL = obsApiURL.JoinPath(operatorconfig.ObservatoriumAPIRemoteWritePath)
 	}
 
 	hubInfo := &operatorconfig.HubInfo{


### PR DESCRIPTION
For the reverse proxy/LB support, the remote write endpoint could be under a custom path prefix (i.e. `host:port/custom-path//api/metrics/v1/default/api/v1/receive`). 

We can't hardcoded the path directly to `/api/metrics/v1/default/api/v1/receive`. So the best way forward if to append this path to the url as a string, unless it's already present, then parse it into an `url.URL`. 