### PR TITLE
Tests: Fix flaky Add_new_labels test

### DIFF
--- a/proxy/pkg/util/util_test.go
+++ b/proxy/pkg/util/util_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -747,6 +748,9 @@ func TestUpdateAllManagedClusterLabelNames(t *testing.T) {
 				}
 			}
 
+			// The label list does not appear to be deterministically sorted
+			// Sorting here in order to ensure the test can pass reliably.
+			slices.Sort(syncLabelList.RegexLabelList)
 			if !reflect.DeepEqual(syncLabelList.RegexLabelList, expectedRegexList) {
 				t.Errorf("syncLabelList.RegexLabelList = %v, want %v", syncLabelList.RegexLabelList, expectedRegexList)
 			}


### PR DESCRIPTION
This should fix flakyness of the test:
TestUpdateAllManagedClusterLabelNames/Add_new_labels

Which would flake due to non-deterministic order of labels. Fixed by sorting the slice in the test.

Introduced by:
448fe4881474b93b1351cc7812303abcfa744810