### PR TITLE
[release-2.11] Revert non-CVE changes

### DIFF
--- a/collectors/metrics/pkg/metricsclient/metricsclient.go
+++ b/collectors/metrics/pkg/metricsclient/metricsclient.go
@@ -16,7 +16,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -24,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff"
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
@@ -510,13 +509,12 @@ func (c *Client) RemoteWrite(ctx context.Context, req *http.Request,
 		}
 		b.MaxElapsedTime = interval / time.Duration(halfInterval)
 		retryable := func() error {
-			return c.sendRequest(ctx, req.URL.String(), compressed)
+			return c.sendRequest(req.URL.String(), compressed)
 		}
 		notify := func(err error, t time.Duration) {
 			msg := fmt.Sprintf("error: %v happened at time: %v", err, t)
 			logger.Log(c.logger, logger.Warn, "msg", msg)
 		}
-
 		err = backoff.RetryNotify(retryable, b, notify)
 		if err != nil {
 			return err
@@ -526,69 +524,43 @@ func (c *Client) RemoteWrite(ctx context.Context, req *http.Request,
 	return nil
 }
 
-func (c *Client) sendRequest(ctx context.Context, serverURL string, body []byte) error {
+func (c *Client) sendRequest(serverURL string, body []byte) error {
 	req1, err := http.NewRequest(http.MethodPost, serverURL, bytes.NewBuffer(body))
 	if err != nil {
-		wrappedErr := fmt.Errorf("failed to create forwarding request: %w", err)
+		msg := "failed to create forwarding request"
+		logger.Log(c.logger, logger.Warn, "msg", msg, "err", err)
 		c.metrics.ForwardRemoteWriteRequests.WithLabelValues("0").Inc()
-		return backoff.Permanent(wrappedErr)
+		return errors.New(msg)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	// req.Header.Add("THANOS-TENANT", tenantID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	req1 = req1.WithContext(ctx)
 
 	resp, err := c.client.Do(req1)
 	if err != nil {
+		msg := "failed to forward request"
+		logger.Log(c.logger, logger.Warn, "msg", msg, "err", err)
 		c.metrics.ForwardRemoteWriteRequests.WithLabelValues("0").Inc()
-
-		wrappedErr := fmt.Errorf("failed to forward request: %w", err)
-		if isTransientError(err) {
-			return wrappedErr
-		}
-
-		return backoff.Permanent(wrappedErr)
+		return errors.New(msg)
 	}
 
 	c.metrics.ForwardRemoteWriteRequests.WithLabelValues(strconv.Itoa(resp.StatusCode)).Inc()
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+	if resp.StatusCode/100 != 2 {
 		// surfacing upstreams error to our users too
-		defer resp.Body.Close()
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			logger.Log(c.logger, logger.Warn, err)
 		}
+		bodyString := string(bodyBytes)
+		msg := fmt.Sprintf("response status code is %s, response body is %s", resp.Status, bodyString)
+		logger.Log(c.logger, logger.Warn, msg)
+		return errors.New(msg)
 
-		retErr := fmt.Errorf("response status code is %s, response body is %s", resp.Status, string(bodyBytes))
-
-		if isTransientResponseError(resp) {
-			return retErr
-		}
-
-		return backoff.Permanent(retErr)
 	}
-
 	return nil
-}
-
-func isTransientError(err error) bool {
-	if urlErr, ok := err.(*url.Error); ok {
-		return urlErr.Timeout()
-	}
-
-	return false
-}
-
-func isTransientResponseError(resp *http.Response) bool {
-	if resp.StatusCode >= 500 && resp.StatusCode != http.StatusNotImplemented {
-		return true
-	}
-
-	if resp.StatusCode == http.StatusTooManyRequests {
-		return true
-	}
-
-	return false
 }

--- a/collectors/metrics/pkg/metricsclient/metricsclient_test.go
+++ b/collectors/metrics/pkg/metricsclient/metricsclient_test.go
@@ -5,22 +5,15 @@
 package metricsclient
 
 import (
-	"bytes"
-	"context"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/gogo/protobuf/proto"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	clientmodel "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/prompb"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDefaultTransport(t *testing.T) {
@@ -277,100 +270,4 @@ func timeseriesEqual(t1 []prompb.TimeSeries, t2 []prompb.TimeSeries) (bool, erro
 	}
 
 	return true, nil
-}
-
-func TestClient_RemoteWrite(t *testing.T) {
-	tests := []struct {
-		name          string
-		families      []*clientmodel.MetricFamily
-		serverHandler http.HandlerFunc
-		expect        func(t *testing.T, err error, retryCount int)
-	}{
-		{
-			name:     "successful write with metrics",
-			families: []*clientmodel.MetricFamily{mockMetricFamily()},
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-			},
-			expect: func(t *testing.T, err error, retryCount int) {
-				assert.NoError(t, err)
-				assert.Equal(t, 1, retryCount)
-			},
-		},
-		{
-			name:     "no metrics to write",
-			families: []*clientmodel.MetricFamily{},
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-			},
-			expect: func(t *testing.T, err error, retryCount int) {
-				assert.NoError(t, err)
-				assert.Equal(t, 0, retryCount)
-			},
-		},
-		{
-			name:     "retryable error",
-			families: []*clientmodel.MetricFamily{mockMetricFamily()},
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusServiceUnavailable)
-			},
-			expect: func(t *testing.T, err error, retryCount int) {
-				assert.Error(t, err)
-				assert.Greater(t, retryCount, 1)
-			},
-		},
-		{
-			name:     "non-retryable error",
-			families: []*clientmodel.MetricFamily{mockMetricFamily()},
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusConflict)
-			},
-			expect: func(t *testing.T, err error, retryCount int) {
-				assert.Error(t, err)
-				assert.Equal(t, 1, retryCount)
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			requestCount := 0
-
-			handler := func(w http.ResponseWriter, r *http.Request) {
-				requestCount++
-				tt.serverHandler(w, r)
-			}
-			ts := httptest.NewServer(http.HandlerFunc(handler))
-			defer ts.Close()
-
-			reg := prometheus.NewRegistry()
-			clientMetrics := &ClientMetrics{
-				ForwardRemoteWriteRequests: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-					Name: "forward_write_requests_total",
-					Help: "Counter of forward remote write requests.",
-				}, []string{"status_code"}),
-			}
-			client := &Client{logger: log.NewNopLogger(), client: ts.Client(), metrics: clientMetrics}
-
-			req, err := http.NewRequest("POST", ts.URL, bytes.NewBuffer([]byte{}))
-			assert.NoError(t, err)
-
-			err = client.RemoteWrite(context.Background(), req, tt.families, 30*time.Second)
-
-			tt.expect(t, err, requestCount)
-		})
-	}
-}
-
-func mockMetricFamily() *clientmodel.MetricFamily {
-	return &clientmodel.MetricFamily{
-		Name: proto.String("test_metric"),
-		Type: clientmodel.MetricType_COUNTER.Enum(),
-		Metric: []*clientmodel.Metric{
-			{
-				Counter:     &clientmodel.Counter{Value: proto.Float64(1)},
-				TimestampMs: proto.Int64(time.Now().UnixNano() / int64(time.Millisecond)),
-			},
-		},
-	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/IBM/controller-filtered-cache v0.3.6
-	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cloudflare/cfssl v1.6.4
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-co-op/gocron v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -844,11 +844,10 @@ github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl
 github.com/brancz/locutus v0.0.0-20210511124350-7a84f4d1bcb3 h1:N7vTNNytk6OFY5WoPJ+cSxxlRbNpCUWdyPW8nDHp0Sw=
 github.com/brancz/locutus v0.0.0-20210511124350-7a84f4d1bcb3/go.mod h1:n+EREm6Tinr9eHmIls4DzojRkkA4IrBe6xRpO4HEw0I=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
-github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
-github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
@@ -5,8 +5,6 @@
 package multiclusterobservability
 
 import (
-	"reflect"
-
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
@@ -141,7 +139,7 @@ func GetMCHPredicateFunc(c client.Client) predicate.Funcs {
 				e.Object.(*mchv1.MultiClusterHub).Status.DesiredVersion == e.Object.(*mchv1.MultiClusterHub).Status.CurrentVersion {
 				// only read the image manifests configmap and enqueue the request when the MCH is
 				// installed/upgraded successfully
-				_, ok, err := config.ReadImageManifestConfigMap(
+				ok, err := config.ReadImageManifestConfigMap(
 					c,
 					e.Object.(*mchv1.MultiClusterHub).Status.CurrentVersion,
 				)
@@ -153,32 +151,20 @@ func GetMCHPredicateFunc(c client.Client) predicate.Funcs {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			// Ensure the event pertains to the target namespace and object type
 			if e.ObjectNew.GetNamespace() == config.GetMCONamespace() &&
-				e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() &&
 				e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion != "" &&
 				e.ObjectNew.(*mchv1.MultiClusterHub).Status.DesiredVersion ==
 					e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion {
-
-				currentData, _, err := config.ReadImageManifestConfigMap(
+				// only read the image manifests configmap and enqueue the request when the MCH is
+				// installed/upgraded successfully
+				ok, err := config.ReadImageManifestConfigMap(
 					c,
 					e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion,
 				)
 				if err != nil {
-					log.Error(err, "Failed to read image manifest ConfigMap")
 					return false
 				}
-
-				previousData, exists := config.GetCachedImageManifestData()
-				if !exists {
-					config.SetCachedImageManifestData(currentData)
-					return true
-				}
-				if !reflect.DeepEqual(currentData, previousData) {
-					config.SetCachedImageManifestData(currentData)
-					return true
-				}
-				return false
+				return ok
 			}
 			return false
 		},

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
@@ -522,7 +522,7 @@ func TestObservabilityAddonController(t *testing.T) {
 		},
 	}
 
-	_, ok, err := config.ReadImageManifestConfigMap(c, testMCHInstance.Status.CurrentVersion)
+	ok, err := config.ReadImageManifestConfigMap(c, testMCHInstance.Status.CurrentVersion)
 	if err != nil || !ok {
 		t.Fatalf("Failed to read image manifest configmap: (%T,%v)", ok, err)
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/predict_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predict_func.go
@@ -109,7 +109,7 @@ func getMchPred(c client.Client) predicate.Funcs {
 				e.Object.(*mchv1.MultiClusterHub).Status.DesiredVersion == e.Object.(*mchv1.MultiClusterHub).Status.CurrentVersion {
 				// only read the image manifests configmap and enqueue the request when the MCH is
 				// installed/upgraded successfully
-				_, ok, err := config.ReadImageManifestConfigMap(
+				ok, err := config.ReadImageManifestConfigMap(
 					c,
 					e.Object.(*mchv1.MultiClusterHub).Status.CurrentVersion,
 				)
@@ -121,32 +121,21 @@ func getMchPred(c client.Client) predicate.Funcs {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			// Ensure the event pertains to the target namespace and object type
 			if e.ObjectNew.GetNamespace() == config.GetMCONamespace() &&
 				e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() &&
 				e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion != "" &&
 				e.ObjectNew.(*mchv1.MultiClusterHub).Status.DesiredVersion ==
 					e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion {
-
-				currentData, _, err := config.ReadImageManifestConfigMap(
+				// / only read the image manifests configmap and enqueue the request when the MCH is
+				// installed/upgraded successfully
+				ok, err := config.ReadImageManifestConfigMap(
 					c,
 					e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion,
 				)
 				if err != nil {
-					log.Error(err, "Failed to read image manifest ConfigMap")
 					return false
 				}
-
-				previousData, exists := config.GetCachedImageManifestData()
-				if !exists {
-					config.SetCachedImageManifestData(currentData)
-					return true
-				}
-				if !reflect.DeepEqual(currentData, previousData) {
-					config.SetCachedImageManifestData(currentData)
-					return true
-				}
-				return false
+				return ok
 			}
 			return false
 		},

--- a/operators/multiclusterobservability/pkg/config/config_test.go
+++ b/operators/multiclusterobservability/pkg/config/config_test.go
@@ -568,7 +568,7 @@ func TestReadImageManifestConfigMap(t *testing.T) {
 			}
 			client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjs...).Build()
 
-			_, gotRet, err := ReadImageManifestConfigMap(client, c.version)
+			gotRet, err := ReadImageManifestConfigMap(client, c.version)
 			if err != nil {
 				t.Errorf("Failed read image manifest configmap due to %v", err)
 			}


### PR DESCRIPTION
git revert eb94214fa06367be250da9f5e824bff2280b46a5
git revert 10cfb4a1aa78c94fd9015041acff579a50f69f2c

which essentially keeps x/net and x/crypto changes for CVE-2024-45337 and CVE-2024-45338  and reverts non-CVE changes

Reinstate later with branch tmp-release-211-01082025

