### PR TITLE
Filter ocp required tests

### DIFF
--- a/cicd-scripts/customize-mco.sh
+++ b/cicd-scripts/customize-mco.sh
@@ -119,7 +119,8 @@ get_changed_components() {
 get_ginkgo_focus() {
   if [[ -n ${IS_KIND_ENV} ]]; then
     # For KinD cluster, do not need to run all test cases
-    GINKGO_FOCUS=" --focus manifestwork/g0 --focus endpoint_preserve/g0 --focus grafana/g0 --focus metrics/g0 --focus addon/g0 --focus alert/g0 --focus dashboard/g0"
+    # and we skip those that explictly requires OCP
+    GINKGO_FOCUS=" --focus manifestwork/g0 --focus endpoint_preserve/g0 --focus grafana/g0 --focus metrics/g0 --focus addon/g0 --focus alert/g0 --focus dashboard/g0 --skip requires-ocp/g0"
   else
     GINKGO_FOCUS=""
   fi


### PR DESCRIPTION
This adds a new regex in the Ginkgo tests, to ensure we can filter out tests which require OCP from being run during the kind tests.

ACM-15734