### PR TITLE
add `-y` to `microdnf update` to unstuck builds

### DIFF
--- a/collectors/metrics/Containerfile.operator
+++ b/collectors/metrics/Containerfile.operator
@@ -43,7 +43,7 @@ LABEL org.label-schema.vendor="Red Hat" \
     io.k8s.description="$IMAGE_DESCRIPTION" \
     io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
 
-RUN microdnf update &&\
+RUN microdnf update -y &&\
     microdnf install ca-certificates vi -y --nodocs &&\
     mkdir /licenses &&\
     microdnf clean all

--- a/collectors/metrics/Dockerfile
+++ b/collectors/metrics/Dockerfile
@@ -42,7 +42,7 @@ LABEL org.label-schema.vendor="Red Hat" \
     io.k8s.description="$IMAGE_DESCRIPTION" \
     io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
 
-RUN microdnf update &&\
+RUN microdnf update -y &&\
     microdnf install ca-certificates vi -y --nodocs &&\
     mkdir /licenses &&\
     microdnf clean all


### PR DESCRIPTION
Builds would be stuck due to waiting on the promt to accept upgraded packages:

```
[2/2] STEP 15/25: LABEL org.label-schema.vendor="Red Hat" org.label-schema.name="$IMAGE_NAME_ARCH" org.label-schema.description="$IMAGE_DESCRIPTION" org.label-schema.vcs-ref=$VCS_REF org.label-schema.vcs-url=$VCS_URL org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" org.label-schema.schema-version="1.0" name="$IMAGE_NAME" maintainer="$IMAGE_MAINTAINER" vendor="$IMAGE_VENDOR" version="$IMAGE_VERSION" release="$IMAGE_RELEASE" description="$IMAGE_DESCRIPTION" summary="$IMAGE_SUMMARY" io.k8s.display-name="$IMAGE_DISPLAY_NAME" io.k8s.description="$IMAGE_DESCRIPTION" io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
[2/2] STEP 16/25: RUN microdnf update && microdnf install ca-certificates vi -y --nodocs && mkdir /licenses && microdnf clean all
(microdnf:7): librhsm-WARNING **: 07:42:09.094: Found 0 entitlement certificates
(microdnf:7): librhsm-WARNING **: 07:42:09.111: Found 0 entitlement certificates
Downloading metadata...
Downloading metadata...
Downloading metadata...
Package Repository Size
Upgrading:
curl-minimal-7.76.1-29.el9_4.1.x86_64 ubi-9-baseos-rpms 131.8 kB
replacing curl-minimal-7.76.1-29.el9_4.x86_64
libcurl-minimal-7.76.1-29.el9_4.1.x86_64 ubi-9-baseos-rpms 233.7 kB
replacing libcurl-minimal-7.76.1-29.el9_4.x86_64
Transaction Summary:
Installing: 0 packages
Reinstalling: 0 packages
Upgrading: 2 packages
Obsoleting: 0 packages
Removing: 0 packages
Downgrading: 0 packages
Is this ok [y/N]: 
```