### PR TITLE
Disable non-applicable Grafana features

### DIFF
--- a/operators/multiclusterobservability/manifests/base/grafana/config.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/config.yaml
@@ -33,3 +33,7 @@ stringData:
     timeout = 300
     dial_timeout = 30
     keep_alive_seconds = 300
+    [feature_toggles]
+    correlations = false
+    [public_dashboards]
+    enabled = false


### PR DESCRIPTION
Disables:
- Correlations (the page anyway just comes up with "Please contact your administrator to create new correlations.")
- Public Dashboards (users anyway doesn't have permissions for that)