### PR TITLE
Remove standard hub rules for MCOA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,15 +126,15 @@ unit-tests: unit-tests-operators unit-tests-loaders unit-tests-proxy unit-tests-
 
 .PHONY: unit-tests-operators
 unit-tests-operators:  ## Run operators unit tests only.
-	go test -v ${VERBOSE} `go list ./operators/... | $(GREP) -v test`
+	go test ${VERBOSE} `go list ./operators/... | $(GREP) -v test`
 
 .PHONY: unit-tests-loaders
 unit-tests-loaders: ## Run loaders unit tests only.
-	go test -v ${VERBOSE} `go list ./loaders/... | $(GREP) -v test`
+	go test ${VERBOSE} `go list ./loaders/... | $(GREP) -v test`
 
 .PHONY: unit-tests-proxy
 unit-tests-proxy: ## Run proxy uni tests only.
-	go test -v ${VERBOSE} `go list ./proxy/... | $(GREP) -v test`
+	go test ${VERBOSE} `go list ./proxy/... | $(GREP) -v test`
 
 .PHONY: unit-tests-collectors
 unit-tests-collectors: ## Run collectors unit tests only. 

--- a/cicd-scripts/metrics/Makefile
+++ b/cicd-scripts/metrics/Makefile
@@ -6,7 +6,6 @@ PLATFORM_DASH_DIR = $(DAHSBOARDS_DIR)/platform-mcoa
 HCP_DASH_DIR = $(DAHSBOARDS_DIR)/hcp-mcoa
 ALERTS_DASH_DIR = $(DAHSBOARDS_DIR)/alerts
 VIRTUALIZATION_DASH_DIR = $(DAHSBOARDS_DIR)/virtualization
-HUB_RULES = cluster:memory_requested:ratio,cluster:memory_utilized:ratio,cluster:cpu_allocatable:sum,cluster:cpu_requested:ratio,cluster:cpu_cores:sum,acm_label_names,acm_managed_cluster_labels
 
 TMPDIR := $(shell mktemp -d)
 
@@ -17,8 +16,7 @@ check-platform-metrics:
 	@echo "--> Checking platform metrics:"
 	@$(CURDIR)/scripts/extract-dashboards-metrics.sh $(PLATFORM_DASH_DIR) | tr '\n' ',' > $(TMPDIR)/dash-metrics
 	@go run cmd/dashcheck/main.go --scrape-configs=$(PLATFORM_DASH_DIR)/scrape-config.yaml \
-		--dashboard-metrics=$$(cat $(TMPDIR)/dash-metrics) \
-		--ignored-dashboard-metrics=$(HUB_RULES)
+		--dashboard-metrics=$$(cat $(TMPDIR)/dash-metrics)
 	@cat $(PLATFORM_DASH_DIR)/prometheus-rule.yaml | yq '.spec' | promtool check rules
 	@go run cmd/rulescheck/main.go --scrape-configs=$(PLATFORM_DASH_DIR)/scrape-config.yaml \
 		--rules=$(PLATFORM_DASH_DIR)/prometheus-rule.yaml \

--- a/cicd-scripts/metrics/cmd/rulescheck/main.go
+++ b/cicd-scripts/metrics/cmd/rulescheck/main.go
@@ -4,7 +4,7 @@
 
 /*
 CI tool that provides a simple CLI to ensure that metrics resulting from rules evaluation defined in scrape configs
-are defined in the listed rule files.
+are defined in the listed rule files. This check applies to rules being evaluated by each spoke's in-cluster Prometheus.
 It ensures that rules are not duplicated and that no unneeded rule is defined.
 */
 package main

--- a/cicd-scripts/metrics/internal/rule/rule.go
+++ b/cicd-scripts/metrics/internal/rule/rule.go
@@ -5,6 +5,7 @@
 package rule
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -21,6 +22,9 @@ func ReadFiles(rulesPath string) ([]*prometheusv1.PrometheusRule, error) {
 		res, err := ReadFile(path)
 		if err != nil {
 			return nil, err
+		}
+		if len(res.Spec.Groups) == 0 {
+			return nil, errors.New("no rule found in file")
 		}
 		ret = append(ret, res)
 	}
@@ -46,6 +50,10 @@ func RuleNames(rules *prometheusv1.PrometheusRule) ([]string, error) {
 	ret := []string{}
 	for _, rule := range rules.Spec.Groups {
 		for _, rule := range rule.Rules {
+			if len(rule.Alert) > 0 {
+				// Is alert, skip
+				continue
+			}
 			ret = append(ret, rule.Record)
 		}
 	}

--- a/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/prometheus-rule.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/prometheus-rule.yaml
@@ -143,7 +143,7 @@ spec:
         / sum(increase(apiserver_request_duration_seconds_bucket{job="apiserver",service="kubernetes",verb=~"POST|PUT|DELETE|PATCH"}[1m]))
       record: sli:apiserver_request_duration_seconds:trend:1m
     - expr: sli:apiserver_request_duration_seconds:trend:1m >= bool 0.9900
-      record: sli:apiserver_request_duration_seconds:bin:trend:1m # Really needed?
+      record: sli:apiserver_request_duration_seconds:bin:trend:1m
     - expr: sum(rate(apiserver_request_total{job="apiserver"}[1h])) by (code, instance)
       record: sum:apiserver_request_total:1h
     - expr: sum(rate(apiserver_request_total{job="apiserver"}[5m])) by (code, instance)
@@ -163,3 +163,49 @@ spec:
       record: grpc_server_started_total:etcd_unary:sum_rate
     - expr: avg(rate(node_cpu_seconds_total{mode="idle"}[5m]))
       record: node_cpu_seconds_total:mode_idle:avg_rate5m
+    - expr: sum(cluster:kube_pod_container_resource_requests:memory:sum) by (cluster) / sum(kube_node_status_allocatable{resource="memory"}) by (cluster)
+      record: cluster:memory_requested:ratio
+    - expr: 1 - sum(:node_memory_MemAvailable_bytes:sum) by (cluster) / sum(kube_node_status_allocatable{resource="memory"}) by (cluster)
+      record: cluster:memory_utilized:ratio
+    - expr: sum(kube_node_status_allocatable{resource="cpu"}) by (cluster)
+      record: cluster:cpu_allocatable:sum
+    - expr: sum(cluster:kube_pod_container_resource_requests:cpu:sum) by (cluster) / sum(kube_node_status_allocatable{resource="cpu"}) by (cluster)
+      record: cluster:cpu_requested:ratio
+    - expr: sum(machine_cpu_cores) by (cluster)
+      record: cluster:cpu_cores:sum
+  - name: kubernetes-storage
+    rules:
+      - alert: KubePersistentVolumeFillingUp1Min
+        annotations:
+          summary: PersistentVolume is filling up.
+          description: "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free."
+        expr: kubelet_volume_stats_available_bytes{namespace="open-cluster-management-observability"}/kubelet_volume_stats_capacity_bytes{namespace="open-cluster-management-observability"} < 0.03
+        for: 1m
+        labels:
+          instance: "{{ $labels.instance }}"
+          cluster: "{{ $labels.cluster }}"
+          clusterID: "{{ $labels.clusterID }}"
+          PersistentVolumeClaim: "{{ $labels.persistentvolumeclaim }}"
+          severity: info
+      - alert: KubePersistentVolumeFillingUp1Hour
+        annotations:
+          summary: PersistentVolume is filling up and is predicted to run out of space in 6h.
+          description: "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free."
+        expr: (kubelet_volume_stats_available_bytes{namespace="open-cluster-management-observability"}/kubelet_volume_stats_capacity_bytes{namespace="open-cluster-management-observability"}) < 0.15 and (predict_linear(kubelet_volume_stats_available_bytes{namespace="open-cluster-management-observability"}[6h], 4 * 24 * 3600)) <0
+        for: 1h
+        labels:
+          instance: "{{ $labels.instance }}"
+          cluster: "{{ $labels.cluster }}"
+          clusterID: "{{ $labels.clusterID }}"
+          PersistentVolumeClaim: "{{ $labels.persistentvolumeclaim }}"
+          severity: info
+  - name: policy-reports
+    rules:
+      - alert: ViolatedPolicyReport
+        annotations:
+          summary: "There is a policy report violation with a {{ $labels.severity }} severity level detected."
+          description: "The policy: {{ $labels.policy }} has a severity of {{ $labels.severity }} on cluster: {{ $labels.cluster }}"
+        expr: sum without (managed_cluster_id) (label_replace((sum without (clusterID) (label_replace((sum(policyreport_info * on (managed_cluster_id) group_left (cluster) label_replace(acm_managed_cluster_labels, "cluster", "$1", "name", "(.*)")) by (cluster, category, clusterID, managed_cluster_id, policy, severity) > 0),"hub_cluster_id", "$1", "clusterID", "(.*)"))),"clusterID", "$1", "managed_cluster_id", "(.*)"))
+        for: 1m
+        labels:
+          severity: "{{ $labels.severity }}"

--- a/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/scrape-config.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/scrape-config.yaml
@@ -14,13 +14,20 @@ spec:
   params:
     match[]:
     - '{__name__=":node_memory_MemAvailable_bytes:sum"}'
+    - '{__name__="acm_label_names"}' # metrics generated on the hub by MCE, needed for Grafana
+    - '{__name__="acm_managed_cluster_labels"}' # metrics generated on the hub by MCE, needed for Grafana
     - '{__name__="active_streams_lease:grpc_server_handled_total:sum"}'
     - '{__name__="active_streams_watch:grpc_server_handled_total:sum"}'
-    - '{__name__="apiserver_request_duration_seconds:histogram_quantile_99"}'
     - '{__name__="apiserver_request_duration_seconds:histogram_quantile_99:instance"}'
+    - '{__name__="apiserver_request_duration_seconds:histogram_quantile_99"}'
+    - '{__name__="cluster:cpu_allocatable:sum"}'
+    - '{__name__="cluster:cpu_cores:sum"}'
+    - '{__name__="cluster:cpu_requested:ratio"}'
     - '{__name__="cluster:kube_pod_container_resource_requests:cpu:sum"}'
     - '{__name__="cluster:kube_pod_container_resource_requests:memory:sum"}'
     - '{__name__="cluster:machine_memory:sum"}'
+    - '{__name__="cluster:memory_requested:ratio"}'
+    - '{__name__="cluster:memory_utilized:ratio"}'
     - '{__name__="cluster:node_cpu:ratio"}'
     - '{__name__="container_cpu_cfs_periods_total"}'
     - '{__name__="container_cpu_cfs_throttled_periods_total"}'
@@ -28,9 +35,9 @@ spec:
     - '{__name__="container_memory_rss",container!="POD",container!=""}'
     - '{__name__="container_memory_swap",container!="POD",container!=""}'
     - '{__name__="container_memory_working_set_bytes",container!="POD",container!=""}'
-    - '{__name__="etcd_mvcc_db_total_size_in_bytes"}'
     - '{__name__="etcd_disk_backend_commit_duration_seconds_bucket"}'
     - '{__name__="etcd_disk_wal_fsync_duration_seconds_bucket"}'
+    - '{__name__="etcd_mvcc_db_total_size_in_bytes"}'
     - '{__name__="etcd_network_client_grpc_received_bytes_total"}'
     - '{__name__="etcd_network_client_grpc_sent_bytes_total"}'
     - '{__name__="etcd_network_peer_received_bytes_total"}'
@@ -43,6 +50,8 @@ spec:
     - '{__name__="etcd_server_proposals_pending"}'
     - '{__name__="go_goroutines",job="apiserver"}'
     - '{__name__="grpc_server_started_total:etcd_unary:sum_rate"}'
+    - '{__name__="instance_device:node_disk_io_time_seconds:rate1m"}'
+    - '{__name__="instance_device:node_disk_io_time_weighted_seconds:rate1m"}'
     - '{__name__="instance:node_cpu_utilisation:rate1m"}'
     - '{__name__="instance:node_load1_per_cpu:ratio"}'
     - '{__name__="instance:node_memory_utilisation:ratio"}'
@@ -52,24 +61,22 @@ spec:
     - '{__name__="instance:node_network_transmit_drop_excluding_lo:rate1m"}'
     - '{__name__="instance:node_num_cpu:sum"}'
     - '{__name__="instance:node_vmstat_pgmajfault:rate1m"}'
-    - '{__name__="instance_device:node_disk_io_time_seconds:rate1m"}'
-    - '{__name__="instance_device:node_disk_io_time_weighted_seconds:rate1m"}'
-    - '{__name__="kube_node_status_allocatable"}' # Allows computing cluster:cpu_allocatable:sum on the hub
-    - '{__name__="kube_pod_container_resource_limits"}'
+    - '{__name__="kube_node_status_allocatable"}'
     - '{__name__="kube_pod_container_resource_limits:sum"}'
+    - '{__name__="kube_pod_container_resource_limits"}'
     - '{__name__="kube_pod_container_resource_requests"}'
     - '{__name__="kube_pod_info"}'
     - '{__name__="kube_resourcequota"}'
-    - '{__name__="namespace_workload_pod:kube_pod_owner:relabel"}'
     - '{__name__="namespace_workload_pod:kube_pod_owner:relabel:avg"}'
+    - '{__name__="namespace_workload_pod:kube_pod_owner:relabel"}'
     - '{__name__="node_cpu_seconds_total:mode_idle:avg_rate5m"}'
     - '{__name__="node_filesystem_avail_bytes"}'
     - '{__name__="node_filesystem_size_bytes"}'
-    - '{__name__="node_namespace_pod_container:container_cpu_usage_seconds_total:sum"}'
     - '{__name__="node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate"}' # result of renaming, check if really needed
-    - '{__name__="node_netstat_TcpExt_TCPSynRetrans"}'
+    - '{__name__="node_namespace_pod_container:container_cpu_usage_seconds_total:sum"}'
     - '{__name__="node_netstat_Tcp_OutSegs"}'
     - '{__name__="node_netstat_Tcp_RetransSegs"}'
+    - '{__name__="node_netstat_TcpExt_TCPSynRetrans"}'
     - '{__name__="process_cpu_seconds_total",job="apiserver"}'
     - '{__name__="process_resident_memory_bytes",job=~"apiserver|etcd"}'
     - '{__name__="rpc_rate:grpc_server_handled_total:sum_rate"}'
@@ -87,5 +94,3 @@ spec:
   staticConfigs:
   - targets:
     - localhost:8090
-
-


### PR DESCRIPTION
Stop relying on [rules](https://github.com/stolostron/multicluster-observability-operator/blob/bf2118fa4a5b644a9962eb63bc9a3714d40e1da6/operators/multiclusterobservability/manifests/base/alertmanager/alert_rules.yaml#L1) computed on the Hub Thanos Ruler. They are replaced by rules pushed to the spokes and computed there.
Resulting rules are added to the scrape config.
Sort alphabetically the scrape config list of metrics.