### PR TITLE
mcoa: add support for MCO installing operators required by MCOA

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/openshift/cluster-monitoring-operator v0.1.1-0.20240628115213-cd0d275afa06
 	github.com/openshift/hypershift/api v0.0.0-20240627155356-f85c65d962aa
 	github.com/openshift/library-go v0.0.0-20240621150525-4bb4238aef81
+	github.com/operator-framework/api v0.24.0
 	github.com/prometheus-community/prom-label-proxy v0.8.1-0.20240127162815-c1195f9aabc0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.74.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.74.0

--- a/go.sum
+++ b/go.sum
@@ -895,6 +895,8 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
+github.com/operator-framework/api v0.24.0 h1:fHynWEzuY/YhUTlsK9hd+QQ0bZcFakxCTdaZbFaVXbc=
+github.com/operator-framework/api v0.24.0/go.mod h1:EXKrka63NyQDDpWZ+DGTDEliNV0xRq6UMZRoUPhilVM=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=

--- a/operators/multiclusterobservability/config/rbac/mco_role.yaml
+++ b/operators/multiclusterobservability/config/rbac/mco_role.yaml
@@ -381,3 +381,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - operatorgroups
+  - subscriptions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete

--- a/operators/multiclusterobservability/main.go
+++ b/operators/multiclusterobservability/main.go
@@ -25,6 +25,8 @@ import (
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -72,6 +74,8 @@ func init() {
 	utilruntime.Must(observatoriumAPIs.AddToScheme(scheme))
 	utilruntime.Must(prometheusv1.AddToScheme(scheme))
 	utilruntime.Must(addonv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(operatorsv1.AddToScheme(scheme))
+	utilruntime.Must(operatorsv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(imagev1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }

--- a/operators/multiclusterobservability/manifests/base/cluster-logging-operator/kustomization.yaml
+++ b/operators/multiclusterobservability/manifests/base/cluster-logging-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- namespace.yaml
+- operator_group.yaml
+- subscription.yaml

--- a/operators/multiclusterobservability/manifests/base/cluster-logging-operator/namespace.yaml
+++ b/operators/multiclusterobservability/manifests/base/cluster-logging-operator/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging
+spec: {}

--- a/operators/multiclusterobservability/manifests/base/cluster-logging-operator/operator_group.yaml
+++ b/operators/multiclusterobservability/manifests/base/cluster-logging-operator/operator_group.yaml
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-logging
+  namespace: openshift-logging
+  annotations:
+    olm.providedAPIs: ClusterLogForwarder.v1.logging.openshift.io,ClusterLogging.v1.logging.openshift.io
+spec:
+  upgradeStrategy: Default

--- a/operators/multiclusterobservability/manifests/base/cluster-logging-operator/subscription.yaml
+++ b/operators/multiclusterobservability/manifests/base/cluster-logging-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  channel: stable-5.9
+  installPlanApproval: Automatic
+  name: cluster-logging
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/addon_deployment_config.yaml
+++ b/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/addon_deployment_config.yaml
@@ -4,7 +4,4 @@ metadata:
   name: multicluster-observability-addon
   namespace: open-cluster-management-observability
 spec:
-  customizedVariables:
-  # Operator Subscription Channels
-  - name: openshiftLoggingChannel
-    value: stable-5.9
+  customizedVariables: []

--- a/operators/multiclusterobservability/pkg/rendering/renderer_clo.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_clo.go
@@ -1,0 +1,99 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package rendering
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/kustomize/api/resource"
+
+	rendererutil "github.com/stolostron/multicluster-observability-operator/operators/pkg/rendering"
+)
+
+const (
+	cloSubscriptionChannel = "stable-5.9"
+)
+
+func (r *MCORenderer) newCLORenderer() {
+	r.renderCLOFns = map[string]rendererutil.RenderFn{
+		"Namespace":     r.renderer.RenderNamespace,
+		"Subscription":  r.renderSubscription,
+		"OperatorGroup": r.renderOperatorGroup,
+	}
+}
+
+func (r *MCORenderer) renderSubscription(
+	res *resource.Resource,
+	namespace string,
+	labels map[string]string,
+) (*unstructured.Unstructured, error) {
+	m, err := res.Map()
+	if err != nil {
+		return nil, err
+	}
+	u := &unstructured.Unstructured{Object: m}
+
+	cLabels := u.GetLabels()
+	if cLabels == nil {
+		cLabels = make(map[string]string)
+	}
+	for k, v := range labels {
+		cLabels[k] = v
+	}
+	u.SetLabels(cLabels)
+
+	return u, nil
+}
+func (r *MCORenderer) renderOperatorGroup(
+	res *resource.Resource,
+	namespace string,
+	labels map[string]string,
+) (*unstructured.Unstructured, error) {
+	m, err := res.Map()
+	if err != nil {
+		return nil, err
+	}
+	u := &unstructured.Unstructured{Object: m}
+
+	cLabels := u.GetLabels()
+	if cLabels == nil {
+		cLabels = make(map[string]string)
+	}
+	for k, v := range labels {
+		cLabels[k] = v
+	}
+	u.SetLabels(cLabels)
+
+	return u, nil
+}
+
+func (r *MCORenderer) renderCLOTemplates(
+	templates []*resource.Resource,
+	namespace string,
+	labels map[string]string,
+) ([]*unstructured.Unstructured, error) {
+	uobjs := []*unstructured.Unstructured{}
+	for _, template := range templates {
+		render, ok := r.renderMCOAFns[template.GetKind()]
+		if !ok {
+			m, err := template.Map()
+			if err != nil {
+				return []*unstructured.Unstructured{}, err
+			}
+			uobjs = append(uobjs, &unstructured.Unstructured{Object: m})
+			continue
+		}
+		uobj, err := render(template.DeepCopy(), namespace, labels)
+		if err != nil {
+			return []*unstructured.Unstructured{}, err
+		}
+		if uobj == nil {
+			continue
+		}
+		uobjs = append(uobjs, uobj)
+
+	}
+
+	return uobjs, nil
+}

--- a/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
@@ -26,6 +26,7 @@ const (
 	nameUserWorkloadLogsCollection   = "userWorkloadLogsCollection"
 	nameUserWorkloadTracesCollection = "userWorkloadTracesCollection"
 	nameUserWorkloadInstrumentation  = "userWorkloadInstrumentation"
+	nameOpenshiftLoggingChannel      = "openshiftLoggingChannel"
 
 	// AODC CustomizedVariable Values
 	clfV1         = "clusterlogforwarders.v1.logging.openshift.io"
@@ -187,6 +188,8 @@ func (r *MCORenderer) renderAddonDeploymentConfig(
 				addonapiv1alpha1.CustomizedVariable{Name: name, Value: value},
 			)
 		}
+
+		appendCustomVar(aodc, nameOpenshiftLoggingChannel, cloSubscriptionChannel)
 
 		if cs.Platform != nil {
 			if cs.Platform.Logs.Collection.Enabled {

--- a/operators/multiclusterobservability/pkg/rendering/templates/templates.go
+++ b/operators/multiclusterobservability/pkg/rendering/templates/templates.go
@@ -21,6 +21,7 @@ var (
 	proxyTemplates                 []*resource.Resource
 	endpointObservabilityTemplates []*resource.Resource
 	prometheusTemplates            []*resource.Resource
+	cloTemplates                   []*resource.Resource
 	mcoaTemplates                  []*resource.Resource
 )
 
@@ -103,6 +104,21 @@ func GetOrLoadProxyTemplates(r *templates.TemplateRenderer) ([]*resource.Resourc
 		return proxyTemplates, err
 	}
 	return proxyTemplates, nil
+}
+
+// GetOrLoadCLOTemplates reads the cluster-logging-operator manifests.
+func GetOrLoadCLOTemplates(r *templates.TemplateRenderer) ([]*resource.Resource, error) {
+	if len(cloTemplates) > 0 {
+		return cloTemplates, nil
+	}
+
+	basePath := path.Join(r.GetTemplatesPath(), "base")
+
+	// add mcoa templates
+	if err := r.AddTemplateFromPath(path.Join(basePath, "cluster-logging-operator"), &cloTemplates); err != nil {
+		return mcoaTemplates, err
+	}
+	return cloTemplates, nil
 }
 
 // GetOrLoadMCOATemplates reads the multicluster-observability-addon manifests.


### PR DESCRIPTION
Missing:
- [ ] Add unit tests
- [ ] Manual test
- [ ] Add status reporting, in case of, operator already installed (CLO or OTEL)
- [ ] Evaluate optional creation of logging namespace
- [ ] Add installation of OpenTelmetryOperator
- [ ] Final manual test
