### PR TITLE
ACM-11985: fix addon status update

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -201,7 +201,7 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 				// ACM 8509: Special case for hub/local cluster metrics collection
 				// We do not report status for hub endpoint operator
 				if !isHubMetricsCollector {
-					if err := util.ReportStatus(ctx, r.Client, util.NotSupportedStatus, obsAddon.Name, obsAddon.Namespace); err != nil {
+					if err := util.ReportStatus(ctx, r.Client, util.NotSupported, obsAddon.Name, obsAddon.Namespace); err != nil {
 						log.Error(err, "Failed to report status")
 					}
 				}
@@ -302,14 +302,14 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 			forceRestart)
 		if err != nil {
 			if !isHubMetricsCollector {
-				if err := util.ReportStatus(ctx, r.Client, util.DegradedStatus, obsAddon.Name, obsAddon.Namespace); err != nil {
+				if err := util.ReportStatus(ctx, r.Client, util.Degraded, obsAddon.Name, obsAddon.Namespace); err != nil {
 					log.Error(err, "Failed to report status")
 				}
 			}
 			return ctrl.Result{}, fmt.Errorf("failed to update metrics collectors: %w", err)
 		}
 		if created && !isHubMetricsCollector {
-			if err := util.ReportStatus(ctx, r.Client, util.DeployedStatus, obsAddon.Name, obsAddon.Namespace); err != nil {
+			if err := util.ReportStatus(ctx, r.Client, util.Deployed, obsAddon.Name, obsAddon.Namespace); err != nil {
 				log.Error(err, "Failed to report status")
 			}
 		}
@@ -319,7 +319,7 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, fmt.Errorf("failed to update metrics collectors: %w", err)
 		}
 		if deleted && !isHubMetricsCollector {
-			if err := util.ReportStatus(ctx, r.Client, util.DisabledStatus, obsAddon.Name, obsAddon.Namespace); err != nil {
+			if err := util.ReportStatus(ctx, r.Client, util.Disabled, obsAddon.Name, obsAddon.Namespace); err != nil {
 				log.Error(err, "Failed to report status")
 			}
 		}


### PR DESCRIPTION
I previously made a change to use the conditions as an history log, but this is not possible.
This PR reverts to in-place update of status conditions for the addon on the spoke.