### PR TITLE
Make URL handling safer and less wasteful

### DIFF
--- a/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
+++ b/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
@@ -26,14 +26,8 @@ func (u URL) Validate() error {
 	return err
 }
 
-// HostPath returns the URL's host together with its path.
-// This also runs a validation of the underlying url.
-func (u URL) HostPath() (string, error) {
-	parsedUrl, err := url.Parse(string(u))
-	if err != nil {
-		return "", err
-	}
-	return parsedUrl.Host + parsedUrl.Path, nil
+func (u URL) URL() (*url.URL, error) {
+	return url.Parse(string(u))
 }
 
 // ObservabilityAddonSpec is the spec of observability addon.

--- a/operators/multiclusterobservability/controllers/placementrule/hub_info_secret.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_info_secret.go
@@ -38,15 +38,12 @@ func generateHubInfoSecret(client client.Client, obsNamespace string,
 
 		// if alerting is disabled, do not set alertmanagerEndpoint
 		if !config.IsAlertingDisabled() {
-			alertmanagerEndpoint, err = config.GetAlertmanagerEndpoint(context.TODO(), client, obsNamespace)
-			if !strings.HasPrefix(alertmanagerEndpoint, "https://") {
-				alertmanagerEndpoint = "https://" + alertmanagerEndpoint
-			}
-
+			alertmanagerURL, err := config.GetAlertmanagerURL(context.TODO(), client, obsNamespace)
 			if err != nil {
 				log.Error(err, "Failed to get alertmanager endpoint")
 				return nil, err
 			}
+			alertmanagerEndpoint = alertmanagerURL.String()
 		}
 
 		alertmanagerRouterCA, err = config.GetAlertmanagerRouterCA(client)

--- a/operators/multiclusterobservability/controllers/placementrule/hub_info_secret.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_info_secret.go
@@ -29,11 +29,12 @@ func generateHubInfoSecret(client client.Client, obsNamespace string,
 
 	if ingressCtlCrdExists {
 		var err error
-		obsAPIHost, err = config.GetObsAPIExternalHost(context.TODO(), client, obsNamespace)
+		obsAPIURL, err := config.GetObsAPIExternalURL(context.TODO(), client, obsNamespace)
 		if err != nil {
 			log.Error(err, "Failed to get the host for Observatorium API host URL")
 			return nil, err
 		}
+		obsAPIHost = obsAPIURL.Hostname()
 
 		// if alerting is disabled, do not set alertmanagerEndpoint
 		if !config.IsAlertingDisabled() {

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -511,7 +511,7 @@ func GetObsAPIExternalURL(ctx context.Context, client client.Client, namespace s
 	if err != nil {
 		return nil, err
 	}
-	return url.Parse(routeHost)
+	return url.Parse("https://" + routeHost)
 }
 
 func GetRouteHost(client client.Client, name string, namespace string) (string, error) {

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -544,23 +544,23 @@ func GetMCONamespace() string {
 	return podNamespace
 }
 
-// GetAlertmanagerEndpoint is used to get the URL for alertmanager.
-func GetAlertmanagerEndpoint(ctx context.Context, client client.Client, namespace string) (string, error) {
+// GetAlertmanagerURL is used to get the URL for alertmanager.
+func GetAlertmanagerURL(ctx context.Context, client client.Client, namespace string) (*url.URL, error) {
 	mco := &observabilityv1beta2.MultiClusterObservability{}
 	err := client.Get(ctx,
 		types.NamespacedName{
 			Name: GetMonitoringCRName(),
 		}, mco)
 	if err != nil && !errors.IsNotFound(err) {
-		return "", err
+		return nil, err
 	}
 	advancedConfig := mco.Spec.AdvancedConfig
 	if advancedConfig != nil && advancedConfig.CustomAlertmanagerHubURL != "" {
 		err := advancedConfig.CustomAlertmanagerHubURL.Validate()
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-		return string(advancedConfig.CustomAlertmanagerHubURL), nil
+		return advancedConfig.CustomAlertmanagerHubURL.URL()
 	}
 
 	found := &routev1.Route{}
@@ -573,13 +573,13 @@ func GetAlertmanagerEndpoint(ctx context.Context, client client.Client, namespac
 			OpenshiftIngressOperatorNamespace,
 		)
 		if err != nil {
-			return "", nil
+			return nil, err
 		}
-		return AlertmanagerRouteName + "-" + namespace + "." + domain, nil
+		return url.Parse("https://" + AlertmanagerRouteName + "-" + namespace + "." + domain)
 	} else if err != nil {
-		return "", err
+		return nil, err
 	}
-	return found.Spec.Host, nil
+	return url.Parse("https://" + found.Spec.Host)
 }
 
 // getDomainForIngressController get the domain for the given ingresscontroller instance.

--- a/operators/multiclusterobservability/pkg/config/config_test.go
+++ b/operators/multiclusterobservability/pkg/config/config_test.go
@@ -322,20 +322,20 @@ func TestGetObsAPIExternalHost(t *testing.T) {
 	scheme.AddKnownTypes(mcov1beta2.GroupVersion, &mcov1beta2.MultiClusterObservability{})
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(route).Build()
 
-	host, err := GetObsAPIExternalHost(context.TODO(), client, "default")
+	obsAPIURL, err := GetObsAPIExternalURL(context.TODO(), client, "default")
 	assert.NoError(t, err)
-	if host == apiServerURL {
+	if obsAPIURL.String() == apiServerURL {
 		t.Errorf("Should not get route host in default namespace")
 	}
 
-	host, err = GetObsAPIExternalHost(context.TODO(), client, "test")
+	obsAPIURL, err = GetObsAPIExternalURL(context.TODO(), client, "test")
 	assert.NoError(t, err)
-	if host != apiServerURL {
-		t.Errorf("Observatorium api (%v) is not the expected (%v)", host, apiServerURL)
+	if obsAPIURL.String() != apiServerURL {
+		t.Errorf("Observatorium api (%v) is not the expected (%v)", obsAPIURL, apiServerURL)
 	}
 
 	customBaseURL := "https://custom.base/url"
-	expectedHost := "custom.base/url"
+	expectedURL := "https://custom.base/url"
 	mco := &mcov1beta2.MultiClusterObservability{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: GetMonitoringCRName(),
@@ -347,15 +347,15 @@ func TestGetObsAPIExternalHost(t *testing.T) {
 		},
 	}
 	client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(route, mco).Build()
-	host, err = GetObsAPIExternalHost(context.TODO(), client, "test")
+	obsAPIURL, err = GetObsAPIExternalURL(context.TODO(), client, "test")
 	assert.NoError(t, err)
-	if host != expectedHost {
-		t.Errorf("Observatorium api (%v) is not the expected (%v)", host, customBaseURL)
+	if obsAPIURL.String() != expectedURL {
+		t.Errorf("Observatorium api (%v) is not the expected (%v)", obsAPIURL, expectedURL)
 	}
 
 	mco.Spec.AdvancedConfig.CustomObservabilityHubURL = "httpa://foob ar.c"
 	client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(route, mco).Build()
-	_, err = GetObsAPIExternalHost(context.TODO(), client, "test")
+	_, err = GetObsAPIExternalURL(context.TODO(), client, "test")
 	if err == nil {
 		t.Errorf("expected error when parsing URL '%v', but got none", mco.Spec.AdvancedConfig.CustomObservabilityHubURL)
 	}

--- a/operators/multiclusterobservability/pkg/config/config_test.go
+++ b/operators/multiclusterobservability/pkg/config/config_test.go
@@ -28,7 +28,8 @@ import (
 )
 
 var (
-	apiServerURL           = "http://example.com"
+	apiServerURL           = "https://example.com"
+	apiServerHost          = "example.com"
 	clusterID              = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 	DefaultDSImgRepository = "quay.io:443/acm-d"
 )
@@ -314,7 +315,7 @@ func TestGetObsAPIExternalHost(t *testing.T) {
 			Namespace: "test",
 		},
 		Spec: routev1.RouteSpec{
-			Host: apiServerURL,
+			Host: apiServerHost,
 		},
 	}
 	scheme := runtime.NewScheme()


### PR DESCRIPTION
Basically updated `GetObsAPIExternalHost` and `GetAlertmanagerEndopint` to return a `url.URL` instead of string and updated the code accordingly.