### PR TITLE
Fix: list of managedClusters in e2e tests for AlertManager

### DIFF
--- a/tests/pkg/tests/observability_alert_test.go
+++ b/tests/pkg/tests/observability_alert_test.go
@@ -344,7 +344,7 @@ var _ = Describe("Observability:", func() {
 		klog.Infof("List of cluster IDs expected to send the alert is: %s", expectClusterIdentifiers)
 
 		// Ensure we have at least a managedCluster
-		Expect(len(expectClusterIdentifiers)).To(Not(BeEmpty()))
+		Expect(expectClusterIdentifiers).To(Not(BeEmpty()))
 
 		// install watchdog PrometheusRule to *KS clusters
 		watchDogRuleKustomizationPath := "../../../examples/alerts/watchdog_rule"

--- a/tests/pkg/tests/observability_alert_test.go
+++ b/tests/pkg/tests/observability_alert_test.go
@@ -335,16 +335,16 @@ var _ = Describe("Observability:", func() {
 			alertGetReq.Header.Set("Authorization", "Bearer "+BearerToken)
 		}
 
-		expectedOCPClusterIDs, err := utils.ListOCPManagedClusterIDs(testOptions)
+		expectedOCPClusterIDs, err := utils.ListAvailableOCPManagedClusterIDs(testOptions)
 		Expect(err).NotTo(HaveOccurred())
-		expectedKSClusterNames, err := utils.ListKSManagedClusterNames(testOptions)
+		expectedKSClusterNames, err := utils.ListAvailableKSManagedClusterNames(testOptions)
 		Expect(err).NotTo(HaveOccurred())
 		expectClusterIdentifiers := append(expectedOCPClusterIDs, expectedKSClusterNames...)
 		missingClusters := slices.Clone(expectClusterIdentifiers)
 		klog.Infof("List of cluster IDs expected to send the alert is: %s", expectClusterIdentifiers)
 
-		// Ensure we have all the managed clusters in the list
-		Expect(len(expectClusterIdentifiers)).To(Equal(len(testOptions.ManagedClusters) + 1))
+		// Ensure we have at least a managedCluster
+		Expect(len(expectClusterIdentifiers)).To(Not(BeEmpty()))
 
 		// install watchdog PrometheusRule to *KS clusters
 		watchDogRuleKustomizationPath := "../../../examples/alerts/watchdog_rule"

--- a/tests/pkg/tests/observability_alert_test.go
+++ b/tests/pkg/tests/observability_alert_test.go
@@ -350,6 +350,7 @@ var _ = Describe("Observability:", func() {
 		watchDogRuleKustomizationPath := "../../../examples/alerts/watchdog_rule"
 		yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: watchDogRuleKustomizationPath})
 		Expect(err).NotTo(HaveOccurred())
+		klog.Infof("List of cluster IDs to install the watchdog alert: %s", expectedKSClusterNames)
 		for _, ks := range expectedKSClusterNames {
 			for idx, mc := range testOptions.ManagedClusters {
 				if mc.Name == ks {


### PR DESCRIPTION
Removes an invalid assertion in e2e tests introduced by https://github.com/stolostron/multicluster-observability-operator/pull/1805 (see details in https://github.com/stolostron/multicluster-observability-operator/pull/1808#issuecomment-2627643353). 
And only list available ManagedClusters (this is necessary for some other environments running our e2e suite).