### PR TITLE
Fix code setting global var with the MCO CR name

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -137,6 +137,11 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 		reqLogger.Info("more than one MultiClusterObservability CR exists, only one should exist")
 		return ctrl.Result{}, nil
 	}
+	if len(mcoList.Items) == 0 {
+		reqLogger.Info("no MultiClusterObservability CR exists, nothing to do")
+		return ctrl.Result{}, nil
+	}
+
 	instance := mcoList.Items[0].DeepCopy()
 	if config.GetMonitoringCRName() != instance.GetName() {
 		config.SetMonitoringCRName(instance.GetName())

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -128,19 +128,18 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	}
 
 	// Fetch the MultiClusterObservability instance
-	instance := &mcov1beta2.MultiClusterObservability{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{
-		Name: config.GetMonitoringCRName(),
-	}, instance)
+	mcoList := &mcov1beta2.MultiClusterObservabilityList{}
+	err := r.Client.List(context.TODO(), mcoList)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
-			return ctrl.Result{}, nil
-		}
-		// Error reading the object - requeue the request.
 		return ctrl.Result{}, err
+	}
+	if len(mcoList.Items) > 1 {
+		reqLogger.Info("more than one MultiClusterObservability CR exists, only one should exist")
+		return ctrl.Result{}, nil
+	}
+	instance := mcoList.Items[0].DeepCopy()
+	if config.GetMonitoringCRName() != instance.GetName() {
+		config.SetMonitoringCRName(instance.GetName())
 	}
 
 	// start to update mco status

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
@@ -23,6 +23,7 @@ func GetMCOPredicateFunc() predicate.Funcs {
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			checkStorageChanged(e.ObjectOld.(*mcov1beta2.MultiClusterObservability).Spec.StorageConfig,
 				e.ObjectNew.(*mcov1beta2.MultiClusterObservability).Spec.StorageConfig)
+			config.SetMonitoringCRName(e.ObjectNew.GetName())
 			return e.ObjectOld.GetResourceVersion() != e.ObjectNew.GetResourceVersion()
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {


### PR DESCRIPTION
`config.SetMonitoringCRName` and `config.GetMonitoringCRName` are the functions used to get and set, respectively, the global with the MCO CR name.

I noticed though the name was only set in the `CreateFunc` of the MCO predicate. This meant that if the MCO controller was not running when the MCO CR was created, nothing would set the CR name. 

I detected this because it would cause an issue in the `config.GetObsAPIExternalHost` function.

Considering that `config.GetMonitoringCRName` is used in many places throughout the code, it must be causing lots of problems.