### PR TITLE
ACM-11073: Add etcd scraping for Microshift

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/collector"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/hypershift"
+	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/microshift"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/openshift"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/rendering"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/status"
@@ -69,6 +70,7 @@ type ObservabilityAddonReconciler struct {
 	HubNamespace          string
 	ServiceAccountName    string
 	InstallPrometheus     bool
+	HostIP                string
 }
 
 // +kubebuilder:rbac:groups=observability.open-cluster-management.io.open-cluster-management.io,resources=observabilityaddons,verbs=get;list;watch;create;update;patch;delete
@@ -240,6 +242,21 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 		toDeploy, err := rendering.Render(ctx, renderer, r.Client, hubInfo, r.Namespace)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to render prometheus templates: %w", err)
+		}
+
+		if !r.IsHubMetricsCollector {
+			microshiftVersion, err := microshift.IsMicroshiftCluster(ctx, r.Client)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to check if the cluster is microshift: %w", err)
+			}
+
+			if len(microshiftVersion) > 0 {
+				mcs := microshift.NewMicroshift(r.Client, r.Namespace, r.HostIP)
+				toDeploy, err = mcs.Render(ctx, toDeploy)
+				if err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to render microshift templates: %w", err)
+				}
+			}
 		}
 
 		deployer := deploying.NewDeployer(r.Client)

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_integration_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_integration_test.go
@@ -21,6 +21,7 @@ import (
 	observabilityshared "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/shared"
 	oav1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
+	"github.com/stolostron/multicluster-observability-operator/operators/pkg/rendering/templates"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -114,6 +115,100 @@ func TestIntegrationReconcileHypershift(t *testing.T) {
 	err = wait.Poll(1*time.Second, 5*time.Second, func() (bool, error) {
 		hypershiftEtcdSm := &promv1.ServiceMonitor{}
 		err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: hostedClusterNs + "-" + hostedClusterName, Name: hypershift.AcmEtcdSmName}, hypershiftEtcdSm)
+		if err != nil && errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return true, err
+	})
+	assert.NoError(t, err)
+}
+
+// TestIntegrationReconcileHypershift tests the reconcile function for hypershift CRDs.
+func TestIntegrationReconcileMicroshift(t *testing.T) {
+	testNamespace := "open-cluster-management-addon-observability"
+	hubNamespace := "microshift-cluster-a"
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working dir %v", err)
+	}
+	os.Setenv(templates.TemplatesPathEnvVar, filepath.Join(filepath.Dir(filepath.Dir(wd)), "manifests"))
+
+	scheme := createBaseScheme()
+
+	k8sClientSpoke, err := client.New(restCfgSpoke, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	setupCommonSpokeResources(t, k8sClientSpoke)
+	defer tearDownCommonSpokeResources(t, k8sClientSpoke)
+
+	resourcesDeps := []client.Object{
+		newObservabilityAddonBis("observability-addon", testNamespace),
+		newMicroshiftVersionCM("kube-public"),
+		newMetricsAllowlistCM(testNamespace),
+	}
+	if err := createResources(k8sClientSpoke, resourcesDeps...); err != nil {
+		t.Fatalf("Failed to create resources: %v", err)
+	}
+
+	k8sHubClient, err := client.New(restCfgHub, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	setupCommonHubResources(t, k8sHubClient, testNamespace)
+	defer tearDownCommonHubResources(t, k8sHubClient, testNamespace)
+
+	// Create resources required for the microshift case on the hub
+	resourcesDeps = []client.Object{
+		makeNamespace(hubNamespace),
+		newObservabilityAddonBis("observability-addon", hubNamespace),
+	}
+	if err := createResources(k8sHubClient, resourcesDeps...); err != nil {
+		t.Fatalf("Failed to create resources on hub: %v", err)
+	}
+
+	mgr, err := ctrl.NewManager(testEnvSpoke.Config, ctrl.Options{
+		Scheme:  k8sClientSpoke.Scheme(),
+		Metrics: metricsserver.Options{BindAddress: "0"}, // Avoids port conflict with the default port 8080
+	})
+	assert.NoError(t, err)
+
+	hubClientWithReload, err := util.NewReloadableHubClientWithReloadFunc(func() (client.Client, error) {
+		return k8sHubClient, nil
+	})
+	assert.NoError(t, err)
+	reconciler := ObservabilityAddonReconciler{
+		Client:                k8sClientSpoke,
+		HubClient:             hubClientWithReload,
+		HostIP:                "192.168.10.10",
+		Scheme:                scheme,
+		IsHubMetricsCollector: false,
+		Namespace:             testNamespace,
+		HubNamespace:          hubNamespace,
+		ServiceAccountName:    "endpoint-monitoring-operator",
+		InstallPrometheus:     true,
+	}
+
+	err = reconciler.SetupWithManager(mgr)
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		err = mgr.Start(ctx)
+		assert.NoError(t, err)
+	}()
+
+	// Microshift resources must be created
+	// Checking the etcd service monitor that is specific to microshift
+	err = wait.Poll(1*time.Second, 5*time.Second, func() (bool, error) {
+		etcdSm := &promv1.ServiceMonitor{}
+		err := k8sClientSpoke.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: "etcd"}, etcdSm)
 		if err != nil && errors.IsNotFound(err) {
 			return false, nil
 		}

--- a/operators/endpointmetrics/pkg/microshift/microshift.go
+++ b/operators/endpointmetrics/pkg/microshift/microshift.go
@@ -7,11 +7,456 @@ package microshift
 import (
 	"context"
 
+	"fmt"
+
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const (
+	etcdClientCertSecretName = "etcd-client-cert" //nolint:gosec
+)
+
+type Microshift struct {
+	client         client.Client
+	addonNamespace string
+	hostIP         string
+}
+
+func NewMicroshift(c client.Client, addonNs, hostIP string) *Microshift {
+	return &Microshift{
+		addonNamespace: addonNs,
+		hostIP:         hostIP,
+		client:         c,
+	}
+}
+
+// Render renders the resources for the microshift cluster
+// If the cluster is not a microshift cluster, it modifies the resources
+// to adapt to the microshift cluster
+func (m *Microshift) Render(ctx context.Context, resources []*unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
+	jobRes, err := m.renderCronJobExposingMicroshiftSecrets()
+	if err != nil {
+		return nil, fmt.Errorf("failed to render cronjob for secrets: %w", err)
+	}
+	resources = append(resources, jobRes...)
+
+	etcdRes, err := m.renderEtcdResources()
+	if err != nil {
+		return nil, fmt.Errorf("failed to render etcd resources: %w", err)
+	}
+	resources = append(resources, etcdRes...)
+
+	if err := m.renderPrometheus(resources); err != nil {
+		return nil, fmt.Errorf("failed to render prometheus: %w", err)
+	}
+
+	return resources, nil
+}
+
+// renderPrometheus modifies the prometheus resource to adapt to the microshift cluster
+// It adds the etcd client key and certificate secret to the prometheus pod
+func (m *Microshift) renderPrometheus(res []*unstructured.Unstructured) error {
+	promRes, err := getResource(res, "Prometheus", "k8s")
+	if err != nil {
+		return fmt.Errorf("failed to get prometheus resource: %w", err)
+	}
+
+	prom := &promv1.Prometheus{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(promRes.Object, prom); err != nil {
+		return fmt.Errorf("failed to convert unstructured object to prometheus object: %w", err)
+	}
+
+	prom.Spec.Secrets = append(prom.Spec.Secrets, etcdClientCertSecretName)
+	prom.Spec.HostNetwork = true
+
+	promRes.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(prom)
+	if err != nil {
+		return fmt.Errorf("failed to convert prometheus object to unstructured object: %w", err)
+	}
+
+	return nil
+
+}
+
+// renderCronJobExposingMicroshiftSecrets creates a cronjob to expose Microshift's host secrets needed in Microshift itself.
+// For example, Microshift clusters run etcd directly on the host. It exposes its metrics via a secured port.
+// The job ensures that etcd client key and certificate are exposed as a secret in the addon namespace.
+func (m *Microshift) renderCronJobExposingMicroshiftSecrets() ([]*unstructured.Unstructured, error) {
+	ret := []*unstructured.Unstructured{}
+	jobName := "microshift-secrets-exposer"
+	completions := int32(1)
+	deadline := int64(60)
+	ttl := int32(60)
+	trueVal := true
+
+	jobSpec := batchv1.JobSpec{
+		Completions:             &completions,
+		ActiveDeadlineSeconds:   &deadline,
+		TTLSecondsAfterFinished: &ttl,
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				RestartPolicy: corev1.RestartPolicyNever,
+				Containers: []corev1.Container{
+					{
+						Name:    "microshift-certs-updater",
+						Image:   "registry.redhat.io/openshift4/ose-cli@sha256:a57eba642e65874fa48738ff5c361e608d4a9b00a47adcf73562925ac52e2204",
+						Command: []string{"/bin/sh", "-c"},
+						Args: []string{fmt.Sprintf(
+							`
+							oc create secret generic %s --from-file=ca.key=/tmp/etcd-certs/ca.key --from-file=ca.crt=/tmp/etcd-certs/ca.crt --dry-run=client -o yaml -n %s | oc apply -f -
+							`, etcdClientCertSecretName, m.addonNamespace),
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "etcd-certs",
+								MountPath: "/tmp/etcd-certs",
+								ReadOnly:  true,
+							},
+						},
+						SecurityContext: &corev1.SecurityContext{
+							ReadOnlyRootFilesystem: &trueVal,
+							Privileged:             &trueVal,
+						},
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("50m"),
+								corev1.ResourceMemory: resource.MustParse("100Mi"),
+							},
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("20m"),
+								corev1.ResourceMemory: resource.MustParse("50Mi"),
+							},
+						},
+					},
+				},
+				ServiceAccountName: jobName,
+				Volumes: []corev1.Volume{
+					{
+						Name: "etcd-certs",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/var/lib/microshift/certs/etcd-signer/",
+								Type: newHostPathType(corev1.HostPathDirectory),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// If the secret does not exist, start a job to create it, then rely on the cronjob to update it
+	job := &batchv1.Job{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "batch/v1",
+			Kind:       "Job",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "init-" + jobName,
+			Namespace: m.addonNamespace,
+		},
+		Spec: jobSpec,
+	}
+	foundJob := &batchv1.Job{}
+	err := m.client.Get(context.Background(), types.NamespacedName{
+		Name:      job.Name,
+		Namespace: job.Namespace,
+	}, foundJob)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			err = m.client.Create(context.Background(), job)
+			if err != nil && !errors.IsAlreadyExists(err) {
+				// If the job already exists, it means it is already running, so we can ignore the error
+				return nil, fmt.Errorf("failed to create the init job: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("failed to get secret %s/%s: %w", m.addonNamespace, etcdClientCertSecretName, err)
+		}
+	}
+
+	// Create a cronjob to update the etcd client key and certificate secret
+	// every hour
+	cronJob := &batchv1.CronJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "batch/v1",
+			Kind:       "CronJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: m.addonNamespace,
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule:          "0/20 * * * *",
+			ConcurrencyPolicy: batchv1.ReplaceConcurrent,
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: jobSpec,
+			},
+		},
+	}
+
+	unstructuredCronJob, err := convertToUnstructured(cronJob)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert cronjob to unstructured: %w", err)
+	}
+	ret = append(ret, unstructuredCronJob)
+
+	// Add service account to the cronjob
+	sa := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: m.addonNamespace,
+		},
+	}
+
+	unstructuredSA, err := convertToUnstructured(sa)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert service account to unstructured: %w", err)
+	}
+	ret = append(ret, unstructuredSA)
+
+	// Add permissions to the service account to update the secret and run as root
+	role := &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "Role",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: m.addonNamespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"create", "update", "get", "list", "patch"},
+			},
+		},
+	}
+
+	unstructuredRole, err := convertToUnstructured(role)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert role to unstructured: %w", err)
+	}
+	ret = append(ret, unstructuredRole)
+
+	roleBinding := &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "RoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: m.addonNamespace,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      jobName,
+				Namespace: m.addonNamespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "Role",
+			Name:     jobName,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+
+	unstructuredRoleBinding, err := convertToUnstructured(roleBinding)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert role binding to unstructured: %w", err)
+	}
+	ret = append(ret, unstructuredRoleBinding)
+
+	// Add cluster role for hostmount and anyuid permissions- apiGroups:
+	clusterRole := &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRole",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: jobName,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{"security.openshift.io"},
+				Resources:     []string{"securitycontextconstraints"},
+				ResourceNames: []string{"privileged"},
+				Verbs:         []string{"use"},
+			},
+		},
+	}
+
+	unstructuredClusterRole, err := convertToUnstructured(clusterRole)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert cluster role to unstructured: %w", err)
+	}
+	ret = append(ret, unstructuredClusterRole)
+
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: jobName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      jobName,
+				Namespace: m.addonNamespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     jobName,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+
+	unstructuredClusterRoleBinding, err := convertToUnstructured(clusterRoleBinding)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert cluster role binding to unstructured: %w", err)
+	}
+	ret = append(ret, unstructuredClusterRoleBinding)
+
+	return ret, nil
+}
+
+// renderServiceMonitors modifies or creates the service monitors to adapt to the microshift cluster
+func (m *Microshift) renderEtcdResources() ([]*unstructured.Unstructured, error) {
+	ret := []*unstructured.Unstructured{}
+
+	// Expose etcd endpoint in the addon namespace
+	endpoint := &corev1.Endpoints{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Endpoints",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd",
+			Namespace: m.addonNamespace,
+			Labels: map[string]string{
+				"app": "etcd",
+			},
+		},
+		Subsets: []corev1.EndpointSubset{
+			{
+				Addresses: []corev1.EndpointAddress{
+					{
+						IP: m.hostIP,
+					},
+				},
+				Ports: []corev1.EndpointPort{
+					{
+						Name:     "metrics",
+						Port:     2381,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+			},
+		},
+	}
+
+	unstructuredEndpoint, err := convertToUnstructured(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert endpoint to unstructured: %w", err)
+	}
+	ret = append(ret, unstructuredEndpoint)
+
+	service := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd",
+			Namespace: m.addonNamespace,
+			Labels: map[string]string{
+				"app": "etcd",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "metrics",
+					Port:       2381,
+					TargetPort: intstr.FromInt(2381),
+				},
+			},
+			Selector: map[string]string{
+				"app": "etcd",
+			},
+		},
+	}
+
+	unstructuredService, err := convertToUnstructured(service)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert service to unstructured: %w", err)
+	}
+	ret = append(ret, unstructuredService)
+
+	// render service monitor for etcd
+	smon := &promv1.ServiceMonitor{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "monitoring.coreos.com/v1",
+			Kind:       "ServiceMonitor",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd",
+			Namespace: m.addonNamespace,
+		},
+		Spec: promv1.ServiceMonitorSpec{
+			Endpoints: []promv1.Endpoint{
+				{
+					Scheme:   "https",
+					Path:     "/metrics",
+					Interval: "15s",
+					// Use secret etcd-cert to scrape etcd metrics
+					TLSConfig: &promv1.TLSConfig{
+						// /etc/prometheus/secrets/etcd-client-cert
+						CertFile: fmt.Sprintf("/etc/prometheus/secrets/%s/ca.crt", etcdClientCertSecretName),
+						KeyFile:  fmt.Sprintf("/etc/prometheus/secrets/%s/ca.key", etcdClientCertSecretName),
+						CAFile:   fmt.Sprintf("/etc/prometheus/secrets/%s/ca.crt", etcdClientCertSecretName),
+					},
+				},
+			},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "etcd",
+				},
+			},
+			NamespaceSelector: promv1.NamespaceSelector{
+				MatchNames: []string{m.addonNamespace},
+			},
+		},
+	}
+
+	unstructuredSMon, err := convertToUnstructured(smon)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert service monitor to unstructured: %w", err)
+	}
+	ret = append(ret, unstructuredSMon)
+
+	return ret, nil
+}
 
 // IsMicroshiftCluster checks if the cluster is a microshift cluster.
 // It verifies the existence of the configmap microshift-version in namespace kube-public.
@@ -31,4 +476,29 @@ func IsMicroshiftCluster(ctx context.Context, client client.Client) (string, err
 	}
 
 	return res.Data["version"], nil
+}
+
+func getResource(res []*unstructured.Unstructured, kind, name string) (*unstructured.Unstructured, error) {
+	for _, r := range res {
+		if r.GetKind() == kind && r.GetName() == name {
+			return r, nil
+		}
+	}
+	return nil, errors.NewNotFound(schema.GroupResource{
+		Group:    "",
+		Resource: kind,
+	}, name)
+}
+
+func convertToUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
+	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return &unstructured.Unstructured{Object: unstructuredObj}, nil
+}
+
+func newHostPathType(pathType corev1.HostPathType) *corev1.HostPathType {
+	return &pathType
 }


### PR DESCRIPTION
ETCD is running on the host and listening localhost. This forces prometheus to access host network. This is possible now that we import a recent version of the prometeus-operator.

A Job is launched with priviledges access to expose the certs on the host in k8s and do mTLS authentication.