### PR TITLE
fix: [ACM-14189] identify healthy managed clusters during e2e

### DIFF
--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -52,16 +52,10 @@ func ListManagedClusters(opt TestOptions) ([]string, error) {
 	for _, obj := range objs.Items {
 		metadata := obj.Object["metadata"].(map[string]interface{})
 		name := metadata["name"].(string)
-		labels := metadata["labels"].(map[string]interface{})
 
 		if os.Getenv("IS_KIND_ENV") == "true" {
 			// We do not have the obs add on label added in kind cluster
 			clusterNames = append(clusterNames, name)
-			continue
-		}
-
-		// Skip "local-cluster" by name or label
-		if name == "local-cluster" || (labels != nil && labels["local-cluster"] == "true") {
 			continue
 		}
 


### PR DESCRIPTION
This is a test setup error.  The PR addresses two issues:

1. ~~Must exclude `local-cluster` from managed cluster list. This is because starting with ACM 2.10, observability is no longer running as a addon on the hub cluster, and always configured on the hub cluster. If a cluster is named "local-cluster" or has a label "local-cluster: true", it should be treated as a hub cluster.~~ Do not skip `local-cluster`.

2. Must exclude unhealthy clusters. From time-to-time, we have seen CICD environment with incomplete/unhealthy clusters in the hub, and the logic should skip testing Obs features on them. This is achieved by checking `ManagedClusterConditionAvailable` with `status="True"` in the managed cluster object. 