### PR TITLE
ACM-18001: Make alert ACMRemoteWriteError fire on percentages

### DIFF
--- a/operators/multiclusterobservability/manifests/base/alertmanager/prometheusrule.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/prometheusrule.yaml
@@ -11,9 +11,9 @@ spec:
       rules:
         - alert: ACMRemoteWriteError
           annotations:
-            summary: "Error in remote write."
-            description: "There are errors when sending requests to remote write endpoint: {{ $labels.name }}"
-          expr: sum by (code)(rate(acm_remote_write_requests_total{code!~"2.*"}[5m])) > 10
+            summary: "Observatorium API remote-write forwards failed"
+            description: "More than 20% of remote-write requests from observatorium-api to endpoint: \'{{ $labels.name }}\' failed"
+          expr: sum by (name) (rate(acm_remote_write_requests_total{code!~"2.*"}[10m])) / sum by (name) (rate(acm_remote_write_requests_total[10m])) > 0.2
           for: 10m
           labels:
             severity: critical


### PR DESCRIPTION
Previously this alert would fire when the per second rate of failures exceeded 10 in total (for all targets, including thanos-receive). This basically means the alert never triggede since we basically only do one remote-write request per 5 minutes/spoke/endpoint that meant you needed a huge number of spoke for this alert to fire, even if all requests fail.

Secondly, the alert made no distinction between endpoints, for example, it's possible to setup export to an external endpoint like victoriametrics, and we probably want to make sure we have different alerts for different endpoints.

Further we increase the timeframe of the rate from 5m to 10m, to make sure we actually get a sample. 5m works, and would be slightly more responsive, but the metric will then potentially jump very rapidly.