### PR TITLE
Correctly handle custom-certs in config tests

### DIFF
--- a/examples/updatemcocr/advancedmcoconfig/custom-certs/kustomization.yaml
+++ b/examples/updatemcocr/advancedmcoconfig/custom-certs/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- v1beta2-observability-custom-mco.yaml

--- a/examples/updatemcocr/advancedmcoconfig/custom-certs/v1beta2-observability-custom-mco.yaml
+++ b/examples/updatemcocr/advancedmcoconfig/custom-certs/v1beta2-observability-custom-mco.yaml
@@ -39,6 +39,23 @@ spec:
           memory: 2Gi
       serviceAccountAnnotations:
         test.com/role-arn: 's3_role'
+      containers:
+        - name: thanos-compact
+          args:
+            - compact
+            - --wait
+            - --log.level=debug
+            - --log.format=logfmt
+            - --objstore.config=$(OBJSTORE_CONFIG)
+            - --data-dir=/var/thanos/compact
+            - --debug.accept-malformed-index
+            - --retention.resolution-raw=6d
+            - --retention.resolution-5m=15d
+            - --retention.resolution-1h=31d
+            - --delete-delay=50h
+            - --compact.concurrency=1
+            - --downsample.concurrency=1
+            - --deduplication.replica-label=replica
     receive:
       resources:
         limits:
@@ -55,6 +72,23 @@ spec:
       replicas: 3
       serviceAccountAnnotations:
         test.com/role-arn: 's3_role'
+      containers:
+        - name: thanos-rule
+          args:
+            - rule
+            - --log.level=debug
+            - --log.format=logfmt
+            - --grpc-address=0.0.0.0:10901
+            - --http-address=0.0.0.0:10902
+            - --objstore.config=$(OBJSTORE_CONFIG)
+            - --data-dir=/var/thanos/rule
+            - --label=rule_replica="$(NAME)"
+            - --alert.label-drop=rule_replica
+            - --tsdb.retention=5d
+            - --tsdb.block-duration=3h
+            - --query=dnssrv+_http._tcp.observability-thanos-query.open-cluster-management-observability.svc.cluster.local
+            - --alertmanagers.config-file=/etc/thanos/config/thanos-ruler-config/config.yaml
+            - --rule-file=/etc/thanos/rules/thanos-ruler-default-rules/default_rules.yaml
     store:
       resources:
         limits:
@@ -119,6 +153,8 @@ spec:
     metricObjectStorage:
       key: thanos.yaml
       name: thanos-object-storage
+      tlsSecretMountPath: /etc/minio/certs
+      tlsSecretName: minio-tls-secret
     receiveStorageSize: 1Gi
     ruleStorageSize: 1Gi
     storageClass: gp2

--- a/examples/updatemcocr/advancedmcoconfig/v1beta2-observability-custom-mco.yaml
+++ b/examples/updatemcocr/advancedmcoconfig/v1beta2-observability-custom-mco.yaml
@@ -153,8 +153,6 @@ spec:
     metricObjectStorage:
       key: thanos.yaml
       name: thanos-object-storage
-      tlsSecretMountPath: /etc/minio/certs
-      tlsSecretName: minio-tls-secret
     receiveStorageSize: 1Gi
     ruleStorageSize: 1Gi
     storageClass: gp2

--- a/examples/updatemcocr/initialmcoconfig/custom-certs/kustomization.yaml
+++ b/examples/updatemcocr/initialmcoconfig/custom-certs/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- v1beta2-observability-initial-mco.yaml

--- a/examples/updatemcocr/initialmcoconfig/custom-certs/v1beta2-observability-initial-mco.yaml
+++ b/examples/updatemcocr/initialmcoconfig/custom-certs/v1beta2-observability-initial-mco.yaml
@@ -119,6 +119,8 @@ spec:
     metricObjectStorage:
       key: thanos.yaml
       name: thanos-object-storage
+      tlsSecretMountPath: /etc/minio/certs
+      tlsSecretName: minio-tls-secret
     receiveStorageSize: 1Gi
     ruleStorageSize: 1Gi
     storageClass: gp2

--- a/tests/pkg/tests/observability_config_test.go
+++ b/tests/pkg/tests/observability_config_test.go
@@ -7,6 +7,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -36,7 +37,15 @@ var _ = Describe("", func() {
 	It("RHACM4K-31474: Observability: Verify memcached setting max_item_size is populated on thanos-store - [P1][Sev1][Observability][Stable]@ocpInterop @non-ui-post-restore @non-ui-post-release @non-ui-pre-upgrade @non-ui-post-upgrade @post-upgrade @post-restore @e2e @post-release(config/g1)", func() {
 
 		By("Updating mco cr to update values in storeMemcached")
-		yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: "../../../examples/updatemcocr/initialmcoconfig"})
+
+		mcoPath := ""
+		if os.Getenv("IS_CANARY_ENV") != trueStr {
+			mcoPath = "../../../examples/updatemcocr/initialmcoconfig/custom-certs"
+		} else {
+			mcoPath = "../../../examples/updatemcocr/initialmcoconfig"
+		}
+
+		yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: mcoPath})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(
 			utils.Apply(
@@ -75,7 +84,15 @@ var _ = Describe("", func() {
 	It("RHACM4K-31475: Observability: Verify memcached setting max_item_size is populated on thanos-query-frontend - [P1][Sev1][Observability][Stable]@ocpInterop @non-ui-post-restore @non-ui-post-release @non-ui-pre-upgrade @non-ui-post-upgrade @post-upgrade @post-restore @e2e @post-release(config/g1)", func() {
 
 		By("Updating mco cr to update values in storeMemcached")
-		yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: "../../../examples/updatemcocr/initialmcoconfig"})
+
+		mcoPath := ""
+		if os.Getenv("IS_CANARY_ENV") != trueStr {
+			mcoPath = "../../../examples/updatemcocr/initialmcoconfig/custom-certs"
+		} else {
+			mcoPath = "../../../examples/updatemcocr/initialmcoconfig"
+		}
+
+		yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: mcoPath})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(
 			utils.Apply(
@@ -350,7 +367,15 @@ var _ = Describe("", func() {
 
 	It("RHACM4K-43019 - Observability - Verify overwrite Thanos components CLI args in MCO CR - [P2][Sev2][Observability][Integration]@ocpInterop @non-ui-post-restore @non-ui-post-release @non-ui-pre-upgrade @non-ui-post-upgrade @post-upgrade @post-restore @e2e @post-release (config/g0)", func() {
 		By("Updating mco cr to update cli args")
-		yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: "../../../examples/updatemcocr/advancedmcoconfig"})
+
+		mcoPath := ""
+		if os.Getenv("IS_CANARY_ENV") != trueStr {
+			mcoPath = "../../../examples/updatemcocr/advancedmcoconfig/custom-certs"
+		} else {
+			mcoPath = "../../../examples/updatemcocr/advancedmcoconfig"
+		}
+
+		yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: mcoPath})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(
 			utils.Apply(
@@ -434,7 +459,12 @@ var _ = Describe("", func() {
 		}, EventuallyTimeoutMinute*1, EventuallyIntervalSecond*10).Should(BeTrue())
 
 		By("Revert MCO back to initial config")
-		yamlB, err = kustomize.Render(kustomize.Options{KustomizationPath: "../../../examples/updatemcocr/initialmcoconfig"})
+		if os.Getenv("IS_CANARY_ENV") != trueStr {
+			mcoPath = "../../../examples/updatemcocr/initial/custom-certs"
+		} else {
+			mcoPath = "../../../examples/updatemcocr/initial"
+		}
+		yamlB, err = kustomize.Render(kustomize.Options{KustomizationPath: mcoPath})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(
 			utils.Apply(

--- a/tests/pkg/tests/observability_config_test.go
+++ b/tests/pkg/tests/observability_config_test.go
@@ -460,9 +460,9 @@ var _ = Describe("", func() {
 
 		By("Revert MCO back to initial config")
 		if os.Getenv("IS_CANARY_ENV") != trueStr {
-			mcoPath = "../../../examples/updatemcocr/initial/custom-certs"
+			mcoPath = "../../../examples/updatemcocr/initialmcoconfig/custom-certs"
 		} else {
-			mcoPath = "../../../examples/updatemcocr/initial"
+			mcoPath = "../../../examples/updatemcocr/initialmcoconfig"
 		}
 		yamlB, err = kustomize.Render(kustomize.Options{KustomizationPath: mcoPath})
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
The config tests, which applies CRs from `examples/updatemcocr` did not correctly handled the cases where the minio-tls-secret was not applied. This commit ensure have two versions of the mcoCR that handle both when the tls-secret is created and when it is not.

/cherry-pick release-2.13