### PR TITLE
ACM-11987: Add self-managed to ClusterManagementAddOn

### DIFF
--- a/operators/multiclusterobservability/pkg/util/clustermanagementaddon.go
+++ b/operators/multiclusterobservability/pkg/util/clustermanagementaddon.go
@@ -49,6 +49,22 @@ func CreateClusterManagementAddon(c client.Client) (
 	} else if err != nil {
 		log.Error(err, "Cannot create observability-controller clustermanagementaddon")
 		return nil, err
+	} else if found.ObjectMeta.Annotations[addonv1alpha1.AddonLifecycleAnnotationKey] != addonv1alpha1.AddonLifecycleSelfManageAnnotationValue {
+		// We need to set "addon.open-cluster-management.io/lifecycle: self" because
+		// we're not correctly setting supportedConfigs and desiredConfig->specHash
+		// ManagedClusterAddOn objects. This should probably be fixed correctly later.
+		// If this is not done the MCA will never get past progressing as the
+		// addon-manager-controller is otherwise looking for these properties to be set
+		// before progressing.
+		found.ObjectMeta.Annotations[addonv1alpha1.AddonLifecycleAnnotationKey] = addonv1alpha1.AddonLifecycleSelfManageAnnotationValue
+		err := c.Update(context.TODO(), found)
+		if err != nil {
+			log.Error(err, "Failed to update observability-controller clustermanagementaddon ")
+			return nil, err
+		} else {
+			log.Info("Updated observability-controller clustermanagementaddon")
+		}
+		return found, nil
 	}
 
 	log.Info(fmt.Sprintf("%s clustermanagementaddon is present ", ObservabilityController))
@@ -95,6 +111,7 @@ func newClusterManagementAddon(c client.Client) (*addonv1alpha1.ClusterManagemen
 			Annotations: map[string]string{
 				"console.open-cluster-management.io/launch-link":      grafanaUrl.String(),
 				"console.open-cluster-management.io/launch-link-text": "Grafana",
+				addonv1alpha1.AddonLifecycleAnnotationKey:             addonv1alpha1.AddonLifecycleSelfManageAnnotationValue,
 			},
 		},
 		Spec: addonv1alpha1.ClusterManagementAddOnSpec{

--- a/operators/multiclusterobservability/pkg/util/clustermanagementaddon.go
+++ b/operators/multiclusterobservability/pkg/util/clustermanagementaddon.go
@@ -49,14 +49,19 @@ func CreateClusterManagementAddon(c client.Client) (
 	} else if err != nil {
 		log.Error(err, "Cannot create observability-controller clustermanagementaddon")
 		return nil, err
-	} else if found.ObjectMeta.Annotations[addonv1alpha1.AddonLifecycleAnnotationKey] != addonv1alpha1.AddonLifecycleSelfManageAnnotationValue {
+	} else if found.ObjectMeta.Annotations[addonv1alpha1.AddonLifecycleAnnotationKey] !=
+		addonv1alpha1.AddonLifecycleSelfManageAnnotationValue {
 		// We need to set "addon.open-cluster-management.io/lifecycle: self" because
 		// we're not correctly setting supportedConfigs and desiredConfig->specHash
 		// ManagedClusterAddOn objects. This should probably be fixed correctly later.
 		// If this is not done the MCA will never get past progressing as the
 		// addon-manager-controller is otherwise looking for these properties to be set
 		// before progressing.
-		found.ObjectMeta.Annotations[addonv1alpha1.AddonLifecycleAnnotationKey] = addonv1alpha1.AddonLifecycleSelfManageAnnotationValue
+		if found.ObjectMeta.Annotations == nil {
+			found.ObjectMeta.Annotations = map[string]string{}
+		}
+		found.ObjectMeta.Annotations[addonv1alpha1.AddonLifecycleAnnotationKey] =
+			addonv1alpha1.AddonLifecycleSelfManageAnnotationValue
 		err := c.Update(context.TODO(), found)
 		if err != nil {
 			log.Error(err, "Failed to update observability-controller clustermanagementaddon ")

--- a/operators/multiclusterobservability/pkg/util/clustermanagementaddon_test.go
+++ b/operators/multiclusterobservability/pkg/util/clustermanagementaddon_test.go
@@ -64,6 +64,14 @@ func TestClusterManagmentAddon(t *testing.T) {
 		}
 	}
 
+	if selfMgmt, found := addon.ObjectMeta.Annotations[addonv1alpha1.AddonLifecycleAnnotationKey]; found == false {
+		t.Fatalf("no AddonLifecycle included")
+	} else {
+		if selfMgmt != addonv1alpha1.AddonLifecycleSelfManageAnnotationValue {
+			t.Fatalf("Wrong AddonLifecycle annotation: %s", selfMgmt)
+		}
+	}
+
 	err = DeleteClusterManagementAddon(c)
 	if err != nil {
 		t.Fatalf("Failed to delete clustermanagementaddon: (%v)", err)
@@ -77,4 +85,45 @@ func TestClusterManagmentAddon(t *testing.T) {
 	if err == nil || !errors.IsNotFound(err) {
 		t.Fatalf("Failed to delete clustermanagementaddon: (%v)", err)
 	}
+
+	// Create a clustermanagement addon without the requires selfmgmt annotation
+	// and then make sure it's set during updates.
+	clusterManagementAddon, err := newClusterManagementAddon(c)
+	if err != nil {
+		t.Fatalf("Failed to create new clustermanagementaddon: (%v)", err)
+	}
+
+	if err := c.Create(context.TODO(), clusterManagementAddon); err != nil {
+		t.Fatalf("Failed to create clustermanagementaddon: (%v)", err)
+	}
+
+	_, err = CreateClusterManagementAddon(c)
+	if err != nil {
+		t.Fatalf("Failed to create clustermanagementaddon: (%v)", err)
+	}
+
+	err = c.Get(context.TODO(),
+		types.NamespacedName{
+			Name: ObservabilityController,
+		},
+		addon,
+	)
+
+	if err != nil {
+		t.Fatalf("Failed to get clustermanagementaddon: (%v)", err)
+	}
+	if selfMgmt, found := addon.ObjectMeta.Annotations[addonv1alpha1.AddonLifecycleAnnotationKey]; found == false {
+		t.Fatalf("no AddonLifecycle included")
+	} else {
+		if selfMgmt != addonv1alpha1.AddonLifecycleSelfManageAnnotationValue {
+			t.Fatalf("Wrong AddonLifecycle annotation: %s", selfMgmt)
+		}
+	}
+
+	// delete it again for good measure
+	err = DeleteClusterManagementAddon(c)
+	if err != nil {
+		t.Fatalf("Failed to delete clustermanagementaddon: (%v)", err)
+	}
+
 }

--- a/operators/multiclusterobservability/pkg/util/clustermanagementaddon_test.go
+++ b/operators/multiclusterobservability/pkg/util/clustermanagementaddon_test.go
@@ -93,6 +93,8 @@ func TestClusterManagmentAddon(t *testing.T) {
 		t.Fatalf("Failed to create new clustermanagementaddon: (%v)", err)
 	}
 
+	delete(clusterManagementAddon.ObjectMeta.Annotations, addonv1alpha1.AddonLifecycleAnnotationKey)
+
 	if err := c.Create(context.TODO(), clusterManagementAddon); err != nil {
 		t.Fatalf("Failed to create clustermanagementaddon: (%v)", err)
 	}


### PR DESCRIPTION
Since we're currently not correctly set "supportedConfigs" and "desiredConfig->specHash" on our ManagedClusterAdddon objects, these will never get past "Progressing" in 2.11. This is because the "addon-management-controller" is now specifically looking for these fields to be set.

As a workaround we set `addon.open-cluster-management.io/lifecycle: self` to ensure this does not happen. This should mirror the current behaviour of 2.10.