### PR TITLE
[release-2.12] Add MCOA status for CRD dependencies

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_status.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_status.go
@@ -25,7 +25,6 @@ import (
 )
 
 const (
-	typeDegraded       = "Degraded"
 	reasonMCOADegraded = "MultiClusterObservabilityAddonDegraded"
 )
 
@@ -417,7 +416,7 @@ func checkAddonSpecStatus(mco *mcov1beta2.MultiClusterObservability) *mcoshared.
 func newInstallingCondition() *mcoshared.Condition {
 	return &mcoshared.Condition{
 		Type:    "Installing",
-		Status:  "True",
+		Status:  metav1.ConditionTrue,
 		Reason:  "Installing",
 		Message: "Installation is in progress",
 	}
@@ -426,7 +425,7 @@ func newInstallingCondition() *mcoshared.Condition {
 func newReadyCondition() *mcoshared.Condition {
 	return &mcoshared.Condition{
 		Type:    "Ready",
-		Status:  "True",
+		Status:  metav1.ConditionTrue,
 		Reason:  "Ready",
 		Message: "Observability components are deployed and running",
 	}
@@ -444,7 +443,7 @@ func newFailedCondition(reason string, msg string) *mcoshared.Condition {
 func newMetricsDisabledCondition() *mcoshared.Condition {
 	return &mcoshared.Condition{
 		Type:    "MetricsDisabled",
-		Status:  "True",
+		Status:  metav1.ConditionTrue,
 		Reason:  "MetricsDisabled",
 		Message: "Collect metrics from the managed clusters is disabled",
 	}
@@ -462,8 +461,8 @@ func newMCOADegradedCondition(missing []string) *mcoshared.Condition {
 	msg := fmt.Sprintf(tmpl, strings.Join(missingVersions, ", "))
 
 	return &mcoshared.Condition{
-		Type:    typeDegraded,
-		Status:  "True",
+		Type:    reasonMCOADegraded,
+		Status:  metav1.ConditionTrue,
 		Reason:  reasonMCOADegraded,
 		Message: msg,
 	}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_status.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_status.go
@@ -450,7 +450,7 @@ func newMetricsDisabledCondition() *mcoshared.Condition {
 }
 
 func newMCOADegradedCondition(missing []string) *mcoshared.Condition {
-	tmpl := "MultiCluster-Observability-Addon degraded because the following CRDs are not installed on this hub cluster: %s"
+	tmpl := "MultiCluster-Observability-Addon degraded because the following CRDs are not installed on the hub: %s"
 
 	var missingVersions []string
 	for _, name := range missing {

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_status.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_status.go
@@ -25,7 +25,8 @@ import (
 )
 
 const (
-	typeMCOADegraded = "MultiClusterObservabilityAddonDegraded"
+	typeDegraded       = "Degraded"
+	reasonMCOADegraded = "MultiClusterObservabilityAddonDegraded"
 )
 
 var (
@@ -297,7 +298,7 @@ outer:
 	}
 
 	if len(missing) == 0 {
-		removeStatusCondition(conds, typeMCOADegraded)
+		removeStatusCondition(conds, reasonMCOADegraded)
 		return
 	}
 
@@ -461,9 +462,9 @@ func newMCOADegradedCondition(missing []string) *mcoshared.Condition {
 	msg := fmt.Sprintf(tmpl, strings.Join(missingVersions, ", "))
 
 	return &mcoshared.Condition{
-		Type:    typeMCOADegraded,
+		Type:    typeDegraded,
 		Status:  "True",
-		Reason:  typeMCOADegraded,
+		Reason:  reasonMCOADegraded,
 		Message: msg,
 	}
 }

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_status.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_status.go
@@ -8,11 +8,13 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,6 +22,10 @@ import (
 	mcoshared "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/shared"
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+)
+
+const (
+	typeMCOADegraded = "MultiClusterObservabilityAddonDegraded"
 )
 
 var (
@@ -108,6 +114,7 @@ func updateStatus(c client.Client) {
 	updateInstallStatus(&newStatus.Conditions)
 	updateReadyStatus(&newStatus.Conditions, c, instance)
 	updateAddonSpecStatus(&newStatus.Conditions, instance)
+	updateMCOAStatus(c, &newStatus.Conditions, instance)
 	fillupStatus(&newStatus.Conditions)
 	instance.Status.Conditions = newStatus.Conditions
 	if !reflect.DeepEqual(newStatus.Conditions, oldStatus.Conditions) {
@@ -136,7 +143,6 @@ func updateInstallStatus(conditions *[]mcoshared.Condition) {
 }
 
 func checkReadyStatus(c client.Client, mco *mcov1beta2.MultiClusterObservability) bool {
-
 	if findStatusCondition(mco.Status.Conditions, "Ready") != nil {
 		return true
 	}
@@ -158,8 +164,8 @@ func checkReadyStatus(c client.Client, mco *mcov1beta2.MultiClusterObservability
 func updateReadyStatus(
 	conditions *[]mcoshared.Condition,
 	c client.Client,
-	mco *mcov1beta2.MultiClusterObservability) {
-
+	mco *mcov1beta2.MultiClusterObservability,
+) {
 	if findStatusCondition(*conditions, "Ready") != nil {
 		return
 	}
@@ -247,13 +253,56 @@ func findStatusCondition(conditions []mcoshared.Condition, conditionType string)
 
 func updateAddonSpecStatus(
 	conditions *[]mcoshared.Condition,
-	mco *mcov1beta2.MultiClusterObservability) {
+	mco *mcov1beta2.MultiClusterObservability,
+) {
 	addonStatus := checkAddonSpecStatus(mco)
 	if addonStatus != nil {
 		setStatusCondition(conditions, *addonStatus)
 	} else {
 		removeStatusCondition(conditions, "MetricsDisabled")
 	}
+}
+
+func updateMCOAStatus(c client.Client, conds *[]mcoshared.Condition, mco *mcov1beta2.MultiClusterObservability) {
+	if mco.Spec.Capabilities == nil {
+		return
+	}
+
+	if mco.Spec.Capabilities.Platform == nil && mco.Spec.Capabilities.UserWorkloads == nil {
+		return
+	}
+
+	var missing []string
+
+outer:
+	for _, crdName := range config.GetMCOASupportedCRDNames() {
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		key := client.ObjectKey{Name: crdName}
+
+		err := c.Get(context.TODO(), key, crd)
+		if client.IgnoreAlreadyExists(err) != nil {
+			missing = append(missing, crdName)
+			continue
+		}
+
+		version := config.GetMCOASupportedCRDVersion(crdName)
+
+		for _, crdVersion := range crd.Spec.Versions {
+			if crdVersion.Name == version && crdVersion.Served {
+				continue outer
+			}
+		}
+
+		missing = append(missing, crdName)
+	}
+
+	if len(missing) == 0 {
+		removeStatusCondition(conds, typeMCOADegraded)
+		return
+	}
+
+	mcoaDegraded := newMCOADegradedCondition(missing)
+	setStatusCondition(conds, *mcoaDegraded)
 }
 
 func getExpectedDeploymentNames() []string {
@@ -327,7 +376,8 @@ func checkStatefulSetStatus(c client.Client) *mcoshared.Condition {
 
 func checkObjStorageStatus(
 	c client.Client,
-	mco *mcov1beta2.MultiClusterObservability) *mcoshared.Condition {
+	mco *mcov1beta2.MultiClusterObservability,
+) *mcoshared.Condition {
 	objStorageConf := mco.Spec.StorageConfig.MetricObjectStorage
 	secret := &corev1.Secret{}
 	namespacedName := types.NamespacedName{
@@ -396,5 +446,24 @@ func newMetricsDisabledCondition() *mcoshared.Condition {
 		Status:  "True",
 		Reason:  "MetricsDisabled",
 		Message: "Collect metrics from the managed clusters is disabled",
+	}
+}
+
+func newMCOADegradedCondition(missing []string) *mcoshared.Condition {
+	tmpl := "MultiCluster-Observability-Addon degraded because the following CRDs are not installed on this hub cluster: %s"
+
+	var missingVersions []string
+	for _, name := range missing {
+		version := config.GetMCOASupportedCRDVersion(name)
+		missingVersions = append(missingVersions, fmt.Sprintf("%s(%s)", name, version))
+	}
+
+	msg := fmt.Sprintf(tmpl, strings.Join(missingVersions, ", "))
+
+	return &mcoshared.Condition{
+		Type:    typeMCOADegraded,
+		Status:  "True",
+		Reason:  typeMCOADegraded,
+		Message: msg,
 	}
 }

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
@@ -16,7 +16,7 @@ import (
 func GetMCOPredicateFunc() predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			//set request name to be used in placementrule controller
+			// set request name to be used in placementrule controller
 			config.SetMonitoringCRName(e.Object.GetName())
 			return true
 		},
@@ -58,8 +58,8 @@ func GetConfigMapPredicateFunc() predicate.Funcs {
 			if e.ObjectNew.GetNamespace() == config.GetDefaultNamespace() {
 				if e.ObjectNew.GetName() == config.AlertRuleCustomConfigMapName {
 					// Grafana dynamically loads AlertRule configmap, nothing more to do
-					//config.SetCustomRuleConfigMap(true)
-					//return e.ObjectOld.GetResourceVersion() != e.ObjectNew.GetResourceVersion()
+					// config.SetCustomRuleConfigMap(true)
+					// return e.ObjectOld.GetResourceVersion() != e.ObjectNew.GetResourceVersion()
 					return false
 				} else if _, ok := e.ObjectNew.GetLabels()[config.BackupLabelName]; ok {
 					// resource already has backup label
@@ -204,5 +204,13 @@ func GetImageStreamPredicateFunc() predicate.Funcs {
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return false
 		},
+	}
+}
+func GetMCOACRDPredicateFunc() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc:  func(_ event.CreateEvent) bool { return true },
+		UpdateFunc:  func(_ event.UpdateEvent) bool { return false },
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return true },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
 	}
 }

--- a/operators/multiclusterobservability/main.go
+++ b/operators/multiclusterobservability/main.go
@@ -29,6 +29,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -73,6 +74,7 @@ func init() {
 	utilruntime.Must(prometheusv1.AddToScheme(scheme))
 	utilruntime.Must(addonv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(imagev1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -251,7 +253,8 @@ func main() {
 				func(t *tls.Config) {
 					t.MinVersion = tls.VersionTLS12
 				},
-			}}),
+			},
+		}),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -876,6 +877,7 @@ func GetMCOASupportedCRDNames() []string {
 	for name := range mcoaSupportedCRDs {
 		names = append(names, name)
 	}
+	sort.Strings(names)
 	return names
 }
 

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -222,6 +222,20 @@ const (
 	OauthProxyImageStreamNamespace = "openshift"
 )
 
+const (
+	ClusterLogForwarderCRDName    = "clusterlogforwarders.logging.openshift.io"
+	OpenTelemetryCollectorCRDName = "opentelemetrycollectors.opentelemetry.io"
+	InstrumentationCRDName        = "instrumentations.opentelemetry.io"
+)
+
+var (
+	mcoaSupportedCRDs = map[string]string{
+		ClusterLogForwarderCRDName:    "v1",
+		OpenTelemetryCollectorCRDName: "v1beta1",
+		InstrumentationCRDName:        "v1alpha1",
+	}
+)
+
 // ObjectStorgeConf is used to Unmarshal from bytes to do validation.
 type ObjectStorgeConf struct {
 	Type   string `yaml:"type"`
@@ -853,5 +867,32 @@ func GetOauthProxyImage(imageClient imagev1client.ImageV1Interface) (bool, strin
 		}
 	}
 	return false, ""
+}
 
+func GetMCOASupportedCRDNames() []string {
+	var names []string
+	for name := range mcoaSupportedCRDs {
+		names = append(names, name)
+	}
+	return names
+}
+
+func GetMCOASupportedCRDVersion(name string) string {
+	version, ok := mcoaSupportedCRDs[name]
+	if !ok {
+		return ""
+	}
+
+	return version
+}
+
+func GetMCOASupportedCRDFQDN(name string) string {
+	version, ok := mcoaSupportedCRDs[name]
+	if !ok {
+		return ""
+	}
+
+	parts := strings.SplitN(name, ".", 2)
+
+	return fmt.Sprintf("%s.%s.%s", parts[0], version, parts[1])
 }

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -217,6 +217,8 @@ const (
 	HubEndpointSaName          = "endpoint-observability-operator-sa"
 )
 
+const schemeHttps = "https"
+
 const (
 	OauthProxyImageStreamName      = "oauth-proxy"
 	OauthProxyImageStreamNamespace = "openshift"
@@ -404,7 +406,7 @@ func GetObsAPIExternalURL(ctx context.Context, client client.Client, namespace s
 	if err != nil {
 		return nil, err
 	}
-	return url.Parse("https://" + routeHost)
+	return url.Parse(fmt.Sprintf("%s://%s", schemeHttps, routeHost))
 }
 
 func GetRouteHost(client client.Client, name string, namespace string) (string, error) {
@@ -468,11 +470,11 @@ func GetAlertmanagerURL(ctx context.Context, client client.Client, namespace str
 		if err != nil {
 			return nil, err
 		}
-		return url.Parse("https://" + AlertmanagerRouteName + "-" + namespace + "." + domain)
+		return url.Parse(fmt.Sprintf("%s://%s-%s.%s", schemeHttps, AlertmanagerRouteName, namespace, domain))
 	} else if err != nil {
 		return nil, err
 	}
-	return url.Parse("https://" + found.Spec.Host)
+	return url.Parse(fmt.Sprintf("%s://%s", schemeHttps, found.Spec.Host))
 }
 
 // getDomainForIngressController get the domain for the given ingresscontroller instance.

--- a/operators/multiclusterobservability/pkg/config/config_test.go
+++ b/operators/multiclusterobservability/pkg/config/config_test.go
@@ -803,3 +803,50 @@ func TestGetOperandName(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMCOASupportedCRDNames(t *testing.T) {
+	expected := []string{
+		"clusterlogforwarders.logging.openshift.io",
+		"opentelemetrycollectors.opentelemetry.io",
+		"instrumentations.opentelemetry.io",
+	}
+
+	result := GetMCOASupportedCRDNames()
+	assert.ElementsMatch(t, expected, result)
+}
+
+func TestGetMCOASupportedCRDFQDN(t *testing.T) {
+	tests := []struct {
+		name     string
+		crdName  string
+		expected string
+	}{
+		{
+			name:     "Valid CRD name with version",
+			crdName:  "clusterlogforwarders.logging.openshift.io",
+			expected: "clusterlogforwarders.v1.logging.openshift.io",
+		},
+		{
+			name:     "Valid CRD name with different version",
+			crdName:  "opentelemetrycollectors.opentelemetry.io",
+			expected: "opentelemetrycollectors.v1beta1.opentelemetry.io",
+		},
+		{
+			name:     "Valid CRD name with another version",
+			crdName:  "instrumentations.opentelemetry.io",
+			expected: "instrumentations.v1alpha1.opentelemetry.io",
+		},
+		{
+			name:     "Invalid CRD name",
+			crdName:  "invalid.crd.name",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetMCOASupportedCRDFQDN(tt.crdName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
@@ -26,11 +26,6 @@ const (
 	nameUserWorkloadLogsCollection   = "userWorkloadLogsCollection"
 	nameUserWorkloadTracesCollection = "userWorkloadTracesCollection"
 	nameUserWorkloadInstrumentation  = "userWorkloadInstrumentation"
-
-	// AODC CustomizedVariable Values
-	clfV1         = "clusterlogforwarders.v1.logging.openshift.io"
-	otelV1beta1   = "opentelemetrycollectors.v1beta1.opentelemetry.io"
-	instrV1alpha1 = "instrumentations.v1alpha1.opentelemetry.io"
 )
 
 func (r *MCORenderer) newMCOARenderer() {
@@ -190,19 +185,23 @@ func (r *MCORenderer) renderAddonDeploymentConfig(
 
 		if cs.Platform != nil {
 			if cs.Platform.Logs.Collection.Enabled {
-				appendCustomVar(aodc, namePlatformLogsCollection, clfV1)
+				fqdn := mcoconfig.GetMCOASupportedCRDFQDN(mcoconfig.ClusterLogForwarderCRDName)
+				appendCustomVar(aodc, namePlatformLogsCollection, fqdn)
 			}
 		}
 
 		if cs.UserWorkloads != nil {
 			if cs.UserWorkloads.Logs.Collection.ClusterLogForwarder.Enabled {
-				appendCustomVar(aodc, nameUserWorkloadLogsCollection, clfV1)
+				fqdn := mcoconfig.GetMCOASupportedCRDFQDN(mcoconfig.ClusterLogForwarderCRDName)
+				appendCustomVar(aodc, nameUserWorkloadLogsCollection, fqdn)
 			}
 			if cs.UserWorkloads.Traces.Collection.Collector.Enabled {
-				appendCustomVar(aodc, nameUserWorkloadTracesCollection, otelV1beta1)
+				fqdn := mcoconfig.GetMCOASupportedCRDFQDN(mcoconfig.OpenTelemetryCollectorCRDName)
+				appendCustomVar(aodc, nameUserWorkloadTracesCollection, fqdn)
 			}
 			if cs.UserWorkloads.Traces.Collection.Instrumentation.Enabled {
-				appendCustomVar(aodc, nameUserWorkloadInstrumentation, instrV1alpha1)
+				fqdn := mcoconfig.GetMCOASupportedCRDFQDN(mcoconfig.InstrumentationCRDName)
+				appendCustomVar(aodc, nameUserWorkloadInstrumentation, fqdn)
 			}
 		}
 

--- a/operators/multiclusterobservability/pkg/rendering/renderer_mcoa_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_mcoa_test.go
@@ -166,6 +166,10 @@ func TestRenderAddonDeploymentConfig(t *testing.T) {
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(uobj.Object, got)
 	assert.NoError(t, err)
 
+	clfV1 := mcoconfig.GetMCOASupportedCRDFQDN(mcoconfig.ClusterLogForwarderCRDName)
+	otelV1beta1 := mcoconfig.GetMCOASupportedCRDFQDN(mcoconfig.OpenTelemetryCollectorCRDName)
+	instrV1alpha1 := mcoconfig.GetMCOASupportedCRDFQDN(mcoconfig.InstrumentationCRDName)
+
 	assert.Len(t, got.Spec.CustomizedVariables, 5)
 	assert.Contains(t, got.Spec.CustomizedVariables, addonv1alpha1.CustomizedVariable{Name: namePlatformLogsCollection, Value: clfV1})
 	assert.Contains(t, got.Spec.CustomizedVariables, addonv1alpha1.CustomizedVariable{Name: nameUserWorkloadLogsCollection, Value: clfV1})


### PR DESCRIPTION
Succeeds https://github.com/stolostron/multicluster-observability-operator/pull/1564 

The following PR is an amendment/extention to https://github.com/stolostron/multicluster-observability-operator/pull/1470 to improve the user experience when a user decides to use the new capabilities spec and in turn MCOA. Currently the MCOA internal reconciliation loop depends on a set of CustomResourceDefinitions (CRD) owned by other operator dependecies (i.e. cluster-logging-operator, opentelemetrycollector-operator). The underlying implementation checks if the CRDs exist and actually serve the required CRD versions. If any is missing the MCO status shows the MCOADegradedCondition, e.g.:

```yaml
conditions:
  - lastTransitionTime: "2024-08-07T09:25:01Z"
    message: 'MultiCluster-Observability-Addon degraded because the following CRDs are not installed on this hub cluster: opentelemetrycollectors.opentelemetry.io(v1beta1)'
    reason: MultiClusterObservabilityAddonDegraded
    status: "True"
    type: MultiClusterObservabilityAddonDegraded
```

cc @periklis 