### PR TITLE
[ACM-13481] - Remove HA mode when AM has one replica

### DIFF
--- a/operators/multiclusterobservability/manifests/base/alertmanager/alertmanager-statefulset.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/alertmanager-statefulset.yaml
@@ -42,7 +42,6 @@ spec:
       containers:
       - args:
         - --config.file=/etc/alertmanager/config/alertmanager.yaml
-        - --cluster.listen-address=[$(POD_IP)]:9094
         - --storage.path=/alertmanager
         - --data.retention=120h
         - --web.listen-address=127.0.0.1:9093

--- a/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
@@ -78,12 +78,17 @@ func (r *MCORenderer) renderAlertManagerStatefulSet(res *resource.Resource, name
 
 	alertManagerContainer.ImagePullPolicy = imagePullPolicy
 	if *dep.Spec.Replicas > 1 {
+		alertManagerContainer.Args = append(alertManagerContainer.Args, "--cluster.listen-address=[$(POD_IP)]:9094")
 		for i := int32(0); i < *dep.Spec.Replicas; i++ {
 			alertManagerContainer.Args = append(alertManagerContainer.Args, "--cluster.peer="+
 				mcoconfig.GetOperandName(mcoconfig.Alertmanager)+"-"+
 				strconv.Itoa(int(i))+".alertmanager-operated."+
 				mcoconfig.GetDefaultNamespace()+".svc:9094")
 		}
+	}
+	// ACM-13481 Disable HA mode for single replica
+	if *dep.Spec.Replicas == 1 {
+		alertManagerContainer.Args = append(alertManagerContainer.Args, "--cluster.listen-address=")
 	}
 	alertManagerContainer.Resources = mcoconfig.GetResources(mcoconfig.Alertmanager, r.cr.Spec.InstanceSize, r.cr.Spec.AdvancedConfig)
 	alertManagerContainer.Image = mcoconfig.DefaultImgRepository + "/" + mcoconfig.AlertManagerImgName + ":" + mcoconfig.DefaultImgTagSuffix

--- a/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager_test.go
@@ -173,6 +173,26 @@ func TestAlertManagerRendererMCOConfig(t *testing.T) {
 				assert.Equal(t, 3, count)
 			},
 		},
+		"one replica": {
+			mco: func() *mcov1beta2.MultiClusterObservability {
+				ret := makeBaseMco()
+				replicas := int32(1)
+				ret.Spec.AdvancedConfig = &mcov1beta2.AdvancedConfig{
+					Alertmanager: &mcov1beta2.AlertmanagerSpec{
+						CommonSpec: mcov1beta2.CommonSpec{
+							Replicas: &replicas,
+						},
+					},
+				}
+				return ret
+			},
+			expect: func(t *testing.T, sts *appsv1.StatefulSet) {
+				assert.Equal(t, int32(1), *sts.Spec.Replicas)
+				args := sts.Spec.Template.Spec.Containers[0].Args
+				assert.NotContains(t, args, "--cluster.peer")
+				assert.Contains(t, args, "--cluster.listen-address=")
+			},
+		},
 		"resources": {
 			mco: func() *mcov1beta2.MultiClusterObservability {
 				ret := makeBaseMco()


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-13481

This is a workaround/hack when AM replicas are set to 1 and are no more in HA mode. https://github.com/prometheus/alertmanager/pull/1971