### PR TITLE
Fix: Flapping addon staus due to 409 response on remote write to the hub

### DIFF
--- a/collectors/metrics/pkg/metricsclient/metricsclient.go
+++ b/collectors/metrics/pkg/metricsclient/metricsclient.go
@@ -44,6 +44,15 @@ const (
 	maxSeriesLength = 10000
 )
 
+type HTTPError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Message)
+}
+
 type Client struct {
 	client      *http.Client
 	maxBytes    int64
@@ -555,7 +564,10 @@ func (c *Client) sendRequest(ctx context.Context, serverURL string, body []byte)
 			logger.Log(c.logger, logger.Warn, err)
 		}
 
-		retErr := fmt.Errorf("response status code is %s, response body is %s", resp.Status, string(bodyBytes))
+		retErr := &HTTPError{
+			StatusCode: resp.StatusCode,
+			Message:    string(bodyBytes),
+		}
 
 		if isTransientResponseError(resp) {
 			return retErr

--- a/collectors/metrics/pkg/metricsclient/metricsclient_test.go
+++ b/collectors/metrics/pkg/metricsclient/metricsclient_test.go
@@ -328,6 +328,10 @@ func TestClient_RemoteWrite(t *testing.T) {
 			expect: func(t *testing.T, err error, retryCount int) {
 				assert.Error(t, err)
 				assert.Equal(t, 1, retryCount)
+				// Ensure the http error is wrapped
+				var httpError *HTTPError
+				assert.ErrorAs(t, err, &httpError)
+				assert.Equal(t, http.StatusConflict, httpError.StatusCode)
 			},
 		},
 	}


### PR DESCRIPTION
Status from the metrics collector now reports available state when receiving a 409 http error on remote write to the hub. 
This reflects more accurately the status of the addon as metrics are well ingested. The error is still logged to make it visible as this is most often the result of an invalid configuration.

Fixes https://issues.redhat.com/browse/ACM-17055