### PR TITLE
Add metrics exceptions for virt dashboards

### DIFF
--- a/cicd-scripts/metrics/Makefile
+++ b/cicd-scripts/metrics/Makefile
@@ -69,6 +69,7 @@ check-virtualization-metrics:
 	@go run cmd/dashcheck/main.go --scrape-configs=$(VIRTUALIZATION_DASH_DIR)/scrape-config.yaml \
 		--dashboard-metrics=$$(cat $(TMPDIR)/dash-metrics) \
 		--ignored-dashboard-metrics=$(HUB_RULES) \
+		--ignored-scrapeconfig-metrics=kubevirt_vm_info,kubevirt_vm_disk_allocated_size_bytes \
 		--additional-scrape-configs=$(PLATFORM_DASH_DIR)/scrape-config.yaml,$(ALERTS_DASH_DIR)/scrape-config.yaml
 	@rm -d $(TMPDIR)/dash-metrics
 


### PR DESCRIPTION
Help fixing pending virt dashboar PRs. Once they rebase on it, some will be green.

These metrics exceptions are needed because the tool extracting metrics from dashboards is missing some.