### PR TITLE
[ACM-10269] Stamp CSR's organization units with the hash of the CA bundle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20230120202327-72f107311084
 	github.com/openshift/cluster-monitoring-operator v0.0.0-20230118025836-20fcb9f6ef4e
 	github.com/openshift/hypershift v0.1.11
+	github.com/openshift/library-go v0.0.0-20230120214501-9bc305884fcb
 	github.com/prometheus-community/prom-label-proxy v0.6.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.58.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.53.1
@@ -116,7 +117,6 @@ require (
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/openshift/library-go v0.0.0-20230120214501-9bc305884fcb // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/operators/multiclusterobservability/pkg/certificates/cert_agent.go
+++ b/operators/multiclusterobservability/pkg/certificates/cert_agent.go
@@ -55,14 +55,17 @@ func observabilitySignerConfigurations(client client.Client) func(cluster *clust
 				OrganizationUnits: []string{"acm"},
 			},
 		}
+		kubeClientSignerConfigurations := agent.KubeClientSignerConfigurations(addonName, agentName)
+		registrationConfigs := append(kubeClientSignerConfigurations(cluster), observabilityConfig)
+
 		_, _, caCertBytes, err := getCA(client, true)
 		if err == nil {
 			caHashStamp := fmt.Sprintf("ca-hash-%x", sha256.Sum256(caCertBytes))
-			observabilityConfig.Subject.OrganizationUnits = append(observabilityConfig.Subject.OrganizationUnits, caHashStamp)
+			for i := range registrationConfigs {
+				registrationConfigs[i].Subject.OrganizationUnits = append(registrationConfigs[i].Subject.OrganizationUnits, caHashStamp)
+			}
 		}
 
-		kubeClientSignerConfigurations := agent.KubeClientSignerConfigurations(addonName, agentName)
-		registrationConfig := append(kubeClientSignerConfigurations(cluster), observabilityConfig)
-		return registrationConfig
+		return registrationConfigs
 	}
 }

--- a/operators/multiclusterobservability/pkg/certificates/cert_agent_test.go
+++ b/operators/multiclusterobservability/pkg/certificates/cert_agent_test.go
@@ -5,15 +5,46 @@
 package certificates
 
 import (
+	"crypto/sha256"
+	"fmt"
+	"slices"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"open-cluster-management.io/api/addon/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+
+	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 )
 
 func TestCertAgent(t *testing.T) {
-	agent := &ObservabilityAgent{}
+	cert, key, err := NewSigningCertKeyPair("testing-mco", 365*24*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serverCACerts,
+			Namespace: config.GetDefaultNamespace(),
+		},
+		Data: map[string][]byte{
+			"tls.crt": cert,
+			"tls.key": key,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Secret{})
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(caSecret).Build()
+
+	agent := &ObservabilityAgent{client: client}
 	agent.Manifests(nil, nil)
 	options := agent.GetAgentAddonOptions()
 	cluster := &clusterv1.ManagedCluster{
@@ -22,7 +53,23 @@ func TestCertAgent(t *testing.T) {
 		},
 	}
 	configs := options.Registration.CSRConfigurations(cluster)
-	if len(configs) != 2 {
-		t.Fatal("Wrong CSRConfigurations")
+	expectedCSRs := 2
+	if len(configs) != expectedCSRs {
+		t.Fatalf("expected %d CSRs, found %d", expectedCSRs, len(configs))
 	}
+
+	assert.True(t, slices.ContainsFunc(configs, func(reg v1alpha1.RegistrationConfig) bool {
+		return reg.SignerName == "kubernetes.io/kube-apiserver-client"
+	}))
+
+	expectedOrganizationUnits := []string{"acm", fmt.Sprintf("ca-hash-%x", sha256.Sum256(cert))}
+	expectedRegConfig := v1alpha1.RegistrationConfig{
+		SignerName: "open-cluster-management.io/observability-signer",
+		Subject: v1alpha1.Subject{
+			User:              "managed-cluster-observability",
+			Groups:            nil,
+			OrganizationUnits: expectedOrganizationUnits,
+		},
+	}
+	assert.Contains(t, configs, expectedRegConfig)
 }

--- a/operators/multiclusterobservability/pkg/certificates/cert_controller.go
+++ b/operators/multiclusterobservability/pkg/certificates/cert_controller.go
@@ -13,8 +13,10 @@ import (
 	"reflect"
 	"time"
 
-	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"open-cluster-management.io/addon-framework/pkg/addonmanager"
+
+	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 
 	"golang.org/x/exp/slices"
 	appv1 "k8s.io/api/apps/v1"
@@ -26,8 +28,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
@@ -55,7 +55,7 @@ func Start(c client.Client, ingressCtlCrdExists bool) {
 		log.Error(err, "Failed to init addon manager")
 		os.Exit(1)
 	}
-	agent := &ObservabilityAgent{}
+	agent := &ObservabilityAgent{client: c}
 	err = addonMgr.AddAgent(agent)
 	if err != nil {
 		log.Error(err, "Failed to add agent for addon manager")
@@ -246,7 +246,7 @@ func onUpdate(c client.Client, ingressCtlCrdExists bool) func(oldObj, newObj int
 					}
 				case name == hubMetricsCollectorMtlsCert:
 					// ACM 8509: Special case for hub metrics collector
-					//Delete the MTLS secret and the placement controller will reconcile to create a new one
+					// Delete the MTLS secret and the placement controller will reconcile to create a new one
 					HubMtlsSecret := &v1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      operatorconfig.HubMetricsCollectorMtlsCert,

--- a/operators/multiclusterobservability/pkg/certificates/cert_controller.go
+++ b/operators/multiclusterobservability/pkg/certificates/cert_controller.go
@@ -84,10 +84,8 @@ func Start(c client.Client, ingressCtlCrdExists bool) {
 		&v1.Secret{},
 		time.Minute*60,
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: onAdd(c),
-
+			AddFunc:    onAdd(c),
 			DeleteFunc: onDelete(c),
-
 			UpdateFunc: onUpdate(c, ingressCtlCrdExists),
 		},
 	)

--- a/operators/multiclusterobservability/pkg/certificates/test_helpers.go
+++ b/operators/multiclusterobservability/pkg/certificates/test_helpers.go
@@ -1,0 +1,23 @@
+package certificates
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+func NewSigningCertKeyPair(signerName string, validity time.Duration) (certData, keyData []byte, err error) {
+	ca, err := crypto.MakeSelfSignedCAConfigForDuration(signerName, validity)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certBytes := &bytes.Buffer{}
+	keyBytes := &bytes.Buffer{}
+	if err := ca.WriteCertConfig(certBytes, keyBytes); err != nil {
+		return nil, nil, err
+	}
+
+	return certBytes.Bytes(), keyBytes.Bytes(), nil
+}

--- a/operators/multiclusterobservability/pkg/certificates/test_helpers.go
+++ b/operators/multiclusterobservability/pkg/certificates/test_helpers.go
@@ -1,3 +1,7 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
 package certificates
 
 import (


### PR DESCRIPTION
This should trigger a reprocessing of the CSR whenever the CA changes.