### PR TITLE
Fix: Deduplicate the __name__ label in the metrics collector

### DIFF
--- a/collectors/metrics/pkg/metricsclient/metricsclient.go
+++ b/collectors/metrics/pkg/metricsclient/metricsclient.go
@@ -389,6 +389,7 @@ func convertToTimeseries(p *PartitionedMetrics, now time.Time) ([]prompb.TimeSer
 			}}
 
 			dedup := make(map[string]struct{})
+			dedup[nameLabelName] = struct{}{}
 			for _, l := range m.Label {
 				// Skip empty labels.
 				if *l.Name == "" || *l.Value == "" {

--- a/collectors/metrics/pkg/metricsclient/metricsclient_test.go
+++ b/collectors/metrics/pkg/metricsclient/metricsclient_test.go
@@ -46,6 +46,7 @@ func Test_convertToTimeseries(t *testing.T) {
 	fooLabelName := "foo"
 	fooLabelValue1 := "bar"
 	fooLabelValue2 := "baz"
+	nameLabel := nameLabelName
 
 	emptyLabelName := ""
 
@@ -206,8 +207,12 @@ func Test_convertToTimeseries(t *testing.T) {
 					Counter:     &clientmodel.Counter{Value: &value42},
 					TimestampMs: &timestamp,
 				}, {
-					// With duplicate labels.
-					Label:       []*clientmodel.LabelPair{{Name: &fooLabelName, Value: &fooLabelValue2}, {Name: &fooLabelName, Value: &fooLabelValue2}},
+					// With duplicate labels, including the __name__ label.
+					Label: []*clientmodel.LabelPair{
+						{Name: &fooLabelName, Value: &fooLabelValue2},
+						{Name: &fooLabelName, Value: &fooLabelValue2},
+						{Name: &nameLabel, Value: &barMetricName},
+					},
 					Counter:     &clientmodel.Counter{Value: &value42},
 					TimestampMs: &timestamp,
 				}, {


### PR DESCRIPTION
All labels are deduplicated, except this one. We have a client configuration where this happens. Adding it to the deduplication process.
Fixes https://issues.redhat.com/browse/ACM-17056