### PR TITLE
Tests: Make JUnit report conform to QE standard

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,9 +104,9 @@ pipeline {
                     fi
                     cat resources/options.yaml
                     if [[ -n "${params.TAGGING}" ]]; then
-                    ginkgo --junit-report=./pkg/tests/results.xml --focus="\$TAGGING" -v pkg/tests/ -- -options=../../resources/options.yaml -v=5
+                    ginkgo --focus="\$TAGGING" -v pkg/tests/ -- -options=../../resources/options.yaml -v=5
                     else
-                    ginkgo --junit-report=./pkg/tests/results.xml -v pkg/tests/ -- -options=../../resources/options.yaml -v=5
+                    ginkgo -v pkg/tests/ -- -options=../../resources/options.yaml -v=5
                     fi
                 fi
                 """

--- a/tests/pkg/tests/observability-e2e-test_suite_test.go
+++ b/tests/pkg/tests/observability-e2e-test_suite_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
 	"k8s.io/klog"
@@ -129,6 +130,19 @@ func init() {
 
 func TestObservabilityE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
+
+	// Generate JUnit report once all tests have finished with customized settings
+	_ = ReportAfterSuite("", func(report Report) {
+		err := reporters.GenerateJUnitReportWithConfig(
+			report,
+			"results.xml",
+			reporters.JunitReportConfig{OmitSpecLabels: true, OmitLeafNodeType: true},
+		)
+		if err != nil {
+			fmt.Printf("error creating junit report file %s", err.Error())
+		}
+	})
+
 	RunSpecs(t, "Observability E2E Suite")
 }
 

--- a/tests/pkg/tests/observability_addon_test.go
+++ b/tests/pkg/tests/observability_addon_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/utils"
 )
 
-var _ = Describe("Observability:", func() {
+var _ = Describe("", func() {
 	BeforeEach(func() {
 		hubClient = utils.NewKubeClient(
 			testOptions.HubCluster.ClusterServerURL,

--- a/tests/pkg/tests/observability_alert_test.go
+++ b/tests/pkg/tests/observability_alert_test.go
@@ -32,7 +32,7 @@ const (
 	trueStr = "true"
 )
 
-var _ = Describe("Observability:", func() {
+var _ = Describe("", func() {
 	BeforeEach(func() {
 		hubClient = utils.NewKubeClient(
 			testOptions.HubCluster.ClusterServerURL,

--- a/tests/pkg/tests/observability_certrenew_test.go
+++ b/tests/pkg/tests/observability_certrenew_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/utils"
 )
 
-var _ = Describe("Observability:", func() {
+var _ = Describe("", func() {
 	BeforeEach(func() {
 		hubClient = utils.NewKubeClient(
 			testOptions.HubCluster.ClusterServerURL,

--- a/tests/pkg/tests/observability_config_test.go
+++ b/tests/pkg/tests/observability_config_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/utils"
 )
 
-var _ = Describe("Observability:", func() {
+var _ = Describe("", func() {
 	BeforeEach(func() {
 		hubClient = utils.NewKubeClient(
 			testOptions.HubCluster.ClusterServerURL,

--- a/tests/pkg/tests/observability_dashboard_test.go
+++ b/tests/pkg/tests/observability_dashboard_test.go
@@ -20,7 +20,7 @@ const (
 	clusterOverviewOptimizedTitle = "ACM - Clusters Overview (Optimized)"
 )
 
-var _ = Describe("Observability:", func() {
+var _ = Describe("", func() {
 	BeforeEach(func() {
 		hubClient = utils.NewKubeClient(
 			testOptions.HubCluster.ClusterServerURL,

--- a/tests/pkg/tests/observability_endpoint_preserve_test.go
+++ b/tests/pkg/tests/observability_endpoint_preserve_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/utils"
 )
 
-var _ = Describe("Observability:", func() {
+var _ = Describe("", func() {
 	BeforeEach(func() {
 		hubClient = utils.NewKubeClient(
 			testOptions.HubCluster.ClusterServerURL,

--- a/tests/pkg/tests/observability_export_test.go
+++ b/tests/pkg/tests/observability_export_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/utils"
 )
 
-var _ = Describe("Observability:", func() {
+var _ = Describe("", func() {
 	BeforeEach(func() {
 		hubClient = utils.NewKubeClient(
 			testOptions.HubCluster.ClusterServerURL,

--- a/tests/pkg/tests/observability_grafana_dev_test.go
+++ b/tests/pkg/tests/observability_grafana_dev_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/utils"
 )
 
-var _ = Describe("Observability:", func() {
+var _ = Describe("", func() {
 
 	// Do not need to run this case in canary environment
 	// If we really need it in canary, ensure the grafana-dev-test.sh is available

--- a/tests/pkg/tests/observability_grafana_test.go
+++ b/tests/pkg/tests/observability_grafana_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/utils"
 )
 
-var _ = Describe("Observability:", func() {
+var _ = Describe("", func() {
 	BeforeEach(func() {
 		hubClient = utils.NewKubeClient(
 			testOptions.HubCluster.ClusterServerURL,

--- a/tests/pkg/tests/observability_manifestwork_test.go
+++ b/tests/pkg/tests/observability_manifestwork_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/utils"
 )
 
-var _ = Describe("Observability:", func() {
+var _ = Describe("", func() {
 	BeforeEach(func() {
 		hubClient = utils.NewKubeClient(
 			testOptions.HubCluster.ClusterServerURL,

--- a/tests/pkg/tests/observability_metrics_test.go
+++ b/tests/pkg/tests/observability_metrics_test.go
@@ -26,7 +26,7 @@ var (
 	clusterError error
 )
 
-var _ = Describe("Observability:", func() {
+var _ = Describe("", func() {
 	BeforeEach(func() {
 		hubClient = utils.NewKubeClient(
 			testOptions.HubCluster.ClusterServerURL,

--- a/tests/pkg/tests/observability_observatorium_preserve_test.go
+++ b/tests/pkg/tests/observability_observatorium_preserve_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/utils"
 )
 
-var _ = Describe("Observability:", func() {
+var _ = Describe("", func() {
 	BeforeEach(func() {
 		hubClient = utils.NewKubeClient(
 			testOptions.HubCluster.ClusterServerURL,

--- a/tests/pkg/tests/observability_rbac_test.go
+++ b/tests/pkg/tests/observability_rbac_test.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/klog"
 )
 
-var _ = Describe("Observability:", Ordered, func() {
+var _ = Describe("", Ordered, func() {
 	BeforeAll(func() {
 		cmd := exec.Command("../../setup_rbac_test.sh")
 		var out bytes.Buffer

--- a/tests/pkg/tests/observability_reconcile_test.go
+++ b/tests/pkg/tests/observability_reconcile_test.go
@@ -29,7 +29,7 @@ var (
 	err       error
 )
 
-var _ = Describe("Observability:", func() {
+var _ = Describe("", func() {
 
 	BeforeEach(func() {
 		hubClient = utils.NewKubeClient(

--- a/tests/pkg/tests/observability_retention_test.go
+++ b/tests/pkg/tests/observability_retention_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/utils"
 )
 
-var _ = Describe("Observability:", func() {
+var _ = Describe("", func() {
 
 	var (
 		deleteDelay              = "48h"

--- a/tests/pkg/tests/observability_route_test.go
+++ b/tests/pkg/tests/observability_route_test.go
@@ -27,7 +27,7 @@ var (
 	alertCreated bool = false
 )
 
-var _ = Describe("Observability:", func() {
+var _ = Describe("", func() {
 	BeforeEach(func() {
 		hubClient = utils.NewKubeClient(
 			testOptions.HubCluster.ClusterServerURL,


### PR DESCRIPTION
All output should now align with the correct format:
```
<Polarion test case ID>: <Component name>: <Test case name>
```