### PR TITLE
Fix e2e watchdog alert test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/golang/snappy v0.0.4
 	github.com/google/go-cmp v0.6.0
-	github.com/hashicorp/go-version v1.6.0
 	github.com/imdario/mergo v0.3.16
 	github.com/oklog/run v1.1.0
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -636,8 +636,6 @@ github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdv
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
-github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/tests/pkg/tests/observability_alert_test.go
+++ b/tests/pkg/tests/observability_alert_test.go
@@ -401,7 +401,7 @@ var _ = Describe("Observability:", func() {
 			}
 
 			// Returned alerts by the alert manager is not consistent. It does not always contain all the alerts.
-			// To make the test more reliable, we romove clusters found in the response continuously on each retry
+			// To make the test more reliable, we remove clusters found in the response continuously on each retry
 			// until all have been identified in the alertmanager responses.
 			for _, foundID := range clusterIDsInAlerts {
 				missingClusters = slices.DeleteFunc(missingClusters, func(e string) bool { return e == foundID })

--- a/tests/pkg/tests/observability_alert_test.go
+++ b/tests/pkg/tests/observability_alert_test.go
@@ -341,6 +341,10 @@ var _ = Describe("Observability:", func() {
 		Expect(err).NotTo(HaveOccurred())
 		expectClusterIdentifiers := append(expectedOCPClusterIDs, expectedKSClusterNames...)
 		missingClusters := slices.Clone(expectClusterIdentifiers)
+		klog.Infof("List of cluster IDs expected to send the alert is: %s", expectClusterIdentifiers)
+
+		// Ensure we have all the managed clusters in the list
+		Expect(len(expectClusterIdentifiers)).To(Equal(len(testOptions.ManagedClusters) + 1))
 
 		// install watchdog PrometheusRule to *KS clusters
 		watchDogRuleKustomizationPath := "../../../examples/alerts/watchdog_rule"
@@ -404,6 +408,7 @@ var _ = Describe("Observability:", func() {
 			}
 
 			if len(missingClusters) != 0 {
+				klog.Infof("Watchdog alerts are still missing from these clusters %q. Retrying...", missingClusters)
 				return fmt.Errorf("Not all managedclusters forward Watchdog alert to hub cluster. Found following clusters in alerts %q. Following clusters are still missing: %q. Full list of expected clusters was: %q", clusterIDsInAlerts, missingClusters, expectClusterIdentifiers)
 			}
 

--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -110,7 +110,7 @@ func ListOCPManagedClusterIDs(opt TestOptions) ([]string, error) {
 			continue
 		}
 
-		if vendor, ok := labels["vendor"]; !ok || vendor != "OpenShift" {
+		if vendor, ok := labels["vendor"]; ok && vendor == "OpenShift" {
 			continue
 		}
 
@@ -136,7 +136,7 @@ func ListKSManagedClusterNames(opt TestOptions) ([]string, error) {
 			continue
 		}
 
-		if vendor, ok := labels["vendor"]; ok && vendor == "OpenShift" {
+		if vendor, ok := labels["vendor"]; !ok || vendor != "OpenShift" {
 			continue
 		}
 

--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -110,7 +110,7 @@ func ListOCPManagedClusterIDs(opt TestOptions) ([]string, error) {
 			continue
 		}
 
-		if vendor, ok := labels["vendor"]; ok && vendor == "OpenShift" {
+		if vendor, ok := labels["vendor"]; !ok || vendor != "OpenShift" {
 			continue
 		}
 
@@ -136,7 +136,7 @@ func ListKSManagedClusterNames(opt TestOptions) ([]string, error) {
 			continue
 		}
 
-		if vendor, ok := labels["vendor"]; !ok || vendor != "OpenShift" {
+		if vendor, ok := labels["vendor"]; ok && vendor == "OpenShift" {
 			continue
 		}
 


### PR DESCRIPTION
The watchdog alert is a Prometheus alert that is always on, and automatically deployed on openshift clusters with the in-cluster stack.

The e2e alert test, verifies that the watchdog alert is well forwarded to the hub alertmanager, validating the communication links. And as this alert is deployed everywhere, it is forwarded by alertmanagers deployed on both the hub and spokes.

The test fetches the watchdog alerts received by the ACM AlertManager, and verifies that is contains the ones from all managed clusters. However, the list of managed clusters is built by fetching the ManagedCluster resources and by checking the label `feature.open-cluster-management.io/addon-observability-controller` that is added by the [addon manager](https://github.com/open-cluster-management-io/enhancements/blob/87ef9534262ecd4d524759c1be41a25c4c61d437/enhancements/sig-architecture/17-cluster-features/README.md?plain=1#L42) is set to `available`. But the addon manager is not anymore deployed on the hub, and this label is not added to the local cluster's ManagedCluster resource.  As a result, the list does not contain the local-cluster ID.

**Why is it not always failing?**
Because the retried queries to the ACM hub alert manager are not consistently returning watchdog alerts from all managed clusters. Most of the time they contain alerts from all clusters. But sometimes none, or just one of them, making the test eventually pass. Sometimes.

This PR changes how the list of expected cluster IDs is built, to always include the local-cluster one. 
It also changes the way clusters are checked from the alermanager response by removing them as they are being found instead of expecting all of them in the same response.