### PR TITLE
fix: add rbac permission to allow MCOA to get Subscriptions on hub

### DIFF
--- a/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
+++ b/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
@@ -60,6 +60,11 @@
     - apiGroups: [""]
       resources: ["secrets"]
       verbs: ["get", "list", "watch"]
+    # The addon will need to pull subscriptions to know if certain operators
+    # are installed in the hub cluster
+    - apiGroups: ["operators.coreos.com"]
+      resources: ["subscriptions"]
+      verbs: ["get", "list", "watch"]
     # Roles for addon to perform logging specific actions
     - apiGroups: ["observability.openshift.io"]
       resources: ["clusterlogforwarders"]


### PR DESCRIPTION
Related to https://github.com/stolostron/multicluster-observability-addon/pull/150