### PR TITLE
Linter fixes

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,9 +33,4 @@ jobs:
       # We exclude the dockerfile as we have manually modified that to use a different user.
       # In addition we exclude createdAt changes in the CSV file that happen on each make bundle.
       - name: check diff
-        run: | 
-          git diff -I '^    createdAt: ' --exit-code -- . \
-          ':(exclude)operators/multiclusterobservability/bundle.Dockerfile' \
-          ':(exclude)operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml' \
-          ':(exclude)operators/multiclusterobservability/manifests/base/grafana/deployment.yaml' \
-          ':(exclude)operators/multiclusterobservability/manifests/base/observatorium/operator.yaml'
+        run: "git diff -I '^    createdAt: ' --exit-code -- . ':(exclude)operators/multiclusterobservability/bundle.Dockerfile'"

--- a/operators/multiclusterobservability/config/manager/manager.yaml
+++ b/operators/multiclusterobservability/config/manager/manager.yaml
@@ -62,9 +62,6 @@ spec:
             exec:
               command: ["/bin/sh", "-c", "/usr/local/bin/prestop.sh"]
         resources:
-          limits:
-            cpu: 600m
-            memory: 3Gi
           requests:
             cpu: 100m
             memory: 128Mi

--- a/tests/pkg/utils/utils.go
+++ b/tests/pkg/utils/utils.go
@@ -597,7 +597,7 @@ func GetPullSecret(opt TestOptions) (string, error) {
 
 func LoginOCUser(opt TestOptions, user string, password string) error {
 	klog.Errorf("Login as %s with server url %s", user, opt.HubCluster.ClusterServerURL)
-	cmd, err := exec.Command("oc", "login", "-u", user, "-p", password, "--server", opt.HubCluster.ClusterServerURL, "--insecure-skip-tls-verify").CombinedOutput()
+	cmd, err := exec.Command("oc", "login", "-u", user, "-p", password, "--server", opt.HubCluster.ClusterServerURL, "--insecure-skip-tls-verify").CombinedOutput() //nolint:gosec
 	if err != nil {
 		return fmt.Errorf("failed to login as %s: %s", user, string(cmd))
 	}


### PR DESCRIPTION
The linter complains about command injection here. There's potentially a better way of getting the user token than passing username/password to `oc login` - however for now ignoring the linter, as this is a test case and we always control the params which are injected.

----

Correctly fix limit removal
Make sure the limits of MCO resources are removed when generating the bundle instead of simply removing it from the generated files and ignoring the changes in our CI.