### PR TITLE
Grafana: Disable unified alerting

### DIFF
--- a/operators/multiclusterobservability/manifests/base/grafana/config.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/config.yaml
@@ -37,3 +37,5 @@ stringData:
     correlations = false
     [public_dashboards]
     enabled = false
+    [unified_alerting]
+    enabled = false


### PR DESCRIPTION
This commit disables Grafanas unified alerting feature. We do this since it is not applicable for MCO, and since the upgrade to Grafana 11.1.5, we can disable it without errors.