### PR TITLE
update MCO cluster role for imagestreams

### DIFF
--- a/loaders/dashboards/Dockerfile
+++ b/loaders/dashboards/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /workspace
 COPY go.sum go.mod ./loaders/dashboards ./
 COPY ./loaders/dashboards ./loaders/dashboards
 
-RUN CGO_ENABLED=1 go build -a -installsuffix cgo -v -o main loaders/dashboards/cmd/main.go
+RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -v -o main loaders/dashboards/cmd/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 

--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -457,6 +457,14 @@ spec:
           - create
           - patch
           - delete
+        - apiGroups:
+            - image.openshift.io
+          resources:
+            - imagestreams
+          verbs:
+            - get
+            - list
+            - watch  -
         serviceAccountName: multicluster-observability-operator
       deployments:
       - label:

--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -458,13 +458,13 @@ spec:
           - patch
           - delete
         - apiGroups:
-            - image.openshift.io
+          - image.openshift.io
           resources:
-            - imagestreams
+          - imagestreams
           verbs:
-            - get
-            - list
-            - watch  -
+          - get
+          - list
+          - watch
         serviceAccountName: multicluster-observability-operator
       deployments:
       - label:

--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -49,7 +49,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-08-01T12:07:10Z"
+    createdAt: "2024-08-29T11:39:17Z"
     operators.operatorframework.io/builder: operator-sdk-v1.34.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-observability-operator.v0.1.0

--- a/operators/multiclusterobservability/config/rbac/mco_role.yaml
+++ b/operators/multiclusterobservability/config/rbac/mco_role.yaml
@@ -373,3 +373,11 @@ rules:
   - create
   - patch
   - delete
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  verbs:
+  - get
+  - list
+  - watch

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /workspace
 COPY go.sum go.mod ./
 COPY ./proxy ./proxy
 
-RUN CGO_ENABLED=1 go build -a -installsuffix cgo -v -o main proxy/cmd/main.go
+RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -v -o main proxy/cmd/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
Initial commit for -> https://github.com/stolostron/multicluster-observability-operator/pull/1587 
Since Cluster role is Managed by MCH. It needs to get updated here first.  -> https://github.com/stolostron/multiclusterhub-operator/blob/main/pkg/templates/charts/toggle/multicluster-observability-operator/templates/multicluster-observability-operator-clusterrole.yaml

This is to prevent the MCO operator from failing to come up due to permission

```
E0829 09:17:02.982625       1 reflector.go:158] "Unhandled Error" err="pkg/mod/k8s.io/client-go@v0.31.0-alpha.2/tools/cache/reflector.go:243: Failed to watch *v1.ImageStream: failed to list *v1.ImageStream: imagestreams.image.openshift.io is forbidden: User \"system:serviceaccount:open-cluster-management:multicluster-observability-operator\" cannot list resource \"imagestreams\" in API group \"image.openshift.io\" at the cluster scope" logger="UnhandledError"
W0829 09:17:33.904106       1 reflector.go:561] pkg/mod/k8s.io/client-go@v0.31.0-alpha.2/tools/cache/reflector.go:243: failed to list *v1.ImageStream: imagestreams.image.openshift.io is forbidden: User "system:serviceaccount:open-cluster-management:multicluster-observability-operator" cannot list resource "imagestreams" in API group "image.openshift.io" at the cluster scope
```