### PR TITLE
Remove Bearer from authorization header when setting X-Forwarded-Access-Token

### DIFF
--- a/proxy/pkg/proxy/proxy.go
+++ b/proxy/pkg/proxy/proxy.go
@@ -133,6 +133,8 @@ func preCheckRequest(req *http.Request) error {
 		if token == "" {
 			return errors.New("found unauthorized user")
 		} else {
+			// Remove Bearer from token if present
+			token = strings.TrimPrefix(token, "Bearer ")
 			req.Header.Set("X-Forwarded-Access-Token", token)
 		}
 	}

--- a/proxy/pkg/proxy/proxy.go
+++ b/proxy/pkg/proxy/proxy.go
@@ -143,7 +143,7 @@ func preCheckRequest(req *http.Request) error {
 	if userName == "" {
 		userName = util.GetUserName(token, config.GetConfigOrDie().Host+userAPIPath)
 		if userName == "" {
-			return errors.New("failed to found user name")
+			return errors.New("failed to find user name")
 		} else {
 			req.Header.Set("X-Forwarded-User", userName)
 		}

--- a/proxy/pkg/proxy/proxy_test.go
+++ b/proxy/pkg/proxy/proxy_test.go
@@ -73,15 +73,19 @@ func TestPreCheckRequest(t *testing.T) {
 	}
 
 	resp.Request.Header.Del("X-Forwarded-Access-Token")
-	resp.Request.Header.Add("Authorization", "test")
+	resp.Request.Header.Add("Authorization", "Bearer test")
 	err = preCheckRequest(req)
 	if err != nil {
-		t.Errorf("failed to test preCheckRequest with bear token: %v", err)
+		t.Errorf("failed to test preCheckRequest with bearer token: %v", err)
+	}
+	// Check if the token is set correctly
+	if resp.Request.Header.Get("X-Forwarded-Access-Token") != "test" {
+		t.Errorf("expected X-Forwarded-Access-Token to be set to 'test', got: %s", resp.Request.Header.Get("X-Forwarded-Access-Token"))
 	}
 
 	resp.Request.Header.Del("X-Forwarded-User")
 	err = preCheckRequest(req)
-	if !strings.Contains(err.Error(), "failed to found user name") {
+	if !strings.Contains(err.Error(), "failed to find user name") {
 		t.Errorf("failed to test preCheckRequest: %v", err)
 	}
 


### PR DESCRIPTION
Remove `Bearer ` from Authorization header when setting X-Forwarded-Access-Token.

This fixes #1942