### PR TITLE
Ensure MCO reconciles for actual updates

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -245,8 +245,6 @@ func updateTenantID(
 		return
 	}
 
-	log.Info("Coleen Updating tenant ID", "oldTenant", oldTenant, "newTenant", newTenant)
-
 	newSpec.API.Tenants[idx].ID = oldTenant.ID
 	for j, hashring := range newSpec.Hashrings {
 		if slices.Contains(hashring.Tenants, newTenant.ID) {

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -245,6 +245,8 @@ func updateTenantID(
 		return
 	}
 
+	log.Info("Coleen Updating tenant ID", "oldTenant", oldTenant, "newTenant", newTenant)
+
 	newSpec.API.Tenants[idx].ID = oldTenant.ID
 	for j, hashring := range newSpec.Hashrings {
 		if slices.Contains(hashring.Tenants, newTenant.ID) {

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -394,7 +394,7 @@ func createManifestWorks(
 	log.Info(fmt.Sprintf("Cluster: %+v, Spec.NodeSelector (after): %+v", clusterName, spec.NodeSelector))
 	log.Info(fmt.Sprintf("Cluster: %+v, Spec.Tolerations (after): %+v", clusterName, spec.Tolerations))
 
-	if clusterName != clusterNamespace {
+	if clusterName == localClusterName {
 		spec.Volumes = []corev1.Volume{}
 		spec.Containers[0].VolumeMounts = []corev1.VolumeMount{}
 		for i, env := range spec.Containers[0].Env {

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -195,7 +195,6 @@ func shouldUpdateManifestWork(desiredManifests []workv1.Manifest, foundManifests
 	if len(desiredManifests) != len(foundManifests) {
 		return true
 	}
-	log.Info("Coleen len desiredManifests", "len", len(desiredManifests), "len", len(foundManifests))
 
 	for i, m := range foundManifests {
 		if !util.CompareObject(m.RawExtension, desiredManifests[i].RawExtension) {

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -395,6 +395,7 @@ func createManifestWorks(
 	log.Info(fmt.Sprintf("Cluster: %+v, Spec.Tolerations (after): %+v", clusterName, spec.Tolerations))
 
 	if clusterName == localClusterName {
+		log.Info("Coleen in local-cluster", "cluster", clusterName, "namespace", clusterNamespace)
 		spec.Volumes = []corev1.Volume{}
 		spec.Containers[0].VolumeMounts = []corev1.VolumeMount{}
 		for i, env := range spec.Containers[0].Env {

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -195,6 +195,7 @@ func shouldUpdateManifestWork(desiredManifests []workv1.Manifest, foundManifests
 	if len(desiredManifests) != len(foundManifests) {
 		return true
 	}
+	log.Info("Coleen len desiredManifests", "len", len(desiredManifests), "len", len(foundManifests))
 
 	for i, m := range foundManifests {
 		if !util.CompareObject(m.RawExtension, desiredManifests[i].RawExtension) {

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -312,7 +312,8 @@ func createManifestWorks(
 	imageRegistryClient := NewImageRegistryClient(c)
 
 	// inject the endpoint operator deployment
-	spec := dep.Spec.Template.Spec
+	endpointMetricsOperatorDeploy = dep.DeepCopy()
+	spec := endpointMetricsOperatorDeploy.Spec.Template.Spec
 	if addonConfig.Spec.NodePlacement != nil {
 		spec.NodeSelector = addonConfig.Spec.NodePlacement.NodeSelector
 		spec.Tolerations = addonConfig.Spec.NodePlacement.Tolerations
@@ -408,12 +409,9 @@ func createManifestWorks(
 			Name:  "HUB_ENDPOINT_OPERATOR",
 			Value: "true",
 		})
-
-		dep.ObjectMeta.Name = config.HubEndpointOperatorName
 	}
-
-	dep.Spec.Template.Spec = spec
-	manifests = injectIntoWork(manifests, dep)
+	endpointMetricsOperatorDeploy.Spec.Template.Spec = spec
+	manifests = injectIntoWork(manifests, endpointMetricsOperatorDeploy)
 	// replace the pull secret and addon components image
 	if hasCustomRegistry {
 		log.Info("Replace the default pull secret to custom pull secret", "cluster", clusterName)

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -395,7 +395,6 @@ func createManifestWorks(
 	log.Info(fmt.Sprintf("Cluster: %+v, Spec.Tolerations (after): %+v", clusterName, spec.Tolerations))
 
 	if clusterName == localClusterName {
-		log.Info("Coleen in local-cluster", "cluster", clusterName, "namespace", clusterNamespace)
 		spec.Volumes = []corev1.Volume{}
 		spec.Containers[0].VolumeMounts = []corev1.VolumeMount{}
 		for i, env := range spec.Containers[0].Env {

--- a/operators/pkg/util/obj_compare.go
+++ b/operators/pkg/util/obj_compare.go
@@ -71,6 +71,9 @@ func GetK8sObjWithVersion(kind, version string) runtime.Object {
 // CompareObject is used to compare two k8s objs are same or not
 func CompareObject(re1 runtime.RawExtension, re2 runtime.RawExtension) bool {
 	if re2.Object == nil {
+		log.Info("Coleen - deep equal", reflect.DeepEqual(re1.Raw, re2.Raw))
+		log.Info("Coleen - deep equal", "re1", re1.Raw)
+		log.Info("Coleen - deep equal", "re2", re2.Raw)
 		return reflect.DeepEqual(re1.Raw, re2.Raw)
 	}
 	obj1, err := GetObject(re1)

--- a/operators/pkg/util/obj_compare.go
+++ b/operators/pkg/util/obj_compare.go
@@ -5,6 +5,7 @@
 package util
 
 import (
+	"k8s.io/apimachinery/pkg/api/equality"
 	"reflect"
 	"strings"
 
@@ -136,7 +137,7 @@ func compareDeployments(obj1 runtime.Object, obj2 runtime.Object) bool {
 		log.Info("Find updated name/namespace for deployment", "deployment", dep1.Name)
 		return false
 	}
-	if !reflect.DeepEqual(dep1.Spec, dep2.Spec) {
+	if !equality.Semantic.DeepEqual(dep1.Spec, dep2.Spec) {
 		log.Info("Coleen print spec", "spec1", dep1.Spec, "spec2", dep2.Spec)
 		log.Info("Find updated deployment", "deployment", dep1.Name)
 		return false

--- a/operators/pkg/util/obj_compare.go
+++ b/operators/pkg/util/obj_compare.go
@@ -134,7 +134,6 @@ func compareDeployments(obj1 runtime.Object, obj2 runtime.Object) bool {
 		return false
 	}
 	if !equality.Semantic.DeepEqual(dep1.Spec, dep2.Spec) {
-		log.Info("Coleen print", "dep1", dep1.Spec, "dep2", dep2.Spec)
 		log.Info("Find updated deployment", "deployment", dep1.Name)
 		return false
 	}

--- a/operators/pkg/util/obj_compare.go
+++ b/operators/pkg/util/obj_compare.go
@@ -71,7 +71,7 @@ func GetK8sObjWithVersion(kind, version string) runtime.Object {
 // CompareObject is used to compare two k8s objs are same or not
 func CompareObject(re1 runtime.RawExtension, re2 runtime.RawExtension) bool {
 	if re2.Object == nil {
-		log.Info("Coleen - deep equal", reflect.DeepEqual(re1.Raw, re2.Raw))
+		log.Info("Coleen - deep equal", "compare", reflect.DeepEqual(re1.Raw, re2.Raw))
 		log.Info("Coleen - deep equal", "re1", re1.Raw)
 		log.Info("Coleen - deep equal", "re2", re2.Raw)
 		return reflect.DeepEqual(re1.Raw, re2.Raw)

--- a/operators/pkg/util/obj_compare.go
+++ b/operators/pkg/util/obj_compare.go
@@ -71,20 +71,24 @@ func GetK8sObjWithVersion(kind, version string) runtime.Object {
 // CompareObject is used to compare two k8s objs are same or not
 func CompareObject(re1 runtime.RawExtension, re2 runtime.RawExtension) bool {
 	if re2.Object == nil {
+		log.Info("Coleen - re2.Object is nil")
 		return reflect.DeepEqual(re1.Raw, re2.Raw)
 	}
 	obj1, err := GetObject(re1)
 	if err != nil {
+		log.Info("Coleen - GetObject failed obj1", "err", err)
 		return false
 	}
 	obj2, err := GetObject(re2)
 	if err != nil {
+		log.Info("Coleen - GetObject failed obj1", "err", err)
 		return false
 	}
 	kind1 := obj1.GetObjectKind().GroupVersionKind().Kind
 	kind2 := obj2.GetObjectKind().GroupVersionKind().Kind
 	version1 := obj1.GetObjectKind().GroupVersionKind().Version
 	version2 := obj2.GetObjectKind().GroupVersionKind().Version
+	log.Info("Coleen - kind1", "kind1", kind1, "kind2", kind2, "version1", version1, "version2", version2)
 	if kind1 != kind2 || version1 != version2 {
 		log.Info("obj1 and obj2 have different Kind or Version",
 			"kind1", kind2, "kind2", kind2, "version1", version1, "version2", version2)
@@ -93,6 +97,7 @@ func CompareObject(re1 runtime.RawExtension, re2 runtime.RawExtension) bool {
 	if kind1 == "CustomResourceDefinition" {
 		kind1 = kind1 + version1
 	}
+	log.Info("Coleen compareObjects")
 	return compFns[kind1](obj1, obj2)
 }
 
@@ -132,6 +137,7 @@ func compareDeployments(obj1 runtime.Object, obj2 runtime.Object) bool {
 		return false
 	}
 	if !reflect.DeepEqual(dep1.Spec, dep2.Spec) {
+		log.Info("Coleen print spec", "spec1", dep1.Spec, "spec2", dep2.Spec)
 		log.Info("Find updated deployment", "deployment", dep1.Name)
 		return false
 	}

--- a/operators/pkg/util/obj_compare.go
+++ b/operators/pkg/util/obj_compare.go
@@ -81,10 +81,13 @@ func CompareObject(re1 runtime.RawExtension, re2 runtime.RawExtension) bool {
 	if err != nil {
 		return false
 	}
+	log.Info("Coleen - obj1", obj1, "obj2", obj2)
 	kind1 := obj1.GetObjectKind().GroupVersionKind().Kind
 	kind2 := obj2.GetObjectKind().GroupVersionKind().Kind
 	version1 := obj1.GetObjectKind().GroupVersionKind().Version
 	version2 := obj2.GetObjectKind().GroupVersionKind().Version
+	//log all variables above
+	log.Info("Coleen - kind1", kind1, "kind2", kind2, "version1", version1, "version2", version2)
 	if kind1 != kind2 || version1 != version2 {
 		log.Info("obj1 and obj2 have different Kind or Version",
 			"kind1", kind2, "kind2", kind2, "version1", version1, "version2", version2)

--- a/operators/pkg/util/obj_compare.go
+++ b/operators/pkg/util/obj_compare.go
@@ -147,7 +147,7 @@ func compareServiceAccounts(obj1 runtime.Object, obj2 runtime.Object) bool {
 		log.Info("Find updated name/namespace for serviceaccount", "serviceaccount", sa1.Name)
 		return false
 	}
-	if !reflect.DeepEqual(sa1.ImagePullSecrets, sa2.ImagePullSecrets) {
+	if !equality.Semantic.DeepEqual(sa1.ImagePullSecrets, sa2.ImagePullSecrets) {
 		log.Info("Find updated imagepullsecrets in serviceaccount", "serviceaccount", sa1.Name)
 		return false
 	}
@@ -161,7 +161,7 @@ func compareClusterRoles(obj1 runtime.Object, obj2 runtime.Object) bool {
 		log.Info("Find updated name for clusterrole", "clusterrole", cr1.Name)
 		return false
 	}
-	if !reflect.DeepEqual(cr1.Rules, cr2.Rules) {
+	if !equality.Semantic.DeepEqual(cr1.Rules, cr2.Rules) {
 		log.Info("Find updated rules in clusterrole", "clusterrole", cr1.Name)
 		return false
 	}
@@ -175,7 +175,7 @@ func compareClusterRoleBindings(obj1 runtime.Object, obj2 runtime.Object) bool {
 		log.Info("Find updated name/namespace for clusterrolebinding", "clusterrolebinding", crb1.Name)
 		return false
 	}
-	if !reflect.DeepEqual(crb1.Subjects, crb2.Subjects) || !reflect.DeepEqual(crb1.RoleRef, crb2.RoleRef) {
+	if !equality.Semantic.DeepEqual(crb1.Subjects, crb2.Subjects) || !reflect.DeepEqual(crb1.RoleRef, crb2.RoleRef) {
 		log.Info("Find updated subjects/rolerefs for clusterrolebinding", "clusterrolebinding", crb1.Name)
 		return false
 	}
@@ -189,7 +189,7 @@ func compareSecrets(obj1 runtime.Object, obj2 runtime.Object) bool {
 		log.Info("Find updated name/namespace for secret", "secret", s1.Name)
 		return false
 	}
-	if !reflect.DeepEqual(s1.Data, s2.Data) {
+	if !equality.Semantic.DeepEqual(s1.Data, s2.Data) {
 		log.Info("Find updated data in secret", "secret", s1.Name)
 		return false
 	}
@@ -203,7 +203,7 @@ func compareServices(obj1 runtime.Object, obj2 runtime.Object) bool {
 		log.Info("Find updated name/namespace for service", "service", s1.Name)
 		return false
 	}
-	if !reflect.DeepEqual(s1.Spec, s2.Spec) {
+	if !equality.Semantic.DeepEqual(s1.Spec, s2.Spec) {
 		log.Info("Find updated data in service", "service", s1.Name)
 		return false
 	}
@@ -217,7 +217,7 @@ func compareConfigMap(obj1 runtime.Object, obj2 runtime.Object) bool {
 		log.Info("Find updated name/namespace for configmap", "configmap", cm1.Name)
 		return false
 	}
-	if !reflect.DeepEqual(cm1.Data, cm2.Data) {
+	if !equality.Semantic.DeepEqual(cm1.Data, cm2.Data) {
 		log.Info("Find updated data in secret", "secret", cm1.Name)
 		return false
 	}
@@ -231,7 +231,7 @@ func compareCRDv1(obj1 runtime.Object, obj2 runtime.Object) bool {
 		log.Info("Find updated name for crd", "crd", crd1.Name)
 		return false
 	}
-	if !reflect.DeepEqual(crd1.Spec, crd2.Spec) {
+	if !equality.Semantic.DeepEqual(crd1.Spec, crd2.Spec) {
 		log.Info("Find updated spec for crd", "crd", crd1.Name)
 		return false
 	}
@@ -245,7 +245,7 @@ func compareCRDv1beta1(obj1 runtime.Object, obj2 runtime.Object) bool {
 		log.Info("Find updated name for crd", "crd", crd1.Name)
 		return false
 	}
-	if !reflect.DeepEqual(crd1.Spec, crd2.Spec) {
+	if !equality.Semantic.DeepEqual(crd1.Spec, crd2.Spec) {
 		log.Info("Find updated spec for crd", "crd", crd1.Name)
 		return false
 	}
@@ -253,5 +253,15 @@ func compareCRDv1beta1(obj1 runtime.Object, obj2 runtime.Object) bool {
 }
 
 func compareObsAddon(obj1 runtime.Object, obj2 runtime.Object) bool {
-	return reflect.DeepEqual(obj1, obj2)
+	addon1 := obj1.(*mcov1beta1.ObservabilityAddon)
+	addon2 := obj2.(*mcov1beta1.ObservabilityAddon)
+	if addon1.Name != addon2.Name || addon1.Namespace != addon2.Namespace {
+		log.Info("Find updated name for ObservabilityAddon", "ObservabilityAddon", addon1.Name)
+		return false
+	}
+	if !equality.Semantic.DeepEqual(addon1.Spec, addon2.Spec) {
+		log.Info("Find updated spec for ObservabilityAddon", "ObservabilityAddon", addon1.Name)
+		return false
+	}
+	return true
 }

--- a/operators/pkg/util/obj_compare.go
+++ b/operators/pkg/util/obj_compare.go
@@ -5,9 +5,10 @@
 package util
 
 import (
-	"k8s.io/apimachinery/pkg/api/equality"
 	"reflect"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/api/equality"
 
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	v1 "k8s.io/api/apps/v1"
@@ -72,24 +73,20 @@ func GetK8sObjWithVersion(kind, version string) runtime.Object {
 // CompareObject is used to compare two k8s objs are same or not
 func CompareObject(re1 runtime.RawExtension, re2 runtime.RawExtension) bool {
 	if re2.Object == nil {
-		log.Info("Coleen - re2.Object is nil")
 		return reflect.DeepEqual(re1.Raw, re2.Raw)
 	}
 	obj1, err := GetObject(re1)
 	if err != nil {
-		log.Info("Coleen - GetObject failed obj1", "err", err)
 		return false
 	}
 	obj2, err := GetObject(re2)
 	if err != nil {
-		log.Info("Coleen - GetObject failed obj1", "err", err)
 		return false
 	}
 	kind1 := obj1.GetObjectKind().GroupVersionKind().Kind
 	kind2 := obj2.GetObjectKind().GroupVersionKind().Kind
 	version1 := obj1.GetObjectKind().GroupVersionKind().Version
 	version2 := obj2.GetObjectKind().GroupVersionKind().Version
-	log.Info("Coleen - kind1", "kind1", kind1, "kind2", kind2, "version1", version1, "version2", version2)
 	if kind1 != kind2 || version1 != version2 {
 		log.Info("obj1 and obj2 have different Kind or Version",
 			"kind1", kind2, "kind2", kind2, "version1", version1, "version2", version2)
@@ -98,7 +95,6 @@ func CompareObject(re1 runtime.RawExtension, re2 runtime.RawExtension) bool {
 	if kind1 == "CustomResourceDefinition" {
 		kind1 = kind1 + version1
 	}
-	log.Info("Coleen compareObjects")
 	return compFns[kind1](obj1, obj2)
 }
 
@@ -138,7 +134,6 @@ func compareDeployments(obj1 runtime.Object, obj2 runtime.Object) bool {
 		return false
 	}
 	if !equality.Semantic.DeepEqual(dep1.Spec, dep2.Spec) {
-		log.Info("Coleen print spec", "spec1", dep1.Spec, "spec2", dep2.Spec)
 		log.Info("Find updated deployment", "deployment", dep1.Name)
 		return false
 	}

--- a/operators/pkg/util/obj_compare.go
+++ b/operators/pkg/util/obj_compare.go
@@ -71,9 +71,6 @@ func GetK8sObjWithVersion(kind, version string) runtime.Object {
 // CompareObject is used to compare two k8s objs are same or not
 func CompareObject(re1 runtime.RawExtension, re2 runtime.RawExtension) bool {
 	if re2.Object == nil {
-		log.Info("Coleen - deep equal", "compare", reflect.DeepEqual(re1.Raw, re2.Raw))
-		log.Info("Coleen - deep equal", "re1", re1.Raw)
-		log.Info("Coleen - deep equal", "re2", re2.Raw)
 		return reflect.DeepEqual(re1.Raw, re2.Raw)
 	}
 	obj1, err := GetObject(re1)
@@ -89,7 +86,6 @@ func CompareObject(re1 runtime.RawExtension, re2 runtime.RawExtension) bool {
 	version1 := obj1.GetObjectKind().GroupVersionKind().Version
 	version2 := obj2.GetObjectKind().GroupVersionKind().Version
 	//log all variables above
-	log.Info("Coleen - kind1", kind1, "kind2", kind2, "version1", version1, "version2", version2)
 	if kind1 != kind2 || version1 != version2 {
 		log.Info("obj1 and obj2 have different Kind or Version",
 			"kind1", kind2, "kind2", kind2, "version1", version1, "version2", version2)

--- a/operators/pkg/util/obj_compare.go
+++ b/operators/pkg/util/obj_compare.go
@@ -134,6 +134,7 @@ func compareDeployments(obj1 runtime.Object, obj2 runtime.Object) bool {
 		return false
 	}
 	if !equality.Semantic.DeepEqual(dep1.Spec, dep2.Spec) {
+		log.Info("Coleen print", "dep1", dep1.Spec, "dep2", dep2.Spec)
 		log.Info("Find updated deployment", "deployment", dep1.Name)
 		return false
 	}

--- a/operators/pkg/util/obj_compare.go
+++ b/operators/pkg/util/obj_compare.go
@@ -85,7 +85,6 @@ func CompareObject(re1 runtime.RawExtension, re2 runtime.RawExtension) bool {
 	kind2 := obj2.GetObjectKind().GroupVersionKind().Kind
 	version1 := obj1.GetObjectKind().GroupVersionKind().Version
 	version2 := obj2.GetObjectKind().GroupVersionKind().Version
-	//log all variables above
 	if kind1 != kind2 || version1 != version2 {
 		log.Info("obj1 and obj2 have different Kind or Version",
 			"kind1", kind2, "kind2", kind2, "version1", version1, "version2", version2)

--- a/operators/pkg/util/obj_compare.go
+++ b/operators/pkg/util/obj_compare.go
@@ -84,7 +84,6 @@ func CompareObject(re1 runtime.RawExtension, re2 runtime.RawExtension) bool {
 	if err != nil {
 		return false
 	}
-	log.Info("Coleen - obj1", obj1, "obj2", obj2)
 	kind1 := obj1.GetObjectKind().GroupVersionKind().Kind
 	kind2 := obj2.GetObjectKind().GroupVersionKind().Kind
 	version1 := obj1.GetObjectKind().GroupVersionKind().Version


### PR DESCRIPTION
Endpoint operator deployment kept getting updated despite having the same spec causing the manifestwork to update and keep reconciling and restarting the endpoint operator 

The changes to the endpoint operator spec  specific to spokes or local-cluster were getting added to a global variable `endpointMetricsOperatorDeploy` and this was causing the manifestworks to differ

https://issues.redhat.com/browse/ACM-12023

Follow up commit after -> https://github.com/stolostron/multicluster-observability-operator/pull/1477


