### PR TITLE
[MCOA]: Update default stack management

### DIFF
--- a/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
+++ b/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
@@ -30,7 +30,7 @@
       verbs: ["update", "patch"]
     - apiGroups: ["addon.open-cluster-management.io"]
       resources: ["clustermanagementaddons"]
-      verbs: ["get", "list", "watch"]
+      verbs: ["get", "list", "watch", "update", "patch"]
     - apiGroups: ["addon.open-cluster-management.io"]
       resources: ["managedclusteraddons"]
       verbs: ["get", "list", "watch", "create", "update", "delete"]

--- a/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
+++ b/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
@@ -77,7 +77,7 @@
     # servicemonitors resource is needed for the HCPs case
     - apiGroups: ["monitoring.coreos.com"]
       resources: ["prometheusagents", "scrapeconfigs", "prometheusrules", "servicemonitors"]
-      verbs: ["get", "list", "watch", "create", "update", "delete"]
+      verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
     # Role for watching and listing hosted clusters for setting HCPs monitoring
     - apiGroups: ["hypershift.openshift.io"]
       resources: ["hostedclusters"]

--- a/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
@@ -186,16 +186,6 @@ func (r *MCORenderer) renderClusterManagementAddOn(
 				{
 					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 						Group:    prometheusalpha1.SchemeGroupVersion.Group,
-						Resource: prometheusalpha1.PrometheusAgentName,
-					},
-					ConfigReferent: addonapiv1alpha1.ConfigReferent{
-						Name:      "acm-platform-metrics-collector-default",
-						Namespace: mcoconfig.GetDefaultNamespace(),
-					},
-				},
-				{
-					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
-						Group:    prometheusalpha1.SchemeGroupVersion.Group,
 						Resource: prometheusalpha1.ScrapeConfigName,
 					},
 					ConfigReferent: addonapiv1alpha1.ConfigReferent{
@@ -248,16 +238,6 @@ func (r *MCORenderer) renderClusterManagementAddOn(
 
 		if r.cr.Spec.Capabilities.UserWorkloads != nil && r.cr.Spec.Capabilities.UserWorkloads.Metrics.Collection.Enabled {
 			globalConfigs = append(globalConfigs, []addonapiv1alpha1.AddOnConfig{
-				{
-					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
-						Group:    prometheusalpha1.SchemeGroupVersion.Group,
-						Resource: prometheusalpha1.PrometheusAgentName,
-					},
-					ConfigReferent: addonapiv1alpha1.ConfigReferent{
-						Name:      "acm-user-workload-metrics-collector-default",
-						Namespace: mcoconfig.GetDefaultNamespace(),
-					},
-				},
 				// HCPs configurations for etcd
 				{
 					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{

--- a/operators/multiclusterobservability/pkg/rendering/renderer_mcoa_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_mcoa_test.go
@@ -216,7 +216,7 @@ func TestMCORenderer_RenderClusterManagementAddOn(t *testing.T) {
 				},
 			},
 			expectConfig: func(t *testing.T, cma *addonv1alpha1.ClusterManagementAddOn) {
-				assert.Len(t, cma.Spec.InstallStrategy.Placements[0].Configs, 6)
+				assert.Len(t, cma.Spec.InstallStrategy.Placements[0].Configs, 5)
 			},
 		},
 		{
@@ -232,7 +232,7 @@ func TestMCORenderer_RenderClusterManagementAddOn(t *testing.T) {
 			},
 			expectConfig: func(t *testing.T, cma *addonv1alpha1.ClusterManagementAddOn) {
 				// PrometheusAgent and 4 HCPs scrapeConfigs and rules
-				assert.Len(t, cma.Spec.InstallStrategy.Placements[0].Configs, 5)
+				assert.Len(t, cma.Spec.InstallStrategy.Placements[0].Configs, 4)
 			},
 		},
 		{
@@ -254,7 +254,7 @@ func TestMCORenderer_RenderClusterManagementAddOn(t *testing.T) {
 				},
 			},
 			expectConfig: func(t *testing.T, cma *addonv1alpha1.ClusterManagementAddOn) {
-				assert.Len(t, cma.Spec.InstallStrategy.Placements[0].Configs, 11)
+				assert.Len(t, cma.Spec.InstallStrategy.Placements[0].Configs, 9)
 			},
 		},
 		{


### PR DESCRIPTION
Adds necessary permissions to the addon manager for updating configurations in the ClusterManagementAddon resource and removes prometheusAgent resources that were previously added here as it is now done in MCOA itself.