### PR TITLE
*ks: correctly define cluster:node_cpu:ratio rule

### DIFF
--- a/operators/endpointmetrics/manifests/prometheus/prometheusrules/kube-prometheus-node-recording.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/prometheusrules/kube-prometheus-node-recording.yaml
@@ -22,6 +22,6 @@ spec:
       record: instance:node_cpu:ratio
     - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[5m]))
       record: cluster:node_cpu:sum_rate5m
-    - expr: cluster:node_cpu_seconds_total:rate5m / count(sum(node_cpu_seconds_total)
+    - expr: cluster:node_cpu:sum_rate5m / count(sum(node_cpu_seconds_total)
         BY (instance, cpu))
       record: cluster:node_cpu:ratio


### PR DESCRIPTION
There was a bug in the rule imported from kube-prometheus causing the rule not to correctly return any results. This caused the data to be missing on the optimized dashboard from *ks clusters.

Upstream fix was here:
https://github.com/prometheus-operator/kube-prometheus/pull/1628