### PR TITLE
Fix grafana dashboards update when adding new folder

### DIFF
--- a/operators/endpointmetrics/pkg/collector/metrics_collector.go
+++ b/operators/endpointmetrics/pkg/collector/metrics_collector.go
@@ -779,7 +779,7 @@ func (m *MetricsCollector) ensureDeployment(ctx context.Context, isUWL bool, dep
 		if isDifferentSpec || isDifferentReplicas || deployParams.forceRestart {
 			m.Log.Info("Updating Deployment", "name", name, "namespace", m.Namespace, "isDifferentSpec", isDifferentSpec, "isDifferentReplicas", isDifferentReplicas, "forceRestart", deployParams.forceRestart)
 			if deployParams.forceRestart && foundMetricsCollectorDep.Status.ReadyReplicas != 0 {
-				desiredMetricsCollectorDep.Spec.Template.ObjectMeta.Labels[restartLabel] = time.Now().Format("2006-1-2.1504")
+				desiredMetricsCollectorDep.Spec.Template.ObjectMeta.Labels[restartLabel] = time.Now().Format("2006-1-2.150405")
 			}
 
 			desiredMetricsCollectorDep.ResourceVersion = foundMetricsCollectorDep.ResourceVersion

--- a/operators/multiclusterobservability/manifests/base/grafana/deployment.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/deployment.yaml
@@ -45,6 +45,9 @@ spec:
           image: quay.io/stolostron/grafana:2.4.0-SNAPSHOT-2021-09-23-07-02-14
           imagePullPolicy: IfNotPresent
           name: grafana
+          env:
+            - name: SQLITE_TMPDIR
+              value: /var/lib/grafana # SQLITE needs write permissions to a temp dir. Letting the default /tmp fails as the root filesystem is read-only.
           ports:
             - containerPort: 3001
               name: http

--- a/operators/multiclusterobservability/pkg/certificates/cert_controller.go
+++ b/operators/multiclusterobservability/pkg/certificates/cert_controller.go
@@ -128,7 +128,7 @@ func updateDeployLabel(c client.Client, dName string, isUpdate bool) {
 	}
 	if isUpdate || dep.Status.ReadyReplicas != 0 {
 		newDep := dep.DeepCopy()
-		newDep.Spec.Template.ObjectMeta.Labels[restartLabel] = time.Now().Format("2006-1-2.1504")
+		newDep.Spec.Template.ObjectMeta.Labels[restartLabel] = time.Now().Format("2006-1-2.150405")
 		err := c.Patch(context.TODO(), newDep, client.StrategicMergeFrom(dep))
 		if err != nil {
 			log.Error(err, "Failed to update the deployment", "name", dName)

--- a/operators/pkg/util/util.go
+++ b/operators/pkg/util/util.go
@@ -123,7 +123,7 @@ func UpdateDeployLabel(c client.Client, dName, namespace, label string) error {
 		return err
 	}
 	if dep.Status.ReadyReplicas != 0 {
-		dep.Spec.Template.ObjectMeta.Labels[label] = time.Now().Format("2006-1-2.1504")
+		dep.Spec.Template.ObjectMeta.Labels[label] = time.Now().Format("2006-1-2.150405")
 		err = c.Update(context.TODO(), dep)
 		if err != nil {
 			log.Error(err, "Failed to update the deployment", "name", dName)


### PR DESCRIPTION
As per [documentation](https://www.sqlite.org/tempfiles.html#temporary_file_storage_locations), sqlite needs access to a temporary directory for some operations. As the root file system is readOnly and it picks by default the `/tmp` dir, adding a folder was failing since we upgraded Grafana.

This PR adds a tempdir env variable for sqlite that point to the same mounted directory as the database as it is writable.

This PR also includes an improvement to reduce e2e test flakiness. Previously, because `cert/time-restarted` only had minute-level accuracy, it was possible for two e2e tests to generate the same timestamp, leaving components unchanged and causing tests to fail (certrenew at least). The time accuracy is now improved, down to the second.