### PR TITLE
[ACM-16335] Reconcile MCO only when there is actual change in mch image manifest

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
@@ -5,10 +5,11 @@
 package multiclusterobservability
 
 import (
+	"reflect"
+
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
@@ -8,6 +8,7 @@ import (
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -139,7 +140,7 @@ func GetMCHPredicateFunc(c client.Client) predicate.Funcs {
 				e.Object.(*mchv1.MultiClusterHub).Status.DesiredVersion == e.Object.(*mchv1.MultiClusterHub).Status.CurrentVersion {
 				// only read the image manifests configmap and enqueue the request when the MCH is
 				// installed/upgraded successfully
-				ok, err := config.ReadImageManifestConfigMap(
+				_, ok, err := config.ReadImageManifestConfigMap(
 					c,
 					e.Object.(*mchv1.MultiClusterHub).Status.CurrentVersion,
 				)
@@ -151,20 +152,32 @@ func GetMCHPredicateFunc(c client.Client) predicate.Funcs {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
+			// Ensure the event pertains to the target namespace and object type
 			if e.ObjectNew.GetNamespace() == config.GetMCONamespace() &&
+				e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() &&
 				e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion != "" &&
 				e.ObjectNew.(*mchv1.MultiClusterHub).Status.DesiredVersion ==
 					e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion {
-				// only read the image manifests configmap and enqueue the request when the MCH is
-				// installed/upgraded successfully
-				ok, err := config.ReadImageManifestConfigMap(
+
+				currentData, _, err := config.ReadImageManifestConfigMap(
 					c,
 					e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion,
 				)
 				if err != nil {
+					log.Error(err, "Failed to read image manifest ConfigMap")
 					return false
 				}
-				return ok
+
+				previousData, exists := config.GetCachedImageManifestData()
+				if !exists {
+					config.SetCachedImageManifestData(currentData)
+					return true
+				}
+				if !reflect.DeepEqual(currentData, previousData) {
+					config.SetCachedImageManifestData(currentData)
+					return true
+				}
+				return false
 			}
 			return false
 		},

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
@@ -522,7 +522,7 @@ func TestObservabilityAddonController(t *testing.T) {
 		},
 	}
 
-	ok, err := config.ReadImageManifestConfigMap(c, testMCHInstance.Status.CurrentVersion)
+	_, ok, err := config.ReadImageManifestConfigMap(c, testMCHInstance.Status.CurrentVersion)
 	if err != nil || !ok {
 		t.Fatalf("Failed to read image manifest configmap: (%T,%v)", ok, err)
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/predict_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predict_func.go
@@ -109,7 +109,7 @@ func getMchPred(c client.Client) predicate.Funcs {
 				e.Object.(*mchv1.MultiClusterHub).Status.DesiredVersion == e.Object.(*mchv1.MultiClusterHub).Status.CurrentVersion {
 				// only read the image manifests configmap and enqueue the request when the MCH is
 				// installed/upgraded successfully
-				ok, err := config.ReadImageManifestConfigMap(
+				_, ok, err := config.ReadImageManifestConfigMap(
 					c,
 					e.Object.(*mchv1.MultiClusterHub).Status.CurrentVersion,
 				)
@@ -121,21 +121,32 @@ func getMchPred(c client.Client) predicate.Funcs {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
+			// Ensure the event pertains to the target namespace and object type
 			if e.ObjectNew.GetNamespace() == config.GetMCONamespace() &&
 				e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() &&
 				e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion != "" &&
 				e.ObjectNew.(*mchv1.MultiClusterHub).Status.DesiredVersion ==
 					e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion {
-				// / only read the image manifests configmap and enqueue the request when the MCH is
-				// installed/upgraded successfully
-				ok, err := config.ReadImageManifestConfigMap(
+
+				currentData, _, err := config.ReadImageManifestConfigMap(
 					c,
 					e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion,
 				)
 				if err != nil {
+					log.Error(err, "Failed to read image manifest ConfigMap")
 					return false
 				}
-				return ok
+
+				previousData, exists := config.GetCachedImageManifestData()
+				if !exists {
+					config.SetCachedImageManifestData(currentData)
+					return true
+				}
+				if !reflect.DeepEqual(currentData, previousData) {
+					config.SetCachedImageManifestData(currentData)
+					return true
+				}
+				return false
 			}
 			return false
 		},

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -319,7 +319,6 @@ func ReadImageManifestConfigMap(c client.Client, version string) (map[string]str
 	}
 
 	imageManifests = imageCMList.Items[0].Data
-	log.V(1).Info("the length of mch-image-manifest configmap", "imageManifests", len(imageManifests))
 	return imageManifests, true, nil
 }
 

--- a/operators/multiclusterobservability/pkg/config/config_test.go
+++ b/operators/multiclusterobservability/pkg/config/config_test.go
@@ -568,7 +568,7 @@ func TestReadImageManifestConfigMap(t *testing.T) {
 			}
 			client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjs...).Build()
 
-			gotRet, err := ReadImageManifestConfigMap(client, c.version)
+			_, gotRet, err := ReadImageManifestConfigMap(client, c.version)
 			if err != nil {
 				t.Errorf("Failed read image manifest configmap due to %v", err)
 			}

--- a/operators/multiclusterobservability/pkg/servicemonitor/sm_controller.go
+++ b/operators/multiclusterobservability/pkg/servicemonitor/sm_controller.go
@@ -6,8 +6,8 @@ package servicemonitor
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"os"
-	"reflect"
 	"time"
 
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -79,7 +79,7 @@ func onUpdate(promClient promclientset.Interface) func(oldObj interface{}, newOb
 		newSm := newObj.(*promv1.ServiceMonitor)
 		oldSm := oldObj.(*promv1.ServiceMonitor)
 		if newSm.ObjectMeta.OwnerReferences != nil && newSm.ObjectMeta.OwnerReferences[0].Kind == "Observatorium" &&
-			!reflect.DeepEqual(newSm.Spec, oldSm.Spec) {
+			!equality.Semantic.DeepEqual(newSm.Spec, oldSm.Spec) {
 			updateServiceMonitor(promClient, newSm)
 		}
 	}

--- a/operators/multiclusterobservability/pkg/servicemonitor/sm_controller.go
+++ b/operators/multiclusterobservability/pkg/servicemonitor/sm_controller.go
@@ -6,9 +6,10 @@ package servicemonitor
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"os"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
 
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	promclientset "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"


### PR DESCRIPTION
MCO and Placement Controller react to creates/updates/deletes from MCH CR . But we only specifically care about the mch-image-manifest configmap changes. So if we continuously get mch updates, the current reconcile logic always returns true after reading the image configmap even if it didnt differ from the previous version. 

The update to mch image configmap has to reflect on all spokes and in scale environment this is going to be a very expensive operation and if we dont check if an actual update is needed, then this is going to noisy in terms of logs and also unnecessary API calls