### PR TITLE
Use multi-arch origin-oauth-proxy image

### DIFF
--- a/operators/multiclusterobservability/manifests/base/alertmanager/alertmanager-statefulset.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/alertmanager-statefulset.yaml
@@ -125,7 +125,7 @@ spec:
         - --skip-provider-button=true
         - --openshift-ca=/etc/pki/tls/cert.pem
         - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        image: quay.io/stolostron/origin-oauth-proxy:4.5
+        image: quay.io/stolostron/origin-oauth-proxy:4.16
         imagePullPolicy: IfNotPresent
         name: alertmanager-proxy
         ports:

--- a/operators/multiclusterobservability/manifests/base/grafana/deployment.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/deployment.yaml
@@ -101,7 +101,7 @@ spec:
               mountPath: /etc/tls/private
             - mountPath: /etc/proxy/secrets
               name: cookie-secret
-          image: quay.io/stolostron/origin-oauth-proxy:4.5
+          image: quay.io/stolostron/origin-oauth-proxy:4.16
           args:
             - '--provider=openshift'
             - '--upstream=http://localhost:3001'

--- a/operators/multiclusterobservability/manifests/base/proxy/deployment.yaml
+++ b/operators/multiclusterobservability/manifests/base/proxy/deployment.yaml
@@ -91,7 +91,7 @@ spec:
             - --skip-provider-button=true
             - --openshift-ca=/etc/pki/tls/cert.pem
             - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          image: quay.io/stolostron/origin-oauth-proxy:4.5
+          image: quay.io/stolostron/origin-oauth-proxy:4.16
           imagePullPolicy: IfNotPresent
           name: oauth-proxy
           ports:


### PR DESCRIPTION
During upgrade from ACM2.11->ACM2.12 for a (currently not fully understood reason) we use the proxy image from the base templates. This seem to happen only for a short while, on later reconciles we appear get the correct image from the OCP imagestream.

The image previously set in the base template were amd64 only, causing the pods to crash on any other architecture. From rbac-query-proxy and Grafana it eventually resolves, however alertmanager uses a stateful set and gets stuck due the known Kubernetes issue described here: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#forced-rollback

Ideally we'd never want to use these images, but meanwhile this should at least ensure we don't crash and leave a unhealthy stateful set for alertmanager.