### PR TITLE
Add controller reference on resources deployed by the endpoint-operator

### DIFF
--- a/operators/multiclusterobservability/manifests/endpoint-observability/role.yaml
+++ b/operators/multiclusterobservability/manifests/endpoint-observability/role.yaml
@@ -71,6 +71,12 @@ rules:
   - observabilityaddons/finalizers
   verbs:
   - update
+- apiGroups: # Required to set MCO as the owner on the hub as there is no addon. 
+  - observability.open-cluster-management.io
+  resources:
+  - multiclusterobservabilities/finalizers
+  verbs:
+  - update
 - apiGroups:
   - config.openshift.io
   resources:


### PR DESCRIPTION
To ensure that resources created by the endpoint operator are deleted, especially on the hub, a controller reference is added to them. The owner is set to:

- The observability addon resource on the spokes
- MCO on the hub

https://issues.redhat.com/browse/ACM-18474