### PR TITLE
[ACM-19970] Make sure detached cluster is cleaned up

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -751,6 +751,11 @@ func getManagedClustersList(ctx context.Context, c client.Client) ([]managedClus
 			continue
 		}
 
+		if mc.GetDeletionTimestamp() != nil {
+			// ignore deleted clusters
+			continue
+		}
+
 		openshiftVersion := nonOCP
 		if version, ok := mc.GetLabels()["openshiftVersion"]; ok {
 			openshiftVersion = version


### PR DESCRIPTION
…ring reconcile

When a cluster detaches, it will still be listed in the managedcluster resource but it will have a DeletionTimeStamp and this causes MCO to think it needs to install Observability. Make sure the managed cluster is not a part of the managedcluster list during delete event.

https://issues.redhat.com/browse/ACM-19970
