### PR TITLE
[ACM-14235]: Ensure CMO ConfigMap is reconciled on any event

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -51,8 +51,6 @@ const (
 	ownerLabelKey                   = "owner"
 	ownerLabelValue                 = "observabilityaddon"
 	obsAddonFinalizer               = "observability.open-cluster-management.io/addon-cleanup"
-	promSvcName                     = "prometheus-k8s"
-	promNamespace                   = "openshift-monitoring"
 	openShiftClusterMonitoringlabel = "openshift.io/cluster-monitoring"
 )
 
@@ -66,6 +64,11 @@ var (
 	namespace             = os.Getenv("WATCH_NAMESPACE")
 	hubNamespace          = os.Getenv("HUB_NAMESPACE")
 	isHubMetricsCollector = os.Getenv("HUB_ENDPOINT_OPERATOR") == "true"
+)
+
+const (
+	promSvcName   = operatorconfig.OCPClusterMonitoringPrometheusService
+	promNamespace = operatorconfig.OCPClusterMonitoringNamespace
 )
 
 // ObservabilityAddonReconciler reconciles a ObservabilityAddon object.
@@ -544,7 +547,7 @@ func (r *ObservabilityAddonReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Watches(
 			&source.Kind{Type: &corev1.ConfigMap{}},
 			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(getPred(clusterMonitoringConfigName, promNamespace, false, true, true)),
+			builder.WithPredicates(getPred(clusterMonitoringConfigName, promNamespace, true, true, true)),
 		).
 		Watches(
 			&source.Kind{Type: &appsv1.Deployment{}},

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
@@ -439,12 +439,14 @@ func createOrUpdateClusterMonitoringConfig(
 			foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs = newAlertmanagerConfigs
 		} else {
 			additionalAlertmanagerConfigExists := false
-			for _, v := range foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs {
+			var atIndex int
+			for i, v := range foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs {
 				if v.TLSConfig != (cmomanifests.TLSConfig{}) &&
 					v.TLSConfig.CA != nil &&
 					v.TLSConfig.CA.LocalObjectReference != (corev1.LocalObjectReference{}) &&
 					v.TLSConfig.CA.LocalObjectReference.Name == hubAmRouterCASecretName {
 					additionalAlertmanagerConfigExists = true
+					atIndex = i
 					break
 				}
 			}
@@ -452,6 +454,8 @@ func createOrUpdateClusterMonitoringConfig(
 				foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs = append(
 					foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs,
 					newAdditionalAlertmanagerConfig(hubInfo))
+			} else {
+				foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs[atIndex] = newAdditionalAlertmanagerConfig(hubInfo)
 			}
 		}
 	}

--- a/operators/endpointmetrics/main.go
+++ b/operators/endpointmetrics/main.go
@@ -92,6 +92,8 @@ func main() {
 			{FieldSelector: namespaceSelector},
 			{FieldSelector: fmt.Sprintf("metadata.name==%s,metadata.namespace!=%s",
 				operatorconfig.AllowlistCustomConfigMapName, "open-cluster-management-observability")},
+			{FieldSelector: fmt.Sprintf("metadata.name==%s,metadata.namespace==%s",
+				operatorconfig.OCPClusterMonitoringConfigMapName, operatorconfig.OCPClusterMonitoringNamespace)},
 		},
 		appsv1.SchemeGroupVersion.WithKind("Deployment"): {
 			{FieldSelector: namespaceSelector},

--- a/operators/pkg/config/config.go
+++ b/operators/pkg/config/config.go
@@ -29,6 +29,13 @@ const (
 )
 
 const (
+	OCPClusterMonitoringNamespace         = "openshift-monitoring"
+	OCPClusterMonitoringConfigMapName     = "cluster-monitoring-config"
+	OCPClusterMonitoringConfigMapKey      = "config.yaml"
+	OCPClusterMonitoringPrometheusService = "prometheus-k8s"
+)
+
+const (
 	MetricsCollectorImgName = "metrics-collector"
 	MetricsCollectorKey     = "metrics_collector"
 


### PR DESCRIPTION
Backport of https://github.com/stolostron/multicluster-observability-operator/pull/1612

1. Adds an integration test for merging of CMO ConfigMap with other clients
1. Adds the Delete event to the Watch for CMO ConfigMap
1. Explicitly adds the CMO ConfigMap reference to the filtered cache