### PR TITLE
Dashboards: Remove custom allValue for fleetwide

### DIFF
--- a/operators/multiclusterobservability/manifests/base/grafana/dash-acm-clusters-overview-optimized.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/dash-acm-clusters-overview-optimized.yaml
@@ -1849,7 +1849,7 @@ data:
             "type": "query"
           },
           {
-            "allValue": ".+",
+            "allValue": null,
             "current": {
               "selected": true,
               "text": [

--- a/operators/multiclusterobservability/manifests/base/grafana/dash-acm-clusters-overview.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/dash-acm-clusters-overview.yaml
@@ -1849,7 +1849,7 @@ data:
             "type": "query"
           },
           {
-            "allValue": ".+",
+            "allValue": null,
             "current": {
               "selected": true,
               "text": [


### PR DESCRIPTION
The custom all value, `.+` was meant to remove very long list of clusters in (default) queries when all cluster was selected, i.e one would see queries like these:

```
{cluster=~"(local-cluster|spoke-1|spoke-2|spoke-3|spoke-4....)"
```

Unfortunately adding this custom all value seem to have completely broken the ability to filter cluster on the dashboard, hence removing this for now.