### PR TITLE
[Fix]: filter out non standard condition types when replicating addon status conditions

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/status.go
+++ b/operators/multiclusterobservability/controllers/placementrule/status.go
@@ -6,6 +6,7 @@ package placementrule
 
 import (
 	"context"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -19,12 +20,14 @@ import (
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 )
 
+var standardConditionTypes = []string{"Available", "Progressing", "Degraded"}
+
 func updateAddonStatus(ctx context.Context, c client.Client, addonList mcov1beta1.ObservabilityAddonList) error {
 	for _, addon := range addonList.Items {
 		if len(addon.Status.Conditions) == 0 {
 			continue
 		}
-		obsAddonConditions := convertConditionsToMeta(addon.Status.Conditions)
+		obsAddonConditions := filterStandardConditions(convertConditionsToMeta(addon.Status.Conditions))
 		isUpdated := false
 		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			managedclusteraddon := &addonv1alpha1.ManagedClusterAddOn{}
@@ -76,4 +79,15 @@ func convertConditionsToMeta(conditions []mcov1beta1.StatusCondition) []metav1.C
 		metaConditions = append(metaConditions, metaCondition)
 	}
 	return metaConditions
+}
+
+func filterStandardConditions(conditions []metav1.Condition) []metav1.Condition {
+	ret := make([]metav1.Condition, 0, len(conditions))
+	for _, c := range conditions {
+		if slices.Contains(standardConditionTypes, c.Type) {
+			ret = append(ret, c)
+		}
+	}
+
+	return ret
 }

--- a/operators/multiclusterobservability/controllers/placementrule/status_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/status_test.go
@@ -38,6 +38,13 @@ func TestUpdateAddonStatus(t *testing.T) {
 					Reason:             "Deployed",
 					Message:            "It is deployed",
 				},
+				{
+					Type:               "RandomType", // non standard type is ignored
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Unix(1e9, 0)),
+					Reason:             "Deployed",
+					Message:            "It is deployed",
+				},
 			},
 			currentClusterAddonConditions: []metav1.Condition{},
 			expectedClusterAddonConditions: []metav1.Condition{
@@ -55,6 +62,13 @@ func TestUpdateAddonStatus(t *testing.T) {
 			currentObsAddonConditions: []mcov1beta1.StatusCondition{
 				{
 					Type:               "Available",
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Unix(1e9, 0)),
+					Reason:             "Deployed",
+					Message:            "It is deployed",
+				},
+				{
+					Type:               "RandomType", // non standard type is ignored
 					Status:             metav1.ConditionTrue,
 					LastTransitionTime: metav1.NewTime(time.Unix(1e9, 0)),
 					Reason:             "Deployed",


### PR DESCRIPTION
Cf https://issues.redhat.com/browse/ACM-19714