### PR TITLE
Fix CI metrics check

### DIFF
--- a/cicd-scripts/metrics/Makefile
+++ b/cicd-scripts/metrics/Makefile
@@ -20,6 +20,7 @@ check-platform-metrics:
 	@cat $(PLATFORM_DASH_DIR)/prometheus-rule.yaml | yq '.spec' | promtool check rules
 	@go run cmd/rulescheck/main.go --scrape-configs=$(PLATFORM_DASH_DIR)/scrape-config.yaml \
 		--rules=$(PLATFORM_DASH_DIR)/prometheus-rule.yaml \
+		--ignored-rules-missing-definition=cluster:health:components:map \
 		--ignore-duplicated-rules=namespace_workload_pod:kube_pod_owner:relabel
 	@rm -d $(TMPDIR)/dash-metrics
 

--- a/cicd-scripts/metrics/cmd/rulescheck/main.go
+++ b/cicd-scripts/metrics/cmd/rulescheck/main.go
@@ -25,6 +25,7 @@ func main() {
 	scrapeConfigsArg := flag.String("scrape-configs", "", "Path to the comma separated scrape_configs")
 	rulesArg := flag.String("rules", "", "Comma separated prometheus rules files")
 	ignoreDupRulesArg := flag.String("ignore-duplicated-rules", "", "Comma separated ignored duplicated rules")
+	ignoredRulesMissingDefArg := flag.String("ignored-rules-missing-definition", "", "Comma separated ignored rules whose definition is missing")
 	greenCheckMark := "\033[32m" + "✓" + "\033[0m"
 	flag.Parse()
 
@@ -97,8 +98,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	if len(removed) > 0 {
-		fmt.Println("Metrics found in scrape configs but missing in rules: ", removed)
+	ignoredRulesMissingDef := strings.Split(*ignoredRulesMissingDefArg, ",")
+	rulesWithoutIgnoredMissingDef := slices.DeleteFunc(slices.Clone(removed), func(s string) bool { return s == "" || slices.Contains(ignoredRulesMissingDef, s) })
+	if len(rulesWithoutIgnoredMissingDef) > 0 {
+		fmt.Println("Metrics found in scrape configs but missing in rules: ", rulesWithoutIgnoredMissingDef)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
- Adds the `--ignored-rules-missing-definition` flag to the rulescheck command.
- Adds the `cluster:health:components:map` metrics to the ignored rules as it is defined directly through COO for incident detection feature.