### PR TITLE
minor update of README and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ deploy:  ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 # UnDeploy controller from the configured Kubernetes cluster in ~/.kube/config
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	@$(MAKE) p-C operators/multiclusterobservability undeploy
+	@$(MAKE) -C operators/multiclusterobservability undeploy
 
 # Build the operator binary
 .PHONY: build

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Thanos Ecosystem | [kube-thanos](https://github.com/stolostron/kube-thanos) | Ku
 
 ### Prerequisites
 
-* Ensure [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) and [kustomize](https://kubernetes-sigs.github.io/kustomize/installation) are installed.
+* Ensure [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) and [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) are installed.
 * Prepare a OpenShift cluster to function as the hub cluster.
 * Ensure [docker 17.03+](https://docs.docker.com/get-started) is installed.
 * Ensure [golang 1.15+](https://golang.org/doc/install) is installed.


### PR DESCRIPTION
This is a minor update to the README link for installing kustomize and a minor update to the Makefile where the `undeploy` command does not seem to be correct.

I was also wondering if the mention of the `kustomize` goal in https://github.com/stolostron/multicluster-observability-operator/blob/main/operators/multiclusterobservability/Makefile should be removed, because it doesn't seem to be defined anywhere (and it's referenced in the `install`, `uninstall` and `deploy` goals)