### PR TITLE
Fix tests for BVT testing

### DIFF
--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -93,9 +93,6 @@ approve_csr_joinrequest() {
           # update vendor label for KinD env
           kubectl label managedcluster ${clustername} vendor-
           kubectl label managedcluster ${clustername} vendor=GKE
-          echo "Coleen update vendor label for KinD env"
-          # update with label  "feature.open-cluster-management.io/addon-observability-controller": "available"
-          kubectl label managedcluster ${clustername} feature.open-cluster-management.io/addon-observability-controller=available --overwrite
         fi
       done
       break

--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -93,8 +93,9 @@ approve_csr_joinrequest() {
           # update vendor label for KinD env
           kubectl label managedcluster ${clustername} vendor-
           kubectl label managedcluster ${clustername} vendor=GKE
+          echo "Coleen update vendor label for KinD env"
           # update with label  "feature.open-cluster-management.io/addon-observability-controller": "available"
-          kubectl label managedcluster ${clustername} feature.open-cluster-management.io/addon-observability-controller=available
+          kubectl label managedcluster ${clustername} feature.open-cluster-management.io/addon-observability-controller=available --overwrite
         fi
       done
       break

--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -93,6 +93,8 @@ approve_csr_joinrequest() {
           # update vendor label for KinD env
           kubectl label managedcluster ${clustername} vendor-
           kubectl label managedcluster ${clustername} vendor=GKE
+          # update with label  "feature.open-cluster-management.io/addon-observability-controller": "available"
+          kubectl label managedcluster ${clustername} feature.open-cluster-management.io/addon-observability-controller=available
         fi
       done
       break

--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -7,7 +7,6 @@ package utils
 import (
 	"context"
 	"errors"
-	"github.com/cloudflare/cfssl/log"
 	goversion "github.com/hashicorp/go-version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
@@ -66,7 +65,6 @@ func ListManagedClusters(opt TestOptions) ([]string, error) {
 	}
 
 	if len(clusterNames) == 0 {
-		log.Info("Coleen no clusters", "clusterNames", clusterNames)
 		return clusterNames, errors.New("no managedcluster found")
 	}
 

--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -7,6 +7,7 @@ package utils
 import (
 	"context"
 	"errors"
+	"github.com/cloudflare/cfssl/log"
 
 	goversion "github.com/hashicorp/go-version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,7 +53,9 @@ func ListManagedClusters(opt TestOptions) ([]string, error) {
 		metadata := obj.Object["metadata"].(map[string]interface{})
 		name := metadata["name"].(string)
 		labels := metadata["labels"].(map[string]interface{})
+		log.Info("Coleen ListManagedClusters", "name", name, "labels", labels)
 		if labels != nil {
+			log.Info("Coleen ListManagedClusters", "name", name, "labels", labels)
 			if obsController, ok := labels["feature.open-cluster-management.io/addon-observability-controller"]; ok && obsController.(string) != "unreachable" {
 				clusterNames = append(clusterNames, name)
 			}
@@ -60,6 +63,7 @@ func ListManagedClusters(opt TestOptions) ([]string, error) {
 	}
 
 	if len(clusterNames) == 0 {
+		log.Info("Coleen no clusters", "clusterNames", clusterNames)
 		return clusterNames, errors.New("no managedcluster found")
 	}
 

--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -7,9 +7,10 @@ package utils
 import (
 	"context"
 	"errors"
+	"os"
+
 	goversion "github.com/hashicorp/go-version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
 )
 
 func UpdateObservabilityFromManagedCluster(opt TestOptions, enableObservability bool) error {

--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -53,13 +53,8 @@ func ListManagedClusters(opt TestOptions) ([]string, error) {
 		name := metadata["name"].(string)
 		labels := metadata["labels"].(map[string]interface{})
 		if labels != nil {
-			if obsController, ok := labels["feature.open-cluster-management.io/addon-observability-controller"]; !ok {
-				continue
-			} else {
-				obsControllerStr := obsController.(string)
-				if obsControllerStr != "unreachable" {
-					clusterNames = append(clusterNames, name)
-				}
+			if obsController, ok := labels["feature.open-cluster-management.io/addon-observability-controller"]; ok && obsController.(string) != "unreachable" {
+				clusterNames = append(clusterNames, name)
 			}
 		}
 	}

--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -8,9 +8,9 @@ import (
 	"context"
 	"errors"
 	"github.com/cloudflare/cfssl/log"
-
 	goversion "github.com/hashicorp/go-version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
 )
 
 func UpdateObservabilityFromManagedCluster(opt TestOptions, enableObservability bool) error {
@@ -53,9 +53,12 @@ func ListManagedClusters(opt TestOptions) ([]string, error) {
 		metadata := obj.Object["metadata"].(map[string]interface{})
 		name := metadata["name"].(string)
 		labels := metadata["labels"].(map[string]interface{})
-		log.Info("Coleen ListManagedClusters", "name", name, "labels", labels)
+		if os.Getenv("IS_KIND_ENV") == "true" {
+			// We do not have the obs add on label added in kind cluster
+			clusterNames = append(clusterNames, name)
+			continue
+		}
 		if labels != nil {
-			log.Info("Coleen ListManagedClusters", "name", name, "labels", labels)
 			if obsController, ok := labels["feature.open-cluster-management.io/addon-observability-controller"]; ok && obsController.(string) != "unreachable" {
 				clusterNames = append(clusterNames, name)
 			}

--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -53,12 +53,13 @@ func ListManagedClusters(opt TestOptions) ([]string, error) {
 		name := metadata["name"].(string)
 		labels := metadata["labels"].(map[string]interface{})
 		if labels != nil {
-			obsControllerStr := ""
-			if obsController, ok := labels["feature.open-cluster-management.io/addon-observability-controller"]; ok {
-				obsControllerStr = obsController.(string)
-			}
-			if obsControllerStr != "unreachable" {
-				clusterNames = append(clusterNames, name)
+			if obsController, ok := labels["feature.open-cluster-management.io/addon-observability-controller"]; !ok {
+				continue
+			} else {
+				obsControllerStr := obsController.(string)
+				if obsControllerStr != "unreachable" {
+					clusterNames = append(clusterNames, name)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The BVT tests are reporting failure because some of the managed clusters are never properly imported. However, Obs tests are also not correctly detecting and skipping these unhealthy clusters, and expecting Obs add-on to be present.

https://app.travis-ci.com/github/stolostron/canary/jobs/625626340