### PR TITLE
Tests: pin victoria metrics image

### DIFF
--- a/examples/export/victoriametrics.yaml
+++ b/examples/export/victoriametrics.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: victoriametrics
           image: >-
-            victoriametrics/victoria-metrics:stable
+            victoriametrics/victoria-metrics:v1.117.1
           ports:
             - name: http
               containerPort: 8428


### PR DESCRIPTION
The `stable` image appears to be removed as well. Pin it to a specific version so the tests can pass.