### PR TITLE
Add Hypershift support for MCOA

### DIFF
--- a/cicd-scripts/metrics/Makefile
+++ b/cicd-scripts/metrics/Makefile
@@ -9,12 +9,12 @@ VIRTUALIZATION_DASH_DIR = $(DAHSBOARDS_DIR)/virtualization
 
 TMPDIR := $(shell mktemp -d)
 
-.PHONY: check-metrics check-platform-metrics check-hcp-metrics check-alerts-metrics check-virtualization-metrics clean-tmpdir
-check-metrics: check-platform-metrics check-hcp-metrics check-alerts-metrics check-virtualization-metrics clean-tmpdir
+.PHONY: check-metrics check-platform-metrics check-hcp-metrics check-uwl-hcp-etcd-metrics check-uwl-hcp-apiserver-metrics check-alerts-metrics check-virtualization-metrics clean-tmpdir
+check-metrics: check-platform-metrics check-hcp-metrics check-uwl-hcp-etcd-metrics check-uwl-hcp-apiserver-metrics check-alerts-metrics check-virtualization-metrics clean-tmpdir
 
 check-platform-metrics: 
 	@echo "--> Checking platform metrics:"
-	@$(CURDIR)/scripts/extract-dashboards-metrics.sh $(PLATFORM_DASH_DIR) | tr '\n' ',' > $(TMPDIR)/dash-metrics
+	@$(CURDIR)/scripts/extract-dashboards-metrics.sh -d $(PLATFORM_DASH_DIR) | tr '\n' ',' > $(TMPDIR)/dash-metrics
 	@go run cmd/dashcheck/main.go --scrape-configs=$(PLATFORM_DASH_DIR)/scrape-config.yaml \
 		--dashboard-metrics=$$(cat $(TMPDIR)/dash-metrics)
 	@cat $(PLATFORM_DASH_DIR)/prometheus-rule.yaml | yq '.spec' | promtool check rules
@@ -25,7 +25,7 @@ check-platform-metrics:
 
 check-hcp-metrics: 
 	@echo "--> Checking hcp metrics:"
-	@$(CURDIR)/scripts/extract-dashboards-metrics.sh $(HCP_DASH_DIR) | tr '\n' ',' > $(TMPDIR)/dash-metrics
+	@$(CURDIR)/scripts/extract-dashboards-metrics.sh -d $(HCP_DASH_DIR) | tr '\n' ',' > $(TMPDIR)/dash-metrics
 	@go run cmd/dashcheck/main.go --scrape-configs=$(HCP_DASH_DIR)/scrape-config.yaml \
 		--dashboard-metrics=$$(cat $(TMPDIR)/dash-metrics) \
 		--ignored-dashboard-metrics=$(HUB_RULES) \
@@ -33,9 +33,30 @@ check-hcp-metrics:
 	@go run cmd/rulescheck/main.go --scrape-configs=$(HCP_DASH_DIR)/scrape-config.yaml \
 	@rm -d $(TMPDIR)/dash-metrics
 
+check-uwl-hcp-etcd-metrics: 
+	@echo "--> Checking uwl hcp metrics:"
+	@$(CURDIR)/scripts/extract-dashboards-metrics.sh -f $(PLATFORM_DASH_DIR)/dash-k8s-etcd.yaml | tr '\n' ',' > $(TMPDIR)/dash-metrics
+	@go run cmd/dashcheck/main.go --scrape-configs=$(PLATFORM_DASH_DIR)/scrape-config-uwl-hcp-etcd.yaml \
+		--dashboard-metrics=$$(cat $(TMPDIR)/dash-metrics) 
+	@cat $(PLATFORM_DASH_DIR)/prometheus-rule-uwl-hcp-etcd.yaml | yq '.spec' | promtool check rules
+	@go run cmd/rulescheck/main.go --scrape-configs=$(PLATFORM_DASH_DIR)/scrape-config-uwl-hcp-etcd.yaml \
+		--rules=$(PLATFORM_DASH_DIR)/prometheus-rule-uwl-hcp-etcd.yaml 
+	@rm -d $(TMPDIR)/dash-metrics
+
+check-uwl-hcp-apiserver-metrics: 
+	@echo "--> Checking uwl apiserver metrics:"
+	@$(CURDIR)/scripts/extract-dashboards-metrics.sh -f $(PLATFORM_DASH_DIR)/dash-k8s-apiserver.yaml | tr '\n' ',' > $(TMPDIR)/dash-metrics
+	@go run cmd/dashcheck/main.go --scrape-configs=$(PLATFORM_DASH_DIR)/scrape-config-uwl-hcp-apiserver.yaml \
+		--ignored-scrapeconfig-metrics=apiserver_request_duration_seconds:histogram_quantile_99 \
+		--dashboard-metrics=$$(cat $(TMPDIR)/dash-metrics) 
+	@cat $(PLATFORM_DASH_DIR)/prometheus-rule-uwl-hcp-apiserver.yaml | yq '.spec' | promtool check rules
+	@go run cmd/rulescheck/main.go --scrape-configs=$(PLATFORM_DASH_DIR)/scrape-config-uwl-hcp-apiserver.yaml \
+		--rules=$(PLATFORM_DASH_DIR)/prometheus-rule-uwl-hcp-apiserver.yaml 
+	@rm -d $(TMPDIR)/dash-metrics
+
 check-alerts-metrics: 
 	@echo "--> Checking alert metrics:"
-	@$(CURDIR)/scripts/extract-dashboards-metrics.sh $(ALERTS_DASH_DIR) | tr '\n' ',' > $(TMPDIR)/dash-metrics
+	@$(CURDIR)/scripts/extract-dashboards-metrics.sh -d $(ALERTS_DASH_DIR) | tr '\n' ',' > $(TMPDIR)/dash-metrics
 	@go run cmd/dashcheck/main.go --scrape-configs=$(ALERTS_DASH_DIR)/scrape-config.yaml \
 		--dashboard-metrics=$$(cat $(TMPDIR)/dash-metrics) \
 		--ignored-dashboard-metrics=$(HUB_RULES) \
@@ -44,7 +65,7 @@ check-alerts-metrics:
 
 check-virtualization-metrics: 
 	@echo "--> Checking virtualization metrics:"
-	@$(CURDIR)/scripts/extract-dashboards-metrics.sh $(VIRTUALIZATION_DASH_DIR) | tr '\n' ',' > $(TMPDIR)/dash-metrics
+	@$(CURDIR)/scripts/extract-dashboards-metrics.sh -d $(VIRTUALIZATION_DASH_DIR) | tr '\n' ',' > $(TMPDIR)/dash-metrics
 	@go run cmd/dashcheck/main.go --scrape-configs=$(VIRTUALIZATION_DASH_DIR)/scrape-config.yaml \
 		--dashboard-metrics=$$(cat $(TMPDIR)/dash-metrics) \
 		--ignored-dashboard-metrics=$(HUB_RULES) \

--- a/cicd-scripts/metrics/cmd/dashcheck/main.go
+++ b/cicd-scripts/metrics/cmd/dashcheck/main.go
@@ -24,6 +24,7 @@ func main() {
 	scrapeConfigsArg := flag.String("scrape-configs", "", "Path to the comma separated scrape_configs")
 	dashboardMetricsArg := flag.String("dashboard-metrics", "", "Comma separated dashboard metrics")
 	ignoredDashboardMetricsArg := flag.String("ignored-dashboard-metrics", "", "Comma separated ignored dashboard metrics. For example, rules that are computed on the hub instead of being collected from the spokes.")
+	ignoredScrapeConfigMetricsArg := flag.String("ignored-scrapeconfig-metrics", "", "Comma separated ignored ScrapeConfig metrics. For example, metrics that are needed for a specific widget in a dashboard that is not included in the check.")
 	additionalScrapeConfigsArg := flag.String("additional-scrape-configs", "", "Path to the comma separated scrape_configs that are collected in addition of the main one. Over collected metrics from them are ignored.")
 	flag.Parse()
 
@@ -48,11 +49,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	ignoredScrapeConfigMetrics := strings.Split(*ignoredScrapeConfigMetricsArg, ",")
+
 	collectedMetrics, err := scrapeconfig.ReadFederatedMetrics(*scrapeConfigsArg)
 	if err != nil {
 		fmt.Printf("Failed to read scrape configs: %v", err)
 		os.Exit(1)
 	}
+	collectedMetrics = slices.DeleteFunc(collectedMetrics, func(s string) bool { return s == "" || slices.Contains(ignoredScrapeConfigMetrics, s) })
 
 	var additionalMetrics []string
 	if len(*additionalScrapeConfigsArg) > 0 {

--- a/cicd-scripts/metrics/cmd/rulescheck/main.go
+++ b/cicd-scripts/metrics/cmd/rulescheck/main.go
@@ -93,12 +93,12 @@ func main() {
 
 	added, removed := utils.Diff(collectedRules, rulesDefined)
 	if len(added) > 0 {
-		fmt.Println("Metrics found in scrape configs but not in rules: ", added)
+		fmt.Println("Metrics found in rules but missing in scrape configs: ", added)
 		os.Exit(1)
 	}
 
 	if len(removed) > 0 {
-		fmt.Println("Metrics found in rules but not in scrape configs: ", removed)
+		fmt.Println("Metrics found in scrape configs but missing in rules: ", removed)
 		os.Exit(1)
 	}
 

--- a/cicd-scripts/metrics/scripts/extract-dashboards-metrics.sh
+++ b/cicd-scripts/metrics/scripts/extract-dashboards-metrics.sh
@@ -5,29 +5,104 @@
 
 set -e -o pipefail
 
-if [ $# -ne 1 ]; then
-  echo "Usage: $0 <directory>"
-  exit 1
-fi
-
-SEARCH_DIR="$1"
+SEARCH_DIR=""
+SEARCH_FILES=()
 
 if [[ "$(uname)" == "Darwin" ]]; then
   TMP_DIR="${TMPDIR:-/tmp}"
 else
   TMP_DIR="/tmp"
 fi
-
 OUTPUT_DIR="$TMP_DIR/grafana-dashboards"
-mkdir -p "$OUTPUT_DIR"
 
-find "$SEARCH_DIR" -name 'dash*.yaml' ! -name '*ocp311.yaml' -print0 | while IFS= read -r -d '' file; do
-  yq '.data | to_entries | .[0].value' "$file" >"$OUTPUT_DIR/$(basename "$file")"
+# Function to display usage information
+usage() {
+  echo "Usage: $0 [--directory DIR] [--files FILE1 [FILE2 ...]]"
+  echo "Either a directory or at least one file must be specified."
+  echo
+  echo "Options:"
+  echo "  --directory, -d   Specify a directory containing dashboard YAML files"
+  echo "  --files, -f       Specify individual dashboard YAML files"
+  echo "  --help, -h        Display this help message"
+  exit 1
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --directory | -d)
+      if [[ -n $SEARCH_DIR ]]; then
+        echo "Error: Only one directory can be specified."
+        usage
+      fi
+      shift
+      if [[ $# -eq 0 || $1 =~ ^-- ]]; then
+        echo "Error: No directory specified after --directory/-d flag."
+        usage
+      fi
+      if [ -d "$1" ]; then
+        SEARCH_DIR="$1"
+      else
+        echo "Error: '$1' is not a valid directory."
+        usage
+      fi
+      shift
+      ;;
+    --files | -f)
+      shift
+      while [[ $# -gt 0 && ! $1 =~ ^-- ]]; do
+        if [ -f "$1" ]; then
+          SEARCH_FILES+=("$1")
+        else
+          echo "Warning: '$1' is not a valid file. Skipping."
+        fi
+        shift
+      done
+      ;;
+    --help | -h)
+      usage
+      ;;
+    *)
+      echo "Unknown option: $1"
+      usage
+      ;;
+  esac
 done
 
-files=$(find "$OUTPUT_DIR" -type f -print0 | xargs -0)
-mimirtool analyze dashboard $files --output "$OUTPUT_DIR/dashboards-metrics.json"
+# Check if either directory or files were specified
+if [ -z "$SEARCH_DIR" ] && [ ${#SEARCH_FILES[@]} -eq 0 ]; then
+  echo "Error: Either a directory or at least one file must be specified."
+  usage
+fi
 
-cat "$OUTPUT_DIR/dashboards-metrics.json" | jq -r '.metricsUsed.[]'
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
 
+# Process directory if specified
+if [ -n "$SEARCH_DIR" ]; then
+  find "$SEARCH_DIR" -name 'dash*.yaml' ! -name '*ocp311.yaml' -print0 | while IFS= read -r -d '' file; do
+    yq '.data | to_entries | .[0].value' "$file" >"$OUTPUT_DIR/$(basename "$file")"
+  done
+fi
+
+# Process individual files
+for file in "${SEARCH_FILES[@]}"; do
+  if [[ "$(basename "$file")" == dash*.yaml && "$(basename "$file")" != *ocp311.yaml ]]; then
+    yq '.data | to_entries | .[0].value' "$file" >"$OUTPUT_DIR/$(basename "$file")"
+  else
+    echo "Skipping $file (doesn't match filename pattern)"
+  fi
+done
+
+# Process the extracted dashboards
+file_count=$(find "$OUTPUT_DIR" -type f | wc -l)
+if [ "$file_count" -gt 0 ]; then
+  files=$(find "$OUTPUT_DIR" -type f -print0 | xargs -0)
+  mimirtool analyze dashboard $files --output "$OUTPUT_DIR/dashboards-metrics.json"
+  cat "$OUTPUT_DIR/dashboards-metrics.json" | jq -r '.metricsUsed.[]'
+else
+  echo "No dashboard files were found or processed."
+fi
+
+# Clean up
 rm -rf "$OUTPUT_DIR"

--- a/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/kustomization.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/kustomization.yaml
@@ -16,4 +16,8 @@ resources:
 - dash-node-rsrc-use.yaml
 - prometheus-rule.yaml
 - scrape-config.yaml
+- scrape-config-uwl-hcp-etcd.yaml
+- scrape-config-uwl-hcp-apiserver.yaml
+- prometheus-rule-uwl-hcp-etcd.yaml
+- prometheus-rule-uwl-hcp-apiserver.yaml
 

--- a/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/prometheus-rule-uwl-hcp-apiserver.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/prometheus-rule-uwl-hcp-apiserver.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: apiserver-hcp-user-workload-metrics-collector # Expected label by MCOA for HCPs
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/managed-by: multicluster-observability-operator
+  name: apiserver-hcp-uwl-rules-default
+  namespace: open-cluster-management-observability
+spec:
+  groups:
+  - name: acm-apiserver-hcp-uwl-rules-default
+    rules:
+    - expr: (histogram_quantile(0.99,sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",
+        verb!="WATCH",clusterID!=""}[5m])) by (le, verb, instance, cluster, clusterID, managementcluster, managementclusterID)))
+      record: apiserver_request_duration_seconds:histogram_quantile_99:instance
+    - expr: sum(rate(apiserver_request_total{job="apiserver",clusterID!=""}[5m])) by (code, instance, cluster, clusterID, managementcluster, managementclusterID)
+      record: sum:apiserver_request_total:5m
+    - expr: histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{job="apiserver",clusterID!=""}[5m])) by (instance, name, le, cluster, clusterID, managementcluster, managementclusterID))
+      record: workqueue_queue_duration_seconds_bucket:apiserver:histogram_quantile_99
+    - expr: (histogram_quantile(0.99,sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",
+        verb!="WATCH",clusterID!=""}[5m])) by (le, cluster, clusterID, managementcluster, managementclusterID)))
+      record: apiserver_request_duration_seconds:histogram_quantile_99

--- a/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/prometheus-rule-uwl-hcp-etcd.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/prometheus-rule-uwl-hcp-etcd.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: etcd-hcp-user-workload-metrics-collector # Expected label by MCOA for HCPs
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/managed-by: multicluster-observability-operator
+  name: etcd-hcp-uwl-rules-default
+  namespace: open-cluster-management-observability
+spec:
+  groups:
+  - name: acm-etcd-hcp-uwl-rules-default
+    rules:
+    - expr: sum(grpc_server_started_total{job="etcd",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream",clusterID!=""}) by (cluster, clusterID, managementcluster, managementclusterID)
+        - sum(grpc_server_handled_total{job="etcd",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream",clusterID!=""}) by (cluster, clusterID, managementcluster, managementclusterID)
+      record: active_streams_lease:grpc_server_handled_total:sum
+    - expr: sum(grpc_server_started_total{job="etcd",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream",clusterID!=""}) by (cluster, clusterID, managementcluster, managementclusterID)
+        - sum(grpc_server_handled_total{job="etcd",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream",clusterID!=""})  by (cluster, clusterID, managementcluster, managementclusterID)
+      record: active_streams_watch:grpc_server_handled_total:sum
+    - expr: sum(rate(grpc_server_started_total{job="etcd",grpc_type="unary",clusterID!=""}[5m])) by (cluster, clusterID, managementcluster, managementclusterID)
+      record: grpc_server_started_total:etcd_unary:sum_rate
+    - expr: sum(rate(grpc_server_handled_total{job="etcd",grpc_type="unary",grpc_code!="OK",clusterID!=""}[5m])) by (cluster, clusterID, managementcluster, managementclusterID)
+      record: rpc_rate:grpc_server_handled_total:sum_rate

--- a/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/scrape-config-uwl-hcp-apiserver.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/scrape-config-uwl-hcp-apiserver.yaml
@@ -1,0 +1,31 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: apiserver-hcp-user-workload-metrics-collector # Expected label by MCOA for HCPs
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/managed-by: multicluster-observability-operator
+  name: apiserver-hcp-uwl-metrics-default
+  namespace: open-cluster-management-observability
+spec:
+  jobName: apiserver-hcp-uwl-metrics-default
+  metricsPath: /federate
+  params:
+    match[]:
+    - '{__name__="apiserver_request_duration_seconds:histogram_quantile_99"}' # needed for the cluster overview dashboard and its apiserver widget
+    - '{__name__="apiserver_request_duration_seconds:histogram_quantile_99:instance"}'
+    - '{__name__="go_goroutines",job="apiserver"}'
+    - '{__name__="process_cpu_seconds_total",job="apiserver"}'
+    - '{__name__="process_resident_memory_bytes",job="apiserver"}'
+    - '{__name__="sum:apiserver_request_total:5m"}'
+    - '{__name__="up",job="apiserver"}'
+    - '{__name__="workqueue_adds_total",job="apiserver"}'
+    - '{__name__="workqueue_depth",job="apiserver"}'
+    - '{__name__="workqueue_queue_duration_seconds_bucket:apiserver:histogram_quantile_99"}'
+  metricRelabelings:
+  - action: labeldrop
+    regex: prometheus_replica|managed_cluster|id
+  staticConfigs:
+  - targets:
+    - localhost:8090

--- a/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/scrape-config-uwl-hcp-etcd.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/scrape-config-uwl-hcp-etcd.yaml
@@ -1,0 +1,41 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: etcd-hcp-user-workload-metrics-collector # Expected label by MCOA for HCPs
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/managed-by: multicluster-observability-operator
+  name: etcd-hcp-uwl-metrics-default
+  namespace: open-cluster-management-observability
+spec:
+  jobName: etcd-hcp-uwl-metrics-default
+  metricsPath: /federate
+  params:
+    match[]:
+    - '{__name__="active_streams_lease:grpc_server_handled_total:sum"}'
+    - '{__name__="active_streams_watch:grpc_server_handled_total:sum"}'
+    - '{__name__="etcd_mvcc_db_total_size_in_bytes"}'
+    - '{__name__="etcd_disk_backend_commit_duration_seconds_bucket"}'
+    - '{__name__="etcd_disk_wal_fsync_duration_seconds_bucket"}'
+    - '{__name__="etcd_network_client_grpc_received_bytes_total"}'
+    - '{__name__="etcd_network_client_grpc_sent_bytes_total"}'
+    - '{__name__="etcd_network_peer_received_bytes_total"}'
+    - '{__name__="etcd_network_peer_sent_bytes_total"}'
+    - '{__name__="etcd_server_has_leader"}'
+    - '{__name__="etcd_server_leader_changes_seen_total"}'
+    - '{__name__="etcd_server_proposals_applied_total"}'
+    - '{__name__="etcd_server_proposals_committed_total"}'
+    - '{__name__="etcd_server_proposals_failed_total"}'
+    - '{__name__="etcd_server_proposals_pending"}'
+    - '{__name__="grpc_server_started_total:etcd_unary:sum_rate"}'
+    - '{__name__="process_resident_memory_bytes",job="etcd"}'
+    - '{__name__="rpc_rate:grpc_server_handled_total:sum_rate"}'
+  metricRelabelings:
+  - action: labeldrop
+    regex: prometheus_replica|managed_cluster|id
+  staticConfigs:
+  - targets:
+    - localhost:8090
+
+

--- a/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
+++ b/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
@@ -69,6 +69,11 @@
       resources: ["opentelemetrycollectors", "instrumentations"]
       verbs: ["get", "list", "watch"]
     # Role for addon to perform prometheus specific actions
+    # servicemonitors resource is needed for the HCPs case
     - apiGroups: ["monitoring.coreos.com"]
-      resources: ["prometheusagents", "scrapeconfigs", "prometheusrules"]
+      resources: ["prometheusagents", "scrapeconfigs", "prometheusrules", "servicemonitors"]
       verbs: ["get", "list", "watch", "create", "update", "delete"]
+    # Role for watching and listing hosted clusters for setting HCPs monitoring
+    - apiGroups: ["hypershift.openshift.io"]
+      resources: ["hostedclusters"]
+      verbs: ["get", "list", "watch"]

--- a/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
@@ -257,6 +257,48 @@ func (r *MCORenderer) renderClusterManagementAddOn(
 						Namespace: mcoconfig.GetDefaultNamespace(),
 					},
 				},
+				// HCPs configurations for etcd
+				{
+					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+						Group:    prometheusalpha1.SchemeGroupVersion.Group,
+						Resource: prometheusalpha1.ScrapeConfigName,
+					},
+					ConfigReferent: addonapiv1alpha1.ConfigReferent{
+						Name:      "etcd-hcp-uwl-metrics-default",
+						Namespace: mcoconfig.GetDefaultNamespace(),
+					},
+				},
+				{
+					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+						Group:    prometheusv1.SchemeGroupVersion.Group,
+						Resource: prometheusv1.PrometheusRuleName,
+					},
+					ConfigReferent: addonapiv1alpha1.ConfigReferent{
+						Name:      "etcd-hcp-uwl-rules-default",
+						Namespace: mcoconfig.GetDefaultNamespace(),
+					},
+				},
+				// HCPs configurations for apiserver
+				{
+					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+						Group:    prometheusalpha1.SchemeGroupVersion.Group,
+						Resource: prometheusalpha1.ScrapeConfigName,
+					},
+					ConfigReferent: addonapiv1alpha1.ConfigReferent{
+						Name:      "apiserver-hcp-uwl-metrics-default",
+						Namespace: mcoconfig.GetDefaultNamespace(),
+					},
+				},
+				{
+					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+						Group:    prometheusv1.SchemeGroupVersion.Group,
+						Resource: prometheusv1.PrometheusRuleName,
+					},
+					ConfigReferent: addonapiv1alpha1.ConfigReferent{
+						Name:      "apiserver-hcp-uwl-rules-default",
+						Namespace: mcoconfig.GetDefaultNamespace(),
+					},
+				},
 			}...)
 		}
 

--- a/operators/multiclusterobservability/pkg/rendering/renderer_mcoa_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_mcoa_test.go
@@ -231,7 +231,8 @@ func TestMCORenderer_RenderClusterManagementAddOn(t *testing.T) {
 				},
 			},
 			expectConfig: func(t *testing.T, cma *addonv1alpha1.ClusterManagementAddOn) {
-				assert.Len(t, cma.Spec.InstallStrategy.Placements[0].Configs, 1)
+				// PrometheusAgent and 4 HCPs scrapeConfigs and rules
+				assert.Len(t, cma.Spec.InstallStrategy.Placements[0].Configs, 5)
 			},
 		},
 		{
@@ -253,7 +254,7 @@ func TestMCORenderer_RenderClusterManagementAddOn(t *testing.T) {
 				},
 			},
 			expectConfig: func(t *testing.T, cma *addonv1alpha1.ClusterManagementAddOn) {
-				assert.Len(t, cma.Spec.InstallStrategy.Placements[0].Configs, 7)
+				assert.Len(t, cma.Spec.InstallStrategy.Placements[0].Configs, 11)
 			},
 		},
 		{


### PR DESCRIPTION
This PR works with its MCOA counterpart: https://github.com/stolostron/multicluster-observability-addon/pull/122

- Add necessary permissions for the addon manager (HostedClusters and ServiceMonitors)
- Define ScrapeConfigs and Rules to be deployed as user workloads monitoring for hosted clusters workloads (etcd and apiserver)
- Add these new configs to the metrics CI checks.
- Reference these configuration in the CMAO when uwl monitoring is enabled.