### PR TITLE
Remove exception for kubevirt PRs

### DIFF
--- a/cicd-scripts/metrics/Makefile
+++ b/cicd-scripts/metrics/Makefile
@@ -69,7 +69,7 @@ check-virtualization-metrics:
 	@go run cmd/dashcheck/main.go --scrape-configs=$(VIRTUALIZATION_DASH_DIR)/scrape-config.yaml \
 		--dashboard-metrics=$$(cat $(TMPDIR)/dash-metrics) \
 		--ignored-dashboard-metrics=$(HUB_RULES) \
-		--ignored-scrapeconfig-metrics=kubevirt_vm_info,kubevirt_vm_disk_allocated_size_bytes,kubevirt_vm_create_date_timestamp_seconds \
+		--ignored-scrapeconfig-metrics=kubevirt_vm_disk_allocated_size_bytes,kubevirt_vm_create_date_timestamp_seconds \
 		--additional-scrape-configs=$(PLATFORM_DASH_DIR)/scrape-config.yaml,$(ALERTS_DASH_DIR)/scrape-config.yaml
 	@rm -d $(TMPDIR)/dash-metrics
 


### PR DESCRIPTION
This exception is not needed for merging next kubevirt PRs