### PR TITLE
e2e: Do not replace object-storage secret with *

### DIFF
--- a/tests/pkg/utils/mco_deploy.go
+++ b/tests/pkg/utils/mco_deploy.go
@@ -673,7 +673,8 @@ func CreateObjSecret(opt TestOptions) error {
 	}
 	re := regexp.MustCompile(`^\*+$`)
 	if re.MatchString(accessKey) || re.MatchString(secretKey) {
-		return fmt.Errorf("store key/secret are invalid, replaced by stars: key %q", secretKey)
+		fmt.Printf("WARNING: store key/secret are invalid, replaced by stars: key %q. Continuing without creating/updating object storage secret.\n", secretKey)
+		return nil
 	}
 
 	objSecret := fmt.Sprintf(`apiVersion: v1


### PR DESCRIPTION
Ensures we don't get bogus secrets when re-running QE tests via Jenkins.