### PR TITLE
[2.13] Correctly fix limit removal

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,9 +33,4 @@ jobs:
       # We exclude the dockerfile as we have manually modified that to use a different user.
       # In addition we exclude createdAt changes in the CSV file that happen on each make bundle.
       - name: check diff
-        run: | 
-          git diff -I '^    createdAt: ' --exit-code -- . \
-          ':(exclude)operators/multiclusterobservability/bundle.Dockerfile' \
-          ':(exclude)operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml' \
-          ':(exclude)operators/multiclusterobservability/manifests/base/grafana/deployment.yaml' \
-          ':(exclude)operators/multiclusterobservability/manifests/base/observatorium/operator.yaml'
+        run: "git diff -I '^    createdAt: ' --exit-code -- . ':(exclude)operators/multiclusterobservability/bundle.Dockerfile'"

--- a/operators/multiclusterobservability/config/manager/manager.yaml
+++ b/operators/multiclusterobservability/config/manager/manager.yaml
@@ -62,9 +62,6 @@ spec:
             exec:
               command: ["/bin/sh", "-c", "/usr/local/bin/prestop.sh"]
         resources:
-          limits:
-            cpu: 600m
-            memory: 3Gi
           requests:
             cpu: 100m
             memory: 128Mi


### PR DESCRIPTION
Make sure the limits of MCO resources are removed when generating the bundle instead of simply removing it from the generated files and ignoring the changes in our CI.

ref: https://github.com/stolostron/multicluster-observability-operator/pull/1824