### PR TITLE
fix status update and cm predicate

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -557,7 +557,7 @@ func (r *ObservabilityAddonReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Watches(
 			&corev1.ConfigMap{},
 			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(getPred(clusterMonitoringConfigName, promNamespace, true, true, true)),
+			builder.WithPredicates(configMapDataChangedPredicate(clusterMonitoringConfigName, promNamespace)),
 		).
 		Watches(
 			&appsv1.Deployment{},

--- a/operators/endpointmetrics/pkg/collector/metrics_collector.go
+++ b/operators/endpointmetrics/pkg/collector/metrics_collector.go
@@ -112,8 +112,10 @@ func (m *MetricsCollector) Update(ctx context.Context, req ctrl.Request) error {
 		m.reportStatus(ctx, status.MetricsCollector, status.UpdateFailed, "Failed to update metrics collector")
 		return err
 	} else {
-		if m.ObsAddon.Spec.EnableMetrics && m.platformCollectorWasUpdated {
-			m.reportStatus(ctx, status.MetricsCollector, status.UpdateSuccessful, "Metrics collector updated")
+		if m.ObsAddon.Spec.EnableMetrics {
+			if m.platformCollectorWasUpdated {
+				m.reportStatus(ctx, status.MetricsCollector, status.UpdateSuccessful, "Metrics collector updated")
+			}
 		} else {
 			m.reportStatus(ctx, status.MetricsCollector, status.Disabled, "Metrics collector disabled")
 		}
@@ -131,8 +133,10 @@ func (m *MetricsCollector) Update(ctx context.Context, req ctrl.Request) error {
 			m.reportStatus(ctx, status.UwlMetricsCollector, status.UpdateFailed, "Failed to update UWL Metrics collector")
 			return err
 		} else {
-			if m.ObsAddon.Spec.EnableMetrics && m.userWorkloadCollectorWasUpdated {
-				m.reportStatus(ctx, status.UwlMetricsCollector, status.UpdateSuccessful, "UWL Metrics collector updated")
+			if m.ObsAddon.Spec.EnableMetrics {
+				if m.userWorkloadCollectorWasUpdated {
+					m.reportStatus(ctx, status.UwlMetricsCollector, status.UpdateSuccessful, "UWL Metrics collector updated")
+				}
 			} else {
 				m.reportStatus(ctx, status.UwlMetricsCollector, status.Disabled, "UWL Metrics collector disabled")
 			}


### PR DESCRIPTION
This PR:
- Introduces a new predicate for the configmap, only triggering reconciles when the data changes.
- Only updates the status if the collector deployment was actually updated.

https://issues.redhat.com/browse/ACM-15458