### PR TITLE
Update renovate.json to pick only main and actual release branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "github>konflux-ci/mintmaker//config/renovate/renovate.json"
   ],
-  "baseBranches": ["main", "/release-\\d+\\.\\d+/"],
+  "baseBranches": ["main", "/^release-\\d+\\.\\d+/"],
   "schedule": ["on saturday at 10am"],
   "updateNotScheduled": false,
   "autoApprove": true


### PR DESCRIPTION
We get unnecessary Konflux  updates to branches not related to the release or work we do. Eg https://github.com/stolostron/multicluster-observability-operator/pull/1799 
https://github.com/stolostron/multicluster-observability-operator/pull/1788