### PR TITLE
[RHOBS-1044] Bump the Compactor's default CPU and memory requests

### DIFF
--- a/operators/multiclusterobservability/pkg/config/resources_map.go
+++ b/operators/multiclusterobservability/pkg/config/resources_map.go
@@ -175,7 +175,7 @@ var (
 
 	ThanosCompactCPURequest ResourceSizeMap = map[observabilityv1beta2.TShirtSize]string{
 		Minimal:    "250m",
-		Default:    "100m",
+		Default:    "500m",
 		Small:      "500m",
 		Medium:     "1",
 		Large:      "3",
@@ -185,7 +185,7 @@ var (
 	}
 	ThanosCompactMemoryRequest ResourceSizeMap = map[observabilityv1beta2.TShirtSize]string{
 		Minimal:    "512Mi",
-		Default:    "512Mi",
+		Default:    "1Gi",
 		Small:      "1Gi",
 		Medium:     "2Gi",
 		Large:      "4Gi",


### PR DESCRIPTION
Now the Compactor's `default` t-shirt size will be matching the small one. This should help to the Compactor get access to an adequate amount of CPU time and memory by default when it ends up in an overcommitted node.