### PR TITLE
[release-2.11] Restore non-CVE changes

### DIFF
--- a/collectors/metrics/pkg/metricsclient/metricsclient_test.go
+++ b/collectors/metrics/pkg/metricsclient/metricsclient_test.go
@@ -5,15 +5,22 @@
 package metricsclient
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	clientmodel "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/prompb"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDefaultTransport(t *testing.T) {
@@ -275,4 +282,100 @@ func timeseriesEqual(t1 []prompb.TimeSeries, t2 []prompb.TimeSeries) (bool, erro
 	}
 
 	return true, nil
+}
+
+func TestClient_RemoteWrite(t *testing.T) {
+	tests := []struct {
+		name          string
+		families      []*clientmodel.MetricFamily
+		serverHandler http.HandlerFunc
+		expect        func(t *testing.T, err error, retryCount int)
+	}{
+		{
+			name:     "successful write with metrics",
+			families: []*clientmodel.MetricFamily{mockMetricFamily()},
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			},
+			expect: func(t *testing.T, err error, retryCount int) {
+				assert.NoError(t, err)
+				assert.Equal(t, 1, retryCount)
+			},
+		},
+		{
+			name:     "no metrics to write",
+			families: []*clientmodel.MetricFamily{},
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			},
+			expect: func(t *testing.T, err error, retryCount int) {
+				assert.NoError(t, err)
+				assert.Equal(t, 0, retryCount)
+			},
+		},
+		{
+			name:     "retryable error",
+			families: []*clientmodel.MetricFamily{mockMetricFamily()},
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			},
+			expect: func(t *testing.T, err error, retryCount int) {
+				assert.Error(t, err)
+				assert.Greater(t, retryCount, 1)
+			},
+		},
+		{
+			name:     "non-retryable error",
+			families: []*clientmodel.MetricFamily{mockMetricFamily()},
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusConflict)
+			},
+			expect: func(t *testing.T, err error, retryCount int) {
+				assert.Error(t, err)
+				assert.Equal(t, 1, retryCount)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestCount := 0
+
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				tt.serverHandler(w, r)
+			}
+			ts := httptest.NewServer(http.HandlerFunc(handler))
+			defer ts.Close()
+
+			reg := prometheus.NewRegistry()
+			clientMetrics := &ClientMetrics{
+				ForwardRemoteWriteRequests: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+					Name: "forward_write_requests_total",
+					Help: "Counter of forward remote write requests.",
+				}, []string{"status_code"}),
+			}
+			client := &Client{logger: log.NewNopLogger(), client: ts.Client(), metrics: clientMetrics}
+
+			req, err := http.NewRequest("POST", ts.URL, bytes.NewBuffer([]byte{}))
+			assert.NoError(t, err)
+
+			err = client.RemoteWrite(context.Background(), req, tt.families, 30*time.Second)
+
+			tt.expect(t, err, requestCount)
+		})
+	}
+}
+
+func mockMetricFamily() *clientmodel.MetricFamily {
+	return &clientmodel.MetricFamily{
+		Name: proto.String("test_metric"),
+		Type: clientmodel.MetricType_COUNTER.Enum(),
+		Metric: []*clientmodel.Metric{
+			{
+				Counter:     &clientmodel.Counter{Value: proto.Float64(1)},
+				TimestampMs: proto.Int64(time.Now().UnixNano() / int64(time.Millisecond)),
+			},
+		},
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/IBM/controller-filtered-cache v0.3.6
-	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudflare/cfssl v1.6.4
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-co-op/gocron v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -844,10 +844,11 @@ github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl
 github.com/brancz/locutus v0.0.0-20210511124350-7a84f4d1bcb3 h1:N7vTNNytk6OFY5WoPJ+cSxxlRbNpCUWdyPW8nDHp0Sw=
 github.com/brancz/locutus v0.0.0-20210511124350-7a84f4d1bcb3/go.mod h1:n+EREm6Tinr9eHmIls4DzojRkkA4IrBe6xRpO4HEw0I=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
@@ -5,6 +5,8 @@
 package multiclusterobservability
 
 import (
+	"reflect"
+
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
@@ -139,7 +141,7 @@ func GetMCHPredicateFunc(c client.Client) predicate.Funcs {
 				e.Object.(*mchv1.MultiClusterHub).Status.DesiredVersion == e.Object.(*mchv1.MultiClusterHub).Status.CurrentVersion {
 				// only read the image manifests configmap and enqueue the request when the MCH is
 				// installed/upgraded successfully
-				ok, err := config.ReadImageManifestConfigMap(
+				_, ok, err := config.ReadImageManifestConfigMap(
 					c,
 					e.Object.(*mchv1.MultiClusterHub).Status.CurrentVersion,
 				)
@@ -151,20 +153,32 @@ func GetMCHPredicateFunc(c client.Client) predicate.Funcs {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
+			// Ensure the event pertains to the target namespace and object type
 			if e.ObjectNew.GetNamespace() == config.GetMCONamespace() &&
+				e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() &&
 				e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion != "" &&
 				e.ObjectNew.(*mchv1.MultiClusterHub).Status.DesiredVersion ==
 					e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion {
-				// only read the image manifests configmap and enqueue the request when the MCH is
-				// installed/upgraded successfully
-				ok, err := config.ReadImageManifestConfigMap(
+
+				currentData, _, err := config.ReadImageManifestConfigMap(
 					c,
 					e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion,
 				)
 				if err != nil {
+					log.Error(err, "Failed to read image manifest ConfigMap")
 					return false
 				}
-				return ok
+
+				previousData, exists := config.GetCachedImageManifestData()
+				if !exists {
+					config.SetCachedImageManifestData(currentData)
+					return true
+				}
+				if !reflect.DeepEqual(currentData, previousData) {
+					config.SetCachedImageManifestData(currentData)
+					return true
+				}
+				return false
 			}
 			return false
 		},

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
@@ -522,7 +522,7 @@ func TestObservabilityAddonController(t *testing.T) {
 		},
 	}
 
-	ok, err := config.ReadImageManifestConfigMap(c, testMCHInstance.Status.CurrentVersion)
+	_, ok, err := config.ReadImageManifestConfigMap(c, testMCHInstance.Status.CurrentVersion)
 	if err != nil || !ok {
 		t.Fatalf("Failed to read image manifest configmap: (%T,%v)", ok, err)
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/predict_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predict_func.go
@@ -109,7 +109,7 @@ func getMchPred(c client.Client) predicate.Funcs {
 				e.Object.(*mchv1.MultiClusterHub).Status.DesiredVersion == e.Object.(*mchv1.MultiClusterHub).Status.CurrentVersion {
 				// only read the image manifests configmap and enqueue the request when the MCH is
 				// installed/upgraded successfully
-				ok, err := config.ReadImageManifestConfigMap(
+				_, ok, err := config.ReadImageManifestConfigMap(
 					c,
 					e.Object.(*mchv1.MultiClusterHub).Status.CurrentVersion,
 				)
@@ -121,21 +121,32 @@ func getMchPred(c client.Client) predicate.Funcs {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
+			// Ensure the event pertains to the target namespace and object type
 			if e.ObjectNew.GetNamespace() == config.GetMCONamespace() &&
 				e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() &&
 				e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion != "" &&
 				e.ObjectNew.(*mchv1.MultiClusterHub).Status.DesiredVersion ==
 					e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion {
-				// / only read the image manifests configmap and enqueue the request when the MCH is
-				// installed/upgraded successfully
-				ok, err := config.ReadImageManifestConfigMap(
+
+				currentData, _, err := config.ReadImageManifestConfigMap(
 					c,
 					e.ObjectNew.(*mchv1.MultiClusterHub).Status.CurrentVersion,
 				)
 				if err != nil {
+					log.Error(err, "Failed to read image manifest ConfigMap")
 					return false
 				}
-				return ok
+
+				previousData, exists := config.GetCachedImageManifestData()
+				if !exists {
+					config.SetCachedImageManifestData(currentData)
+					return true
+				}
+				if !reflect.DeepEqual(currentData, previousData) {
+					config.SetCachedImageManifestData(currentData)
+					return true
+				}
+				return false
 			}
 			return false
 		},

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	ocinfrav1 "github.com/openshift/api/config/v1"
@@ -250,6 +251,7 @@ var (
 	}
 
 	multicloudConsoleRouteHost = ""
+	imageManifestCache         sync.Map
 )
 
 // GetCrLabelKey returns the key for the CR label injected into the resources created by the operator.
@@ -267,7 +269,7 @@ func GetImageManifestConfigMapName() string {
 }
 
 // ReadImageManifestConfigMap reads configmap with the label ocm-configmap-type=image-manifest.
-func ReadImageManifestConfigMap(c client.Client, version string) (bool, error) {
+func ReadImageManifestConfigMap(c client.Client, version string) (map[string]string, bool, error) {
 	mcoNamespace := GetMCONamespace()
 	// List image manifest configmap with label ocm-configmap-type=image-manifest and ocm-release-version
 	matchLabels := map[string]string{
@@ -282,17 +284,16 @@ func ReadImageManifestConfigMap(c client.Client, version string) (bool, error) {
 	imageCMList := &corev1.ConfigMapList{}
 	err := c.List(context.TODO(), imageCMList, listOpts...)
 	if err != nil {
-		return false, fmt.Errorf("failed to list mch-image-manifest configmaps: %w", err)
+		return nil, false, fmt.Errorf("failed to list mch-image-manifest configmaps: %w", err)
 	}
 
 	if len(imageCMList.Items) != 1 {
 		// there should be only one matched image manifest configmap found
-		return false, nil
+		return nil, false, nil
 	}
 
 	imageManifests = imageCMList.Items[0].Data
-	log.V(1).Info("the length of mch-image-manifest configmap", "imageManifests", len(imageManifests))
-	return true, nil
+	return imageManifests, true, nil
 }
 
 // GetImageManifests...
@@ -818,4 +819,17 @@ func IsAlertingDisabledInSpec(mco *observabilityv1beta2.MultiClusterObservabilit
 
 	annotations := mco.GetAnnotations()
 	return annotations != nil && annotations[AnnotationDisableMCOAlerting] == "true"
+}
+
+func SetCachedImageManifestData(data map[string]string) {
+	imageManifestCache.Store("mch-image-manifest", data)
+}
+
+func GetCachedImageManifestData() (map[string]string, bool) {
+	if value, ok := imageManifestCache.Load("mch-image-manifest"); ok {
+		if cachedData, valid := value.(map[string]string); valid {
+			return cachedData, true
+		}
+	}
+	return nil, false
 }

--- a/operators/multiclusterobservability/pkg/config/config_test.go
+++ b/operators/multiclusterobservability/pkg/config/config_test.go
@@ -568,7 +568,7 @@ func TestReadImageManifestConfigMap(t *testing.T) {
 			}
 			client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjs...).Build()
 
-			gotRet, err := ReadImageManifestConfigMap(client, c.version)
+			_, gotRet, err := ReadImageManifestConfigMap(client, c.version)
 			if err != nil {
 				t.Errorf("Failed read image manifest configmap due to %v", err)
 			}


### PR DESCRIPTION
Related to https://github.com/stolostron/multicluster-observability-operator/pull/1761

Restore previously reverted changes after CVE-only release.

git cherry-pick 10cfb4a
git cherry-pick eb94214f 