### PR TITLE
Kind: do not copy incompatible binaries to VM & fallback to previous release if no snapshots found

### DIFF
--- a/cicd-scripts/run-e2e-in-kind-via-prow.sh
+++ b/cicd-scripts/run-e2e-in-kind-via-prow.sh
@@ -48,7 +48,6 @@ ssh "${OPT[@]}" "$HOST" sudo yum install gcc git -y
 ssh "${OPT[@]}" "$HOST" sudo mkdir -p /home/ec2-user/bin
 ssh "${OPT[@]}" "$HOST" sudo chmod 777 /home/ec2-user/bin
 scp "${OPT[@]}" -r ../multicluster-observability-operator "$HOST:/tmp/multicluster-observability-operator"
-scp "${OPT[@]}" $(which kubectl) "$HOST:/home/ec2-user/bin"
 scp "${OPT[@]}" $KUSTOMIZE "$HOST:/home/ec2-user/bin/kustomize"
 scp "${OPT[@]}" $(which jq) "$HOST:/home/ec2-user/bin"
 ssh "${OPT[@]}" "$HOST" "cd /tmp/multicluster-observability-operator && make mco-kind-env"

--- a/cicd-scripts/run-e2e-in-kind-via-prow.sh
+++ b/cicd-scripts/run-e2e-in-kind-via-prow.sh
@@ -44,11 +44,12 @@ if [[ -n ${RBAC_QUERY_PROXY_IMAGE_REF} ]]; then
   ${SED_COMMAND} "$ a\export RBAC_QUERY_PROXY_IMAGE_REF=${RBAC_QUERY_PROXY_IMAGE_REF}" ./tests/run-in-kind/env.sh
 fi
 
-ssh "${OPT[@]}" "$HOST" sudo yum install gcc git -y
+ssh "${OPT[@]}" "$HOST" sudo yum install gcc git bc -y
 ssh "${OPT[@]}" "$HOST" sudo mkdir -p /home/ec2-user/bin
 ssh "${OPT[@]}" "$HOST" sudo chmod 777 /home/ec2-user/bin
 scp "${OPT[@]}" -r ../multicluster-observability-operator "$HOST:/tmp/multicluster-observability-operator"
-scp "${OPT[@]}" $KUSTOMIZE "$HOST:/home/ec2-user/bin/kustomize"
+#scp "${OPT[@]}" $KUSTOMIZE "$HOST:/home/ec2-user/bin/kustomize"
 scp "${OPT[@]}" $(which jq) "$HOST:/home/ec2-user/bin"
+ssh "${OPT[@]}" "$HOST" "cd /home/ec2-user/bin && curl -s https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash"
 ssh "${OPT[@]}" "$HOST" "cd /tmp/multicluster-observability-operator && make mco-kind-env"
 ssh "${OPT[@]}" "$HOST" "cd /tmp/multicluster-observability-operator && make e2e-tests-in-kind" > >(tee "$ARTIFACT_DIR/run-e2e-in-kind.log") 2>&1

--- a/cicd-scripts/run-e2e-in-kind-via-prow.sh
+++ b/cicd-scripts/run-e2e-in-kind-via-prow.sh
@@ -48,7 +48,6 @@ ssh "${OPT[@]}" "$HOST" sudo yum install gcc git bc -y
 ssh "${OPT[@]}" "$HOST" sudo mkdir -p /home/ec2-user/bin
 ssh "${OPT[@]}" "$HOST" sudo chmod 777 /home/ec2-user/bin
 scp "${OPT[@]}" -r ../multicluster-observability-operator "$HOST:/tmp/multicluster-observability-operator"
-#scp "${OPT[@]}" $KUSTOMIZE "$HOST:/home/ec2-user/bin/kustomize"
 scp "${OPT[@]}" $(which jq) "$HOST:/home/ec2-user/bin"
 ssh "${OPT[@]}" "$HOST" "cd /home/ec2-user/bin && curl -s https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash"
 ssh "${OPT[@]}" "$HOST" "cd /tmp/multicluster-observability-operator && make mco-kind-env"

--- a/scripts/test-utils.sh
+++ b/scripts/test-utils.sh
@@ -30,7 +30,7 @@ get_latest_acm_snapshot() {
   # try previous version if none were found.
   # this makes builds work during branching times.
   # we only go back once
-  if [[ -z $LATEST_SNAPSHOT ]] && [[ -z "${PREVIOUS_VERSION:-}" ]]; then
+  if [[ -z $LATEST_SNAPSHOT ]] && [[ -z ${PREVIOUS_VERSION:-} ]]; then
     PREVIOUS_VERSION=$(bc -l <<<"$SNAPSHOT_RELEASE-0.01")
     echo >&2 "****WARNING**** Attempting to use previous ACM version $PREVIOUS_VERSION as no snapshots found for $SNAPSHOT_RELEASE"
     LATEST_SNAPSHOT=$(SNAPSHOT_RELEASE=$PREVIOUS_VERSION get_latest_acm_snapshot)
@@ -59,7 +59,7 @@ get_latest_mce_snapshot() {
   # try previous version if none were found.
   # this makes builds work during branching times.
   # we only go back once
-  if [[ -z $LATEST_SNAPSHOT ]] && [[ -z "${PREVIOUS_VERSION:-}" ]]; then
+  if [[ -z $LATEST_SNAPSHOT ]] && [[ -z ${PREVIOUS_VERSION:-} ]]; then
     PREVIOUS_VERSION=$(bc -l <<<"$SNAPSHOT_RELEASE-0.01")
     echo >&2 "****WARNING**** Attempting to use previous MCE version $PREVIOUS_VERSION as no snapshots found for $SNAPSHOT_RELEASE"
     LATEST_SNAPSHOT=$(SNAPSHOT_RELEASE=$PREVIOUS_VERSION get_latest_mce_snapshot)

--- a/scripts/test-utils.sh
+++ b/scripts/test-utils.sh
@@ -30,7 +30,7 @@ get_latest_acm_snapshot() {
   # try previous version if none were found.
   # this makes builds work during branching times.
   # we only go back once
-  if [[ -z $LATEST_SNAPSHOT ]] && [[ -z $PREVIOUS_VERSION ]]; then
+  if [[ -z $LATEST_SNAPSHOT ]] && [[ -z "${PREVIOUS_VERSION:-}" ]]; then
     PREVIOUS_VERSION=$(bc -l <<<"$SNAPSHOT_RELEASE-0.01")
     echo >&2 "****WARNING**** Attempting to use previous ACM version $PREVIOUS_VERSION as no snapshots found for $SNAPSHOT_RELEASE"
     LATEST_SNAPSHOT=$(SNAPSHOT_RELEASE=$PREVIOUS_VERSION get_latest_acm_snapshot)
@@ -59,7 +59,7 @@ get_latest_mce_snapshot() {
   # try previous version if none were found.
   # this makes builds work during branching times.
   # we only go back once
-  if [[ -z $LATEST_SNAPSHOT ]] && [[ -z $PREVIOUS_VERSION ]]; then
+  if [[ -z $LATEST_SNAPSHOT ]] && [[ -z "${PREVIOUS_VERSION:-}" ]]; then
     PREVIOUS_VERSION=$(bc -l <<<"$SNAPSHOT_RELEASE-0.01")
     echo >&2 "****WARNING**** Attempting to use previous MCE version $PREVIOUS_VERSION as no snapshots found for $SNAPSHOT_RELEASE"
     LATEST_SNAPSHOT=$(SNAPSHOT_RELEASE=$PREVIOUS_VERSION get_latest_mce_snapshot)

--- a/scripts/test-utils.sh
+++ b/scripts/test-utils.sh
@@ -21,11 +21,25 @@ get_latest_acm_snapshot() {
   # z version 1-2 digits
   # -SNAPSHOT
   MATCH=$SNAPSHOT_RELEASE".\d{1,2}-SNAPSHOT"
-  LATEST_SNAPSHOT=$(curl "https://quay.io/api/v1/repository/stolostron/multicluster-observability-operator/tag/?filter_tag_name=like:$SNAPSHOT_RELEASE&limit=100" | jq --arg MATCH "$MATCH" '.tags[] | select(.name | match($MATCH; "i")  ).name' | sort -r --version-sort | head -n 1)
+  LATEST_SNAPSHOT=$(curl -s "https://quay.io/api/v1/repository/stolostron/multicluster-observability-operator/tag/?filter_tag_name=like:$SNAPSHOT_RELEASE&limit=100" | jq --arg MATCH "$MATCH" '.tags[] | select(.name | match($MATCH; "i")  ).name' | sort -r --version-sort | head -n 1)
 
   # trim the leading and tailing quotes
   LATEST_SNAPSHOT="${LATEST_SNAPSHOT#\"}"
   LATEST_SNAPSHOT="${LATEST_SNAPSHOT%\"}"
+
+  # try previous version if none were found.
+  # this makes builds work during branching times.
+  # we only go back once
+  if [[ -z $LATEST_SNAPSHOT ]] && [[ -z $PREVIOUS_VERSION ]]; then
+    PREVIOUS_VERSION=$(bc -l <<<"$SNAPSHOT_RELEASE-0.01")
+    echo >&2 "****WARNING**** Attempting to use previous ACM version $PREVIOUS_VERSION as no snapshots found for $SNAPSHOT_RELEASE"
+    LATEST_SNAPSHOT=$(SNAPSHOT_RELEASE=$PREVIOUS_VERSION get_latest_acm_snapshot)
+  fi
+
+  if [[ -z $LATEST_SNAPSHOT ]]; then
+    echo >&2 "****ERROR**** Unable to find ACM image for release: $SNAPSHOT_RELEASE"
+  fi
+
   echo "${LATEST_SNAPSHOT}"
 }
 
@@ -36,10 +50,24 @@ get_latest_mce_snapshot() {
   # z version 1-2 digits
   # -SNAPSHOT
   MATCH=$SNAPSHOT_RELEASE".\d{1,2}-SNAPSHOT"
-  LATEST_SNAPSHOT=$(curl "https://quay.io/api/v1/repository/stolostron/registration/tag/?filter_tag_name=like:$SNAPSHOT_RELEASE&limit=100" | jq --arg MATCH "$MATCH" '.tags[] | select(.name | match($MATCH; "i")  ).name' | sort -r --version-sort | head -n 1)
+  LATEST_SNAPSHOT=$(curl -s "https://quay.io/api/v1/repository/stolostron/registration/tag/?filter_tag_name=like:$SNAPSHOT_RELEASE&limit=100" | jq --arg MATCH "$MATCH" '.tags[] | select(.name | match($MATCH; "i")  ).name' | sort -r --version-sort | head -n 1)
 
   # trim the leading and tailing quotes
   LATEST_SNAPSHOT="${LATEST_SNAPSHOT#\"}"
   LATEST_SNAPSHOT="${LATEST_SNAPSHOT%\"}"
+
+  # try previous version if none were found.
+  # this makes builds work during branching times.
+  # we only go back once
+  if [[ -z $LATEST_SNAPSHOT ]] && [[ -z $PREVIOUS_VERSION ]]; then
+    PREVIOUS_VERSION=$(bc -l <<<"$SNAPSHOT_RELEASE-0.01")
+    echo >&2 "****WARNING**** Attempting to use previous MCE version $PREVIOUS_VERSION as no snapshots found for $SNAPSHOT_RELEASE"
+    LATEST_SNAPSHOT=$(SNAPSHOT_RELEASE=$PREVIOUS_VERSION get_latest_mce_snapshot)
+  fi
+
+  if [[ -z $LATEST_SNAPSHOT ]]; then
+    echo >&2 "****ERROR**** Unable to find MCE image for release: $SNAPSHOT_RELEASE"
+  fi
+
   echo "${LATEST_SNAPSHOT}"
 }


### PR DESCRIPTION
- Tooling changes required as we're now running later versions of ci-opertor which uses RHEL9, and the remote VM uses RHEL8 which means binaries are not compatible
- If we cannot find a snapshot for the current component version, fallback to a snapshot from the previous version. 