### PR TITLE
Use ubi9 based go-toolset

### DIFF
--- a/operators/multiclusterobservability/Dockerfile.dev
+++ b/operators/multiclusterobservability/Dockerfile.dev
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.access.redhat.com/ubi8/go-toolset@sha256:115b2d7032e9ea9e4532a727900b35d66ff47ec6aff8ee3b4de16c1e4e95a2d4 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:75b74b4d4f589965d1d1d2086b951f543cf0c8152693a8640ea09a0c3b14f9e3 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./


### PR DESCRIPTION
As the rest of the images use ubi9, this one should too.