### PR TITLE
Use prom port 9092 in metrics-collector to skip going through oauth-proxy

### DIFF
--- a/operators/endpointmetrics/manifests/prometheus/prometheus-resource.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/prometheus-resource.yaml
@@ -33,7 +33,7 @@ spec:
   containers:
     - args:
       - --logtostderr
-      - --secure-listen-address=[$(IP)]:9091
+      - --secure-listen-address=[$(IP)]:9092
       - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
       - --upstream=http://127.0.0.1:9090/
       env:

--- a/operators/endpointmetrics/manifests/prometheus/prometheus-resource.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/prometheus-resource.yaml
@@ -33,7 +33,7 @@ spec:
   containers:
     - args:
       - --logtostderr
-      - --secure-listen-address=[$(IP)]:9092
+      - --secure-listen-address=[$(IP)]:9091
       - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
       - --upstream=http://127.0.0.1:9090/
       env:

--- a/operators/endpointmetrics/pkg/collector/metrics_collector.go
+++ b/operators/endpointmetrics/pkg/collector/metrics_collector.go
@@ -60,10 +60,10 @@ const (
 )
 
 var (
-	ocpPromURL  = "https://prometheus-k8s.openshift-monitoring.svc:9091"
+	ocpPromURL  = "https://prometheus-k8s.openshift-monitoring.svc:9092"
 	uwlPromURL  = "https://prometheus-user-workload.openshift-user-workload-monitoring.svc:9092"
-	uwlQueryURL = "https://thanos-querier.openshift-monitoring.svc:9091"
-	promURL     = "https://prometheus-k8s:9091"
+	uwlQueryURL = "https://thanos-querier.openshift-monitoring.svc:9092"
+	promURL     = "https://prometheus-k8s:9092"
 )
 
 type ClusterInfo struct {

--- a/operators/endpointmetrics/pkg/collector/metrics_collector.go
+++ b/operators/endpointmetrics/pkg/collector/metrics_collector.go
@@ -63,7 +63,7 @@ var (
 	ocpPromURL  = "https://prometheus-k8s.openshift-monitoring.svc:9092"
 	uwlPromURL  = "https://prometheus-user-workload.openshift-user-workload-monitoring.svc:9092"
 	uwlQueryURL = "https://thanos-querier.openshift-monitoring.svc:9091"
-	promURL     = "https://prometheus-k8s:9092"
+	promURL     = "https://prometheus-k8s:9091"
 )
 
 type ClusterInfo struct {

--- a/operators/endpointmetrics/pkg/collector/metrics_collector.go
+++ b/operators/endpointmetrics/pkg/collector/metrics_collector.go
@@ -60,10 +60,11 @@ const (
 )
 
 var (
-	ocpPromURL  = "https://prometheus-k8s.openshift-monitoring.svc:9092"
-	uwlPromURL  = "https://prometheus-user-workload.openshift-user-workload-monitoring.svc:9092"
-	uwlQueryURL = "https://thanos-querier.openshift-monitoring.svc:9091"
-	promURL     = "https://prometheus-k8s:9091"
+	ocpPromURL      = "https://prometheus-k8s.openshift-monitoring.svc:9092"
+	ocpPromQueryURL = "https://prometheus-k8s.openshift-monitoring.svc:9091"
+	uwlPromURL      = "https://prometheus-user-workload.openshift-user-workload-monitoring.svc:9092"
+	uwlQueryURL     = "https://thanos-querier.openshift-monitoring.svc:9091"
+	promURL         = "https://prometheus-k8s:9091"
 )
 
 type ClusterInfo struct {
@@ -616,7 +617,7 @@ func (m *MetricsCollector) ensureDeployment(ctx context.Context, isUWL bool, dep
 		}
 	}
 
-	fromQuery := from
+	fromQuery := ocpPromQueryURL
 	name := metricsCollectorName
 	if isUWL {
 		fromQuery = uwlQueryURL

--- a/operators/endpointmetrics/pkg/collector/metrics_collector.go
+++ b/operators/endpointmetrics/pkg/collector/metrics_collector.go
@@ -62,7 +62,7 @@ const (
 var (
 	ocpPromURL  = "https://prometheus-k8s.openshift-monitoring.svc:9092"
 	uwlPromURL  = "https://prometheus-user-workload.openshift-user-workload-monitoring.svc:9092"
-	uwlQueryURL = "https://thanos-querier.openshift-monitoring.svc:9092"
+	uwlQueryURL = "https://thanos-querier.openshift-monitoring.svc:9091"
 	promURL     = "https://prometheus-k8s:9092"
 )
 


### PR DESCRIPTION
cc: @philipgough as we talked about last day
Let's check if this works!