### PR TITLE
Fixing ACM-12888 by supplying a UID for fixed URL ref in the URL

### DIFF
--- a/operators/multiclusterobservability/manifests/base/grafana/dash-acm-openshift-virtualization-overview.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/dash-acm-openshift-virtualization-overview.yaml
@@ -26,6 +26,7 @@ data:
       "gnetId": null,
       "graphTooltip": 0,
       "id": 29,
+      "uid": "OmpD1ZoSk",
       "iteration": 1709210609633,
       "links": [],
       "panels": [
@@ -357,7 +358,7 @@ data:
                     "value": [
                       {
                         "title": "",
-                        "url": "d/OmpD1ZoSk/openshift-virtualization-overview?${__url_time_range}&orgId=1&var-alert=All&var-severity=$${severity:queryparam}&refresh=5m&var-health_impact=$${health_impact:queryparam}&var-cluster=${__data.fields.Cluster}"
+                        "url": "d/OmpD1ZoSk/openshift-virtualization-overview?${__url_time_range}&orgId=1&var-alert=All&${severity:queryparam}&refresh=5m&${health_impact:queryparam}&var-cluster=${__data.fields.Cluster}"
                       }
                     ]
                   }


### PR DESCRIPTION
Grafana should accept this, provided there is no clash, and the linkref will now reference a fixed dashboard URL instead of a grafana generated UID which changes per-installation.

Also fixed the query param templating for the severity and health impact.

The value of `${severity:queryparam}` already includes the query param tag in it, so the previous template would substitute the tag with `var-health_impact=$var-health_impact=All` instead of `var-health_impact=All`.