### PR TITLE
Tests: Skip victoria-metrics test on IBMZ

### DIFF
--- a/tests/pkg/tests/observability_export_test.go
+++ b/tests/pkg/tests/observability_export_test.go
@@ -7,6 +7,7 @@ package tests
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,6 +18,12 @@ import (
 
 var _ = Describe("", func() {
 	BeforeEach(func() {
+
+		cloudProvider := strings.ToLower(os.Getenv("CLOUD_PROVIDER"))
+		if strings.Contains(cloudProvider, "ibmz") {
+			Skip("skip on IMB-z as victoria-metrics image not available")
+		}
+
 		hubClient = utils.NewKubeClient(
 			testOptions.HubCluster.ClusterServerURL,
 			testOptions.KubeConfig,
@@ -111,7 +118,11 @@ var _ = Describe("", func() {
 	})
 
 	AfterEach(func() {
-		Expect(utils.CleanExportResources(testOptions)).NotTo(HaveOccurred())
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+
+		cloudProvider := strings.ToLower(os.Getenv("CLOUD_PROVIDER"))
+		if !strings.Contains(cloudProvider, "ibmz") {
+			Expect(utils.CleanExportResources(testOptions)).NotTo(HaveOccurred())
+			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		}
 	})
 })


### PR DESCRIPTION
Victoriametrics doesn't ship an image for IMBZ, so this test is skipped on this arch.