### PR TITLE
Tests: Skip watchdog alert on *ks on missing login

### DIFF
--- a/tests/pkg/tests/observability_alert_test.go
+++ b/tests/pkg/tests/observability_alert_test.go
@@ -406,31 +406,39 @@ var _ = Describe("", func() {
 		Expect(err).NotTo(HaveOccurred())
 		expectedKSClusterNames, err := utils.ListAvailableKSManagedClusterNames(testOptions)
 		Expect(err).NotTo(HaveOccurred())
-		expectClusterIdentifiers := append(expectedOCPClusterIDs, expectedKSClusterNames...)
-		missingClusters := slices.Clone(expectClusterIdentifiers)
-		klog.Infof("List of cluster IDs expected to send the alert is: %s", expectClusterIdentifiers)
-
-		// Ensure we have at least a managedCluster
-		Expect(expectClusterIdentifiers).To(Not(BeEmpty()))
 
 		// install watchdog PrometheusRule to *KS clusters
 		watchDogRuleKustomizationPath := "../../../examples/alerts/watchdog_rule"
 		yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: watchDogRuleKustomizationPath})
 		Expect(err).NotTo(HaveOccurred())
 		klog.Infof("List of cluster IDs to install the watchdog alert: %s", expectedKSClusterNames)
-		for _, ks := range expectedKSClusterNames {
-			for idx, mc := range testOptions.ManagedClusters {
+		for idx, ks := range expectedKSClusterNames {
+			promRuleAdded := false
+			for ydx, mc := range testOptions.ManagedClusters {
 				if mc.Name == ks {
 					err = utils.Apply(
-						testOptions.ManagedClusters[idx].ClusterServerURL,
-						testOptions.ManagedClusters[idx].KubeConfig,
-						testOptions.ManagedClusters[idx].KubeContext,
+						testOptions.ManagedClusters[ydx].ClusterServerURL,
+						testOptions.ManagedClusters[ydx].KubeConfig,
+						testOptions.ManagedClusters[ydx].KubeContext,
 						yamlB,
 					)
+					promRuleAdded = true
 					Expect(err).NotTo(HaveOccurred())
 				}
 			}
+			// If we couldn't find the credentials for the cluster and therefore
+			// unable to add the Prometheus rule, we skip the checking the cluster
+			if !promRuleAdded {
+				klog.Infof("WARNING: Credentials for cluster %s not found, removing from list of expected clusters", ks)
+				expectedKSClusterNames = slices.Delete(expectedKSClusterNames, idx, idx+1)
+			}
 		}
+
+		expectClusterIdentifiers := append(expectedOCPClusterIDs, expectedKSClusterNames...)
+		klog.Infof("List of cluster IDs expected to send the alert is: %s", expectClusterIdentifiers)
+		missingClusters := slices.Clone(expectClusterIdentifiers)
+		// Ensure we have at least a managedCluster
+		Expect(expectClusterIdentifiers).To(Not(BeEmpty()))
 
 		By("Checking Watchdog alerts are forwarded to the hub")
 		Eventually(func() error {


### PR DESCRIPTION
For *ks clusters, the watchdog alert is not installed by default. Our testcase, therefore tries to login to the managed *ks clusters and install the alert. However this depends on the login details for the *ks cluster being correctly supplied in the options.yaml file, which often is not the case.

This PR removes any *ks clusters for the expected clusters list, if we are unable to login and add the watchdog alert the the *ks clusters' prometheus instance.