### PR TITLE
Add Observatorium API's external host to tls certs SAN

### DIFF
--- a/operators/multiclusterobservability/pkg/certificates/certificates.go
+++ b/operators/multiclusterobservability/pkg/certificates/certificates.go
@@ -469,7 +469,9 @@ func getHosts(c client.Client, ingressCtlCrdExists bool) ([]string, error) {
 		if err != nil {
 			log.Error(err, "Failed to get api route address")
 			return nil, err
-		} else {
+		}
+		// Sometimes these two are the same, so we avoid the duplication.
+		if url != externalHost {
 			hosts = append(hosts, url)
 		}
 	}

--- a/operators/multiclusterobservability/pkg/certificates/certificates.go
+++ b/operators/multiclusterobservability/pkg/certificates/certificates.go
@@ -14,6 +14,7 @@ import (
 	"encoding/pem"
 	"math/big"
 	"net"
+	"net/url"
 	"time"
 
 	certificatesv1 "k8s.io/api/certificates/v1"
@@ -460,10 +461,17 @@ func pemEncode(cert []byte, key []byte) (*bytes.Buffer, *bytes.Buffer) {
 
 func getHosts(c client.Client, ingressCtlCrdExists bool) ([]string, error) {
 	hosts := []string{config.GetObsAPISvc(config.GetOperandName(config.Observatorium))}
-	externalHost, err := config.GetObsAPIExternalHost(context.TODO(), c, config.GetDefaultNamespace())
-	if err == nil && externalHost != "" {
-		hosts = append(hosts, externalHost)
+
+	customHostPath, err := config.GetObsAPIExternalHost(context.TODO(), c, config.GetDefaultNamespace())
+	if err != nil {
+		return nil, err
 	}
+	// The config.GetObsAPIExternalHost call is already doing URL parsing under the hood to ensure it's valid,
+	// so we don't need to check the error of url.Parse again.
+	url, _ := url.Parse(customHostPath)
+	customHost := url.Hostname()
+	hosts = append(hosts, customHost)
+
 	if ingressCtlCrdExists {
 		url, err := config.GetObsAPIRouteHost(context.TODO(), c, config.GetDefaultNamespace())
 		if err != nil {
@@ -471,7 +479,7 @@ func getHosts(c client.Client, ingressCtlCrdExists bool) ([]string, error) {
 			return nil, err
 		}
 		// Sometimes these two are the same, so we avoid the duplication.
-		if url != externalHost {
+		if url != customHost {
 			hosts = append(hosts, url)
 		}
 	}

--- a/operators/multiclusterobservability/pkg/certificates/certificates.go
+++ b/operators/multiclusterobservability/pkg/certificates/certificates.go
@@ -460,6 +460,10 @@ func pemEncode(cert []byte, key []byte) (*bytes.Buffer, *bytes.Buffer) {
 
 func getHosts(c client.Client, ingressCtlCrdExists bool) ([]string, error) {
 	hosts := []string{config.GetObsAPISvc(config.GetOperandName(config.Observatorium))}
+	externalHost, err := config.GetObsAPIExternalHost(context.TODO(), c, config.GetDefaultNamespace())
+	if err == nil && externalHost != "" {
+		hosts = append(hosts, externalHost)
+	}
 	if ingressCtlCrdExists {
 		url, err := config.GetObsAPIRouteHost(context.TODO(), c, config.GetDefaultNamespace())
 		if err != nil {


### PR DESCRIPTION
If we have an intermediate component, like a load balancer, between Observatorium API and the metrics-collector, we need that component's URL to be part of the SANs.