### PR TITLE
Fix `dnf install` to prevent interactive confirmation

### DIFF
--- a/collectors/metrics/Containerfile.operator
+++ b/collectors/metrics/Containerfile.operator
@@ -44,7 +44,7 @@ LABEL org.label-schema.vendor="Red Hat" \
     io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
 
 RUN microdnf update &&\
-    microdnf install ca-certificates vi --nodocs &&\
+    microdnf install ca-certificates vi -y --nodocs &&\
     mkdir /licenses &&\
     microdnf clean all
 

--- a/collectors/metrics/Dockerfile
+++ b/collectors/metrics/Dockerfile
@@ -43,7 +43,7 @@ LABEL org.label-schema.vendor="Red Hat" \
     io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
 
 RUN microdnf update &&\
-    microdnf install ca-certificates vi --nodocs &&\
+    microdnf install ca-certificates vi -y --nodocs &&\
     mkdir /licenses &&\
     microdnf clean all
 


### PR DESCRIPTION
This should unblock https://github.com/openshift/release/pull/53852, which gets stuck on the build process because of the interactive confirmation prompt that these `dnf install` commands were triggering.