### PR TITLE
[ACM-12773] Fix flaky test

### DIFF
--- a/proxy/pkg/util/util.go
+++ b/proxy/pkg/util/util.go
@@ -747,6 +747,7 @@ func getClusterList(userMetricsAccess map[string][]string) []string {
 	for clusterName := range userMetricsAccess {
 		clusterList = append(clusterList, clusterName)
 	}
+	slices.Sort(clusterList)
 	return clusterList
 }
 


### PR DESCRIPTION
CI upgrade to go 1.21 fails due to unsorted list from a map: https://github.com/openshift/release/pull/54478
This PR fixes this.