### PR TITLE
Tests: skip RHACM4K-7518 if no managed cluster

### DIFF
--- a/tests/pkg/tests/observability_addon_test.go
+++ b/tests/pkg/tests/observability_addon_test.go
@@ -220,20 +220,22 @@ var _ = Describe("", func() {
 				return utils.UpdateObservabilityFromManagedCluster(testOptions, true)
 			}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 
-			By("Waiting for MCO addon components ready")
-			Eventually(func() bool {
-				err, podList := utils.GetPodList(
-					testOptions,
-					false,
-					MCO_ADDON_NAMESPACE,
-					"component=metrics-collector",
-				)
-				// starting with OCP 4.13, userWorkLoadMonitoring is enabled by default
-				if len(podList.Items) >= 1 && err == nil {
-					return true
-				}
-				return false
-			}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(BeTrue())
+			if len(testOptions.ManagedClusters) > 0 {
+				By("Waiting for MCO addon components ready")
+				Eventually(func() bool {
+					err, podList := utils.GetPodList(
+						testOptions,
+						false,
+						MCO_ADDON_NAMESPACE,
+						"component=metrics-collector",
+					)
+					// starting with OCP 4.13, userWorkLoadMonitoring is enabled by default
+					if len(podList.Items) >= 1 && err == nil {
+						return true
+					}
+					return false
+				}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(BeTrue())
+			}
 		})
 	},
 	)


### PR DESCRIPTION
This test depends on the managed cluster being correctly added to the testoptions. Therefore we skip the test completetly, if this is not the case.