### PR TITLE
Expose metrics-collector scrape limit size in CRD

### DIFF
--- a/examples/mco/e2e/v1beta1/observability-v1beta1-to-v1beta2-golden.yaml
+++ b/examples/mco/e2e/v1beta1/observability-v1beta1-to-v1beta2-golden.yaml
@@ -16,6 +16,7 @@ spec:
   observabilityAddonSpec:
     enableMetrics: true
     interval: 300
+    scrapeSizeLimitBytes: 1073741824
   storageConfig:
     alertmanagerStorageSize: 1Gi
     compactStorageSize: 1Gi

--- a/examples/mco/e2e/v1beta2/custom-certs/observability.yaml
+++ b/examples/mco/e2e/v1beta2/custom-certs/observability.yaml
@@ -102,6 +102,7 @@ spec:
   nodeSelector:
     kubernetes.io/os: linux
   observabilityAddonSpec:
+    scrapeSizeLimitBytes: 1073741824
     enableMetrics: true
     interval: 30
     resources:

--- a/examples/mco/e2e/v1beta2/observability.yaml
+++ b/examples/mco/e2e/v1beta2/observability.yaml
@@ -102,6 +102,7 @@ spec:
   nodeSelector:
     kubernetes.io/os: linux
   observabilityAddonSpec:
+    scrapeSizeLimitBytes: 1073741824
     enableMetrics: true
     interval: 30
     resources:

--- a/operators/endpointmetrics/pkg/collector/metrics_collector.go
+++ b/operators/endpointmetrics/pkg/collector/metrics_collector.go
@@ -797,6 +797,11 @@ func (m *MetricsCollector) getCommands(isUSW bool, deployParams *deploymentParam
 		evaluateInterval = interval
 	}
 
+	scrapeSizeLimitBytes := 1073741824
+	if m.ObsAddon.Spec.ScrapeSizeLimitBytes != 0 {
+		scrapeSizeLimitBytes = m.ObsAddon.Spec.ScrapeSizeLimitBytes
+	}
+
 	caFile := caMounthPath + "/service-ca.crt"
 	clusterID := m.ClusterInfo.ClusterID
 	if clusterID == "" {
@@ -821,7 +826,7 @@ func (m *MetricsCollector) getCommands(isUSW bool, deployParams *deploymentParam
 		"--to-upload-key=/tlscerts/certs/tls.key",
 		"--interval=" + interval,
 		"--evaluate-interval=" + evaluateInterval,
-		"--limit-bytes=" + strconv.Itoa(m.ObsAddon.Spec.ScrapeSizeLimitBytes),
+		"--limit-bytes=" + strconv.Itoa(scrapeSizeLimitBytes),
 		fmt.Sprintf("--label=\"cluster=%s\"", m.HubInfo.ClusterName),
 		fmt.Sprintf("--label=\"clusterID=%s\"", clusterID),
 	}

--- a/operators/endpointmetrics/pkg/collector/metrics_collector.go
+++ b/operators/endpointmetrics/pkg/collector/metrics_collector.go
@@ -47,7 +47,6 @@ const (
 	mtlsCertName            = "observability-controller-open-cluster-management.io-observability-signer-client-cert"
 	mtlsCaName              = "observability-managed-cluster-certs"
 	mtlsServerCaName        = "observability-server-ca-certs"
-	limitBytes              = 1073741824
 	defaultInterval         = "30s"
 	uwlNamespace            = "openshift-user-workload-monitoring"
 	uwlSts                  = "prometheus-user-workload"

--- a/operators/endpointmetrics/pkg/collector/metrics_collector.go
+++ b/operators/endpointmetrics/pkg/collector/metrics_collector.go
@@ -822,7 +822,7 @@ func (m *MetricsCollector) getCommands(isUSW bool, deployParams *deploymentParam
 		"--to-upload-key=/tlscerts/certs/tls.key",
 		"--interval=" + interval,
 		"--evaluate-interval=" + evaluateInterval,
-		"--limit-bytes=" + strconv.Itoa(limitBytes),
+		"--limit-bytes=" + strconv.Itoa(m.ObsAddon.Spec.ScrapeSizeLimitBytes),
 		fmt.Sprintf("--label=\"cluster=%s\"", m.HubInfo.ClusterName),
 		fmt.Sprintf("--label=\"clusterID=%s\"", clusterID),
 	}

--- a/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
+++ b/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
@@ -44,6 +44,11 @@ type ObservabilityAddonSpec struct {
 	// +kubebuilder:validation:Maximum=3600
 	Interval int32 `json:"interval,omitempty"`
 
+	// ScrapeSizeLimitBytes is the max size in bytes for a single metrics scrape from in-cluster Prometheus.
+	// Default is 1 GiB.
+	// +kubebuilder:default:=1073741824
+	ScrapeSizeLimitBytes int `json:"scrapeSizeLimitBytes,omitempty"`
+
 	// Resource requirement for metrics-collector
 	// +optional
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -163,6 +163,12 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  scrapeSizeLimitBytes:
+                    default: 1073741824
+                    description: |-
+                      ScrapeSizeLimitBytes is the max size in bytes for a single metrics scrape from in-cluster Prometheus.
+                      Default is 1 GiB.
+                    type: integer
                 type: object
               retentionResolution1h:
                 default: 30d
@@ -10186,6 +10192,12 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  scrapeSizeLimitBytes:
+                    default: 1073741824
+                    description: |-
+                      ScrapeSizeLimitBytes is the max size in bytes for a single metrics scrape from in-cluster Prometheus.
+                      Default is 1 GiB.
+                    type: integer
                 type: object
               storageConfig:
                 description: Specifies the storage to be used by Observability

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_observabilityaddons.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_observabilityaddons.yaml
@@ -109,6 +109,12 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              scrapeSizeLimitBytes:
+                default: 1073741824
+                description: |-
+                  ScrapeSizeLimitBytes is the max size in bytes for a single metrics scrape from in-cluster Prometheus.
+                  Default is 1 GiB.
+                type: integer
             type: object
           status:
             description: ObservabilityAddonStatus defines the observed state of ObservabilityAddon

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -145,6 +145,12 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  scrapeSizeLimitBytes:
+                    default: 1073741824
+                    description: |-
+                      ScrapeSizeLimitBytes is the max size in bytes for a single metrics scrape from in-cluster Prometheus.
+                      Default is 1 GiB.
+                    type: integer
                 type: object
               retentionResolution1h:
                 default: 30d
@@ -10170,6 +10176,12 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  scrapeSizeLimitBytes:
+                    default: 1073741824
+                    description: |-
+                      ScrapeSizeLimitBytes is the max size in bytes for a single metrics scrape from in-cluster Prometheus.
+                      Default is 1 GiB.
+                    type: integer
                 type: object
               storageConfig:
                 description: Specifies the storage to be used by Observability

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_observabilityaddons.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_observabilityaddons.yaml
@@ -109,6 +109,12 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              scrapeSizeLimitBytes:
+                default: 1073741824
+                description: |-
+                  ScrapeSizeLimitBytes is the max size in bytes for a single metrics scrape from in-cluster Prometheus.
+                  Default is 1 GiB.
+                type: integer
             type: object
           status:
             description: ObservabilityAddonStatus defines the observed state of ObservabilityAddon


### PR DESCRIPTION
Expose the scrape size limit as a CRD option.