### PR TITLE
Make e2e fail on any errors

### DIFF
--- a/cicd-scripts/run-e2e-tests.sh
+++ b/cicd-scripts/run-e2e-tests.sh
@@ -3,9 +3,7 @@
 # Copyright (c) 2021 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
-#set -exo pipefail
-
-set -x
+set -exo pipefail
 
 ROOTDIR="$(
   cd "$(dirname "$0")/.."


### PR DESCRIPTION
To ensure we don't miss any scripts failing to execute.