### PR TITLE
Fix flaky symlink creation in placement unit tests

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
@@ -345,7 +345,7 @@ func TestManifestWork(t *testing.T) {
 		WithRuntimeObjects(objs...).
 		Build()
 
-	defer setupTest(t)()
+	setupTest(t)
 
 	works, crdWork, _, err := generateGlobalManifestResources(c, newTestMCO())
 	if err != nil {


### PR DESCRIPTION
Fixes flaky unit test resulting in:

```
=== RUN   TestManifestWork
    placementrule_controller_test.go:140: begin setupTest
    placementrule_controller_test.go:154: Failed to create symbollink(/go/src/github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/tests/manifests) to(/go/src/github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/manifests) for the test manifests: (symlink /go/src/github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/manifests /go/src/github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/tests/manifests: file exists)
```

This PR replaces os commands with test package utilities for creating a temporary directory and setting environment variables that are automatically cleaned at the end of the test. Overall simplifying the setup function.