### PR TITLE
[main] Render: fail if no oauth image is found+kind fix

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -91,7 +91,7 @@ type MultiClusterObservabilityReconciler struct {
 	CRDMap      map[string]bool
 	APIReader   client.Reader
 	RESTMapper  meta.RESTMapper
-	ImageClient *imagev1client.ImageV1Client
+	ImageClient imagev1client.ImageV1Interface
 }
 
 // +kubebuilder:rbac:groups=observability.open-cluster-management.io,resources=multiclusterobservabilities,verbs=get;list;watch;create;update;patch;delete

--- a/operators/multiclusterobservability/pkg/rendering/renderer.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	obv1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
@@ -192,4 +193,23 @@ func (r *MCORenderer) MCOAResources(namespace string, labels map[string]string) 
 	}
 
 	return mcoaResources, nil
+}
+
+func (r *MCORenderer) HasImagestream() bool {
+	dcl := discovery.NewDiscoveryClient(r.imageClient.RESTClient())
+
+	apiList, err := dcl.ServerGroups()
+	if err != nil {
+		log.Error(err, "unable to get ServerGroups from imagestream detection")
+		return false
+	}
+
+	apiGroups := apiList.Groups
+	for i := 0; i < len(apiGroups); i++ {
+		if apiGroups[i].Name == "image.openshift.io" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/operators/multiclusterobservability/pkg/rendering/renderer.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer.go
@@ -29,7 +29,7 @@ type RendererOptions struct {
 
 type MCORenderer struct {
 	kubeClient            client.Client
-	imageClient           *imagev1client.ImageV1Client
+	imageClient           imagev1client.ImageV1Interface
 	renderer              *rendererutil.Renderer
 	cr                    *obv1beta2.MultiClusterObservability
 	rendererOptions       *RendererOptions
@@ -40,7 +40,7 @@ type MCORenderer struct {
 	renderMCOAFns         map[string]rendererutil.RenderFn
 }
 
-func NewMCORenderer(multipleClusterMonitoring *obv1beta2.MultiClusterObservability, kubeClient client.Client, imageClient *imagev1client.ImageV1Client) *MCORenderer {
+func NewMCORenderer(multipleClusterMonitoring *obv1beta2.MultiClusterObservability, kubeClient client.Client, imageClient imagev1client.ImageV1Interface) *MCORenderer {
 	mcoRenderer := &MCORenderer{
 		renderer:    rendererutil.NewRenderer(),
 		cr:          multipleClusterMonitoring,

--- a/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
@@ -126,6 +126,8 @@ func (r *MCORenderer) renderAlertManagerStatefulSet(res *resource.Resource, name
 	found, image = mcoconfig.GetOauthProxyImage(r.imageClient)
 	if found {
 		oauthProxyContainer.Image = image
+	} else {
+		return nil, fmt.Errorf("failed to get OAuth image for alertmanager")
 	}
 	oauthProxyContainer.ImagePullPolicy = imagePullPolicy
 

--- a/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
@@ -123,10 +123,13 @@ func (r *MCORenderer) renderAlertManagerStatefulSet(res *resource.Resource, name
 		configReloaderContainer.Image = image
 	}
 
+	// If we're on OCP and has imagestreams, we always want the oauth image
+	// from the imagestream, and fail the reconcile if we don't find it.
+	// If we're on non-OCP (tests) we use the base template image
 	found, image = mcoconfig.GetOauthProxyImage(r.imageClient)
 	if found {
 		oauthProxyContainer.Image = image
-	} else {
+	} else if r.HasImagestream() {
 		return nil, fmt.Errorf("failed to get OAuth image for alertmanager")
 	}
 	oauthProxyContainer.ImagePullPolicy = imagePullPolicy

--- a/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager_test.go
@@ -5,6 +5,7 @@
 package rendering
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,9 @@ import (
 	"strings"
 	"testing"
 
+	imagev1 "github.com/openshift/api/image/v1"
+	fakeimageclient "github.com/openshift/client-go/image/clientset/versioned/fake"
+	fakeimagev1client "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1/fake"
 	mcoshared "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/shared"
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
@@ -288,7 +292,31 @@ func renderTemplates(t *testing.T, kubeClient client.Client, mco *mcov1beta2.Mul
 	defer os.Unsetenv(templatesutil.TemplatesPathEnvVar)
 
 	config.ReadImageManifestConfigMap(kubeClient, "v1")
-	renderer := NewMCORenderer(mco, kubeClient, nil)
+
+	imageClient := &fakeimagev1client.FakeImageV1{Fake: &(fakeimageclient.NewSimpleClientset().Fake)}
+	_, err = imageClient.ImageStreams(config.OauthProxyImageStreamNamespace).Create(context.Background(),
+		&imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      config.OauthProxyImageStreamName,
+				Namespace: config.OauthProxyImageStreamNamespace,
+			},
+			Spec: imagev1.ImageStreamSpec{
+				Tags: []imagev1.TagReference{
+					{
+						Name: "v4.4",
+						From: &corev1.ObjectReference{
+							Kind: "DockerImage",
+							Name: "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+						},
+					},
+				},
+			},
+		}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	renderer := NewMCORenderer(mco, kubeClient, imageClient)
 
 	//load and render alertmanager templates
 	alertTemplates, err := templates.GetOrLoadAlertManagerTemplates(templatesutil.GetTemplateRenderer())

--- a/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
@@ -70,11 +70,14 @@ func (r *MCORenderer) renderGrafanaDeployments(res *resource.Resource,
 	}
 	spec.Containers[1].ImagePullPolicy = imagePullPolicy
 
+	// If we're on OCP and has imagestreams, we always want the oauth image
+	// from the imagestream, and fail the reconcile if we don't find it.
+	// If we're on non-OCP (tests) we use the base template image
 	found, image = config.GetOauthProxyImage(r.imageClient)
 	if found {
 		spec.Containers[2].Image = image
-	} else {
-		return nil, fmt.Errorf("failed to get OAuth image for Grafana")
+	} else if r.HasImagestream() {
+		return nil, fmt.Errorf("failed to get OAuth image for alertmanager")
 	}
 	spec.Containers[2].ImagePullPolicy = imagePullPolicy
 

--- a/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
@@ -5,6 +5,8 @@
 package rendering
 
 import (
+	"fmt"
+
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -71,6 +73,8 @@ func (r *MCORenderer) renderGrafanaDeployments(res *resource.Resource,
 	found, image = config.GetOauthProxyImage(r.imageClient)
 	if found {
 		spec.Containers[2].Image = image
+	} else {
+		return nil, fmt.Errorf("failed to get OAuth image for Grafana")
 	}
 	spec.Containers[2].ImagePullPolicy = imagePullPolicy
 

--- a/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
@@ -5,6 +5,7 @@
 package rendering
 
 import (
+	"fmt"
 	"strings"
 
 	v1 "k8s.io/api/apps/v1"
@@ -96,6 +97,8 @@ func (r *MCORenderer) renderProxyDeployment(res *resource.Resource,
 	found, image = mcoconfig.GetOauthProxyImage(r.imageClient)
 	if found {
 		spec.Containers[1].Image = image
+	} else {
+		return nil, fmt.Errorf("failed to get OAuth image for rbacqueryproxy")
 	}
 
 	for idx := range spec.Volumes {

--- a/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
@@ -94,11 +94,14 @@ func (r *MCORenderer) renderProxyDeployment(res *resource.Resource,
 		spec.Containers[0].Image = image
 	}
 
+	// If we're on OCP and has imagestreams, we always want the oauth image
+	// from the imagestream, and fail the reconcile if we don't find it.
+	// If we're on non-OCP (tests) we use the base template image
 	found, image = mcoconfig.GetOauthProxyImage(r.imageClient)
 	if found {
 		spec.Containers[1].Image = image
-	} else {
-		return nil, fmt.Errorf("failed to get OAuth image for rbacqueryproxy")
+	} else if r.HasImagestream() {
+		return nil, fmt.Errorf("failed to get OAuth image for alertmanager")
 	}
 
 	for idx := range spec.Volumes {


### PR DESCRIPTION
cherry-pick of https://github.com/stolostron/multicluster-observability-operator/pull/1669 +

Renderer: detect if imagestream is available
Only try to get the oauth image from the OCP imagestream, if the
image.openshift.io api type is available. Otherwise, it likely means
we're running a non-ocp system (for kind tests for example) and in this
case we accept using the base template image.