### PR TITLE
Expose cmo config revert binary

### DIFF
--- a/operators/endpointmetrics/Containerfile.operator
+++ b/operators/endpointmetrics/Containerfile.operator
@@ -9,6 +9,7 @@ COPY ./operators/multiclusterobservability/api ./operators/multiclusterobservabi
 COPY ./operators/pkg ./operators/pkg
 
 RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -o build/_output/bin/endpoint-monitoring-operator operators/endpointmetrics/main.go
+RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -o build/_output/bin/cmo-config-revert operators/endpointmetrics/cmd/cmo-config-revert/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
@@ -53,6 +54,8 @@ COPY ./operators/endpointmetrics/manifests /usr/local/manifests
 
 # install operator binary
 COPY --from=builder /workspace/build/_output/bin/endpoint-monitoring-operator ${OPERATOR}
-USER ${USER_UID}
+# install cmo-config-revert binary
+COPY --from=builder /workspace/build/_output/bin/cmo-config-revert cmo-config-revert
 
+USER ${USER_UID}
 ENTRYPOINT ["/usr/local/bin/endpoint-monitoring-operator"]

--- a/operators/endpointmetrics/Dockerfile
+++ b/operators/endpointmetrics/Dockerfile
@@ -8,7 +8,8 @@ COPY ./operators/endpointmetrics ./operators/endpointmetrics
 COPY ./operators/multiclusterobservability/api ./operators/multiclusterobservability/api
 COPY ./operators/pkg ./operators/pkg
 
-RUN CGO_ENABLED=1 go build -a -installsuffix cgo -o build/_output/bin/endpoint-monitoring-operator operators/endpointmetrics/main.go
+RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -o build/_output/bin/endpoint-monitoring-operator operators/endpointmetrics/main.go
+RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -o build/_output/bin/cmo-config-revert operators/endpointmetrics/cmd/cmo-config-revert/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
@@ -53,6 +54,8 @@ COPY ./operators/endpointmetrics/manifests /usr/local/manifests
 
 # install operator binary
 COPY --from=builder /workspace/build/_output/bin/endpoint-monitoring-operator ${OPERATOR}
-USER ${USER_UID}
+# install cmo-config-revert binary
+COPY --from=builder /workspace/build/_output/bin/cmo-config-revert cmo-config-revert
 
+USER ${USER_UID}
 ENTRYPOINT ["/usr/local/bin/endpoint-monitoring-operator"]

--- a/operators/endpointmetrics/cmd/cmo-config-revert/main.go
+++ b/operators/endpointmetrics/cmd/cmo-config-revert/main.go
@@ -1,0 +1,40 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"time"
+
+	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
+
+	"go.uber.org/zap/zapcore"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func main() {
+	kubeClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{})
+	if err != nil {
+		log.Fatalf("unable to create client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	opts := zap.Options{Development: true, TimeEncoder: zapcore.ISO8601TimeEncoder}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	if err := observabilityendpoint.RevertClusterMonitoringConfig(ctx, kubeClient); err != nil {
+		log.Fatalf("unable to revert cluster monitoring config: %v", err)
+	}
+	log.Println("reverted cluster monitoring config")
+}

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -339,7 +339,7 @@ func (r *ObservabilityAddonReconciler) initFinalization(
 		}
 
 		// revert the change to cluster monitoring stack
-		err := revertClusterMonitoringConfig(ctx, r.Client)
+		err := RevertClusterMonitoringConfig(ctx, r.Client)
 		if err != nil {
 			return false, err
 		}

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
@@ -320,7 +320,7 @@ func createOrUpdateClusterMonitoringConfig(
 			return err
 		}
 		if !revertedAlready {
-			if err = revertClusterMonitoringConfig(ctx, client); err != nil {
+			if err = RevertClusterMonitoringConfig(ctx, client); err != nil {
 				return err
 			}
 			if err = setConfigReverted(ctx, client, namespace); err != nil {
@@ -494,10 +494,10 @@ func unset(ctx context.Context, client client.Client, ns string) error {
 	return err
 }
 
-// revertClusterMonitoringConfig reverts the configmap cluster-monitoring-config and relevant resources
+// RevertClusterMonitoringConfig reverts the configmap cluster-monitoring-config and relevant resources
 // (observability-alertmanager-accessor and hub-alertmanager-router-ca) for the openshift cluster monitoring stack.
-func revertClusterMonitoringConfig(ctx context.Context, client client.Client) error {
-	log.Info("revertClusterMonitoringConfig called")
+func RevertClusterMonitoringConfig(ctx context.Context, client client.Client) error {
+	log.Info("RevertClusterMonitoringConfig called")
 
 	// try to retrieve the current configmap in the cluster
 	found := &corev1.ConfigMap{}

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
@@ -415,7 +415,7 @@ func testCreateOrUpdateClusterMonitoringConfig(t *testing.T, hubInfo *operatorco
 		t.Fatalf("no AlertmanagerConfig for OCM in ClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs: %v", foundClusterMonitoringConfiguration)
 	}
 
-	err = revertClusterMonitoringConfig(ctx, c)
+	err = RevertClusterMonitoringConfig(ctx, c)
 	if err != nil {
 		t.Fatalf("Failed to revert cluster-monitoring-config configmap: (%v)", err)
 	}
@@ -442,7 +442,7 @@ func testCreateOrUpdateClusterMonitoringConfig(t *testing.T, hubInfo *operatorco
 		t.Fatalf("the secret %s should not be deleted", hubAmRouterCASecretName)
 	}
 
-	err = revertClusterMonitoringConfig(ctx, c)
+	err = RevertClusterMonitoringConfig(ctx, c)
 	if err != nil {
 		t.Fatalf("Run into error when try to revert cluster-monitoring-config configmap twice: (%v)", err)
 	}


### PR DESCRIPTION
This change creates a new binary inside the endpoint metrics operator to enable manually/programatically revert the config in the managed cluster if the Hub for some reason is not able to clean it up like https://issues.redhat.com/browse/ACM-13355.

This change is driven by a customer request in https://issues.redhat.com/browse/ACM-13149 where they are using the cleanup script https://github.com/stolostron/deploy/blob/master/hack/cleanup-managed-cluster.sh.

This change can be paired with https://github.com/stolostron/deploy/pull/276