### PR TITLE
Render: fail if no oauth image is found

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -91,7 +91,7 @@ type MultiClusterObservabilityReconciler struct {
 	CRDMap      map[string]bool
 	APIReader   client.Reader
 	RESTMapper  meta.RESTMapper
-	ImageClient *imagev1client.ImageV1Client
+	ImageClient imagev1client.ImageV1Interface
 }
 
 // +kubebuilder:rbac:groups=observability.open-cluster-management.io,resources=multiclusterobservabilities,verbs=get;list;watch;create;update;patch;delete

--- a/operators/multiclusterobservability/pkg/rendering/renderer.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer.go
@@ -29,7 +29,7 @@ type RendererOptions struct {
 
 type MCORenderer struct {
 	kubeClient            client.Client
-	imageClient           *imagev1client.ImageV1Client
+	imageClient           imagev1client.ImageV1Interface
 	renderer              *rendererutil.Renderer
 	cr                    *obv1beta2.MultiClusterObservability
 	rendererOptions       *RendererOptions
@@ -40,7 +40,7 @@ type MCORenderer struct {
 	renderMCOAFns         map[string]rendererutil.RenderFn
 }
 
-func NewMCORenderer(multipleClusterMonitoring *obv1beta2.MultiClusterObservability, kubeClient client.Client, imageClient *imagev1client.ImageV1Client) *MCORenderer {
+func NewMCORenderer(multipleClusterMonitoring *obv1beta2.MultiClusterObservability, kubeClient client.Client, imageClient imagev1client.ImageV1Interface) *MCORenderer {
 	mcoRenderer := &MCORenderer{
 		renderer:    rendererutil.NewRenderer(),
 		cr:          multipleClusterMonitoring,

--- a/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
@@ -126,6 +126,8 @@ func (r *MCORenderer) renderAlertManagerStatefulSet(res *resource.Resource, name
 	found, image = mcoconfig.GetOauthProxyImage(r.imageClient)
 	if found {
 		oauthProxyContainer.Image = image
+	} else {
+		return nil, fmt.Errorf("failed to get OAuth image for alertmanager")
 	}
 	oauthProxyContainer.ImagePullPolicy = imagePullPolicy
 

--- a/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager_test.go
@@ -5,6 +5,7 @@
 package rendering
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,9 @@ import (
 	"strings"
 	"testing"
 
+	imagev1 "github.com/openshift/api/image/v1"
+	fakeimageclient "github.com/openshift/client-go/image/clientset/versioned/fake"
+	fakeimagev1client "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1/fake"
 	mcoshared "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/shared"
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
@@ -288,7 +292,31 @@ func renderTemplates(t *testing.T, kubeClient client.Client, mco *mcov1beta2.Mul
 	defer os.Unsetenv(templatesutil.TemplatesPathEnvVar)
 
 	config.ReadImageManifestConfigMap(kubeClient, "v1")
-	renderer := NewMCORenderer(mco, kubeClient, nil)
+
+	imageClient := &fakeimagev1client.FakeImageV1{Fake: &(fakeimageclient.NewSimpleClientset().Fake)}
+	_, err = imageClient.ImageStreams(config.OauthProxyImageStreamNamespace).Create(context.Background(),
+		&imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      config.OauthProxyImageStreamName,
+				Namespace: config.OauthProxyImageStreamNamespace,
+			},
+			Spec: imagev1.ImageStreamSpec{
+				Tags: []imagev1.TagReference{
+					{
+						Name: "v4.4",
+						From: &corev1.ObjectReference{
+							Kind: "DockerImage",
+							Name: "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+						},
+					},
+				},
+			},
+		}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	renderer := NewMCORenderer(mco, kubeClient, imageClient)
 
 	//load and render alertmanager templates
 	alertTemplates, err := templates.GetOrLoadAlertManagerTemplates(templatesutil.GetTemplateRenderer())

--- a/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
@@ -5,6 +5,8 @@
 package rendering
 
 import (
+	"fmt"
+
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -71,6 +73,8 @@ func (r *MCORenderer) renderGrafanaDeployments(res *resource.Resource,
 	found, image = config.GetOauthProxyImage(r.imageClient)
 	if found {
 		spec.Containers[2].Image = image
+	} else {
+		return nil, fmt.Errorf("failed to get OAuth image for Grafana")
 	}
 	spec.Containers[2].ImagePullPolicy = imagePullPolicy
 

--- a/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
@@ -5,6 +5,7 @@
 package rendering
 
 import (
+	"fmt"
 	"strings"
 
 	v1 "k8s.io/api/apps/v1"
@@ -96,6 +97,8 @@ func (r *MCORenderer) renderProxyDeployment(res *resource.Resource,
 	found, image = mcoconfig.GetOauthProxyImage(r.imageClient)
 	if found {
 		spec.Containers[1].Image = image
+	} else {
+		return nil, fmt.Errorf("failed to get OAuth image for rbacqueryproxy")
 	}
 
 	for idx := range spec.Volumes {


### PR DESCRIPTION
For some unknown reason, during upgrades from ACM 2.11, the template image is briefly used, instead of the image from the openshift imagestream. The template image is not available in disconnected environments, and as a result causes the pods be unable to come up.

This is a problem especially for alertmanager. Because of it being a statefulset when it gets into the bad state, with the wrong image, it doesn't automatically recover on the next reconcile. This requires manual intervention to fix.

Instead with this PR, we make the reconcile fail if we do not find the oauth image. This will make it retry later, when the imagestream is able to be found.