### PR TITLE
Manage deployment of resources for MCOA and metrics collector

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -429,7 +429,7 @@ func (r *MultiClusterObservabilityReconciler) initFinalization(
 			log.Error(err, "Failed to remove cluster scoped resources")
 			return false, err
 		}
-		if err := placementctrl.DeleteHubMetricsCollectionDeployments(r.Client); err != nil {
+		if err := placementctrl.DeleteHubMetricsCollectionDeployments(context.TODO(), r.Client); err != nil {
 			log.Error(err, "Failed to delete hub metrics collection deployments and resources")
 			return false, err
 		}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -188,7 +188,7 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	}
 
 	// Init finalizers
-	operatorconfig.IsMCOTerminating, err = r.initFinalization(instance)
+	operatorconfig.IsMCOTerminating, err = r.initFinalization(ctx, instance)
 	if err != nil {
 		return ctrl.Result{}, err
 	} else if operatorconfig.IsMCOTerminating {
@@ -418,9 +418,7 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	return ctrl.Result{}, nil
 }
 
-func (r *MultiClusterObservabilityReconciler) initFinalization(
-	mco *mcov1beta2.MultiClusterObservability,
-) (bool, error) {
+func (r *MultiClusterObservabilityReconciler) initFinalization(ctx context.Context, mco *mcov1beta2.MultiClusterObservability) (bool, error) {
 	if mco.GetDeletionTimestamp() != nil && slices.Contains(mco.GetFinalizers(), resFinalizer) {
 		log.Info("To delete resources across namespaces")
 		// clean up the cluster resources, eg. clusterrole, clusterrolebinding, etc
@@ -429,7 +427,7 @@ func (r *MultiClusterObservabilityReconciler) initFinalization(
 			log.Error(err, "Failed to remove cluster scoped resources")
 			return false, err
 		}
-		if err := placementctrl.DeleteHubMetricsCollectionDeployments(context.TODO(), r.Client); err != nil {
+		if err := placementctrl.DeleteHubMetricsCollectionDeployments(ctx, r.Client); err != nil {
 			log.Error(err, "Failed to delete hub metrics collection deployments and resources")
 			return false, err
 		}
@@ -437,7 +435,7 @@ func (r *MultiClusterObservabilityReconciler) initFinalization(
 		config.CleanUpOperandNames()
 
 		mco.SetFinalizers(commonutil.Remove(mco.GetFinalizers(), resFinalizer))
-		err := r.Client.Update(context.TODO(), mco)
+		err := r.Client.Update(ctx, mco)
 		if err != nil {
 			log.Error(err, "Failed to remove finalizer from mco resource")
 			return false, err
@@ -452,7 +450,7 @@ func (r *MultiClusterObservabilityReconciler) initFinalization(
 	if !slices.Contains(mco.GetFinalizers(), resFinalizer) {
 		mco.SetFinalizers(commonutil.Remove(mco.GetFinalizers(), certFinalizer))
 		mco.SetFinalizers(append(mco.GetFinalizers(), resFinalizer))
-		err := r.Client.Update(context.TODO(), mco)
+		err := r.Client.Update(ctx, mco)
 		if err != nil {
 			log.Error(err, "Failed to add finalizer to mco resource")
 			return false, err

--- a/operators/multiclusterobservability/controllers/placementrule/endpoint_metrics_operator.go
+++ b/operators/multiclusterobservability/controllers/placementrule/endpoint_metrics_operator.go
@@ -5,6 +5,8 @@
 package placementrule
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -38,9 +40,9 @@ func loadTemplates(mco *mcov1beta2.MultiClusterObservability) (
 	// render endpoint-observability templates
 	endpointObsTemplates, err := templates.GetOrLoadEndpointObservabilityTemplates(templatesutil.GetTemplateRenderer())
 	if err != nil {
-		log.Error(err, "Failed to load templates")
-		return nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, fmt.Errorf("failed to load load endpoint observability templates: %w", err)
 	}
+
 	crdv1 := &apiextensionsv1.CustomResourceDefinition{}
 	crdv1beta1 := &apiextensionsv1beta1.CustomResourceDefinition{}
 	dep := &appsv1.Deployment{}
@@ -49,7 +51,7 @@ func loadTemplates(mco *mcov1beta2.MultiClusterObservability) (
 	for _, r := range endpointObsTemplates {
 		obj, err := updateRes(r, mco)
 		if err != nil {
-			return nil, nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, fmt.Errorf("failed to edit templates: %w", err)
 		}
 		if r.GetKind() == "Deployment" {
 			dep = obj.(*appsv1.Deployment)

--- a/operators/multiclusterobservability/controllers/placementrule/hub_ocp_monitoring_util.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_ocp_monitoring_util.go
@@ -155,24 +155,6 @@ func DeleteHubMonitoringClusterRoleBinding(ctx context.Context, client client.Cl
 	return nil
 }
 
-func DeleteHubCAConfigmap(ctx context.Context, client client.Client) error {
-	cm := &corev1.ConfigMap{}
-	err := client.Get(ctx, types.NamespacedName{Name: caConfigmapName,
-		Namespace: hubMetricsCollectionNamespace}, cm)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to check the configmap: %w", err)
-	}
-	log.Info("Deleting configmap")
-	err = client.Delete(ctx, cm)
-	if err != nil {
-		return fmt.Errorf("failed to delete configmap: %w", err)
-	}
-	return nil
-}
-
 func DeleteServiceMonitors(ctx context.Context, c client.Client) error {
 	hList := &hyperv1.HostedClusterList{}
 	err := c.List(context.TODO(), hList, &client.ListOptions{})

--- a/operators/multiclusterobservability/controllers/placementrule/hub_ocp_monitoring_util.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_ocp_monitoring_util.go
@@ -16,7 +16,6 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -133,23 +132,6 @@ func RevertHubClusterMonitoringConfig(ctx context.Context, client client.Client)
 	found.Data[clusterMonitoringConfigDataKey] = string(updatedClusterMonitoringConfigurationYAMLBytes)
 	if err := client.Update(ctx, found); err != nil {
 		return fmt.Errorf("failed to update configmap %s: %w", clusterMonitoringConfigName, err)
-	}
-
-	return nil
-}
-
-func DeleteHubMonitoringClusterRoleBinding(ctx context.Context, client client.Client) error {
-	rb := &rbacv1.ClusterRoleBinding{}
-	if err := client.Get(ctx, types.NamespacedName{Name: clusterRoleBindingName}, rb); err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to get clusterrolebinding %s: %w", clusterRoleBindingName, err)
-	}
-
-	log.Info("deleting clusterrolebinding", "name", clusterRoleBindingName)
-	if err := client.Delete(ctx, rb); err != nil {
-		return fmt.Errorf("failed to delete clusterrolebinding %s: %w", clusterRoleBindingName, err)
 	}
 
 	return nil

--- a/operators/multiclusterobservability/controllers/placementrule/hub_ocp_monitoring_util.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_ocp_monitoring_util.go
@@ -16,6 +16,7 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -109,7 +110,7 @@ func RevertHubClusterMonitoringConfig(ctx context.Context, client client.Client)
 	}
 
 	// check if the foundClusterMonitoringConfiguration is empty
-	if reflect.DeepEqual(*foundClusterMonitoringConfiguration, cmomanifests.ClusterMonitoringConfiguration{}) {
+	if equality.Semantic.DeepEqual(*foundClusterMonitoringConfiguration, cmomanifests.ClusterMonitoringConfiguration{}) {
 		log.Info("empty ClusterMonitoringConfiguration, deleting configmap", "name", clusterMonitoringConfigName)
 		if err := client.Delete(ctx, found); err != nil {
 			return fmt.Errorf("failed to delete configmap %s: %w", clusterMonitoringConfigName, err)

--- a/operators/multiclusterobservability/controllers/placementrule/hub_ocp_monitoring_util.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_ocp_monitoring_util.go
@@ -16,7 +16,6 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,27 +37,19 @@ const ( // #nosec G101 -- Not a hardcoded credential.
 // revertClusterMonitoringConfig reverts the configmap cluster-monitoring-config and relevant resources
 // (observability-alertmanager-accessor and hub-alertmanager-router-ca) for the openshift cluster monitoring stack.
 func RevertHubClusterMonitoringConfig(ctx context.Context, client client.Client) error {
-	log.Info("revertClusterMonitoringConfig called")
-
 	// try to retrieve the current configmap in the cluster
 	found := &corev1.ConfigMap{}
-	err := client.Get(ctx, types.NamespacedName{Name: clusterMonitoringConfigName,
-		Namespace: promNamespace}, found)
-	if err != nil {
+	if err := client.Get(ctx, types.NamespacedName{Name: clusterMonitoringConfigName,
+		Namespace: promNamespace}, found); err != nil {
 		if errors.IsNotFound(err) {
-			log.Info("configmap not found, no need action", "name", clusterMonitoringConfigName)
 			return nil
-		} else {
-			log.Error(err, "failed to check configmap", "name", clusterMonitoringConfigName)
-			return err
 		}
+		return fmt.Errorf("failed to get configmap %s: %w", clusterMonitoringConfigName, err)
 	}
 
 	// do not touch the configmap if are not already a manager
 	touched := false
-	log.Info("checking field.Manager")
 	for _, field := range found.GetManagedFields() {
-		log.Info("filed.Manager", "manager", field.Manager)
 		if field.Manager == endpointMonitoringOperatorMgr {
 			touched = true
 			break
@@ -66,139 +57,83 @@ func RevertHubClusterMonitoringConfig(ctx context.Context, client client.Client)
 	}
 
 	if !touched {
-		log.Info(
-			"endpoint-monitoring-operator is not a manager of configmap, no action needed",
-			"name",
-			clusterMonitoringConfigName,
-		)
 		return nil
 	}
 
-	// revert the existing cluster-monitor-config configmap
-	log.Info("configmap exists, check if it needs revert", "name", clusterMonitoringConfigName)
 	foundClusterMonitoringConfigurationYAML, ok := found.Data[clusterMonitoringConfigDataKey]
 	if !ok {
-		log.Info(
-			"configmap data doesn't contain key, no action need",
-			"name",
-			clusterMonitoringConfigName,
-			"key",
-			clusterMonitoringConfigDataKey,
-		)
 		return nil
 	}
+
 	foundClusterMonitoringConfigurationJSON, err := yaml.YAMLToJSON([]byte(foundClusterMonitoringConfigurationYAML))
 	if err != nil {
-		log.Error(err, "failed to transform YAML to JSON", "YAML", foundClusterMonitoringConfigurationYAML)
-		return err
+		return fmt.Errorf("failed to transform YAML to JSON for configmap %s: %w", clusterMonitoringConfigName, err)
 	}
 
-	log.Info(
-		"configmap exists and key config.yaml exists, check if the value needs revert",
-		"name",
-		clusterMonitoringConfigName,
-		"key",
-		clusterMonitoringConfigDataKey,
-	)
 	foundClusterMonitoringConfiguration := &cmomanifests.ClusterMonitoringConfiguration{}
 	if err := json.Unmarshal([]byte(foundClusterMonitoringConfigurationJSON), foundClusterMonitoringConfiguration); err != nil {
-		log.Error(err, "failed to marshal the cluster monitoring config")
-		return err
+		return fmt.Errorf("failed to unmarshal cluster monitoring config: %w", err)
 	}
 
 	if foundClusterMonitoringConfiguration.PrometheusK8sConfig == nil {
-		log.Info(
-			"configmap data doesn't key: prometheusK8s, no need action",
-			"name",
-			clusterMonitoringConfigName,
-			"key",
-			clusterMonitoringConfigDataKey,
-		)
 		return nil
-	} else {
-		// check if externalLabels exists
-		if foundClusterMonitoringConfiguration.PrometheusK8sConfig.ExternalLabels != nil {
-			delete(foundClusterMonitoringConfiguration.PrometheusK8sConfig.ExternalLabels, operatorconfig.ClusterLabelKeyForAlerts)
+	}
 
-			if len(foundClusterMonitoringConfiguration.PrometheusK8sConfig.ExternalLabels) == 0 {
-				foundClusterMonitoringConfiguration.PrometheusK8sConfig.ExternalLabels = nil
-			}
-		}
-
-		// check if alertmanagerConfigs exists
-		if foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs != nil {
-			copiedAlertmanagerConfigs := make([]cmomanifests.AdditionalAlertmanagerConfig, 0)
-			for _, v := range foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs {
-				if v.TLSConfig == (cmomanifests.TLSConfig{}) ||
-					v.TLSConfig.CA == nil ||
-					v.TLSConfig.CA.LocalObjectReference == (corev1.LocalObjectReference{}) ||
-					v.TLSConfig.CA.LocalObjectReference.Name != hubAmRouterCASecretName {
-					copiedAlertmanagerConfigs = append(copiedAlertmanagerConfigs, v)
-				}
-			}
-			if len(copiedAlertmanagerConfigs) == 0 {
-				foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs = nil
-				if reflect.DeepEqual(*foundClusterMonitoringConfiguration.PrometheusK8sConfig, cmomanifests.PrometheusK8sConfig{}) {
-					foundClusterMonitoringConfiguration.PrometheusK8sConfig = nil
-				}
-			} else {
-				foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs = copiedAlertmanagerConfigs
-			}
+	// check if externalLabels exists
+	if foundClusterMonitoringConfiguration.PrometheusK8sConfig.ExternalLabels != nil {
+		delete(foundClusterMonitoringConfiguration.PrometheusK8sConfig.ExternalLabels, operatorconfig.ClusterLabelKeyForAlerts)
+		if len(foundClusterMonitoringConfiguration.PrometheusK8sConfig.ExternalLabels) == 0 {
+			foundClusterMonitoringConfiguration.PrometheusK8sConfig.ExternalLabels = nil
 		}
 	}
 
-	// check if the foundClusterMonitoringConfiguration is empty ClusterMonitoringConfiguration
-	if reflect.DeepEqual(*foundClusterMonitoringConfiguration, cmomanifests.ClusterMonitoringConfiguration{}) {
-		log.Info("empty ClusterMonitoringConfiguration, should delete configmap", "name", clusterMonitoringConfigName)
-		err = client.Delete(ctx, found)
-		if err != nil {
-			log.Error(err, "failed to delete configmap", "name", clusterMonitoringConfigName)
-			return err
+	// check if alertmanagerConfigs exists
+	if foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs != nil {
+		copiedAlertmanagerConfigs := make([]cmomanifests.AdditionalAlertmanagerConfig, 0)
+		for _, v := range foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs {
+			if v.TLSConfig == (cmomanifests.TLSConfig{}) ||
+				v.TLSConfig.CA == nil ||
+				v.TLSConfig.CA.LocalObjectReference == (corev1.LocalObjectReference{}) ||
+				v.TLSConfig.CA.LocalObjectReference.Name != hubAmRouterCASecretName {
+				copiedAlertmanagerConfigs = append(copiedAlertmanagerConfigs, v)
+			}
 		}
-		log.Info("configmap delete", "name", clusterMonitoringConfigName)
+		if len(copiedAlertmanagerConfigs) == 0 {
+			foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs = nil
+			if reflect.DeepEqual(*foundClusterMonitoringConfiguration.PrometheusK8sConfig, cmomanifests.PrometheusK8sConfig{}) {
+				foundClusterMonitoringConfiguration.PrometheusK8sConfig = nil
+			}
+		} else {
+			foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs = copiedAlertmanagerConfigs
+		}
+	}
+
+	// check if the foundClusterMonitoringConfiguration is empty
+	if reflect.DeepEqual(*foundClusterMonitoringConfiguration, cmomanifests.ClusterMonitoringConfiguration{}) {
+		log.Info("empty ClusterMonitoringConfiguration, deleting configmap", "name", clusterMonitoringConfigName)
+		if err := client.Delete(ctx, found); err != nil {
+			return fmt.Errorf("failed to delete configmap %s: %w", clusterMonitoringConfigName, err)
+		}
 		return nil
 	}
 
 	// prepare to write back the cluster monitoring configuration
 	updatedClusterMonitoringConfigurationJSONBytes, err := json.Marshal(foundClusterMonitoringConfiguration)
 	if err != nil {
-		log.Error(err, "failed to marshal the cluster monitoring config")
-		return err
+		return fmt.Errorf("failed to marshal updated cluster monitoring config: %w", err)
 	}
-	updatedClusterMonitoringConfigurationYAMLBytes, err := yaml.JSONToYAML(
-		updatedClusterMonitoringConfigurationJSONBytes,
-	)
+
+	updatedClusterMonitoringConfigurationYAMLBytes, err := yaml.JSONToYAML(updatedClusterMonitoringConfigurationJSONBytes)
 	if err != nil {
-		log.Error(err, "failed to transform JSON to YAML", "JSON", updatedClusterMonitoringConfigurationJSONBytes)
-		return err
+		return fmt.Errorf("failed to transform JSON to YAML for updated config: %w", err)
 	}
+
+	log.Info("updating configmap", "name", clusterMonitoringConfigName)
 	found.Data[clusterMonitoringConfigDataKey] = string(updatedClusterMonitoringConfigurationYAMLBytes)
-	err = client.Update(ctx, found)
-	if err != nil {
-		log.Error(err, "failed to update configmap", "name", clusterMonitoringConfigName)
-		return err
+	if err := client.Update(ctx, found); err != nil {
+		return fmt.Errorf("failed to update configmap %s: %w", clusterMonitoringConfigName, err)
 	}
-	log.Info("configmap updated", "name", clusterMonitoringConfigName)
-	return nil
-}
-func DeleteHubMonitoringClusterRoleBinding(ctx context.Context, client client.Client) error {
-	rb := &rbacv1.ClusterRoleBinding{}
-	err := client.Get(ctx, types.NamespacedName{Name: clusterRoleBindingName,
-		Namespace: ""}, rb)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			log.Info("clusterrolebinding already deleted")
-			return nil
-		}
-		log.Error(err, "Failed to check the clusterrolebinding")
-		return err
-	}
-	err = client.Delete(ctx, rb)
-	if err != nil {
-		log.Error(err, "Error deleting clusterrolebinding")
-		return err
-	}
-	log.Info("clusterrolebinding deleted")
+
 	return nil
 }
 
@@ -208,18 +143,15 @@ func DeleteHubCAConfigmap(ctx context.Context, client client.Client) error {
 		Namespace: hubMetricsCollectionNamespace}, cm)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			log.Info("configmap already deleted")
 			return nil
 		}
-		log.Error(err, "Failed to check the configmap")
-		return err
+		return fmt.Errorf("failed to check the configmap: %w", err)
 	}
+	log.Info("Deleting configmap")
 	err = client.Delete(ctx, cm)
 	if err != nil {
-		log.Error(err, "Error deleting configmap")
-		return err
+		return fmt.Errorf("failed to delete configmap: %w", err)
 	}
-	log.Info("configmap deleted")
 	return nil
 }
 

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -226,7 +226,7 @@ func generateGlobalManifestResources(c client.Client, mco *mcov1beta2.MultiClust
 	// inject the certificates
 	if managedClusterObsCert == nil {
 		var err error
-		if managedClusterObsCert, err = generateObservabilityServerCACerts(c); err != nil {
+		if managedClusterObsCert, err = generateObservabilityServerCACerts(context.Background(), c); err != nil {
 			return nil, nil, nil, err
 		}
 	}
@@ -861,11 +861,11 @@ func generatePullSecret(c client.Client, name string) (*corev1.Secret, error) {
 	}, nil
 }
 
-// generateObservabilityServerCACerts generates the certificate for managed cluster
-func generateObservabilityServerCACerts(client client.Client) (*corev1.Secret, error) {
+// generateObservabilityServerCACerts extracts the CA cert from the secret holding the observability TLS certs
+// and returns a secret to be deployed on spokes containing it.
+func generateObservabilityServerCACerts(ctx context.Context, client client.Client) (*corev1.Secret, error) {
 	ca := &corev1.Secret{}
-	err := client.Get(context.TODO(), types.NamespacedName{Name: config.ServerCACerts,
-		Namespace: config.GetDefaultNamespace()}, ca)
+	err := client.Get(ctx, types.NamespacedName{Name: config.ServerCACerts, Namespace: config.GetDefaultNamespace()}, ca)
 	if err != nil {
 		return nil, err
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -1013,7 +1013,7 @@ func removeObservabilityAddonInManifestWork(ctx context.Context, client client.C
 	}
 
 	updateManifests := slices.DeleteFunc(slices.Clone(found.Spec.Workload.Manifests), func(e workv1.Manifest) bool {
-		return e.Object.GetObjectKind().GroupVersionKind().Kind == "ObservabilityAddon"
+		return e.Object != nil && e.Object.GetObjectKind().GroupVersionKind().Kind == "ObservabilityAddon"
 	})
 
 	if len(updateManifests) != len(found.Spec.Workload.Manifests) {

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -64,7 +64,6 @@ var (
 	imageListConfigMap            *corev1.ConfigMap
 
 	rawExtensionList []runtime.RawExtension
-	hubManifestCopy  []workv1.Manifest
 )
 
 func deleteManifestWork(c client.Client, name string, namespace string) error {

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -952,7 +952,7 @@ func removeObservabilityAddonInManifestWork(ctx context.Context, client client.C
 	}
 
 	updateManifests := slices.DeleteFunc(slices.Clone(found.Spec.Workload.Manifests), func(e workv1.Manifest) bool {
-		return e.Object != nil && e.Object.GetObjectKind().GroupVersionKind().Kind == "ObservabilityAddon"
+		return e.RawExtension.Object != nil && e.RawExtension.Object.GetObjectKind().GroupVersionKind().Kind == "ObservabilityAddon"
 	})
 
 	if len(updateManifests) != len(found.Spec.Workload.Manifests) {

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -580,6 +580,10 @@ func DeleteHubMetricsCollectionDeployments(ctx context.Context, c client.Client)
 			Name:      config.AlertmanagerAccessorSecretName,
 			Namespace: config.GetDefaultNamespace(),
 		}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{ // cert and key for mTLS connection with hub observability api
+			Name:      operatorconfig.HubMetricsCollectorMtlsCert,
+			Namespace: config.GetDefaultNamespace(),
+		}},
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{ // images list configmap
 			Name:      operatorconfig.ImageConfigMap,
 			Namespace: config.GetDefaultNamespace(),
@@ -613,10 +617,6 @@ func DeleteHubMetricsCollectorResourcesNotNeededForMCOA(ctx context.Context, c c
 		}},
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{ // CA cert for service-serving certificates
 			Name:      operatorconfig.CaConfigmapName,
-			Namespace: config.GetDefaultNamespace(),
-		}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{ // cert and key for mTLS connection with hub observability api (handled by the registration-operator)
-			Name:      operatorconfig.HubMetricsCollectorMtlsCert,
 			Namespace: config.GetDefaultNamespace(),
 		}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{ // hub info secret

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
@@ -347,7 +347,7 @@ func TestManifestWork(t *testing.T) {
 
 	setupTest(t)
 
-	works, crdWork, _, err := generateGlobalManifestResources(c, newTestMCO())
+	works, crdWork, _, err := generateGlobalManifestResources(context.Background(), c, newTestMCO())
 	if err != nil {
 		t.Fatalf("Failed to get global manifestwork resource: (%v)", err)
 	}
@@ -426,7 +426,7 @@ func TestManifestWork(t *testing.T) {
 	}
 	// reset image pull secret
 	pullSecret = nil
-	works, crdWork, _, err = generateGlobalManifestResources(c, newTestMCO())
+	works, crdWork, _, err = generateGlobalManifestResources(context.Background(), c, newTestMCO())
 	if err != nil {
 		t.Fatalf("Failed to get global manifestwork resource: (%v)", err)
 	}
@@ -464,7 +464,7 @@ func TestManifestWork(t *testing.T) {
 	managedClusterImageRegistry[clusterName] = "open-cluster-management.io/image-registry=" + namespace + ".image_registry"
 	managedClusterImageRegistryMutex.Unlock()
 
-	works, crdWork, _, err = generateGlobalManifestResources(c, newTestMCO())
+	works, crdWork, _, err = generateGlobalManifestResources(context.Background(), c, newTestMCO())
 	if err != nil {
 		t.Fatalf("Failed to get global manifestwork resource: (%v)", err)
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
@@ -347,7 +347,7 @@ func TestManifestWork(t *testing.T) {
 
 	setupTest(t)
 
-	works, crdWork, _, err := generateGlobalManifestResources(context.Background(), c, newTestMCO())
+	works, crdWork, err := generateGlobalManifestResources(context.Background(), c, newTestMCO())
 	if err != nil {
 		t.Fatalf("Failed to get global manifestwork resource: (%v)", err)
 	}
@@ -429,7 +429,7 @@ func TestManifestWork(t *testing.T) {
 	}
 	// reset image pull secret
 	pullSecret = nil
-	works, crdWork, _, err = generateGlobalManifestResources(context.Background(), c, newTestMCO())
+	works, crdWork, err = generateGlobalManifestResources(context.Background(), c, newTestMCO())
 	if err != nil {
 		t.Fatalf("Failed to get global manifestwork resource: (%v)", err)
 	}
@@ -473,7 +473,7 @@ func TestManifestWork(t *testing.T) {
 	managedClusterImageRegistry[clusterName] = "open-cluster-management.io/image-registry=" + namespace + ".image_registry"
 	managedClusterImageRegistryMutex.Unlock()
 
-	works, crdWork, _, err = generateGlobalManifestResources(context.Background(), c, newTestMCO())
+	works, crdWork, err = generateGlobalManifestResources(context.Background(), c, newTestMCO())
 	if err != nil {
 		t.Fatalf("Failed to get global manifestwork resource: (%v)", err)
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
@@ -383,7 +383,7 @@ func TestManifestWork(t *testing.T) {
 		},
 	}
 
-	err = createManifestWorks(
+	manWork, err := createManifestWorks(
 		c,
 		namespace,
 		clusterName,
@@ -398,6 +398,9 @@ func TestManifestWork(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("Failed to create manifestworks: (%v)", err)
+	}
+	if err := createManifestwork(c, manWork); err != nil {
+		t.Fatalf("Failed to apply manifestworks: (%v)", err)
 	}
 
 	annotations := endpointMetricsOperatorDeploy.Spec.Template.Annotations
@@ -430,9 +433,12 @@ func TestManifestWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get global manifestwork resource: (%v)", err)
 	}
-	err = createManifestWorks(c, namespace, clusterName, newTestMCO(), works, metricsAllowlistConfigMap, crdWork, endpointMetricsOperatorDeploy, hubInfoSecret, addonConfig, false)
+	manWork, err = createManifestWorks(c, namespace, clusterName, newTestMCO(), works, metricsAllowlistConfigMap, crdWork, endpointMetricsOperatorDeploy, hubInfoSecret, addonConfig, false)
 	if err != nil {
 		t.Fatalf("Failed to create manifestworks: (%v)", err)
+	}
+	if err := createManifestwork(c, manWork); err != nil {
+		t.Fatalf("Failed to apply manifestworks: (%v)", err)
 	}
 	err = c.Get(context.TODO(), types.NamespacedName{Name: workName, Namespace: namespace}, found)
 	if err != nil {
@@ -443,9 +449,12 @@ func TestManifestWork(t *testing.T) {
 	}
 
 	spokeNameSpace = "spoke-ns"
-	err = createManifestWorks(c, namespace, clusterName, newTestMCO(), works, metricsAllowlistConfigMap, crdWork, endpointMetricsOperatorDeploy, hubInfoSecret, addonConfig, false)
+	manWork, err = createManifestWorks(c, namespace, clusterName, newTestMCO(), works, metricsAllowlistConfigMap, crdWork, endpointMetricsOperatorDeploy, hubInfoSecret, addonConfig, false)
 	if err != nil {
 		t.Fatalf("Failed to create manifestworks with updated namespace: (%v)", err)
+	}
+	if err := createManifestwork(c, manWork); err != nil {
+		t.Fatalf("Failed to apply manifestworks: (%v)", err)
 	}
 
 	err = deleteManifestWorks(c, namespace)
@@ -472,9 +481,12 @@ func TestManifestWork(t *testing.T) {
 		t.Fatalf("Failed to generate hubInfo secret: (%v)", err)
 	}
 
-	err = createManifestWorks(c, namespace, clusterName, newTestMCO(), works, metricsAllowlistConfigMap, crdWork, endpointMetricsOperatorDeploy, hubInfoSecret, addonConfig, false)
+	manWork, err = createManifestWorks(c, namespace, clusterName, newTestMCO(), works, metricsAllowlistConfigMap, crdWork, endpointMetricsOperatorDeploy, hubInfoSecret, addonConfig, false)
 	if err != nil {
 		t.Fatalf("Failed to create manifestworks: (%v)", err)
+	}
+	if err := createManifestwork(c, manWork); err != nil {
+		t.Fatalf("Failed to apply manifestworks: (%v)", err)
 	}
 	found = &workv1.ManifestWork{}
 	workName = namespace + workNameSuffix

--- a/operators/multiclusterobservability/controllers/placementrule/obsaddon.go
+++ b/operators/multiclusterobservability/controllers/placementrule/obsaddon.go
@@ -184,13 +184,12 @@ func deleteStaleObsAddon(c client.Client, namespace string, isForce bool) error 
 
 func deleteFinalizer(c client.Client, obsaddon *obsv1beta1.ObservabilityAddon) error {
 	if slices.Contains(obsaddon.GetFinalizers(), obsAddonFinalizer) {
+		log.Info("Deleting observabilityaddon's finalizer", "namespace", obsaddon.Namespace)
 		obsaddon.SetFinalizers(util.Remove(obsaddon.GetFinalizers(), obsAddonFinalizer))
 		err := c.Update(context.TODO(), obsaddon)
 		if err != nil {
-			log.Error(err, "Failed to delete finalizer in observabilityaddon", "namespace", obsaddon.Namespace)
-			return err
+			return fmt.Errorf("failed to delete finalizer in observabilityaddon: %w", err)
 		}
-		log.Info("observabilityaddon's finalizer is deleted", "namespace", obsaddon.Namespace)
 	}
 	return nil
 }

--- a/operators/multiclusterobservability/controllers/placementrule/obsaddon.go
+++ b/operators/multiclusterobservability/controllers/placementrule/obsaddon.go
@@ -57,15 +57,16 @@ func deleteObsAddonObject(ctx context.Context, c client.Client, namespace string
 
 	// is staled, delete finalizer
 	if deletionStalled(found) {
-		log.Info("Deleting observabilityaddon finalizer", "namespace", namespace)
+		log.Info("Deleting stalled observabilityaddon finalizer", "namespace", namespace)
 		if err := deleteFinalizer(c, found); err != nil {
 			return fmt.Errorf("failed to delete observabilityaddon %s/%s finalizer: %w", namespace, obsAddonName, err)
 		}
+		return nil
 	}
 
 	log.Info("Deleting observabilityaddon", "namespace", namespace)
 	if err := c.Delete(ctx, found); err != nil {
-		log.Error(err, "Failed to delete observabilityaddon", "namespace", namespace)
+		return fmt.Errorf("failed to delete observabilityaddon %s/%s: %w", namespace, obsAddonName, err)
 	}
 
 	return nil

--- a/operators/multiclusterobservability/controllers/placementrule/obsaddon.go
+++ b/operators/multiclusterobservability/controllers/placementrule/obsaddon.go
@@ -143,7 +143,6 @@ func createObsAddon(mco *mcov1beta2.MultiClusterObservability, c client.Client, 
 func deletionStalled(obj client.Object) bool {
 	delTs := obj.GetDeletionTimestamp()
 	if delTs == nil {
-		// Not in Terminating state at all
 		return false
 	}
 

--- a/operators/multiclusterobservability/controllers/placementrule/obsaddon_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/obsaddon_test.go
@@ -7,10 +7,12 @@ package placementrule
 import (
 	"context"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -90,29 +92,30 @@ func TestObsAddonCR(t *testing.T) {
 func TestStaleObsAddonCR(t *testing.T) {
 	initSchema(t)
 
-	objs := []runtime.Object{newTestObsApiRoute()}
-	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
-
-	err := createObsAddon(&mcov1beta2.MultiClusterObservability{}, c, namespace)
-	if err != nil {
-		t.Fatalf("Failed to create observabilityaddon: (%v)", err)
+	deletetionTime := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+	addon := &mcov1beta1.ObservabilityAddon{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              obsAddonName,
+			Namespace:         namespace,
+			DeletionTimestamp: &deletetionTime,
+			Finalizers:        []string{obsAddonFinalizer},
+		},
 	}
-	found := &mcov1beta1.ObservabilityAddon{}
-	err = c.Get(context.TODO(), types.NamespacedName{Name: obsAddonName, Namespace: namespace}, found)
-	if err != nil {
-		t.Fatalf("Failed to get observabilityaddon: (%v)", err)
-	}
+	c := fake.NewClientBuilder().WithRuntimeObjects(addon).Build()
 
-	found.SetFinalizers([]string{obsAddonFinalizer})
-	err = c.Update(context.TODO(), found)
-	if err != nil {
-		t.Fatalf("Failed to update observabilityaddon: (%v)", err)
-	}
-
-	err = deleteStaleObsAddon(c, namespace, true)
-	if err != nil {
+	if err := deleteObsAddonObject(context.Background(), c, namespace); err != nil {
 		t.Fatalf("Failed to remove stale observabilityaddon: (%v)", err)
 	}
+
+	found := &mcov1beta1.ObservabilityAddon{}
+	err := c.Get(context.TODO(), types.NamespacedName{Name: obsAddonName, Namespace: namespace}, found)
+	if err == nil {
+		t.Fatalf("Failed to delete observabilityaddon, still present")
+	}
+	if err != nil && !k8serrors.IsNotFound(err) {
+		t.Fatalf("Failed to delete observabilityaddon: %v", err)
+	}
+
 }
 
 func TestSetObservabilityAddonSpec(t *testing.T) {

--- a/operators/multiclusterobservability/controllers/placementrule/obsaddon_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/obsaddon_test.go
@@ -67,7 +67,7 @@ func TestObsAddonCR(t *testing.T) {
 		t.Fatalf("Failed to create manifestwork: (%v)", err)
 	}
 
-	err = deleteObsAddon(c, namespace)
+	err = deleteObsAddon(context.Background(), c, namespace)
 	if err != nil {
 		t.Fatalf("Failed to delete observabilityaddon: (%v)", err)
 	}
@@ -76,7 +76,7 @@ func TestObsAddonCR(t *testing.T) {
 		t.Fatalf("Failed to delete observabilityaddon: (%v)", err)
 	}
 
-	err = deleteObsAddon(c, namespace)
+	err = deleteObsAddon(context.Background(), c, namespace)
 	if err != nil {
 		t.Fatalf("Failed to delete observabilityaddon: (%v)", err)
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -326,7 +326,7 @@ func (r *PlacementRuleReconciler) cleanSpokesAddonResources(ctx context.Context)
 	}
 
 	if len(workList.Items) == 0 {
-		if err := deleteGlobalResource(r.Client); err != nil {
+		if err := deleteGlobalResource(ctx, r.Client); err != nil {
 			return fmt.Errorf("failed to delete global resources: %w", err)
 		}
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -148,30 +148,21 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 		// Don't return right away from here because the above cleanup is not complete and it requires
 		// call to cleanOrphanResources for manifest works
-		if err := r.cleanOrphanResources(ctx, req); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to clean orphaned resources: %w", err)
+	} else {
+		if err := createAllRelatedRes(
+			ctx,
+			r.Client,
+			req,
+			mco,
+			obsAddonList,
+			r.CRDMap,
+		); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to create all related resources: %w", err)
 		}
-
-		return ctrl.Result{}, nil
-	}
-
-	if err := deleteObsAddon(ctx, r.Client, localClusterName); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to delete observabilityaddon: %w", err)
-	}
-
-	if err := createAllRelatedRes(
-		ctx,
-		r.Client,
-		req,
-		mco,
-		obsAddonList,
-		r.CRDMap,
-	); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to create all related resources: %w", err)
 	}
 
 	// This cleanup must be kept at the end of the reconcile as createAllRelatedRes can remove some observabilityAddon
-	// resources that trigger then some cleanup here.
+	// resources that trigger then some cleanup here. Same for cleanResources that leaves resources behind.
 	if err := r.cleanOrphanResources(ctx, req); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to clean orphaned resources: %w", err)
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -361,7 +361,7 @@ func createAllRelatedRes(
 		return fmt.Errorf("failed to load templates: %w", err)
 	}
 
-	works, crdv1Work, _, err := generateGlobalManifestResources(ctx, c, mco)
+	works, crdv1Work, err := generateGlobalManifestResources(ctx, c, mco)
 	if err != nil {
 		return err
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -133,7 +133,7 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// When MCOA is enabled, additionnally clean the hub resources as they are deployed wihtout the addon resource,
 	// and thus are not removed by the cleanResources function.
 	if mcoaForMetricsIsEnabled(mco) {
-		reqLogger.Info("Deleting hub resources not needed for MCOA")
+		reqLogger.Info("Ensuring MCOA resources on the hub")
 		if err := r.ensureMCAOResources(ctx, mco); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to ensure MCOA resources: %w", err)
 		}

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -598,17 +598,17 @@ func deleteAllObsAddons(
 	return nil
 }
 
-func deleteGlobalResource(c client.Client) error {
-	err := deleteClusterRole(c)
+func deleteGlobalResource(ctx context.Context, c client.Client) error {
+	err := deleteClusterRole(ctx, c)
 	if err != nil {
 		return err
 	}
-	err = deleteResourceRole(c)
+	err = deleteResourceRole(ctx, c)
 	if err != nil {
 		return err
 	}
 	// delete ClusterManagementAddon
-	err = util.DeleteClusterManagementAddon(c)
+	err = util.DeleteClusterManagementAddon(ctx, c)
 	if err != nil {
 		return err
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -426,10 +426,6 @@ func createAllRelatedRes(
 				failedCreateManagedClusterRes = true
 				log.Error(err, "Failed to create managedcluster resources", "namespace", managedCluster)
 			}
-			if request.Namespace == managedCluster {
-				// Kept to avoid modifying processing, but why breaking??
-				break
-			}
 		}
 	}
 

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -134,7 +134,7 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// and thus are not removed by the cleanResources function.
 	if mcoaForMetricsIsEnabled(mco) {
 		reqLogger.Info("Ensuring MCOA resources on the hub")
-		if err := r.ensureMCAOResources(ctx, mco); err != nil {
+		if err := r.ensureMCOAResources(ctx, mco); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to ensure MCOA resources: %w", err)
 		}
 		if err := DeleteHubMetricsCollectorResourcesNotNeededForMCOA(ctx, r.Client); err != nil {
@@ -334,13 +334,13 @@ func (r *PlacementRuleReconciler) cleanSpokesAddonResources(ctx context.Context)
 	return nil
 }
 
-// ensureMCAOResources reconciliates resources needed for MCOA (both hub and spoke).
+// ensureMCOAResources reconciliates resources needed for MCOA (both hub and spoke).
 // This includes:
 // - The hub server CA cert to trust when sending metrics
 // - The Hub AlertManager Token to forward alerts from the spoke cluster's Prometheus
 // - The image list configMap
 // - the mTLS key and cert for sending metrics to the hub
-func (r *PlacementRuleReconciler) ensureMCAOResources(ctx context.Context, mco *mcov1beta2.MultiClusterObservability) error {
+func (r *PlacementRuleReconciler) ensureMCOAResources(ctx context.Context, mco *mcov1beta2.MultiClusterObservability) error {
 	resourcesToCreate := []client.Object{}
 	hubServerCaCertSecret, err := generateObservabilityServerCACerts(ctx, r.Client)
 	if err != nil {

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -347,7 +347,9 @@ func (r *PlacementRuleReconciler) ensureMCAOResources(ctx context.Context, mco *
 		return fmt.Errorf("failed to generate observability server ca certs: %w", err)
 	}
 	hubServerCaCertSecret.SetNamespace(config.GetDefaultNamespace())
-	controllerutil.SetControllerReference(mco, hubServerCaCertSecret, r.Client.Scheme())
+	if err := controllerutil.SetControllerReference(mco, hubServerCaCertSecret, r.Client.Scheme()); err != nil {
+		return fmt.Errorf("failed to set controller reference: %w", err)
+	}
 	resourcesToCreate = append(resourcesToCreate, hubServerCaCertSecret)
 
 	amAccessorTokenSecret, err := generateAmAccessorTokenSecret(r.Client)
@@ -355,7 +357,9 @@ func (r *PlacementRuleReconciler) ensureMCAOResources(ctx context.Context, mco *
 		return fmt.Errorf("failed to generate alertManager token secret: %w", err)
 	}
 	hubServerCaCertSecret.SetNamespace(config.GetDefaultNamespace())
-	controllerutil.SetControllerReference(mco, hubServerCaCertSecret, r.Client.Scheme())
+	if err := controllerutil.SetControllerReference(mco, hubServerCaCertSecret, r.Client.Scheme()); err != nil {
+		return fmt.Errorf("failed to set controller reference: %w", err)
+	}
 	resourcesToCreate = append(resourcesToCreate, amAccessorTokenSecret)
 
 	imageListCm, err := generateImageListConfigMap(mco)
@@ -363,7 +367,9 @@ func (r *PlacementRuleReconciler) ensureMCAOResources(ctx context.Context, mco *
 		return fmt.Errorf("failed to generate image list configmap: %w", err)
 	}
 	imageListCm.SetNamespace(config.GetDefaultNamespace())
-	controllerutil.SetControllerReference(mco, imageListCm, r.Client.Scheme())
+	if err := controllerutil.SetControllerReference(mco, imageListCm, r.Client.Scheme()); err != nil {
+		return fmt.Errorf("failed to set controller reference: %w", err)
+	}
 	resourcesToCreate = append(resourcesToCreate, imageListCm)
 
 	for _, obj := range resourcesToCreate {

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -145,13 +145,14 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if !deleteAll {
 		if !mco.Spec.ObservabilityAddonSpec.EnableMetrics {
 			reqLogger.Info("EnableMetrics is set to false. Delete Observability addons")
+			deleteAll = true
 		}
 
 		if mcoaForMetricsIsEnabled(mco) {
 			reqLogger.Info("MCOA for metrics is enabled. Deleting standard Observability addon")
+			deleteAll = true
 		}
 
-		deleteAll = true
 	}
 
 	// check if the MCH CRD exists

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -243,6 +243,12 @@ func (r *PlacementRuleReconciler) cleanOrphanResources(ctx context.Context, req 
 
 	namespacesWithResources := map[string]struct{}{}
 	for _, work := range workList.Items {
+		if work.Name != work.Namespace+workNameSuffix {
+			log.Info("Deleting ManifestWork with invalid name", "namespace", work.Namespace, "name", work.Name)
+			if err := deleteManifestWork(r.Client, work.Name, work.Namespace); err != nil {
+				return fmt.Errorf("failed to delete invalid ManifestWork: %w", err)
+			}
+		}
 		namespacesWithResources[work.GetNamespace()] = struct{}{}
 	}
 

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -141,7 +141,7 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// When MCOA is enabled, additionnally clean the hub resources as they are deployed wihtout the addon resource,
 	// and thus are not removed by the cleanResources function.
 	if mcoaForMetricsIsEnabled(mco) {
-		if err := DeleteHubMetricsCollectionDeployments(r.Client); err != nil {
+		if err := DeleteHubMetricsCollectorResourcesForMCOA(ctx, r.Client); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to delete hub metrics collection resources: %w", err)
 		}
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -356,8 +356,8 @@ func (r *PlacementRuleReconciler) ensureMCAOResources(ctx context.Context, mco *
 	if err != nil {
 		return fmt.Errorf("failed to generate alertManager token secret: %w", err)
 	}
-	hubServerCaCertSecret.SetNamespace(config.GetDefaultNamespace())
-	if err := controllerutil.SetControllerReference(mco, hubServerCaCertSecret, r.Client.Scheme()); err != nil {
+	amAccessorTokenSecret.SetNamespace(config.GetDefaultNamespace())
+	if err := controllerutil.SetControllerReference(mco, amAccessorTokenSecret, r.Client.Scheme()); err != nil {
 		return fmt.Errorf("failed to set controller reference: %w", err)
 	}
 	resourcesToCreate = append(resourcesToCreate, amAccessorTokenSecret)

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -260,7 +260,7 @@ func (r *PlacementRuleReconciler) cleanOrphanResources(ctx context.Context, req 
 	}
 
 	// Delete orphen resources in namespaces with no observability addon
-	for ns, _ := range namespacesWithResources {
+	for ns := range namespacesWithResources {
 		if _, ok := currentAddonNamespaces[ns]; ok {
 			continue
 		}

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
@@ -19,7 +19,6 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -159,17 +158,8 @@ func TestObservabilityAddonController(t *testing.T) {
 	config.SetMonitoringCRName(mcoName)
 	mco := newTestMCO()
 	pull := newTestPullSecret()
-	deprecatedRole := &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "endpoint-observability-role",
-			Namespace: namespace,
-			Labels: map[string]string{
-				ownerLabelKey: ownerLabelValue,
-			},
-		},
-	}
 	objs := []runtime.Object{mco, pull, newConsoleRoute(), newTestObsApiRoute(), newTestAlertmanagerRoute(), newTestIngressController(), newTestRouteCASecret(), newCASecret(), newCertSecret(mcoNamespace), NewMetricsAllowListCM(),
-		NewAmAccessorSA(), NewAmAccessorTokenSecret(), deprecatedRole, newClusterMgmtAddon(),
+		NewAmAccessorSA(), NewAmAccessorTokenSecret(), newClusterMgmtAddon(),
 		newAddonDeploymentConfig(defaultAddonConfigName, namespace), newAddonDeploymentConfig(addonConfigName, namespace)}
 	c := fake.
 		NewClientBuilder().
@@ -206,11 +196,6 @@ func TestObservabilityAddonController(t *testing.T) {
 	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace2 + workNameSuffix, Namespace: namespace2}, found)
 	if err != nil {
 		t.Fatalf("Failed to get manifestwork for %s: (%v)", namespace2, err)
-	}
-	foundRole := &rbacv1.Role{}
-	err = c.Get(context.TODO(), types.NamespacedName{Name: "endpoint-observability-role", Namespace: namespace}, foundRole)
-	if err == nil || !errors.IsNotFound(err) {
-		t.Fatalf("Deprecated role not removed")
 	}
 
 	managedClusterList.Range(func(key, value interface{}) bool {

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
@@ -28,7 +28,7 @@ func getClusterPreds() predicate.Funcs {
 			return false
 		}
 		updateManagedClusterImageRegistry(e.Object)
-		return !areManagedClusterLabelsReady(e.Object)
+		return areManagedClusterLabelsReady(e.Object)
 	}
 
 	updateFunc := func(e event.UpdateEvent) bool {

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
@@ -31,11 +31,6 @@ func getClusterPreds() predicate.Funcs {
 		if !areManagedClusterLabelsReady(e.Object) {
 			return false
 		}
-		//ACM 8509: Special case for local-cluster, we deploy endpoint and metrics collector in the hub
-		//whether hubSelfManagement is enabled or not
-		if e.Object.GetName() != localClusterName {
-			updateManagedClusterList(e.Object)
-		}
 
 		return true
 	}
@@ -52,7 +47,6 @@ func getClusterPreds() predicate.Funcs {
 
 		if e.ObjectNew.GetDeletionTimestamp() != nil {
 			log.Info("managedcluster is in terminating state", "managedCluster", e.ObjectNew.GetName())
-			managedClusterList.Delete(e.ObjectNew.GetName())
 			managedClusterImageRegistryMutex.Lock()
 			delete(managedClusterImageRegistry, e.ObjectNew.GetName())
 			managedClusterImageRegistryMutex.Unlock()
@@ -61,12 +55,6 @@ func getClusterPreds() predicate.Funcs {
 			if !areManagedClusterLabelsReady(e.ObjectNew) {
 				return false
 			}
-			//ACM 8509: Special case for local-cluster, we deploy endpoint and metrics collector in the hub
-			//whether hubSelfManagement is enabled or not
-			if e.ObjectNew.GetName() != localClusterName {
-				updateManagedClusterList(e.ObjectNew)
-			}
-
 		}
 
 		return true
@@ -79,11 +67,6 @@ func getClusterPreds() predicate.Funcs {
 			return false
 		}
 
-		//ACM 8509: Special case for local-cluster, we deploy endpoint and metrics collector in the hub
-		//whether hubSelfManagement is enabled or not
-		if e.Object.GetName() != localClusterName {
-			managedClusterList.Delete(e.Object.GetName())
-		}
 		managedClusterImageRegistryMutex.Lock()
 		delete(managedClusterImageRegistry, e.Object.GetName())
 		managedClusterImageRegistryMutex.Unlock()

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
@@ -32,8 +32,6 @@ func getClusterPreds() predicate.Funcs {
 	}
 
 	updateFunc := func(e event.UpdateEvent) bool {
-		log.Info("UpdateFunc", "managedCluster", e.ObjectNew.GetName())
-
 		if e.ObjectNew.GetResourceVersion() == e.ObjectOld.GetResourceVersion() {
 			return false
 		}

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
@@ -28,11 +28,7 @@ func getClusterPreds() predicate.Funcs {
 			return false
 		}
 		updateManagedClusterImageRegistry(e.Object)
-		if !areManagedClusterLabelsReady(e.Object) {
-			return false
-		}
-
-		return true
+		return !areManagedClusterLabelsReady(e.Object)
 	}
 
 	updateFunc := func(e event.UpdateEvent) bool {

--- a/operators/multiclusterobservability/controllers/placementrule/role.go
+++ b/operators/multiclusterobservability/controllers/placementrule/role.go
@@ -335,11 +335,14 @@ func deleteRolebindings(c client.Client, namespace string) error {
 		},
 	}
 	err := c.Delete(context.TODO(), crb)
-	if err != nil && !errors.IsNotFound(err) {
-		log.Error(err, "Failed to delete clusterrolebinding", "name", namespace+"-"+resRoleBindingName)
-		return err
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			log.Error(err, "Failed to delete clusterrolebinding", "name", namespace+"-"+resRoleBindingName)
+			return err
+		}
+
+		log.Info("Clusterrolebinding deleted", "name", namespace+"-"+resRoleBindingName)
 	}
-	log.Info("Clusterrolebinding deleted", "name", namespace+"-"+resRoleBindingName)
 
 	rb := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -348,11 +351,13 @@ func deleteRolebindings(c client.Client, namespace string) error {
 		},
 	}
 	err = c.Delete(context.TODO(), rb)
-	if err != nil && !errors.IsNotFound(err) {
-		log.Error(err, "Failed to delete rolebinding", "name", resRoleBindingName, "namespace", namespace)
-		return err
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			log.Error(err, "Failed to delete rolebinding", "name", resRoleBindingName, "namespace", namespace)
+			return err
+		}
+		log.Info("Rolebinding deleted", "name", resRoleBindingName, "namespace", namespace)
 	}
-	log.Info("Rolebinding deleted", "name", resRoleBindingName, "namespace", namespace)
 
 	return nil
 }

--- a/operators/multiclusterobservability/controllers/placementrule/role.go
+++ b/operators/multiclusterobservability/controllers/placementrule/role.go
@@ -340,7 +340,7 @@ func deleteRolebindings(c client.Client, namespace string) error {
 			log.Error(err, "Failed to delete clusterrolebinding", "name", namespace+"-"+resRoleBindingName)
 			return err
 		}
-
+	} else {
 		log.Info("Clusterrolebinding deleted", "name", namespace+"-"+resRoleBindingName)
 	}
 
@@ -356,6 +356,7 @@ func deleteRolebindings(c client.Client, namespace string) error {
 			log.Error(err, "Failed to delete rolebinding", "name", resRoleBindingName, "namespace", namespace)
 			return err
 		}
+	} else {
 		log.Info("Rolebinding deleted", "name", resRoleBindingName, "namespace", namespace)
 	}
 

--- a/operators/multiclusterobservability/controllers/placementrule/role.go
+++ b/operators/multiclusterobservability/controllers/placementrule/role.go
@@ -29,7 +29,8 @@ const (
 	epStatusRsName     = "observabilityaddons/status"
 )
 
-func createClusterRole(ctx context.Context, c client.Client) error {
+// createReadMCOClusterRole creates a role with read permissions on the MCO resource
+func createReadMCOClusterRole(ctx context.Context, c client.Client) error {
 	role := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: mcoRoleName,
@@ -80,7 +81,7 @@ func createClusterRole(ctx context.Context, c client.Client) error {
 	return nil
 }
 
-func createClusterRoleBinding(c client.Client, namespace string, name string) error {
+func createReadMCOClusterRoleBinding(c client.Client, namespace string, name string) error {
 	rb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace + "-" + mcoRoleBindingName,
@@ -128,11 +129,6 @@ func createClusterRoleBinding(c client.Client, namespace string, name string) er
 		return nil
 	}
 
-	log.Info(
-		"clusterrolebinding endpoint-observability-mco-rolebinding already existed/unchanged",
-		"namespace",
-		namespace,
-	)
 	return nil
 }
 
@@ -364,7 +360,7 @@ func deleteRolebindings(c client.Client, namespace string) error {
 }
 
 func createRolebindings(c client.Client, namespace string, name string) error {
-	err := createClusterRoleBinding(c, namespace, name)
+	err := createReadMCOClusterRoleBinding(c, namespace, name)
 	if err != nil {
 		return err
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/role.go
+++ b/operators/multiclusterobservability/controllers/placementrule/role.go
@@ -294,32 +294,38 @@ func createResourceRoleBinding(c client.Client, namespace string, name string) e
 	return nil
 }
 
-func deleteClusterRole(c client.Client) error {
+func deleteClusterRole(ctx context.Context, c client.Client) error {
 	clusterrole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: mcoRoleName,
 		},
 	}
-	err := c.Delete(context.TODO(), clusterrole)
-	if err != nil && !errors.IsNotFound(err) {
-		log.Error(err, "Failed to delete clusterrole", "name", mcoRoleName)
-		return err
+	err := c.Delete(ctx, clusterrole)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete clusterrole %s: %w", clusterrole.Name, err)
 	}
+
 	log.Info("Clusterrole deleted", "name", mcoRoleName)
 	return nil
 }
 
-func deleteResourceRole(c client.Client) error {
+func deleteResourceRole(ctx context.Context, c client.Client) error {
 	role := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: resRoleName,
 		},
 	}
-	err := c.Delete(context.TODO(), role)
-	if err != nil && !errors.IsNotFound(err) {
-		log.Error(err, "Failed to delete clusterrole", "name", resRoleName)
-		return err
+	err := c.Delete(ctx, role)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete clusterrole %s: %w", role.Name, err)
 	}
+
 	log.Info("Role deleted", "name", resRoleName)
 	return nil
 }

--- a/operators/multiclusterobservability/controllers/placementrule/role.go
+++ b/operators/multiclusterobservability/controllers/placementrule/role.go
@@ -12,7 +12,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -30,8 +29,7 @@ const (
 	epStatusRsName     = "observabilityaddons/status"
 )
 
-func createClusterRole(c client.Client) error {
-
+func createClusterRole(ctx context.Context, c client.Client) error {
 	role := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: mcoRoleName,
@@ -57,32 +55,28 @@ func createClusterRole(c client.Client) error {
 	}
 
 	found := &rbacv1.ClusterRole{}
-	err := c.Get(context.TODO(), types.NamespacedName{Name: mcoRoleName}, found)
+	err := c.Get(ctx, types.NamespacedName{Name: mcoRoleName}, found)
 	if err != nil && errors.IsNotFound(err) {
 		log.Info("Creating mco clusterRole")
-		err = c.Create(context.TODO(), role)
+		err = c.Create(ctx, role)
 		if err != nil {
-			log.Error(err, "Failed to create endpoint-observability-mco-role clusterRole")
-			return err
+			return fmt.Errorf("failed to create endpoint-observability-mco-role clusterRole: %w", err)
 		}
 		return nil
 	} else if err != nil {
-		log.Error(err, "Failed to check endpoint-observability-mco-role clusterRole")
-		return err
+		return fmt.Errorf("failed to check endpoint-observability-mco-role clusterRole: %w", err)
 	}
 
 	if !reflect.DeepEqual(found.Rules, role.Rules) {
 		log.Info("Updating endpoint-observability-mco-role clusterRole")
 		role.ObjectMeta.ResourceVersion = found.ObjectMeta.ResourceVersion
-		err = c.Update(context.TODO(), role)
+		err = c.Update(ctx, role)
 		if err != nil {
-			log.Error(err, "Failed to update endpoint-observability-mco-role clusterRole")
-			return err
+			return fmt.Errorf("failed to update endpoint-observability-mco-role clusterRole: %w", err)
 		}
 		return nil
 	}
 
-	log.Info("clusterrole endpoint-observability-mco-role already existed/unchanged")
 	return nil
 }
 
@@ -142,9 +136,7 @@ func createClusterRoleBinding(c client.Client, namespace string, name string) er
 	return nil
 }
 
-func createResourceRole(c client.Client) error {
-
-	deleteDeprecatedRoles(c)
+func createResourceRole(ctx context.Context, c client.Client) error {
 	role := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: resRoleName,
@@ -220,32 +212,27 @@ func createResourceRole(c client.Client) error {
 	}
 
 	found := &rbacv1.ClusterRole{}
-	err := c.Get(context.TODO(), types.NamespacedName{Name: resRoleName}, found)
+	err := c.Get(ctx, types.NamespacedName{Name: resRoleName}, found)
 	if err != nil && errors.IsNotFound(err) {
 		log.Info("Creating endpoint-observability-res-role clusterrole")
-		err = c.Create(context.TODO(), role)
-		if err != nil {
-			log.Error(err, "Failed to create endpoint-observability-res-role clusterrole")
-			return err
+		if err := c.Create(ctx, role); err != nil {
+			return fmt.Errorf("failed to create endpoint-observability-res-role clusterrole: %w", err)
 		}
 		return nil
 	} else if err != nil {
-		log.Error(err, "Failed to check endpoint-observability-res-role clusterrole")
-		return err
+		return fmt.Errorf("failed to check endpoint-observability-res-role clusterrole: %w", err)
 	}
 
 	if !reflect.DeepEqual(found.Rules, role.Rules) {
 		log.Info("Updating endpoint-observability-res-role clusterrole")
 		role.ObjectMeta.ResourceVersion = found.ObjectMeta.ResourceVersion
-		err = c.Update(context.TODO(), role)
-		if err != nil {
+		if err := c.Update(ctx, role); err != nil {
 			log.Error(err, "Failed to update endpoint-observability-res-role clusterrole")
 			return err
 		}
 		return nil
 	}
 
-	log.Info("clusterrole endpoint-observability-res-role already existed/unchanged")
 	return nil
 }
 
@@ -368,30 +355,6 @@ func deleteRolebindings(c client.Client, namespace string) error {
 	log.Info("Rolebinding deleted", "name", resRoleBindingName, "namespace", namespace)
 
 	return nil
-}
-
-// function to remove the deprecated roles
-func deleteDeprecatedRoles(c client.Client) {
-	opts := &client.ListOptions{
-		LabelSelector: labels.SelectorFromSet(map[string]string{ownerLabelKey: ownerLabelValue}),
-	}
-	roleList := &rbacv1.RoleList{}
-	err := c.List(context.TODO(), roleList, opts)
-	if err != nil {
-		log.Error(err, "Failed to list deprecated roles")
-		return
-	}
-	for idx := range roleList.Items {
-		role := roleList.Items[idx]
-		if role.Name == "endpoint-observability-role" {
-			err = c.Delete(context.TODO(), &role)
-			if err != nil && !errors.IsNotFound(err) {
-				log.Error(err, "Failed to delete deprecated roles", "name", role.Name, "namespace", role.Namespace)
-			} else {
-				log.Info("Deprecated role deleted", "name", role.Name, "namespace", role.Namespace)
-			}
-		}
-	}
 }
 
 func createRolebindings(c client.Client, namespace string, name string) error {

--- a/operators/multiclusterobservability/controllers/placementrule/role_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/role_test.go
@@ -62,7 +62,7 @@ func TestCreateClusterRole(t *testing.T) {
 	}
 	objs := []runtime.Object{role}
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
-	err := createClusterRole(context.Background(), c)
+	err := createReadMCOClusterRole(context.Background(), c)
 	if err != nil {
 		t.Fatalf("createRole: (%v)", err)
 	}
@@ -99,7 +99,7 @@ func TestCreateClusterRoleBinding(t *testing.T) {
 	}
 	objs := []runtime.Object{rb}
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
-	err := createClusterRoleBinding(c, namespace, namespace)
+	err := createReadMCOClusterRoleBinding(c, namespace, namespace)
 	if err != nil {
 		t.Fatalf("createRoleBinding: (%v)", err)
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/role_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/role_test.go
@@ -62,7 +62,7 @@ func TestCreateClusterRole(t *testing.T) {
 	}
 	objs := []runtime.Object{role}
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
-	err := createClusterRole(c)
+	err := createClusterRole(context.Background(), c)
 	if err != nil {
 		t.Fatalf("createRole: (%v)", err)
 	}
@@ -116,7 +116,7 @@ func TestCreateClusterRoleBinding(t *testing.T) {
 
 func TestCreateRole(t *testing.T) {
 	c := fake.NewClientBuilder().Build()
-	err := createResourceRole(c)
+	err := createResourceRole(context.Background(), c)
 	if err != nil {
 		t.Fatalf("createRole: (%v)", err)
 	}
@@ -156,7 +156,7 @@ func TestCreateRole(t *testing.T) {
 	}
 	objs := []runtime.Object{role}
 	c = fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
-	err = createResourceRole(c)
+	err = createResourceRole(context.Background(), c)
 	if err != nil {
 		t.Fatalf("createRole: (%v)", err)
 	}

--- a/operators/multiclusterobservability/pkg/certificates/cert_agent.go
+++ b/operators/multiclusterobservability/pkg/certificates/cert_agent.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 
+	certificatesv1 "k8s.io/api/certificates/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,6 +34,13 @@ func (o *ObservabilityAgent) Manifests(
 }
 
 func (o *ObservabilityAgent) GetAgentAddonOptions() agent.AgentAddonOptions {
+	signAdaptor := func(csr *certificatesv1.CertificateSigningRequest) []byte {
+		res, err := Sign(csr)
+		if err != nil {
+			log.Error(err, "failed to sign")
+		}
+		return res
+	}
 	return agent.AgentAddonOptions{
 		AddonName: addonName,
 		Registration: &agent.RegistrationOption{
@@ -41,7 +49,7 @@ func (o *ObservabilityAgent) GetAgentAddonOptions() agent.AgentAddonOptions {
 			PermissionConfig: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) error {
 				return nil
 			},
-			CSRSign: Sign,
+			CSRSign: signAdaptor,
 		},
 	}
 }

--- a/operators/multiclusterobservability/pkg/certificates/certificates.go
+++ b/operators/multiclusterobservability/pkg/certificates/certificates.go
@@ -557,7 +557,7 @@ func CreateUpdateMtlsCertSecretForHubCollector(ctx context.Context, c client.Cli
 
 		isSignedByCA, err := childCertIsSignedByCA(caSecret.Data["tls.crt"], hubMtlsCert)
 		if err != nil {
-			return fmt.Errorf("failed to check if the mtls cert is signed by the current CA: %w", err)
+			return fmt.Errorf("failed to check if the mtls cert %q is signed by the current CA %q: %w", hubMtlsSecret.Name, caSecret.Name, err)
 		}
 		if !isSignedByCA {
 			updateReason = "mTLS cert is not signed by current CA"
@@ -643,7 +643,8 @@ func childCertIsSignedByCA(caPemCert, childPemCert []byte) (bool, error) {
 
 	// Check child is signed by CA
 	_, err = childCerts[0].Verify(x509.VerifyOptions{
-		Roots: caCertPool,
+		Roots:     caCertPool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	})
 	if err != nil {
 		return false, fmt.Errorf("child certificate verification against the CA certificate failed: %w", err)

--- a/operators/multiclusterobservability/pkg/certificates/certificates.go
+++ b/operators/multiclusterobservability/pkg/certificates/certificates.go
@@ -577,7 +577,7 @@ func CreateUpdateMtlsCertSecretForHubCollector(ctx context.Context, c client.Cli
 		return fmt.Errorf("failed to create or update HubMtlsSecret: %w", err)
 	}
 	if res != controllerutil.OperationResultNone {
-		log.Info("updated succesfully HubMtlsSecret", "name", hubMtlsSecret.Name, "updateReason", updateReason)
+		log.Info("updated successfully HubMtlsSecret", "name", hubMtlsSecret.Name, "updateReason", updateReason)
 	}
 
 	return nil

--- a/operators/multiclusterobservability/pkg/certificates/signer_test.go
+++ b/operators/multiclusterobservability/pkg/certificates/signer_test.go
@@ -44,7 +44,11 @@ func TestSign(t *testing.T) {
 		},
 	}
 
-	if Sign(csr) == nil {
-		t.Fatal("Failed to sign CSR")
+	res, err := Sign(csr)
+	if err != nil {
+		t.Fatal("Failed to sign CSR", err)
+	}
+	if res == nil {
+		t.Fatal("Failed to sign CSR, nil result")
 	}
 }

--- a/operators/multiclusterobservability/pkg/util/clustermanagementaddon.go
+++ b/operators/multiclusterobservability/pkg/util/clustermanagementaddon.go
@@ -73,17 +73,20 @@ func CreateClusterManagementAddon(ctx context.Context, c client.Client) (
 	return found, nil
 }
 
-func DeleteClusterManagementAddon(client client.Client) error {
+func DeleteClusterManagementAddon(ctx context.Context, client client.Client) error {
 	clustermanagementaddon := &addonv1alpha1.ClusterManagementAddOn{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ObservabilityController,
 		},
 	}
-	err := client.Delete(context.TODO(), clustermanagementaddon)
-	if err != nil && !errors.IsNotFound(err) {
-		log.Error(err, "Failed to delete clustermanagementaddon", "name", ObservabilityController)
-		return err
+	err := client.Delete(ctx, clustermanagementaddon)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete clustermanagementaddon %s: %w", clustermanagementaddon.Name, err)
 	}
+
 	log.Info("ClusterManagementAddon deleted", "name", ObservabilityController)
 	return nil
 }

--- a/operators/multiclusterobservability/pkg/util/clustermanagementaddon_test.go
+++ b/operators/multiclusterobservability/pkg/util/clustermanagementaddon_test.go
@@ -35,11 +35,11 @@ func TestClusterManagmentAddon(t *testing.T) {
 	}
 
 	c := fake.NewClientBuilder().WithRuntimeObjects(consoleRoute).Build()
-	_, err := CreateClusterManagementAddon(c)
+	_, err := CreateClusterManagementAddon(context.Background(), c)
 	if err != nil {
 		t.Fatalf("Failed to create clustermanagementaddon: (%v)", err)
 	}
-	_, err = CreateClusterManagementAddon(c)
+	_, err = CreateClusterManagementAddon(context.Background(), c)
 	if err != nil {
 		t.Fatalf("Failed to create clustermanagementaddon twice: (%v)", err)
 	}
@@ -99,7 +99,7 @@ func TestClusterManagmentAddon(t *testing.T) {
 		t.Fatalf("Failed to create clustermanagementaddon: (%v)", err)
 	}
 
-	_, err = CreateClusterManagementAddon(c)
+	_, err = CreateClusterManagementAddon(context.Background(), c)
 	if err != nil {
 		t.Fatalf("Failed to create clustermanagementaddon: (%v)", err)
 	}

--- a/operators/multiclusterobservability/pkg/util/clustermanagementaddon_test.go
+++ b/operators/multiclusterobservability/pkg/util/clustermanagementaddon_test.go
@@ -72,7 +72,7 @@ func TestClusterManagmentAddon(t *testing.T) {
 		}
 	}
 
-	err = DeleteClusterManagementAddon(c)
+	err = DeleteClusterManagementAddon(context.Background(), c)
 	if err != nil {
 		t.Fatalf("Failed to delete clustermanagementaddon: (%v)", err)
 	}
@@ -123,7 +123,7 @@ func TestClusterManagmentAddon(t *testing.T) {
 	}
 
 	// delete it again for good measure
-	err = DeleteClusterManagementAddon(c)
+	err = DeleteClusterManagementAddon(context.Background(), c)
 	if err != nil {
 		t.Fatalf("Failed to delete clustermanagementaddon: (%v)", err)
 	}


### PR DESCRIPTION
When enabling the MCOA feature, we must disable the current metrics-collector related resources. However, some resources, like certificates, must be preserved/created. And eventually, they will probably be handled by MCOA directly at a later stage.

Because the necessary changes were complex to implement, I ended up refactoring the high-level logic of the placementrule_controller to improve readability and maintainability. For this part I tried to keep identical processing. 
The only breaking change is the end of OCP 3 support.

Here are some of the refactoring actions done:
- Simplify logging: remove error logs when not needed (error is returned), remove noisy doing nothing logs (only keeping high level ones in the Reconcile function), log write operations
- Wrap returned errors to provide more context
- Avoid ignoring errors, especially in the certificates package
- Forward context to functions calling the k8s api (replacing .TODO())
- Stop processing on errors if possible (some were just logged)
- Extract processing in coherent sub functions
- Reduce nested if statements
- Reduce deep function call chains with long parameter lists
- Remove processing specific to the upgrade from 2.9 to 2.10
- Remove some shared variables
- Remove setting variables in predicates when possible