### PR TITLE
Make federate sharding possible in metrics-collector by using workers

### DIFF
--- a/collectors/metrics/Dockerfile.dev
+++ b/collectors/metrics/Dockerfile.dev
@@ -1,0 +1,17 @@
+FROM golang:1.22-alpine3.18 AS builder
+
+WORKDIR /workspace
+COPY go.sum go.mod ./
+COPY ./collectors/metrics ./collectors/metrics
+COPY ./operators/pkg ./operators/pkg
+COPY ./operators/multiclusterobservability/api ./operators/multiclusterobservability/api
+RUN go build -v -o metrics-collector ./collectors/metrics/cmd/metrics-collector/main.go
+
+FROM alpine:3.18 AS runner
+
+USER 1001:1001
+
+COPY --from=builder /workspace/metrics-collector /usr/bin/
+
+
+CMD ["/bin/bash", "-c", "/usr/bin/metrics-collector"]

--- a/collectors/metrics/cmd/metrics-collector/main.go
+++ b/collectors/metrics/cmd/metrics-collector/main.go
@@ -61,7 +61,7 @@ func main() {
 		&opt.WorkerNum,
 		"worker-number",
 		opt.WorkerNum,
-		"The number of workers that will be used to send metrics.")
+		"The number of workers that will work in parallel to send metrics.")
 	cmd.Flags().StringVar(
 		&opt.Listen,
 		"listen",
@@ -355,7 +355,7 @@ func (o *Options) Run() error {
 		g.Add(func() error {
 			for i, shardWorker := range shardWorkers {
 				go func(i int, shardWorker *forwarder.Worker) {
-					fmt.Printf("Starting shard worker %d\n", i)
+					logger.Log(o.Logger, logger.Info, "msg", "Starting shard worker", "worker", i)
 					shardWorker.Run(ctx)
 				}(i, shardWorker)
 			}
@@ -435,7 +435,7 @@ func splitMatchersIntoShards(matchers []string, shardCount int) [][]string {
 }
 
 // Agent is the type of the worker agent that will be running.
-// They are classed according to what they collect.
+// They are classified according to what they collect.
 type Agent string
 
 const (

--- a/collectors/metrics/cmd/metrics-collector/main_test.go
+++ b/collectors/metrics/cmd/metrics-collector/main_test.go
@@ -25,7 +25,7 @@ func TestMultiWorkers(t *testing.T) {
 	opt := &Options{
 		Listen:                  "localhost:9002",
 		LimitBytes:              200 * 1024,
-		Rules:                   []string{`{__name__="instance:node_vmstat_pgmajfault:rate1m"}`},
+		Matchers:                []string{`{__name__="instance:node_vmstat_pgmajfault:rate1m"}`},
 		Interval:                4*time.Minute + 30*time.Second,
 		WorkerNum:               2,
 		SimulatedTimeseriesFile: "../../testdata/timeseries.txt",
@@ -35,11 +35,6 @@ func TestMultiWorkers(t *testing.T) {
 			"cluster=local-cluster",
 			"clusterID=245c2253-7b0d-4080-8e33-f6f0d6c6ff73",
 		},
-		FromCAFile:             "../../testdata/service-ca.crt",
-		FromTokenFile:          "../../testdata/token",
-		ToUploadCA:             "../../testdata/tls/ca.crt",
-		ToUploadCert:           "../../testdata/tls/tls.crt",
-		ToUploadKey:            "../../testdata/tls/tls.key",
 		DisableHyperShift:      true,
 		DisableStatusReporting: true,
 	}

--- a/collectors/metrics/pkg/collectrule/evaluator.go
+++ b/collectors/metrics/pkg/collectrule/evaluator.go
@@ -329,7 +329,7 @@ func (e *Evaluator) evaluate(ctx context.Context) {
 		from.RawQuery = v.Encode()
 
 		req := &http.Request{Method: "GET", URL: from}
-		result, err := e.fromClient.RetrievRecordingMetrics(ctx, req, r.Name)
+		result, err := e.fromClient.RetrieveRecordingMetrics(ctx, req, r.Name)
 		if err != nil {
 			rlogger.Log(e.logger, rlogger.Error, "msg", "failed to evaluate collect rule", "err", err, "rule", r.Expr)
 			continue

--- a/collectors/metrics/pkg/collectrule/evaluator.go
+++ b/collectors/metrics/pkg/collectrule/evaluator.go
@@ -66,15 +66,8 @@ type Evaluator struct {
 
 func New(cfg forwarder.Config) (*Evaluator, error) {
 	config = forwarder.Config{
-		From:          cfg.From,
-		FromToken:     cfg.FromToken,
-		FromTokenFile: cfg.FromTokenFile,
-		FromCAFile:    cfg.FromCAFile,
-
-		ToUpload:     cfg.ToUpload,
-		ToUploadCA:   cfg.ToUploadCA,
-		ToUploadCert: cfg.ToUploadCert,
-		ToUploadKey:  cfg.ToUploadKey,
+		FromClientConfig: cfg.FromClientConfig,
+		ToClientConfig:   cfg.ToClientConfig,
 
 		AnonymizeLabels:   cfg.AnonymizeLabels,
 		AnonymizeSalt:     cfg.AnonymizeSalt,
@@ -88,8 +81,8 @@ func New(cfg forwarder.Config) (*Evaluator, error) {
 		Metrics: cfg.Metrics,
 	}
 	from := &url.URL{
-		Scheme: cfg.From.Scheme,
-		Host:   cfg.From.Host,
+		Scheme: cfg.FromClientConfig.URL.Scheme,
+		Host:   cfg.FromClientConfig.URL.Host,
 		Path:   "/api/v1/query",
 	}
 	evaluator := Evaluator{
@@ -108,7 +101,7 @@ func New(cfg forwarder.Config) (*Evaluator, error) {
 		evaluator.interval = 30 * time.Second
 	}
 
-	fromClient, err := forwarder.CreateFromClient(cfg, cfg.Metrics, evaluator.interval, "evaluate_query", cfg.Logger)
+	fromClient, err := cfg.CreateFromClient(cfg.Metrics, evaluator.interval, "evaluate_query", cfg.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -347,9 +340,9 @@ func (e *Evaluator) evaluate(ctx context.Context) {
 		}
 	}
 	if isUpdate {
-		config.Rules = getMatches()
+		config.Matchers = getMatches()
 
-		if len(config.Rules) == 0 {
+		if len(config.Matchers) == 0 {
 			if forwardWorker != nil && cancel != nil {
 				cancel()
 				forwardWorker = nil

--- a/collectors/metrics/pkg/forwarder/forwarder.go
+++ b/collectors/metrics/pkg/forwarder/forwarder.go
@@ -54,7 +54,7 @@ type Config struct {
 	ToClientConfig ToClientConfig
 	// Enable debug roundtrippers for from and to clients.
 	Debug bool
-	// LimitBytes limits the size of the response read from requests made to from and to clients.
+	// LimitBytes limits the size of the requests made to from and to clients.
 	LimitBytes int64
 
 	// Interval is the interval at which workers will federate Prometheus and send remote write requests.

--- a/collectors/metrics/pkg/forwarder/forwarder_test.go
+++ b/collectors/metrics/pkg/forwarder/forwarder_test.go
@@ -38,133 +38,132 @@ func TestNew(t *testing.T) {
 		{
 			// Empty configuration should error.
 			c: Config{
-				Logger:       log.NewNopLogger(),
-				ToUploadCA:   "../../testdata/tls/ca.crt",
-				ToUploadCert: "../../testdata/tls/tls.crt",
-				ToUploadKey:  "../../testdata/tls/tls.key",
+				Logger: log.NewNopLogger(),
 			},
 			err: true,
 		},
 		{
 			// Only providing a `From` should not error.
 			c: Config{
-				From:         from,
-				Logger:       log.NewNopLogger(),
-				ToUploadCA:   "../../testdata/tls/ca.crt",
-				ToUploadCert: "../../testdata/tls/tls.crt",
-				ToUploadKey:  "../../testdata/tls/tls.key",
+				FromClientConfig: FromClientConfig{
+					URL: from,
+				},
+				Logger: log.NewNopLogger(),
 			},
 			err: false,
 		},
 		{
 			// Providing `From` and `ToUpload` should not error.
 			c: Config{
-				From:         from,
-				ToUpload:     toUpload,
-				Logger:       log.NewNopLogger(),
-				ToUploadCA:   "../../testdata/tls/ca.crt",
-				ToUploadCert: "../../testdata/tls/tls.crt",
-				ToUploadKey:  "../../testdata/tls/tls.key",
+				FromClientConfig: FromClientConfig{
+					URL: from,
+				},
+				ToClientConfig: ToClientConfig{
+					URL: toUpload,
+				},
+				Logger: log.NewNopLogger(),
 			},
 			err: false,
 		},
 		{
 			// Providing an invalid `FromTokenFile` file should error.
 			c: Config{
-				From:          from,
-				FromTokenFile: "/this/path/does/not/exist",
-				Logger:        log.NewNopLogger(),
-				ToUploadCA:    "../../testdata/tls/ca.crt",
-				ToUploadCert:  "../../testdata/tls/tls.crt",
-				ToUploadKey:   "../../testdata/tls/tls.key",
+				FromClientConfig: FromClientConfig{
+					URL:       from,
+					TokenFile: "/this/path/does/not/exist",
+				},
+				Logger: log.NewNopLogger(),
 			},
 			err: true,
 		},
 		{
 			// Providing only `AnonymizeSalt` should not error.
 			c: Config{
-				From:          from,
+				FromClientConfig: FromClientConfig{
+					URL: from,
+				},
 				AnonymizeSalt: "1",
 				Logger:        log.NewNopLogger(),
-				ToUploadCA:    "../../testdata/tls/ca.crt",
-				ToUploadCert:  "../../testdata/tls/tls.crt",
-				ToUploadKey:   "../../testdata/tls/tls.key",
 			},
 			err: false,
 		},
 		{
 			// Providing only `AnonymizeLabels` should error.
 			c: Config{
-				From:            from,
+				FromClientConfig: FromClientConfig{
+					URL: from,
+				},
 				AnonymizeLabels: []string{"foo"},
 				Logger:          log.NewNopLogger(),
-				ToUploadCA:      "../../testdata/tls/ca.crt",
-				ToUploadCert:    "../../testdata/tls/tls.crt",
-				ToUploadKey:     "../../testdata/tls/tls.key",
 			},
 			err: true,
 		},
 		{
 			// Providing only `AnonymizeSalt` and `AnonymizeLabels should not error.
 			c: Config{
-				From:            from,
+				FromClientConfig: FromClientConfig{
+					URL: from,
+				},
 				AnonymizeLabels: []string{"foo"},
 				AnonymizeSalt:   "1",
 				Logger:          log.NewNopLogger(),
-				ToUploadCA:      "../../testdata/tls/ca.crt",
-				ToUploadCert:    "../../testdata/tls/tls.crt",
-				ToUploadKey:     "../../testdata/tls/tls.key",
 			},
 			err: false,
 		},
 		{
 			// Providing an invalid `AnonymizeSaltFile` should error.
 			c: Config{
-				From:              from,
+				FromClientConfig: FromClientConfig{
+					URL: from,
+				},
 				AnonymizeLabels:   []string{"foo"},
 				AnonymizeSaltFile: "/this/path/does/not/exist",
 				Logger:            log.NewNopLogger(),
-				ToUploadCA:        "../../testdata/tls/ca.crt",
-				ToUploadCert:      "../../testdata/tls/tls.crt",
-				ToUploadKey:       "../../testdata/tls/tls.key",
 			},
 			err: true,
 		},
 		{
 			// Providing `AnonymizeSalt` takes preference over an invalid `AnonymizeSaltFile` and should not error.
 			c: Config{
-				From:              from,
+				FromClientConfig: FromClientConfig{
+					URL: from,
+				},
 				AnonymizeLabels:   []string{"foo"},
 				AnonymizeSalt:     "1",
 				AnonymizeSaltFile: "/this/path/does/not/exist",
 				Logger:            log.NewNopLogger(),
-				ToUploadCA:        "../../testdata/tls/ca.crt",
-				ToUploadCert:      "../../testdata/tls/tls.crt",
-				ToUploadKey:       "../../testdata/tls/tls.key",
+				ToClientConfig: ToClientConfig{
+					CAFile:   "../../testdata/tls/ca.crt",
+					CertFile: "../../testdata/tls/tls.crt",
+					KeyFile:  "../../testdata/tls/tls.key",
+				},
 			},
 			err: false,
 		},
 		{
 			// Providing an invalid `FromCAFile` should error.
 			c: Config{
-				From:         from,
-				FromCAFile:   "/this/path/does/not/exist",
-				Logger:       log.NewNopLogger(),
-				ToUploadCA:   "../../testdata/tls/ca.crt",
-				ToUploadCert: "../../testdata/tls/tls.crt",
-				ToUploadKey:  "../../testdata/tls/tls.key",
+				FromClientConfig: FromClientConfig{
+					URL:    from,
+					CAFile: "/this/path/does/not/exist",
+				},
+				Logger: log.NewNopLogger(),
 			},
 			err: true,
 		},
 		{
 			// Providing CustomCA should not error.
 			c: Config{
-				From:         from,
-				ToUpload:     toUpload,
-				Logger:       log.NewNopLogger(),
-				ToUploadCA:   "../../testdata/tls/ca.crt",
-				ToUploadCert: "../../testdata/tls/tls.crt",
-				ToUploadKey:  "../../testdata/tls/tls.key",
+				FromClientConfig: FromClientConfig{
+					URL: from,
+				},
+				ToClientConfig: ToClientConfig{
+					URL:      toUpload,
+					CAFile:   "../../testdata/tls/ca.crt",
+					CertFile: "../../testdata/tls/tls.crt",
+					KeyFile:  "../../testdata/tls/tls.key",
+				},
+				Logger: log.NewNopLogger(),
 			},
 			err: false,
 		},
@@ -191,12 +190,11 @@ func TestReconfigure(t *testing.T) {
 		t.Fatalf("failed to parse `from` URL: %v", err)
 	}
 	c := Config{
-		From:         from,
-		Logger:       log.NewNopLogger(),
-		Metrics:      NewWorkerMetrics(prometheus.NewRegistry()),
-		ToUploadCA:   "../../testdata/tls/ca.crt",
-		ToUploadCert: "../../testdata/tls/tls.crt",
-		ToUploadKey:  "../../testdata/tls/tls.key",
+		FromClientConfig: FromClientConfig{
+			URL: from,
+		},
+		Logger:  log.NewNopLogger(),
+		Metrics: NewWorkerMetrics(prometheus.NewRegistry()),
 	}
 	w, err := New(c)
 	if err != nil {
@@ -215,33 +213,28 @@ func TestReconfigure(t *testing.T) {
 		{
 			// Empty configuration should error.
 			c: Config{
-				Logger:       log.NewNopLogger(),
-				ToUploadCA:   "../../testdata/tls/ca.crt",
-				ToUploadCert: "../../testdata/tls/tls.crt",
-				ToUploadKey:  "../../testdata/tls/tls.key",
+				Logger: log.NewNopLogger(),
 			},
 			err: true,
 		},
 		{
 			// Configuration with new `From` should not error.
 			c: Config{
-				From:         from2,
-				Logger:       log.NewNopLogger(),
-				ToUploadCA:   "../../testdata/tls/ca.crt",
-				ToUploadCert: "../../testdata/tls/tls.crt",
-				ToUploadKey:  "../../testdata/tls/tls.key",
+				FromClientConfig: FromClientConfig{
+					URL: from2,
+				},
+				Logger: log.NewNopLogger(),
 			},
 			err: false,
 		},
 		{
 			// Configuration with new invalid field should error.
 			c: Config{
-				From:          from,
-				FromTokenFile: "/this/path/does/not/exist",
-				Logger:        log.NewNopLogger(),
-				ToUploadCA:    "../../testdata/tls/ca.crt",
-				ToUploadCert:  "../../testdata/tls/tls.crt",
-				ToUploadKey:   "../../testdata/tls/tls.key",
+				FromClientConfig: FromClientConfig{
+					URL:       from,
+					TokenFile: "/this/path/does/not/exist",
+				},
+				Logger: log.NewNopLogger(),
 			},
 			err: true,
 		},
@@ -270,13 +263,17 @@ func TestReconfigure(t *testing.T) {
 func TestRun(t *testing.T) {
 	c := Config{
 		// Use a dummy URL.
-		From:         &url.URL{},
-		FromQuery:    &url.URL{},
-		Logger:       log.NewNopLogger(),
-		Metrics:      NewWorkerMetrics(prometheus.NewRegistry()),
-		ToUploadCA:   "../../testdata/tls/ca.crt",
-		ToUploadCert: "../../testdata/tls/tls.crt",
-		ToUploadKey:  "../../testdata/tls/tls.key",
+		FromClientConfig: FromClientConfig{
+			URL:      &url.URL{},
+			QueryURL: &url.URL{},
+		},
+		Logger:  log.NewNopLogger(),
+		Metrics: NewWorkerMetrics(prometheus.NewRegistry()),
+		ToClientConfig: ToClientConfig{
+			CAFile:   "../../testdata/tls/ca.crt",
+			CertFile: "../../testdata/tls/tls.crt",
+			KeyFile:  "../../testdata/tls/tls.key",
+		},
 	}
 	w, err := New(c)
 	if err != nil {
@@ -307,13 +304,16 @@ func TestRun(t *testing.T) {
 				stdlog.Fatalf("failed to parse second test server URL: %v", err)
 			}
 			if err := w.Reconfigure(Config{
-				From:         from,
-				FromQuery:    from,
-				Logger:       log.NewNopLogger(),
-				Metrics:      NewWorkerMetrics(prometheus.NewRegistry()),
-				ToUploadCA:   "../../testdata/tls/ca.crt",
-				ToUploadCert: "../../testdata/tls/tls.crt",
-				ToUploadKey:  "../../testdata/tls/tls.key",
+				FromClientConfig: FromClientConfig{
+					URL: from,
+				},
+				Logger:  log.NewNopLogger(),
+				Metrics: NewWorkerMetrics(prometheus.NewRegistry()),
+				ToClientConfig: ToClientConfig{
+					CAFile:   "../../testdata/tls/ca.crt",
+					CertFile: "../../testdata/tls/tls.crt",
+					KeyFile:  "../../testdata/tls/tls.key",
+				},
 			}); err != nil {
 				stdlog.Fatalf("failed to reconfigure worker with second test server url: %v", err)
 			}
@@ -326,14 +326,17 @@ func TestRun(t *testing.T) {
 		t.Fatalf("failed to parse first test server URL: %v", err)
 	}
 	if err := w.Reconfigure(Config{
-		From:           from,
-		FromQuery:      from,
+		FromClientConfig: FromClientConfig{
+			URL: from,
+		},
 		RecordingRules: []string{"{\"name\":\"test\",\"query\":\"test\"}"},
 		Logger:         log.NewNopLogger(),
 		Metrics:        NewWorkerMetrics(prometheus.NewRegistry()),
-		ToUploadCA:     "../../testdata/tls/ca.crt",
-		ToUploadCert:   "../../testdata/tls/tls.crt",
-		ToUploadKey:    "../../testdata/tls/tls.key",
+		ToClientConfig: ToClientConfig{
+			CAFile:   "../../testdata/tls/ca.crt",
+			CertFile: "../../testdata/tls/tls.crt",
+			KeyFile:  "../../testdata/tls/tls.key",
+		},
 	}); err != nil {
 		t.Fatalf("failed to reconfigure worker with first test server url: %v", err)
 	}

--- a/collectors/metrics/pkg/forwarder/forwarder_test.go
+++ b/collectors/metrics/pkg/forwarder/forwarder_test.go
@@ -21,10 +21,6 @@ import (
 // Base64 encoded CA cert string
 var customCA = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURXVENDQWtHZ0F3SUJBZ0lVWTRHWjZPWk5uTnZySjFjNUk1RjNYZzQrRTFjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1BERUxNQWtHQTFVRUJoTUNSRVV4RHpBTkJnTlZCQWdNQm1KbGNteHBiakVQTUEwR0ExVUVCd3dHWW1WeQpiR2x1TVFzd0NRWURWUVFLREFKeWFEQWVGdzB5TXpFeU1URXhNelF6TURaYUZ3MHpNekV5TURneE16UXpNRFphCk1Ed3hDekFKQmdOVkJBWVRBa1JGTVE4d0RRWURWUVFJREFaaVpYSnNhVzR4RHpBTkJnTlZCQWNNQm1KbGNteHAKYmpFTE1Ba0dBMVVFQ2d3Q2NtZ3dnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDdwprNEhLV3VBOFptN0JQR2IvZEJjaGtNUFZhWGw0dzJlVHhxRG14OVhYaGVCRFZva0lKZkFGTGZ6a3YwYUd0NWV4ClprenQxc0tQVHk0NEY5ckRKSEg2dWpEODA4U1FPV0p3WFJCakI4Tk1zSjhTTVRCUm5KUE5YNTJ0akdQNjc3UEUKNWpINnc2OW9hMG9tcGVvRDk2eUM2RTZmWU9pbFl0cVF5UFdsT0MzNEQ3TnNXU1gxdnN4cmx3VTBsQXJCbWdQYQpuZURFMnQ1cU1aK1F5TXBhQi80SFh4L2NLYU5XYXJWN3FzV3ZwSE9mOGN2OUNKd1c3VkhWdjJvNUVReVI1MkcrCitOYXE4bTduSVBzaFJSMjBHMjRsR01sVUFaTjFaMkl6VjN3UExUUmZNTXRYdGtIMFVKT3pnZTQvaExSWVJBSzMKTnhZU0xJYmFscWJsa2lUTWxFbEpBZ01CQUFHalV6QlJNQjBHQTFVZERnUVdCQlNJVFZVY2s2Wmg2WTZkY2RxZwo0VHVYRjMxcjFqQWZCZ05WSFNNRUdEQVdnQlNJVFZVY2s2Wmg2WTZkY2RxZzRUdVhGMzFyMWpBUEJnTlZIUk1CCkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ0FKUWFKM2RkYVkvNVMydHU0TnNVeXNiVG8KY3BrL3YyZkxpUkthdmtiZk1kTjBFdkV6K2gwd3FqOUpQdGJjUm5Md2tlQWdmQ3Uzb29zSG4rOXc4SkFaRjJNcwpEM1FucVovaVNNVjVHSDdQTjlIK0h0M1lVQTIwWWh3QkY0RFVXYm5wS0lnL2p4NWdmVTFYZEljK2JpUWJhdHk3CmxUL0hVOVhPRmlqM3VwbWRFakgrQVlJT2QxSFh4M3dsZlFhNHFrdWhHeUMwWXNkeldidWFxaE1tdnJkQksrSDAKUUxPcnAzN3l2OHVwUFVlMXhwTzZTeUg5QjVEeXhEWkVjMXN6WVpSVXdNVzZxc3NkWEZvWGZ0SjYxZmo3S05XagoyamcwZkQ1ZEhFT1RObDFDT3p3Q1lvR1k5ejVWOHNhYy9sSDg3UkxYWXdBcXdvcEdpanM4QXBCeklURm8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
 
-func init() {
-	os.Setenv("UNIT_TEST", "true")
-}
-
 func TestNew(t *testing.T) {
 	from, err := url.Parse("https://redhat.com")
 	if err != nil {
@@ -41,23 +37,34 @@ func TestNew(t *testing.T) {
 	}{
 		{
 			// Empty configuration should error.
-			c:   Config{Logger: log.NewNopLogger()},
+			c: Config{
+				Logger:       log.NewNopLogger(),
+				ToUploadCA:   "../../testdata/tls/ca.crt",
+				ToUploadCert: "../../testdata/tls/tls.crt",
+				ToUploadKey:  "../../testdata/tls/tls.key",
+			},
 			err: true,
 		},
 		{
 			// Only providing a `From` should not error.
 			c: Config{
-				From:   from,
-				Logger: log.NewNopLogger(),
+				From:         from,
+				Logger:       log.NewNopLogger(),
+				ToUploadCA:   "../../testdata/tls/ca.crt",
+				ToUploadCert: "../../testdata/tls/tls.crt",
+				ToUploadKey:  "../../testdata/tls/tls.key",
 			},
 			err: false,
 		},
 		{
 			// Providing `From` and `ToUpload` should not error.
 			c: Config{
-				From:     from,
-				ToUpload: toUpload,
-				Logger:   log.NewNopLogger(),
+				From:         from,
+				ToUpload:     toUpload,
+				Logger:       log.NewNopLogger(),
+				ToUploadCA:   "../../testdata/tls/ca.crt",
+				ToUploadCert: "../../testdata/tls/tls.crt",
+				ToUploadKey:  "../../testdata/tls/tls.key",
 			},
 			err: false,
 		},
@@ -67,6 +74,9 @@ func TestNew(t *testing.T) {
 				From:          from,
 				FromTokenFile: "/this/path/does/not/exist",
 				Logger:        log.NewNopLogger(),
+				ToUploadCA:    "../../testdata/tls/ca.crt",
+				ToUploadCert:  "../../testdata/tls/tls.crt",
+				ToUploadKey:   "../../testdata/tls/tls.key",
 			},
 			err: true,
 		},
@@ -76,6 +86,9 @@ func TestNew(t *testing.T) {
 				From:          from,
 				AnonymizeSalt: "1",
 				Logger:        log.NewNopLogger(),
+				ToUploadCA:    "../../testdata/tls/ca.crt",
+				ToUploadCert:  "../../testdata/tls/tls.crt",
+				ToUploadKey:   "../../testdata/tls/tls.key",
 			},
 			err: false,
 		},
@@ -85,6 +98,9 @@ func TestNew(t *testing.T) {
 				From:            from,
 				AnonymizeLabels: []string{"foo"},
 				Logger:          log.NewNopLogger(),
+				ToUploadCA:      "../../testdata/tls/ca.crt",
+				ToUploadCert:    "../../testdata/tls/tls.crt",
+				ToUploadKey:     "../../testdata/tls/tls.key",
 			},
 			err: true,
 		},
@@ -95,6 +111,9 @@ func TestNew(t *testing.T) {
 				AnonymizeLabels: []string{"foo"},
 				AnonymizeSalt:   "1",
 				Logger:          log.NewNopLogger(),
+				ToUploadCA:      "../../testdata/tls/ca.crt",
+				ToUploadCert:    "../../testdata/tls/tls.crt",
+				ToUploadKey:     "../../testdata/tls/tls.key",
 			},
 			err: false,
 		},
@@ -105,6 +124,9 @@ func TestNew(t *testing.T) {
 				AnonymizeLabels:   []string{"foo"},
 				AnonymizeSaltFile: "/this/path/does/not/exist",
 				Logger:            log.NewNopLogger(),
+				ToUploadCA:        "../../testdata/tls/ca.crt",
+				ToUploadCert:      "../../testdata/tls/tls.crt",
+				ToUploadKey:       "../../testdata/tls/tls.key",
 			},
 			err: true,
 		},
@@ -116,25 +138,33 @@ func TestNew(t *testing.T) {
 				AnonymizeSalt:     "1",
 				AnonymizeSaltFile: "/this/path/does/not/exist",
 				Logger:            log.NewNopLogger(),
+				ToUploadCA:        "../../testdata/tls/ca.crt",
+				ToUploadCert:      "../../testdata/tls/tls.crt",
+				ToUploadKey:       "../../testdata/tls/tls.key",
 			},
 			err: false,
 		},
 		{
 			// Providing an invalid `FromCAFile` should error.
 			c: Config{
-				From:       from,
-				FromCAFile: "/this/path/does/not/exist",
-				Logger:     log.NewNopLogger(),
+				From:         from,
+				FromCAFile:   "/this/path/does/not/exist",
+				Logger:       log.NewNopLogger(),
+				ToUploadCA:   "../../testdata/tls/ca.crt",
+				ToUploadCert: "../../testdata/tls/tls.crt",
+				ToUploadKey:  "../../testdata/tls/tls.key",
 			},
 			err: true,
 		},
 		{
 			// Providing CustomCA should not error.
 			c: Config{
-				From:       from,
-				ToUpload:   toUpload,
-				ToUploadCA: customCA,
-				Logger:     log.NewNopLogger(),
+				From:         from,
+				ToUpload:     toUpload,
+				Logger:       log.NewNopLogger(),
+				ToUploadCA:   "../../testdata/tls/ca.crt",
+				ToUploadCert: "../../testdata/tls/tls.crt",
+				ToUploadKey:  "../../testdata/tls/tls.key",
 			},
 			err: false,
 		},
@@ -142,7 +172,7 @@ func TestNew(t *testing.T) {
 
 	for i := range tc {
 		tc[i].c.Metrics = NewWorkerMetrics(prometheus.NewRegistry())
-		if tc[i].c.ToUploadCA == customCA {
+		if i == 10 {
 			os.Setenv("HTTPS_PROXY_CA_BUNDLE", customCA)
 		}
 		if _, err := New(tc[i].c); (err != nil) != tc[i].err {
@@ -161,9 +191,12 @@ func TestReconfigure(t *testing.T) {
 		t.Fatalf("failed to parse `from` URL: %v", err)
 	}
 	c := Config{
-		From:    from,
-		Logger:  log.NewNopLogger(),
-		Metrics: NewWorkerMetrics(prometheus.NewRegistry()),
+		From:         from,
+		Logger:       log.NewNopLogger(),
+		Metrics:      NewWorkerMetrics(prometheus.NewRegistry()),
+		ToUploadCA:   "../../testdata/tls/ca.crt",
+		ToUploadCert: "../../testdata/tls/tls.crt",
+		ToUploadKey:  "../../testdata/tls/tls.key",
 	}
 	w, err := New(c)
 	if err != nil {
@@ -181,14 +214,22 @@ func TestReconfigure(t *testing.T) {
 	}{
 		{
 			// Empty configuration should error.
-			c:   Config{Logger: log.NewNopLogger()},
+			c: Config{
+				Logger:       log.NewNopLogger(),
+				ToUploadCA:   "../../testdata/tls/ca.crt",
+				ToUploadCert: "../../testdata/tls/tls.crt",
+				ToUploadKey:  "../../testdata/tls/tls.key",
+			},
 			err: true,
 		},
 		{
 			// Configuration with new `From` should not error.
 			c: Config{
-				From:   from2,
-				Logger: log.NewNopLogger(),
+				From:         from2,
+				Logger:       log.NewNopLogger(),
+				ToUploadCA:   "../../testdata/tls/ca.crt",
+				ToUploadCert: "../../testdata/tls/tls.crt",
+				ToUploadKey:  "../../testdata/tls/tls.key",
 			},
 			err: false,
 		},
@@ -198,6 +239,9 @@ func TestReconfigure(t *testing.T) {
 				From:          from,
 				FromTokenFile: "/this/path/does/not/exist",
 				Logger:        log.NewNopLogger(),
+				ToUploadCA:    "../../testdata/tls/ca.crt",
+				ToUploadCert:  "../../testdata/tls/tls.crt",
+				ToUploadKey:   "../../testdata/tls/tls.key",
 			},
 			err: true,
 		},
@@ -226,10 +270,13 @@ func TestReconfigure(t *testing.T) {
 func TestRun(t *testing.T) {
 	c := Config{
 		// Use a dummy URL.
-		From:      &url.URL{},
-		FromQuery: &url.URL{},
-		Logger:    log.NewNopLogger(),
-		Metrics:   NewWorkerMetrics(prometheus.NewRegistry()),
+		From:         &url.URL{},
+		FromQuery:    &url.URL{},
+		Logger:       log.NewNopLogger(),
+		Metrics:      NewWorkerMetrics(prometheus.NewRegistry()),
+		ToUploadCA:   "../../testdata/tls/ca.crt",
+		ToUploadCert: "../../testdata/tls/tls.crt",
+		ToUploadKey:  "../../testdata/tls/tls.key",
 	}
 	w, err := New(c)
 	if err != nil {
@@ -259,7 +306,15 @@ func TestRun(t *testing.T) {
 			if err != nil {
 				stdlog.Fatalf("failed to parse second test server URL: %v", err)
 			}
-			if err := w.Reconfigure(Config{From: from, FromQuery: from, Logger: log.NewNopLogger(), Metrics: NewWorkerMetrics(prometheus.NewRegistry())}); err != nil {
+			if err := w.Reconfigure(Config{
+				From:         from,
+				FromQuery:    from,
+				Logger:       log.NewNopLogger(),
+				Metrics:      NewWorkerMetrics(prometheus.NewRegistry()),
+				ToUploadCA:   "../../testdata/tls/ca.crt",
+				ToUploadCert: "../../testdata/tls/tls.crt",
+				ToUploadKey:  "../../testdata/tls/tls.key",
+			}); err != nil {
 				stdlog.Fatalf("failed to reconfigure worker with second test server url: %v", err)
 			}
 		}()
@@ -270,9 +325,16 @@ func TestRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse first test server URL: %v", err)
 	}
-	if err := w.Reconfigure(Config{From: from, FromQuery: from,
+	if err := w.Reconfigure(Config{
+		From:           from,
+		FromQuery:      from,
 		RecordingRules: []string{"{\"name\":\"test\",\"query\":\"test\"}"},
-		Logger:         log.NewNopLogger(), Metrics: NewWorkerMetrics(prometheus.NewRegistry())}); err != nil {
+		Logger:         log.NewNopLogger(),
+		Metrics:        NewWorkerMetrics(prometheus.NewRegistry()),
+		ToUploadCA:     "../../testdata/tls/ca.crt",
+		ToUploadCert:   "../../testdata/tls/tls.crt",
+		ToUploadKey:    "../../testdata/tls/tls.key",
+	}); err != nil {
 		t.Fatalf("failed to reconfigure worker with first test server url: %v", err)
 	}
 

--- a/collectors/metrics/pkg/metricfamily/hypershift_transformer_test.go
+++ b/collectors/metrics/pkg/metricfamily/hypershift_transformer_test.go
@@ -49,13 +49,12 @@ var (
 	}
 )
 
-func init() {
-	os.Setenv("UNIT_TEST", "true")
-	s := scheme.Scheme
-	hyperv1.AddToScheme(s)
-}
-
 func TestTransform(t *testing.T) {
+	s := scheme.Scheme
+	if err := hyperv1.AddToScheme(s); err != nil {
+		t.Fatal("couldn't add hyperv1 to scheme")
+	}
+
 	c := fake.NewClientBuilder().WithRuntimeObjects(hCluster).Build()
 
 	l := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
@@ -63,10 +62,12 @@ func TestTransform(t *testing.T) {
 		"cluster":   "test-cluster",
 		"clusterID": "test-clusterID",
 	}
-	h, err := NewHypershiftTransformer(l, c, labels)
+
+	h, err := NewHypershiftTransformer(c, l, labels)
 	if err != nil {
 		t.Fatal("Failed to new HyperShiftTransformer", err)
 	}
+
 	family := &prom.MetricFamily{
 		Name: &metricsName,
 		Metric: []*prom.Metric{

--- a/collectors/metrics/pkg/metricsclient/metricsclient.go
+++ b/collectors/metrics/pkg/metricsclient/metricsclient.go
@@ -363,7 +363,7 @@ func MTLSTransport(logger log.Logger, caCertFile, tlsCrtFile, tlsKeyFile string)
 
 }
 
-func DefaultTransport(logger log.Logger, isTLS bool) *http.Transport {
+func DefaultTransport(logger log.Logger) *http.Transport {
 	return &http.Transport{
 		Dial: (&net.Dialer{
 			Timeout:   30 * time.Second,

--- a/collectors/metrics/pkg/metricsclient/metricsclient.go
+++ b/collectors/metrics/pkg/metricsclient/metricsclient.go
@@ -88,7 +88,7 @@ type MetricsResult struct {
 	Value  []interface{}     `json:"value"`
 }
 
-func (c *Client) RetrievRecordingMetrics(
+func (c *Client) RetrieveRecordingMetrics(
 	ctx context.Context,
 	req *http.Request,
 	name string) ([]*clientmodel.MetricFamily, error) {

--- a/collectors/metrics/pkg/metricsclient/metricsclient.go
+++ b/collectors/metrics/pkg/metricsclient/metricsclient.go
@@ -365,10 +365,10 @@ func MTLSTransport(logger log.Logger, caCertFile, tlsCrtFile, tlsKeyFile string)
 
 func DefaultTransport(logger log.Logger) *http.Transport {
 	return &http.Transport{
-		Dial: (&net.Dialer{
+		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
-		}).Dial,
+		}).DialContext,
 		TLSHandshakeTimeout: 10 * time.Second,
 		DisableKeepAlives:   true,
 	}

--- a/collectors/metrics/pkg/metricsclient/metricsclient.go
+++ b/collectors/metrics/pkg/metricsclient/metricsclient.go
@@ -319,12 +319,6 @@ func withCancel(ctx context.Context, client *http.Client, req *http.Request, fn 
 }
 
 func MTLSTransport(logger log.Logger, caCertFile, tlsCrtFile, tlsKeyFile string) (*http.Transport, error) {
-	testMode := os.Getenv("UNIT_TEST") != ""
-	if testMode {
-		caCertFile = "../../testdata/tls/ca.crt"
-		tlsKeyFile = "../../testdata/tls/tls.key"
-		tlsCrtFile = "../../testdata/tls/tls.crt"
-	}
 	// Load Server CA cert
 	var caCert []byte
 	var err error

--- a/collectors/metrics/pkg/metricsclient/metricsclient_test.go
+++ b/collectors/metrics/pkg/metricsclient/metricsclient_test.go
@@ -23,7 +23,7 @@ func TestDefaultTransport(t *testing.T) {
 		DisableKeepAlives:   true,
 	}
 	http := DefaultTransport(logger)
-	if http.Dial == nil || reflect.TypeOf(http) != reflect.TypeOf(want) {
+	if http.DialContext == nil || reflect.TypeOf(http) != reflect.TypeOf(want) {
 		t.Errorf("Default transport doesn't match expected format")
 	}
 

--- a/collectors/metrics/pkg/metricsclient/metricsclient_test.go
+++ b/collectors/metrics/pkg/metricsclient/metricsclient_test.go
@@ -22,7 +22,7 @@ func TestDefaultTransport(t *testing.T) {
 		TLSHandshakeTimeout: 10 * time.Second,
 		DisableKeepAlives:   true,
 	}
-	http := DefaultTransport(logger, true)
+	http := DefaultTransport(logger)
 	if http.Dial == nil || reflect.TypeOf(http) != reflect.TypeOf(want) {
 		t.Errorf("Default transport doesn't match expected format")
 	}

--- a/collectors/metrics/pkg/status/status.go
+++ b/collectors/metrics/pkg/status/status.go
@@ -6,18 +6,13 @@ package status
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"os"
 
 	"github.com/go-kit/log"
 	"github.com/go-logr/logr"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	oav1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
 	"github.com/stolostron/multicluster-observability-operator/operators/pkg/status"
 )
 
@@ -25,6 +20,13 @@ const (
 	addonName      = "observability-addon"
 	addonNamespace = "open-cluster-management-addon-observability"
 )
+
+type Reporter interface {
+	UpdateStatus(ctx context.Context, reason status.Reason, message string) error
+}
+
+var _ Reporter = &StatusReport{}
+var _ Reporter = &NoopReporter{}
 
 type StatusReport struct {
 	statusClient   client.Client
@@ -34,41 +36,15 @@ type StatusReport struct {
 	logger         log.Logger
 }
 
-func New(logger log.Logger, standalone, isUwl bool) (*StatusReport, error) {
-	testMode := os.Getenv("UNIT_TEST") != ""
-	var kubeClient client.Client
-	if testMode {
-		s := scheme.Scheme
-		if err := oav1beta1.AddToScheme(s); err != nil {
-			return nil, errors.New("failed to add observabilityaddon into scheme")
-		}
-		kubeClient = fake.NewClientBuilder().
-			WithScheme(s).
-			WithStatusSubresource(&oav1beta1.ObservabilityAddon{}).
-			Build()
-	} else {
-		config, err := clientcmd.BuildConfigFromFlags("", "")
-		if err != nil {
-			return nil, errors.New("failed to create the kube config")
-		}
-		s := scheme.Scheme
-		if err := oav1beta1.AddToScheme(s); err != nil {
-			return nil, errors.New("failed to add observabilityaddon into scheme")
-		}
-		kubeClient, err = client.New(config, client.Options{Scheme: s})
-		if err != nil {
-			return nil, errors.New("failed to create the kube client")
-		}
-	}
-
+func New(c client.Client, logger log.Logger, standalone, isUwl bool) (*StatusReport, error) {
 	logger.Log("msg", "Creating status client", "standalone", standalone, "isUwl", isUwl)
 
 	statusLogger := logr.FromSlogHandler(slog.New(slog.NewTextHandler(os.Stdout, nil)).With("component", "statusclient").Handler())
 	return &StatusReport{
-		statusClient:   kubeClient,
+		statusClient:   c,
 		standalone:     standalone,
 		isUwl:          isUwl,
-		statusReporter: status.NewStatus(kubeClient, addonName, addonNamespace, statusLogger),
+		statusReporter: status.NewStatus(c, addonName, addonNamespace, statusLogger),
 		logger:         logger,
 	}, nil
 }
@@ -91,5 +67,11 @@ func (s *StatusReport) UpdateStatus(ctx context.Context, reason status.Reason, m
 		s.logger.Log("msg", "Status updated", "component", component, "reason", reason, "message", message)
 	}
 
+	return nil
+}
+
+type NoopReporter struct{}
+
+func (s *NoopReporter) UpdateStatus(_ context.Context, _ status.Reason, _ string) error {
 	return nil
 }

--- a/examples/mco/e2e/v1beta1/observability-v1beta1-to-v1beta2-golden.yaml
+++ b/examples/mco/e2e/v1beta1/observability-v1beta1-to-v1beta2-golden.yaml
@@ -17,6 +17,7 @@ spec:
     enableMetrics: true
     interval: 300
     scrapeSizeLimitBytes: 1073741824
+    workers: 1
   storageConfig:
     alertmanagerStorageSize: 1Gi
     compactStorageSize: 1Gi

--- a/examples/mco/e2e/v1beta2/custom-certs/observability.yaml
+++ b/examples/mco/e2e/v1beta2/custom-certs/observability.yaml
@@ -104,6 +104,7 @@ spec:
   observabilityAddonSpec:
     scrapeSizeLimitBytes: 1073741824
     enableMetrics: true
+    workers: 1
     interval: 30
     resources:
       limits:

--- a/examples/mco/e2e/v1beta2/observability.yaml
+++ b/examples/mco/e2e/v1beta2/observability.yaml
@@ -103,6 +103,7 @@ spec:
     kubernetes.io/os: linux
   observabilityAddonSpec:
     scrapeSizeLimitBytes: 1073741824
+    workers: 1
     enableMetrics: true
     interval: 30
     resources:

--- a/operators/endpointmetrics/pkg/collector/metrics_collector.go
+++ b/operators/endpointmetrics/pkg/collector/metrics_collector.go
@@ -792,6 +792,11 @@ func (m *MetricsCollector) getCommands(isUSW bool, deployParams *deploymentParam
 		interval = fmt.Sprintf("%ds", m.ObsAddon.Spec.Interval)
 	}
 
+	workers := 1
+	if m.ObsAddon.Spec.Workers != 0 {
+		workers = int(m.ObsAddon.Spec.Workers)
+	}
+
 	evaluateInterval := "30s"
 	if m.ObsAddon.Spec.Interval < 30 {
 		evaluateInterval = interval
@@ -819,6 +824,7 @@ func (m *MetricsCollector) getCommands(isUSW bool, deployParams *deploymentParam
 		"/usr/bin/metrics-collector",
 		"--listen=:8080",
 		"--from=$(FROM)",
+		"--worker-number=" + strconv.Itoa(workers),
 		"--from-query=$(FROM_QUERY)",
 		"--to-upload=$(TO)",
 		"--to-upload-ca=/tlscerts/ca/ca.crt",

--- a/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
+++ b/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
@@ -49,9 +49,10 @@ type ObservabilityAddonSpec struct {
 	// +kubebuilder:default:=1073741824
 	ScrapeSizeLimitBytes int `json:"scrapeSizeLimitBytes,omitempty"`
 
-	// Workers is the number of workers that work parallelly to push metrics to hub server.
-	// If set to > 1, metrics-collector will shard /federate calls to Prometheus, based on
-	// matcher rules provided by allowlist.
+	// Workers is the number of workers in metrics-collector that work in parallel to
+	// push metrics to hub server. If set to > 1, metrics-collector will shard
+	// /federate calls to Prometheus, based on matcher rules provided by allowlist.
+	// Ensure that number of matchers exceeds number of workers.
 	// +optional
 	// +kubebuilder:default:=1
 	// +kubebuilder:validation:Minimum=1

--- a/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
+++ b/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
@@ -49,6 +49,14 @@ type ObservabilityAddonSpec struct {
 	// +kubebuilder:default:=1073741824
 	ScrapeSizeLimitBytes int `json:"scrapeSizeLimitBytes,omitempty"`
 
+	// Workers is the number of workers that work parallelly to push metrics to hub server.
+	// If set to > 1, metrics-collector will shard /federate calls to Prometheus, based on
+	// matcher rules provided by allowlist.
+	// +optional
+	// +kubebuilder:default:=1
+	// +kubebuilder:validation:Minimum=1
+	Workers int32 `json:"workers,omitempty"`
+
 	// Resource requirement for metrics-collector
 	// +optional
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`

--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -49,7 +49,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-09-09T14:04:08Z"
+    createdAt: "2024-09-16T10:55:32Z"
     operators.operatorframework.io/builder: operator-sdk-v1.34.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-observability-operator.v0.1.0

--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -49,7 +49,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-09-16T10:55:32Z"
+    createdAt: "2024-09-23T12:07:01Z"
     operators.operatorframework.io/builder: operator-sdk-v1.34.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-observability-operator.v0.1.0

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -169,6 +169,15 @@ spec:
                       ScrapeSizeLimitBytes is the max size in bytes for a single metrics scrape from in-cluster Prometheus.
                       Default is 1 GiB.
                     type: integer
+                  workers:
+                    default: 1
+                    description: |-
+                      Workers is the number of workers that work parallelly to push metrics to hub server.
+                      If set to > 1, metrics-collector will shard /federate calls to Prometheus, based on
+                      matcher rules provided by allowlist.
+                    format: int32
+                    minimum: 1
+                    type: integer
                 type: object
               retentionResolution1h:
                 default: 30d
@@ -10197,6 +10206,15 @@ spec:
                     description: |-
                       ScrapeSizeLimitBytes is the max size in bytes for a single metrics scrape from in-cluster Prometheus.
                       Default is 1 GiB.
+                    type: integer
+                  workers:
+                    default: 1
+                    description: |-
+                      Workers is the number of workers that work parallelly to push metrics to hub server.
+                      If set to > 1, metrics-collector will shard /federate calls to Prometheus, based on
+                      matcher rules provided by allowlist.
+                    format: int32
+                    minimum: 1
                     type: integer
                 type: object
               storageConfig:

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -172,9 +172,10 @@ spec:
                   workers:
                     default: 1
                     description: |-
-                      Workers is the number of workers that work parallelly to push metrics to hub server.
-                      If set to > 1, metrics-collector will shard /federate calls to Prometheus, based on
-                      matcher rules provided by allowlist.
+                      Workers is the number of workers in metrics-collector that work in parallel to
+                      push metrics to hub server. If set to > 1, metrics-collector will shard
+                      /federate calls to Prometheus, based on matcher rules provided by allowlist.
+                      Ensure that number of matchers exceeds number of workers.
                     format: int32
                     minimum: 1
                     type: integer
@@ -10210,9 +10211,10 @@ spec:
                   workers:
                     default: 1
                     description: |-
-                      Workers is the number of workers that work parallelly to push metrics to hub server.
-                      If set to > 1, metrics-collector will shard /federate calls to Prometheus, based on
-                      matcher rules provided by allowlist.
+                      Workers is the number of workers in metrics-collector that work in parallel to
+                      push metrics to hub server. If set to > 1, metrics-collector will shard
+                      /federate calls to Prometheus, based on matcher rules provided by allowlist.
+                      Ensure that number of matchers exceeds number of workers.
                     format: int32
                     minimum: 1
                     type: integer

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_observabilityaddons.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_observabilityaddons.yaml
@@ -118,9 +118,10 @@ spec:
               workers:
                 default: 1
                 description: |-
-                  Workers is the number of workers that work parallelly to push metrics to hub server.
-                  If set to > 1, metrics-collector will shard /federate calls to Prometheus, based on
-                  matcher rules provided by allowlist.
+                  Workers is the number of workers in metrics-collector that work in parallel to
+                  push metrics to hub server. If set to > 1, metrics-collector will shard
+                  /federate calls to Prometheus, based on matcher rules provided by allowlist.
+                  Ensure that number of matchers exceeds number of workers.
                 format: int32
                 minimum: 1
                 type: integer

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_observabilityaddons.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_observabilityaddons.yaml
@@ -115,6 +115,15 @@ spec:
                   ScrapeSizeLimitBytes is the max size in bytes for a single metrics scrape from in-cluster Prometheus.
                   Default is 1 GiB.
                 type: integer
+              workers:
+                default: 1
+                description: |-
+                  Workers is the number of workers that work parallelly to push metrics to hub server.
+                  If set to > 1, metrics-collector will shard /federate calls to Prometheus, based on
+                  matcher rules provided by allowlist.
+                format: int32
+                minimum: 1
+                type: integer
             type: object
           status:
             description: ObservabilityAddonStatus defines the observed state of ObservabilityAddon

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -154,9 +154,10 @@ spec:
                   workers:
                     default: 1
                     description: |-
-                      Workers is the number of workers that work parallelly to push metrics to hub server.
-                      If set to > 1, metrics-collector will shard /federate calls to Prometheus, based on
-                      matcher rules provided by allowlist.
+                      Workers is the number of workers in metrics-collector that work in parallel to
+                      push metrics to hub server. If set to > 1, metrics-collector will shard
+                      /federate calls to Prometheus, based on matcher rules provided by allowlist.
+                      Ensure that number of matchers exceeds number of workers.
                     format: int32
                     minimum: 1
                     type: integer
@@ -10194,9 +10195,10 @@ spec:
                   workers:
                     default: 1
                     description: |-
-                      Workers is the number of workers that work parallelly to push metrics to hub server.
-                      If set to > 1, metrics-collector will shard /federate calls to Prometheus, based on
-                      matcher rules provided by allowlist.
+                      Workers is the number of workers in metrics-collector that work in parallel to
+                      push metrics to hub server. If set to > 1, metrics-collector will shard
+                      /federate calls to Prometheus, based on matcher rules provided by allowlist.
+                      Ensure that number of matchers exceeds number of workers.
                     format: int32
                     minimum: 1
                     type: integer

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -151,6 +151,15 @@ spec:
                       ScrapeSizeLimitBytes is the max size in bytes for a single metrics scrape from in-cluster Prometheus.
                       Default is 1 GiB.
                     type: integer
+                  workers:
+                    default: 1
+                    description: |-
+                      Workers is the number of workers that work parallelly to push metrics to hub server.
+                      If set to > 1, metrics-collector will shard /federate calls to Prometheus, based on
+                      matcher rules provided by allowlist.
+                    format: int32
+                    minimum: 1
+                    type: integer
                 type: object
               retentionResolution1h:
                 default: 30d
@@ -10181,6 +10190,15 @@ spec:
                     description: |-
                       ScrapeSizeLimitBytes is the max size in bytes for a single metrics scrape from in-cluster Prometheus.
                       Default is 1 GiB.
+                    type: integer
+                  workers:
+                    default: 1
+                    description: |-
+                      Workers is the number of workers that work parallelly to push metrics to hub server.
+                      If set to > 1, metrics-collector will shard /federate calls to Prometheus, based on
+                      matcher rules provided by allowlist.
+                    format: int32
+                    minimum: 1
                     type: integer
                 type: object
               storageConfig:

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_observabilityaddons.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_observabilityaddons.yaml
@@ -118,9 +118,10 @@ spec:
               workers:
                 default: 1
                 description: |-
-                  Workers is the number of workers that work parallelly to push metrics to hub server.
-                  If set to > 1, metrics-collector will shard /federate calls to Prometheus, based on
-                  matcher rules provided by allowlist.
+                  Workers is the number of workers in metrics-collector that work in parallel to
+                  push metrics to hub server. If set to > 1, metrics-collector will shard
+                  /federate calls to Prometheus, based on matcher rules provided by allowlist.
+                  Ensure that number of matchers exceeds number of workers.
                 format: int32
                 minimum: 1
                 type: integer

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_observabilityaddons.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_observabilityaddons.yaml
@@ -115,6 +115,15 @@ spec:
                   ScrapeSizeLimitBytes is the max size in bytes for a single metrics scrape from in-cluster Prometheus.
                   Default is 1 GiB.
                 type: integer
+              workers:
+                default: 1
+                description: |-
+                  Workers is the number of workers that work parallelly to push metrics to hub server.
+                  If set to > 1, metrics-collector will shard /federate calls to Prometheus, based on
+                  matcher rules provided by allowlist.
+                format: int32
+                minimum: 1
+                type: integer
             type: object
           status:
             description: ObservabilityAddonStatus defines the observed state of ObservabilityAddon


### PR DESCRIPTION
Attempting to implement federate sharding by sharding the match rules (both passed as file and flag) between a number of workers. 

If the code looks messy, that is because it is, there is a lot of unused and scattered logic throughout metrics-collector. I have tried to refactor a lot of this