### PR TITLE
Prevent unnecessary update of observatorium in MCO

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -161,6 +161,15 @@ func GenerateObservatoriumCR(
 
 	oldSpec := observatoriumCRFound.Spec
 	newSpec := observatoriumCR.Spec
+
+	// keep the tenant id unchanged and ensure the new spec has the same tenant ID as the old spec to prevent Observatorium
+	// from updating
+	for i, newTenant := range newSpec.API.Tenants {
+		for _, oldTenant := range oldSpec.API.Tenants {
+			updateTenantID(&newSpec, newTenant, oldTenant, i)
+		}
+	}
+
 	oldSpecBytes, _ := yaml.Marshal(oldSpec)
 	newSpecBytes, _ := yaml.Marshal(newSpec)
 	if bytes.Equal(newSpecBytes, oldSpecBytes) &&
@@ -171,13 +180,6 @@ func GenerateObservatoriumCR(
 	log.Info("Coleen oldSpec", "oldSpec", string(oldSpecBytes))
 	log.Info("Coleen newSpec", "newSpec", string(newSpecBytes))
 	log.Info("Coleen oldSpecHash", "oldSpecHash", observatoriumCRFound.Labels[obsCRConfigHashLabelName], "newSpecHash", labels[obsCRConfigHashLabelName])
-
-	// keep the tenant id unchanged
-	for i, newTenant := range newSpec.API.Tenants {
-		for _, oldTenant := range oldSpec.API.Tenants {
-			updateTenantID(&newSpec, newTenant, oldTenant, i)
-		}
-	}
 
 	log.Info("Updating observatorium CR",
 		"observatorium", observatoriumCR.Name,

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -177,8 +177,6 @@ func GenerateObservatoriumCR(
 		return nil, nil
 	}
 
-	log.Info("Coleen oldSpec", "oldSpec", string(oldSpecBytes))
-	log.Info("Coleen newSpec", "newSpec", string(newSpecBytes))
 	log.Info("Coleen oldSpecHash", "oldSpecHash", observatoriumCRFound.Labels[obsCRConfigHashLabelName], "newSpecHash", labels[obsCRConfigHashLabelName])
 
 	log.Info("Updating observatorium CR",

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -177,8 +177,6 @@ func GenerateObservatoriumCR(
 		return nil, nil
 	}
 
-	log.Info("Coleen oldSpecHash", "oldSpecHash", observatoriumCRFound.Labels[obsCRConfigHashLabelName], "newSpecHash", labels[obsCRConfigHashLabelName])
-
 	log.Info("Updating observatorium CR",
 		"observatorium", observatoriumCR.Name,
 	)
@@ -246,8 +244,6 @@ func updateTenantID(
 	if oldTenant.Name == newTenant.Name && newTenant.ID == oldTenant.ID {
 		return
 	}
-
-	log.Info("Coleen Updating tenant ID", "oldTenant", oldTenant, "newTenant", newTenant)
 
 	newSpec.API.Tenants[idx].ID = oldTenant.ID
 	for j, hashring := range newSpec.Hashrings {

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -168,6 +168,10 @@ func GenerateObservatoriumCR(
 		return nil, nil
 	}
 
+	log.Info("Coleen oldSpec", "oldSpec", string(oldSpecBytes))
+	log.Info("Coleen newSpec", "newSpec", string(newSpecBytes))
+	log.Info("Coleen oldSpecHash", "oldSpecHash", observatoriumCRFound.Labels[obsCRConfigHashLabelName], "newSpecHash", labels[obsCRConfigHashLabelName])
+
 	// keep the tenant id unchanged
 	for i, newTenant := range newSpec.API.Tenants {
 		for _, oldTenant := range oldSpec.API.Tenants {
@@ -242,6 +246,8 @@ func updateTenantID(
 	if oldTenant.Name == newTenant.Name && newTenant.ID == oldTenant.ID {
 		return
 	}
+
+	log.Info("Coleen Updating tenant ID", "oldTenant", oldTenant, "newTenant", newTenant)
 
 	newSpec.API.Tenants[idx].ID = oldTenant.ID
 	for j, hashring := range newSpec.Hashrings {

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -195,7 +195,8 @@ func shouldUpdateManifestWork(desiredManifests []workv1.Manifest, foundManifests
 	if len(desiredManifests) != len(foundManifests) {
 		return true
 	}
-
+	log.Info("Coleen Desired manifests", "manifests", desiredManifests, "len", len(desiredManifests))
+	log.Info("Coleen Found manifests", "manifests", foundManifests, "len", len(foundManifests))
 	for i, m := range desiredManifests {
 		if !util.CompareObject(m.RawExtension, foundManifests[i].RawExtension) {
 			return true

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -195,8 +195,6 @@ func shouldUpdateManifestWork(desiredManifests []workv1.Manifest, foundManifests
 	if len(desiredManifests) != len(foundManifests) {
 		return true
 	}
-	log.Info("Coleen Desired manifests", "manifests", desiredManifests, "len", len(desiredManifests))
-	log.Info("Coleen Found manifests", "manifests", foundManifests, "len", len(foundManifests))
 	for i, m := range desiredManifests {
 		if !util.CompareObject(m.RawExtension, foundManifests[i].RawExtension) {
 			return true

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -195,6 +195,7 @@ func shouldUpdateManifestWork(desiredManifests []workv1.Manifest, foundManifests
 	if len(desiredManifests) != len(foundManifests) {
 		return true
 	}
+
 	for i, m := range desiredManifests {
 		if !util.CompareObject(m.RawExtension, foundManifests[i].RawExtension) {
 			return true


### PR DESCRIPTION
Everytime we create an Observatorium CR we create a new tenantID for `default` tenant and then ensure that the tenant ID is the same as the ID created the first time. Because of which the comparison in old and new spec differs and we update the spec again although nothing has changed. 