### PR TITLE
Add support for grafana folder in generate-dashboard-configmap-yaml script

### DIFF
--- a/tests/grafana-dev-test.sh
+++ b/tests/grafana-dev-test.sh
@@ -9,29 +9,29 @@ readonly TEST_USER="test"
 
 # Helper functions
 log() {
-    echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"
+  echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"
 }
 
 fail() {
-    log "ERROR: $*"
-    exit 1
+  log "ERROR: $*"
+  exit 1
 }
 
 wait_for_condition() {
-    local cmd="$1"
-    local desc="$2"
-    local max_attempts="$3"
-    local interval="${4:-5}"
-    
-    for ((i=1; i<=max_attempts; i++)); do
-        if eval "$cmd"; then
-            return 0
-        fi
-        log "Attempt $i/$max_attempts: Waiting for $desc... Retrying in ${interval}s"
-        sleep "$interval"
-    done
-    
-    fail "Timeout waiting for $desc after $max_attempts attempts"
+  local cmd="$1"
+  local desc="$2"
+  local max_attempts="$3"
+  local interval="${4:-5}"
+
+  for ((i = 1; i <= max_attempts; i++)); do
+    if eval "$cmd"; then
+      return 0
+    fi
+    log "Attempt $i/$max_attempts: Waiting for $desc... Retrying in ${interval}s"
+    sleep "$interval"
+  done
+
+  fail "Timeout waiting for $desc after $max_attempts attempts"
 }
 
 # Ensure working directory
@@ -47,29 +47,29 @@ kubectl wait --for=condition=Ready --timeout=120s pods -n "$OBS_NAMESPACE" -l "$
 
 # Get pod name
 POD_NAME=$(kubectl get pods -n "$OBS_NAMESPACE" -l "$GRAFANA_POD_LABEL" \
-    --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}') || fail "Failed to get Grafana pod name"
-[[ -z "$POD_NAME" ]] && fail "Grafana pod name is empty"
+  --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}') || fail "Failed to get Grafana pod name"
+[[ -z $POD_NAME ]] && fail "Grafana pod name is empty"
 
 log "Creating test user"
 kubectl -n "$OBS_NAMESPACE" exec -i "$POD_NAME" -c grafana-dashboard-loader -- /usr/bin/curl \
-    -XPOST -s \
-    -H "Content-Type: application/json" \
-    -H "X-Forwarded-User: WHAT_YOU_ARE_DOING_IS_VOIDING_SUPPORT_0000000000000000000000000000000000000000000000000000000000000000" \
-    -d "{ \"name\":\"$TEST_USER\", \"email\":\"$TEST_USER\", \"login\":\"$TEST_USER\", \"password\":\"$TEST_USER\" }" \
-    '127.0.0.1:3001/api/admin/users' || fail "Failed to create test user"
+  -XPOST -s \
+  -H "Content-Type: application/json" \
+  -H "X-Forwarded-User: WHAT_YOU_ARE_DOING_IS_VOIDING_SUPPORT_0000000000000000000000000000000000000000000000000000000000000000" \
+  -d "{ \"name\":\"$TEST_USER\", \"email\":\"$TEST_USER\", \"login\":\"$TEST_USER\", \"password\":\"$TEST_USER\" }" \
+  '127.0.0.1:3001/api/admin/users' || fail "Failed to create test user"
 
 # Switch to admin and generate dashboard
 wait_for_condition \
-    "./switch-to-grafana-admin.sh \"$TEST_USER\"" \
-    "switching to Grafana admin" \
-    10 \
-    2
+  "./switch-to-grafana-admin.sh \"$TEST_USER\"" \
+  "switching to Grafana admin" \
+  10 \
+  2
 
 wait_for_condition \
-    "./generate-dashboard-configmap-yaml.sh -f 'Alerts' 'Alert Analysis'" \
-    "generating dashboard configmap" \
-    10 \
-    2
+  "./generate-dashboard-configmap-yaml.sh -f 'Alerts' 'Alert Analysis'" \
+  "generating dashboard configmap" \
+  10 \
+  2
 
 # Cleanup
 log "Cleaning up Grafana dev environment"

--- a/tools/generate-dashboard-configmap-yaml.sh
+++ b/tools/generate-dashboard-configmap-yaml.sh
@@ -101,8 +101,9 @@ start() {
   dashboard=$(echo $dashboards | $PYTHON_CMD -c "
 import sys, json
 data = json.load(sys.stdin)
+folder = '$dashboard_folder_name' if '$dashboard_folder_name' else None
 for dash in data:
-    if dash['title'] == '$org_dashboard_name' and (not folder or dash['folderTitle'] == '$dashboard_folder_name'):
+    if dash['title'] == '$org_dashboard_name' and (not folder or dash.get('folderTitle') == folder):
         sys.stdout.write(json.dumps(dash))
         sys.exit(0)
 ")

--- a/tools/generate-dashboard-configmap-yaml.sh
+++ b/tools/generate-dashboard-configmap-yaml.sh
@@ -2,8 +2,6 @@
 # Copyright (c) 2021 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
-obs_namespace='open-cluster-management-observability'
-
 if command -v python &>/dev/null; then
   PYTHON_CMD="python"
 elif command -v python2 &>/dev/null; then
@@ -17,51 +15,66 @@ fi
 
 usage() {
   cat <<EOF
-Usage: $(basename "${BASH_SOURCE[0]}") [-h] dashboard_name [configmap_path]
-       [-n namespace]
+Usage: $(basename "$0") [flags] dashboard_name [configmap_path]
 
-Fetch grafana dashboard and save with a configmap.
+Options:
+  -h, --help           Print this help and exit
+  -n, --namespace      Specify the observability namespace
+  -f, --folder         Grafana folder of the dashboard
 
-Available options:
-
--h, --help           Print this help and exit
-dashboard_name       Specified the dashboard to be fetch
-configmap_path       Specified the path to save the configmap
--n, --namespace      Specify the observability components namespace
+Positional arguments:
+  dashboard_name       The dashboard name to fetch (required)
+  configmap_path       Path to save the configmap (optional)
 EOF
-  exit
+  exit 1
 }
 
 start() {
-  if [ $# -eq 0 -o $# -gt 4 ]; then
-    usage
-  fi
-
+  # Defaults
+  obs_namespace="open-cluster-management-observability"
+  dashboard_folder_name=""
   savePath="."
-  if [ $# -ge 2 ]; then
-    savePath=$2
-  fi
-  org_dashboard_name=$1
-  dashboard_name=$(echo ${1//[!(a-z\A-Z\0-9\-\.)]/-} | tr '[:upper:]' '[:lower:]')
+  org_dashboard_name=""
 
+  # Parse all flags first
   while [[ $# -gt 0 ]]; do
-    key="$1"
-    case $key in
-      -h | --help)
+    case "$1" in
+      -h|--help)
         usage
         ;;
-
-      -n | --namespace)
+      -n|--namespace)
         obs_namespace="$2"
-        shift
-        shift
+        shift 2
         ;;
-
+      -f|--folder)
+        dashboard_folder_name="$2"
+        shift 2
+        ;;
+      # Anything not recognized as a flag => break and treat as positional
       *)
-        shift
+        break
         ;;
     esac
   done
+
+  # Parse positional arguments
+  if [[ $# -lt 1 ]]; then
+    echo "ERROR: Missing required dashboard_name"
+    usage
+  fi
+  org_dashboard_name="$1"
+  dashboard_name=$(echo "${1//[!(a-zA-Z0-9\-\.)]/-}" | tr '[:upper:]' '[:lower:]')
+  shift 1
+
+  if [[ $# -ge 1 ]]; then
+    savePath="$1"
+    shift 1
+  fi
+
+  if [[ $# -gt 0 ]]; then
+    echo "ERROR: Unexpected extra arguments: $*"
+    usage
+  fi
 
   if [ ! -d $savePath ]; then
     mkdir -p $savePath
@@ -77,7 +90,7 @@ start() {
     exit 1
   fi
 
-  curlCMD="kubectl exec -it -n "$obs_namespace" $podName -c grafana-dashboard-loader -- /usr/bin/curl"
+  curlCMD="kubectl exec -n "$obs_namespace" $podName -c grafana-dashboard-loader -- /usr/bin/curl"
   XForwardedUser="WHAT_YOU_ARE_DOING_IS_VOIDING_SUPPORT_0000000000000000000000000000000000000000000000000000000000000000"
   dashboards=$($curlCMD -s -X GET -H "Content-Type: application/json" -H "X-Forwarded-User: $XForwardedUser" 127.0.0.1:3001/api/search)
   if [ $? -ne 0 ]; then
@@ -85,7 +98,19 @@ start() {
     exit 1
   fi
 
-  dashboard=$(echo $dashboards | $PYTHON_CMD -c "import sys, json;[sys.stdout.write(json.dumps(dash)) for dash in json.load(sys.stdin) if dash['title'] == '$org_dashboard_name']")
+  dashboard=$(echo $dashboards | $PYTHON_CMD -c "
+import sys, json
+data = json.load(sys.stdin)
+for dash in data:
+    if dash['title'] == '$org_dashboard_name' and (not folder or dash['folderTitle'] == '$dashboard_folder_name'):
+        sys.stdout.write(json.dumps(dash))
+        sys.exit(0)
+")
+  if [[ -z "$dashboard" ]]; then
+    echo "No matching dashboard found, please check your dashboard name <$org_dashboard_name> and folder name <$dashboard_folder_name>"
+    exit 1
+  fi
+
 
   dashboardUID=$(echo $dashboard | $PYTHON_CMD -c "import sys, json; print(json.load(sys.stdin)['uid'])" 2>/dev/null)
   dashboardFolderId=$(echo $dashboard | $PYTHON_CMD -c "import sys, json; print(json.load(sys.stdin)['folderId'])" 2>/dev/null)
@@ -93,7 +118,7 @@ start() {
 
   dashboardJson=$($curlCMD -s -X GET -H "Content-Type: application/json" -H "X-Forwarded-User:$XForwardedUser" 127.0.0.1:3001/api/dashboards/uid/$dashboardUID | $PYTHON_CMD -c "import sys, json; print(json.dumps(json.load(sys.stdin)['dashboard']))" 2>/dev/null)
   if [ $? -ne 0 ]; then
-    echo "Failed to fetch dashboard json data, please check your dashboard name <$org_dashboard_name>"
+    echo "Failed to fetch dashboard json data with dashboard id <$dashboardUID>, please check your dashboard name <$org_dashboard_name>."
     exit 1
   fi
 

--- a/tools/generate-dashboard-configmap-yaml.sh
+++ b/tools/generate-dashboard-configmap-yaml.sh
@@ -39,14 +39,14 @@ start() {
   # Parse all flags first
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      -h|--help)
+      -h | --help)
         usage
         ;;
-      -n|--namespace)
+      -n | --namespace)
         obs_namespace="$2"
         shift 2
         ;;
-      -f|--folder)
+      -f | --folder)
         dashboard_folder_name="$2"
         shift 2
         ;;
@@ -106,11 +106,10 @@ for dash in data:
         sys.stdout.write(json.dumps(dash))
         sys.exit(0)
 ")
-  if [[ -z "$dashboard" ]]; then
+  if [[ -z $dashboard ]]; then
     echo "No matching dashboard found, please check your dashboard name <$org_dashboard_name> and folder name <$dashboard_folder_name>"
     exit 1
   fi
-
 
   dashboardUID=$(echo $dashboard | $PYTHON_CMD -c "import sys, json; print(json.load(sys.stdin)['uid'])" 2>/dev/null)
   dashboardFolderId=$(echo $dashboard | $PYTHON_CMD -c "import sys, json; print(json.load(sys.stdin)['folderId'])" 2>/dev/null)

--- a/tools/setup-grafana-dev.sh
+++ b/tools/setup-grafana-dev.sh
@@ -5,9 +5,9 @@
 obs_namespace='open-cluster-management-observability'
 deploy_flag=0
 
-sed_command='sed -i-e -e'
+sed_command="sed -i -e"
 if [[ "$(uname)" == "Darwin" ]]; then
-  sed_command='sed -i '-e' -e'
+  sed_command="sed -i '' -e"
 fi
 
 usage() {

--- a/tools/setup-grafana-dev.sh
+++ b/tools/setup-grafana-dev.sh
@@ -5,9 +5,10 @@
 obs_namespace='open-cluster-management-observability'
 deploy_flag=0
 
-sed_command="sed -i -e"
-if [[ "$(uname)" == "Darwin" ]]; then
-  sed_command="sed -i '' -e"
+if sed --version 2>/dev/null | grep -q "GNU sed"; then
+  sed_command="sed -i -e"
+else
+  sed_command="sed -i '' -e" # BSD sed
 fi
 
 usage() {


### PR DESCRIPTION
In the PR https://github.com/stolostron/multicluster-observability-operator/pull/1726 refactoring dashboards for MCOA, there are cases where the same dashboard name can be given to two different dashboards in different Grafana folders. This makes e2e fail because it uses such a dashboard in the `grafana_dev_test`. 
This PR:

- Adds support for specifying the Grafana folder in the script `generate-dashboard-configmap-yaml.sh`
- Changes the dashboard used in the `grafana_dev_test` for a stable one between current setup and MCOA
- Improves sed command support in `setup-grafana-dev.sh` (it was failing for me using GNU sed on Darwin)
- Refactors `grafana-dev-test.sh` for better readability and improved robustness with retries on more commands (including test user creation that is flaky) and removes sleep commands.