### PR TITLE
Renderer: detect if imagestream is available

### DIFF
--- a/operators/multiclusterobservability/pkg/rendering/renderer.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	obv1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
@@ -192,4 +193,23 @@ func (r *MCORenderer) MCOAResources(namespace string, labels map[string]string) 
 	}
 
 	return mcoaResources, nil
+}
+
+func (r *MCORenderer) HasImagestream() bool {
+	dcl := discovery.NewDiscoveryClient(r.imageClient.RESTClient())
+
+	apiList, err := dcl.ServerGroups()
+	if err != nil {
+		log.Error(err, "unable to get ServerGroups from imagestream detection")
+		return false
+	}
+
+	apiGroups := apiList.Groups
+	for i := 0; i < len(apiGroups); i++ {
+		if apiGroups[i].Name == "image.openshift.io" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
@@ -123,10 +123,13 @@ func (r *MCORenderer) renderAlertManagerStatefulSet(res *resource.Resource, name
 		configReloaderContainer.Image = image
 	}
 
+	// If we're on OCP and has imagestreams, we always want the oauth image
+	// from the imagestream, and fail the reconcile if we don't find it.
+	// If we're on non-OCP (tests) we use the base template image
 	found, image = mcoconfig.GetOauthProxyImage(r.imageClient)
 	if found {
 		oauthProxyContainer.Image = image
-	} else {
+	} else if r.HasImagestream() {
 		return nil, fmt.Errorf("failed to get OAuth image for alertmanager")
 	}
 	oauthProxyContainer.ImagePullPolicy = imagePullPolicy

--- a/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
@@ -70,11 +70,14 @@ func (r *MCORenderer) renderGrafanaDeployments(res *resource.Resource,
 	}
 	spec.Containers[1].ImagePullPolicy = imagePullPolicy
 
+	// If we're on OCP and has imagestreams, we always want the oauth image
+	// from the imagestream, and fail the reconcile if we don't find it.
+	// If we're on non-OCP (tests) we use the base template image
 	found, image = config.GetOauthProxyImage(r.imageClient)
 	if found {
 		spec.Containers[2].Image = image
-	} else {
-		return nil, fmt.Errorf("failed to get OAuth image for Grafana")
+	} else if r.HasImagestream() {
+		return nil, fmt.Errorf("failed to get OAuth image for alertmanager")
 	}
 	spec.Containers[2].ImagePullPolicy = imagePullPolicy
 

--- a/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
@@ -94,11 +94,14 @@ func (r *MCORenderer) renderProxyDeployment(res *resource.Resource,
 		spec.Containers[0].Image = image
 	}
 
+	// If we're on OCP and has imagestreams, we always want the oauth image
+	// from the imagestream, and fail the reconcile if we don't find it.
+	// If we're on non-OCP (tests) we use the base template image
 	found, image = mcoconfig.GetOauthProxyImage(r.imageClient)
 	if found {
 		spec.Containers[1].Image = image
-	} else {
-		return nil, fmt.Errorf("failed to get OAuth image for rbacqueryproxy")
+	} else if r.HasImagestream() {
+		return nil, fmt.Errorf("failed to get OAuth image for alertmanager")
 	}
 
 	for idx := range spec.Volumes {


### PR DESCRIPTION
Only try to get the oauth image from the OCP imagestream, if the image.openshift.io api type is available. Otherwise, it likely means we're running a non-ocp system (for kind tests for example) and in this case we accept using the base template image.