### PR TITLE
Make sure local cluster is always in the managedcluster list

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -127,9 +127,21 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// We want to ensure that the local-cluster is always in the managedClusterList
 	// In the case when hubSelfManagement is enabled, we will delete it from the list and modify the object
 	// to cater to the use case of deploying in open-cluster-management-observability namespace
-	if req.Name == "local-cluster" {
+	delete(managedClusterList, "local-cluster")
+	if _, ok := managedClusterList["local-cluster"]; !ok {
+		obj := &clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "local-cluster",
+				Namespace: config.GetDefaultNamespace(),
+				Labels: map[string]string{
+					"openshiftVersion": "mimical",
+				},
+			},
+		}
 		installMetricsWithoutAddon = true
+		updateManagedClusterList(obj)
 	}
+
 	if !deleteAll && !mco.Spec.ObservabilityAddonSpec.EnableMetrics {
 		reqLogger.Info("EnableMetrics is set to false. Delete Observability addons")
 		deleteAll = true

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -62,7 +62,6 @@ var (
 	defaultAddonDeploymentConfig  = &addonv1alpha1.AddOnDeploymentConfig{}
 	isplacementControllerRunnning = false
 	managedClusterList            = sync.Map{}
-	managedClusterListMutex       = &sync.RWMutex{}
 	installMetricsWithoutAddon    = false
 )
 

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
@@ -205,10 +205,9 @@ func TestObservabilityAddonController(t *testing.T) {
 		},
 	}
 
-	managedClusterList = map[string]string{
-		namespace:  "4",
-		namespace2: "4",
-	}
+	managedClusterList.Store(namespace, "4")
+	managedClusterList.Store(namespace2, "4")
+
 	_, err := r.Reconcile(context.TODO(), req)
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
@@ -228,7 +227,11 @@ func TestObservabilityAddonController(t *testing.T) {
 		t.Fatalf("Deprecated role not removed")
 	}
 
-	managedClusterList = map[string]string{namespace: "4"}
+	managedClusterList.Range(func(key, value interface{}) bool {
+		managedClusterList.Delete(key)
+		return true
+	})
+	managedClusterList.Store(namespace, "4")
 	_, err = r.Reconcile(context.TODO(), req)
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
@@ -83,7 +83,7 @@ func getClusterPreds() predicate.Funcs {
 		}
 
 		if e.Object.GetName() != localClusterName {
-			updateManagedClusterList(e.Object)
+			managedClusterList.Delete(e.Object.GetName())
 		}
 		managedClusterImageRegistryMutex.Lock()
 		delete(managedClusterImageRegistry, e.Object.GetName())

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
@@ -6,6 +6,7 @@ package placementrule
 
 import (
 	"fmt"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"reflect"
 	"strings"
 
@@ -60,6 +61,11 @@ func getClusterPreds() predicate.Funcs {
 				return false
 			}
 			updateManagedClusterList(e.ObjectNew)
+		}
+		//log the diff in managedccluster object
+		if !reflect.DeepEqual(e.ObjectNew.(*clusterv1.ManagedCluster), e.ObjectOld.(*clusterv1.ManagedCluster)) {
+			log.Info("managedcluster object New diff", "managedCluster", e.ObjectNew.GetName(), "diff", fmt.Sprintf("%+v", e.ObjectNew.(*clusterv1.ManagedCluster)))
+			log.Info("managedcluster object Old diff", "managedCluster", e.ObjectOld.GetName(), "diff", fmt.Sprintf("%+v", e.ObjectOld.(*clusterv1.ManagedCluster)))
 		}
 
 		return true


### PR DESCRIPTION
- Make sure local-cluster is always a part of  internal `managedcluster` list and not depend on the CRUD events of the Managedcluster  resource because when `disableHubSelfManagement: true`, the resource for local-cluster will not be created. 
- Use sync.Map for thread safe read and writes
- fix unit tests to run predicate tests against managedcluster resource and not deployment