### PR TITLE
Tests: Increase custom dashboard test timeout

### DIFF
--- a/tests/pkg/tests/observability_dashboard_test.go
+++ b/tests/pkg/tests/observability_dashboard_test.go
@@ -64,11 +64,11 @@ var _ = Describe("Observability:", func() {
 		Eventually(func() bool {
 			_, result := utils.ContainDashboard(testOptions, dashboardTitle)
 			return result
-		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(BeFalse())
+		}, EventuallyTimeoutMinute*7, EventuallyIntervalSecond*5).Should(BeFalse())
 		Eventually(func() bool {
 			_, result := utils.ContainDashboard(testOptions, updateDashboardTitle)
 			return result
-		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(BeTrue())
+		}, EventuallyTimeoutMinute*7, EventuallyIntervalSecond*5).Should(BeTrue())
 	})
 
 	It("[P2][Sev2][observability][Stable] Should have no custom dashboard in grafana after related configmap removed (dashboard/g0)", func() {


### PR DESCRIPTION
The retrying of adding custom dashboards lasts at least 7 minutes. So increase timeout slightly in the hopes that the success rate is of test passings are a bit higher untill we get a better solution in place.