### PR TITLE
ACM-10812: Fix status report

### DIFF
--- a/collectors/metrics/pkg/forwarder/forwarder.go
+++ b/collectors/metrics/pkg/forwarder/forwarder.go
@@ -378,7 +378,7 @@ func (w *Worker) forward(ctx context.Context) error {
 	} else {
 		families, err = w.getFederateMetrics(ctx)
 		if err != nil {
-			statusErr := w.status.UpdateStatus("Degraded", "Failed to retrieve metrics")
+			statusErr := w.status.UpdateStatus(ctx, "Degraded", "Failed to retrieve metrics")
 			if statusErr != nil {
 				rlogger.Log(w.logger, rlogger.Warn, "msg", failedStatusReportMsg, "err", statusErr)
 			}
@@ -387,7 +387,7 @@ func (w *Worker) forward(ctx context.Context) error {
 
 		rfamilies, err := w.getRecordingMetrics(ctx)
 		if err != nil && len(rfamilies) == 0 {
-			statusErr := w.status.UpdateStatus("Degraded", "Failed to retrieve recording metrics")
+			statusErr := w.status.UpdateStatus(ctx, "Degraded", "Failed to retrieve recording metrics")
 			if statusErr != nil {
 				rlogger.Log(w.logger, rlogger.Warn, "msg", failedStatusReportMsg, "err", statusErr)
 			}
@@ -399,7 +399,7 @@ func (w *Worker) forward(ctx context.Context) error {
 
 	before := metricfamily.MetricsCount(families)
 	if err := metricfamily.Filter(families, w.transformer); err != nil {
-		statusErr := w.status.UpdateStatus("Degraded", "Failed to filter metrics")
+		statusErr := w.status.UpdateStatus(ctx, "Degraded", "Failed to filter metrics")
 		if statusErr != nil {
 			rlogger.Log(w.logger, rlogger.Warn, "msg", failedStatusReportMsg, "err", statusErr)
 		}
@@ -416,7 +416,7 @@ func (w *Worker) forward(ctx context.Context) error {
 
 	if len(families) == 0 {
 		rlogger.Log(w.logger, rlogger.Warn, "msg", "no metrics to send, doing nothing")
-		statusErr := w.status.UpdateStatus("Available", "No metrics to send")
+		statusErr := w.status.UpdateStatus(ctx, "Available", "No metrics to send")
 		if statusErr != nil {
 			rlogger.Log(w.logger, rlogger.Warn, "msg", failedStatusReportMsg, "err", statusErr)
 		}
@@ -425,7 +425,7 @@ func (w *Worker) forward(ctx context.Context) error {
 
 	if w.to == nil {
 		rlogger.Log(w.logger, rlogger.Warn, "msg", "to is nil, doing nothing")
-		statusErr := w.status.UpdateStatus("Available", "Metrics is not required to send")
+		statusErr := w.status.UpdateStatus(ctx, "Available", "Metrics is not required to send")
 		if statusErr != nil {
 			rlogger.Log(w.logger, rlogger.Warn, "msg", failedStatusReportMsg, "err", statusErr)
 		}
@@ -435,12 +435,12 @@ func (w *Worker) forward(ctx context.Context) error {
 	req := &http.Request{Method: "POST", URL: w.to}
 	err = w.toClient.RemoteWrite(ctx, req, families, w.interval)
 	if err != nil {
-		statusErr := w.status.UpdateStatus("Degraded", "Failed to send metrics")
+		statusErr := w.status.UpdateStatus(ctx, "Degraded", "Failed to send metrics")
 		if statusErr != nil {
 			rlogger.Log(w.logger, rlogger.Warn, "msg", failedStatusReportMsg, "err", statusErr)
 		}
 	} else if w.simulatedTimeseriesFile == "" {
-		statusErr := w.status.UpdateStatus("Available", "Cluster metrics sent successfully")
+		statusErr := w.status.UpdateStatus(ctx, "Available", "Cluster metrics sent successfully")
 		if statusErr != nil {
 			rlogger.Log(w.logger, rlogger.Warn, "msg", failedStatusReportMsg, "err", statusErr)
 		}

--- a/collectors/metrics/pkg/status/status.go
+++ b/collectors/metrics/pkg/status/status.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -71,7 +72,7 @@ func New(logger log.Logger) (*StatusReport, error) {
 	}, nil
 }
 
-func (s *StatusReport) UpdateStatus(t string, m string) error {
+func (s *StatusReport) UpdateStatus(ctx context.Context, t string, m string) error {
 	if s.statusClient == nil {
 		return nil
 	}
@@ -79,27 +80,40 @@ func (s *StatusReport) UpdateStatus(t string, m string) error {
 	if strings.Contains(os.Getenv("FROM"), uwlPromURL) {
 		isUwl = true
 	}
-	addon := &oav1beta1.ObservabilityAddon{}
-	err := s.statusClient.Get(context.TODO(), types.NamespacedName{
-		Name:      name,
-		Namespace: namespace,
-	}, addon)
-	if err != nil {
-		logger.Log(s.logger, logger.Error, "err", err)
-		return err
-	}
-	update := false
-	found := false
-	conditions := []oav1beta1.StatusCondition{}
-	latestC := oav1beta1.StatusCondition{}
-	message, conditionType, reason := mergeCondtion(isUwl, m, addon.Status.Conditions[len(addon.Status.Conditions)-1])
-	for _, c := range addon.Status.Conditions {
-		if c.Status == metav1.ConditionTrue {
-			if c.Type != conditionType {
-				c.Status = metav1.ConditionFalse
+
+	retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		addon := &oav1beta1.ObservabilityAddon{}
+		err := s.statusClient.Get(ctx, types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		}, addon)
+		if err != nil {
+			return fmt.Errorf("failed to get ObservabilityAddon %s/%s: %w", namespace, name, err)
+		}
+		update := false
+		found := false
+		conditions := []oav1beta1.StatusCondition{}
+		latestC := oav1beta1.StatusCondition{}
+		message, conditionType, reason := mergeCondtion(isUwl, m, addon.Status.Conditions[len(addon.Status.Conditions)-1])
+		for _, c := range addon.Status.Conditions {
+			if c.Status == metav1.ConditionTrue {
+				if c.Type != conditionType {
+					c.Status = metav1.ConditionFalse
+				} else {
+					found = true
+					if c.Reason != reason || c.Message != message {
+						c.Reason = reason
+						c.Message = message
+						c.LastTransitionTime = metav1.NewTime(time.Now())
+						update = true
+						latestC = c
+						continue
+					}
+				}
 			} else {
-				found = true
-				if c.Reason != reason || c.Message != message {
+				if c.Type == conditionType {
+					found = true
+					c.Status = metav1.ConditionTrue
 					c.Reason = reason
 					c.Message = message
 					c.LastTransitionTime = metav1.NewTime(time.Now())
@@ -108,40 +122,33 @@ func (s *StatusReport) UpdateStatus(t string, m string) error {
 					continue
 				}
 			}
-		} else {
-			if c.Type == conditionType {
-				found = true
-				c.Status = metav1.ConditionTrue
-				c.Reason = reason
-				c.Message = message
-				c.LastTransitionTime = metav1.NewTime(time.Now())
-				update = true
-				latestC = c
-				continue
+			conditions = append(conditions, c)
+		}
+		if update {
+			conditions = append(conditions, latestC)
+		}
+		if !found {
+			conditions = append(conditions, oav1beta1.StatusCondition{
+				Type:               conditionType,
+				Status:             metav1.ConditionTrue,
+				Reason:             reason,
+				Message:            message,
+				LastTransitionTime: metav1.NewTime(time.Now()),
+			})
+			update = true
+		}
+		if update {
+			addon.Status.Conditions = conditions
+			err = s.statusClient.Status().Update(ctx, addon)
+			if err != nil {
+				return fmt.Errorf("failed to update ObservabilityAddon %s/%s: %w", namespace, name, err)
 			}
 		}
-		conditions = append(conditions, c)
-	}
-	if update {
-		conditions = append(conditions, latestC)
-	}
-	if !found {
-		conditions = append(conditions, oav1beta1.StatusCondition{
-			Type:               conditionType,
-			Status:             metav1.ConditionTrue,
-			Reason:             reason,
-			Message:            message,
-			LastTransitionTime: metav1.NewTime(time.Now()),
-		})
-		update = true
-	}
-	if update {
-		addon.Status.Conditions = conditions
-		err = s.statusClient.Status().Update(context.TODO(), addon)
-		if err != nil {
-			logger.Log(s.logger, logger.Error, "err", err)
-		}
-		return err
+		return nil
+	})
+	if retryErr != nil {
+		logger.Log(s.logger, logger.Error, "err", retryErr)
+		return retryErr
 	}
 	return nil
 }

--- a/collectors/metrics/pkg/status/status_test.go
+++ b/collectors/metrics/pkg/status/status_test.go
@@ -46,48 +46,49 @@ func TestUpdateStatus(t *testing.T) {
 			},
 		},
 	}
-	err = s.statusClient.Create(context.TODO(), addon)
+	ctx := context.Background()
+	err = s.statusClient.Create(ctx, addon)
 	if err != nil {
 		t.Fatalf("Failed to create observabilityAddon: (%v)", err)
 	}
 
-	err = s.UpdateStatus("Disabled", "enableMetrics is set to False")
+	err = s.UpdateStatus(ctx, "Disabled", "enableMetrics is set to False")
 	if err != nil {
 		t.Fatalf("Failed to update status: (%v)", err)
 	}
 
-	err = s.UpdateStatus("Ready", "Metrics collector deployed and functional")
+	err = s.UpdateStatus(ctx, "Ready", "Metrics collector deployed and functional")
 	if err != nil {
 		t.Fatalf("Failed to update status: (%v)", err)
 	}
 
-	err = s.UpdateStatus("Ready", "Metrics collector deployed and updated")
+	err = s.UpdateStatus(ctx, "Ready", "Metrics collector deployed and updated")
 	if err != nil {
 		t.Fatalf("Failed to update status: (%v)", err)
 	}
 
-	err = s.UpdateStatus("Available", "Cluster metrics sent successfully")
+	err = s.UpdateStatus(ctx, "Available", "Cluster metrics sent successfully")
 	if err != nil {
 		t.Fatalf("Failed to update status: (%v)", err)
 	}
 
 	os.Setenv("FROM", uwlPromURL)
-	err = s.UpdateStatus("Degraded", "Failed to retrieve metrics")
+	err = s.UpdateStatus(ctx, "Degraded", "Failed to retrieve metrics")
 	if err != nil {
 		t.Fatalf("Failed to update status: (%v)", err)
 	}
 
-	err = s.UpdateStatus("Degraded", "Failed to send metrics")
+	err = s.UpdateStatus(ctx, "Degraded", "Failed to send metrics")
 	if err != nil {
 		t.Fatalf("Failed to update status: (%v)", err)
 	}
 
-	err = s.UpdateStatus("Available", "Cluster metrics sent successfully")
+	err = s.UpdateStatus(ctx, "Available", "Cluster metrics sent successfully")
 	if err != nil {
 		t.Fatalf("Failed to update status: (%v)", err)
 	}
 	os.Setenv("FROM", "")
-	err = s.UpdateStatus("Available", "Cluster metrics sent successfully")
+	err = s.UpdateStatus(ctx, "Available", "Cluster metrics sent successfully")
 	if err != nil {
 		t.Fatalf("Failed to update status: (%v)", err)
 	}


### PR DESCRIPTION
We are still having issues with status reporting. In the latest instance, the `endpoint-operator` fails to update the `metrics-collector` deployment because of a conflict, then sets the status to degraded. And it remains in that state while the metrics are forwarded.

This PR:

- Adds retry on conflict error to the `metrics-collector` related updates.
- Changes the comparison between the found resources version and the desired ones to use `DeepDerivative`. This will reduce the number of unnecessary updates.
- Adds retry on conflict for status updates made by the `metrics-collector`.
- Sort conditions before updating the status in the `metrics-collector` to ensure it handles the most recent one.

I tried to change as few things as possible.