### PR TITLE
forward user workload alerts from spoke clusters to acm hub alert manager

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
@@ -11,6 +11,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -214,115 +215,6 @@ func TestClusterMonitoringConfigAlertsDisabled(t *testing.T) {
 	cmc := newClusterMonitoringConfigCM(clusterMonitoringConfigDataYaml, "endpoint-monitoring-operator")
 	objs := []runtime.Object{hubInfoObj, amAccessSrt, cmc}
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
-	// t.Run("disable alert forwarding as manager", func(t *testing.T) {
-	// 	err = createOrUpdateClusterMonitoringConfig(ctx, hubInfo, testClusterID, c, false)
-	// 	if err != nil {
-	// 		t.Fatalf("Failed to create or update the cluster-monitoring-config configmap: (%v)", err)
-	// 	}
-
-	// 	foundclusterMonitoringRevertedCM := &corev1.ConfigMap{}
-	// 	err = c.Get(ctx, types.NamespacedName{Name: clusterMonitoringRevertedName,
-	// 		Namespace: namespace}, foundclusterMonitoringRevertedCM)
-	// 	if err != nil {
-	// 		t.Fatalf("failed to retrieve configmap %s: %v", clusterMonitoringRevertedName, err)
-	// 	}
-
-	// 	foundCusterMonitoringConfigMap := &corev1.ConfigMap{}
-	// 	err = c.Get(ctx, types.NamespacedName{Name: clusterMonitoringConfigName,
-	// 		Namespace: promNamespace}, foundCusterMonitoringConfigMap)
-	// 	if err != nil {
-	// 		t.Fatalf("could not retrieve configmap %s: %v", clusterMonitoringConfigName, err)
-	// 	}
-
-	// 	foundClusterMonitoringConfigurationYAML, ok := foundCusterMonitoringConfigMap.Data[clusterMonitoringConfigDataKey]
-	// 	if !ok {
-	// 		t.Fatalf("configmap: %s doesn't contain key: %s", clusterMonitoringConfigName, clusterMonitoringConfigDataKey)
-	// 	}
-	// 	foundClusterMonitoringConfigurationJSON, err := yamltool.YAMLToJSON([]byte(foundClusterMonitoringConfigurationYAML))
-	// 	if err != nil {
-	// 		t.Fatalf("failed to transform YAML to JSON:\n%s\n", foundClusterMonitoringConfigurationYAML)
-	// 	}
-
-	// 	foundClusterMonitoringConfiguration := &cmomanifests.ClusterMonitoringConfiguration{}
-	// 	if err := json.Unmarshal([]byte(foundClusterMonitoringConfigurationJSON), foundClusterMonitoringConfiguration); err != nil {
-	// 		t.Fatalf("failed to marshal the cluster monitoring config: %v:\n%s\n", err, foundClusterMonitoringConfigurationJSON)
-	// 	}
-
-	// 	if foundClusterMonitoringConfiguration.PrometheusK8sConfig == nil {
-	// 		t.Fatalf("empty prometheusK8s in ClusterMonitoringConfiguration: %v", foundClusterMonitoringConfiguration)
-	// 	}
-
-	// 	if label := foundClusterMonitoringConfiguration.PrometheusK8sConfig.ExternalLabels[operatorconfig.ClusterLabelKeyForAlerts]; label != "" {
-	// 		t.Fatalf("managed cluster label not deleted on revert: %s:%s",
-	// 			operatorconfig.ClusterLabelKeyForAlerts,
-	// 			label)
-	// 	}
-
-	// 	if foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs != nil {
-	// 		t.Fatalf("AlertmanagerConfigs in ClusterMonitoringConfiguration.PrometheusK8sConfig: is not null")
-	// 	}
-	// })
-
-	// // Scenario 2:
-	// //    cluster-monitoring-config created externally (e.g, policy)
-	// //    disable alert forwarding
-	// //    verify cluster-monitoring-config is not reverted
-	// // err = c.Delete(ctx, cmc)
-	// // if err != nil {
-	// // 	t.Fatalf("could not delete existing cluster-monitoring-config")
-	// // }
-	// err = c.Create(ctx, newClusterMonitoringConfigCM(clusterMonitoringConfigDataYaml, "some-other-manager"))
-	// if err != nil {
-	// 	t.Fatalf("could not recreate cluster-monitoring-config with alerts enabled")
-	// }
-	// t.Run("disable alert forwarding as non-manager", func(t *testing.T) {
-	// 	err = createOrUpdateClusterMonitoringConfig(ctx, hubInfo, testClusterID, c, false)
-	// 	if err != nil {
-	// 		t.Fatalf("Failed to create or update the cluster-monitoring-config configmap: (%v)", err)
-	// 	}
-
-	// 	foundclusterMonitoringRevertedCM := &corev1.ConfigMap{}
-	// 	err = c.Get(ctx, types.NamespacedName{Name: clusterMonitoringRevertedName,
-	// 		Namespace: namespace}, foundclusterMonitoringRevertedCM)
-	// 	if err != nil {
-	// 		t.Fatalf("failed to retrieve configmap %s: %v", clusterMonitoringRevertedName, err)
-	// 	}
-
-	// 	foundCusterMonitoringConfigMap := &corev1.ConfigMap{}
-	// 	err = c.Get(ctx, types.NamespacedName{Name: clusterMonitoringConfigName,
-	// 		Namespace: promNamespace}, foundCusterMonitoringConfigMap)
-	// 	if err != nil {
-	// 		t.Fatalf("could not retrieve configmap %s: %v", clusterMonitoringConfigName, err)
-	// 	}
-
-	// 	foundClusterMonitoringConfigurationYAML, ok := foundCusterMonitoringConfigMap.Data[clusterMonitoringConfigDataKey]
-	// 	if !ok {
-	// 		t.Fatalf("configmap: %s doesn't contain key: %s", clusterMonitoringConfigName, clusterMonitoringConfigDataKey)
-	// 	}
-	// 	foundClusterMonitoringConfigurationJSON, err := yamltool.YAMLToJSON([]byte(foundClusterMonitoringConfigurationYAML))
-	// 	if err != nil {
-	// 		t.Fatalf("failed to transform YAML to JSON:\n%s\n", foundClusterMonitoringConfigurationYAML)
-	// 	}
-
-	// 	foundClusterMonitoringConfiguration := &cmomanifests.ClusterMonitoringConfiguration{}
-	// 	if err := json.Unmarshal([]byte(foundClusterMonitoringConfigurationJSON), foundClusterMonitoringConfiguration); err != nil {
-	// 		t.Fatalf("failed to marshal the cluster monitoring config: %v:\n%s\n", err, foundClusterMonitoringConfigurationJSON)
-	// 	}
-
-	// 	if foundClusterMonitoringConfiguration.PrometheusK8sConfig == nil {
-	// 		t.Fatalf("empty prometheusK8s in ClusterMonitoringConfiguration: %v, expected to preserve content", foundClusterMonitoringConfiguration)
-	// 	}
-
-	// 	if label := foundClusterMonitoringConfiguration.PrometheusK8sConfig.ExternalLabels[operatorconfig.ClusterLabelKeyForAlerts]; label != "" {
-	// 		t.Fatalf("managed cluster label not deleted on revert: %s:%s",
-	// 			operatorconfig.ClusterLabelKeyForAlerts,
-	// 			label)
-	// 	}
-
-	// 	if foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs == nil {
-	// 		t.Fatalf("AlertmanagerConfigs in ClusterMonitoringConfiguration.PrometheusK8sConfig reverted, expected to be preserved")
-	// 	}
-	// })
 
 	// Scenario 3:
 	//   Reenable alert forwarding.
@@ -488,5 +380,369 @@ func testCreateOrUpdateClusterMonitoringConfig(t *testing.T, hubInfo *operatorco
 	err = RevertClusterMonitoringConfig(ctx, c)
 	if err != nil {
 		t.Fatalf("Run into error when try to revert cluster-monitoring-config configmap twice: (%v)", err)
+	}
+}
+
+func TestUserWorkloadMonitoringConfig(t *testing.T) {
+	testNamespace := operatorconfig.OCPUserWorkloadMonitoringNamespace
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
+	tests := []struct {
+		name                                   string
+		UserWorkloadMonitoringConfigCMExist    bool
+		UserWorkloadMonitoringConfigDataYaml   string
+		Manager                                string
+		ExpectedDeleteUserWorkloadMonitoringCM bool
+	}{
+		{
+			name:                                   "no user-workload-monitoring-config exists",
+			UserWorkloadMonitoringConfigCMExist:    false,
+			ExpectedDeleteUserWorkloadMonitoringCM: false,
+		},
+		{
+			name:                                   "user-workload-monitoring-config with empty config.yaml",
+			UserWorkloadMonitoringConfigCMExist:    true,
+			UserWorkloadMonitoringConfigDataYaml:   "",
+			Manager:                                endpointMonitoringOperatorMgr,
+			ExpectedDeleteUserWorkloadMonitoringCM: false,
+		},
+		{
+			name:                                "user-workload-monitoring-config with non-empty config.yaml and empty prometheus",
+			UserWorkloadMonitoringConfigCMExist: true,
+			Manager:                             "some-other-manager",
+			UserWorkloadMonitoringConfigDataYaml: `
+prometheus: null`,
+			ExpectedDeleteUserWorkloadMonitoringCM: false,
+		},
+		{
+			name:                                "user-workload-monitoring-config with non-empty config.yaml and prometheus and empty alertmanagerConfigs",
+			UserWorkloadMonitoringConfigCMExist: true,
+			UserWorkloadMonitoringConfigDataYaml: `
+prometheus:
+  alertmanagerConfigs: null`,
+			ExpectedDeleteUserWorkloadMonitoringCM: false,
+		},
+		{
+			name:                                "user-workload-monitoring-config with non-empty config.yaml and empty prometheus with endpoint-monitoring-operator manager",
+			UserWorkloadMonitoringConfigCMExist: true,
+			Manager:                             endpointMonitoringOperatorMgr,
+			UserWorkloadMonitoringConfigDataYaml: `
+prometheus: null`,
+			ExpectedDeleteUserWorkloadMonitoringCM: false,
+		},
+		{
+			name:                                "user-workload-monitoring-config with non-empty config.yaml and prometheus and alertmanagerConfigs",
+			UserWorkloadMonitoringConfigCMExist: true,
+			UserWorkloadMonitoringConfigDataYaml: `
+prometheus:
+  alertmanagerConfigs:
+  - apiVersion: v2
+    bearerToken:
+      key: token
+      name: foo
+    pathPrefix: /
+    scheme: https
+    staticConfigs:
+    - test-host.com
+    tlsConfig:
+      insecureSkipVerify: true`,
+			ExpectedDeleteUserWorkloadMonitoringCM: false,
+		},
+	}
+
+	hubInfo := &operatorconfig.HubInfo{}
+	err := yaml.Unmarshal([]byte(hubInfoYAML), &hubInfo)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal hubInfo: (%v)", err)
+	}
+	hubInfoObj := newHubInfoSecret([]byte(hubInfoYAML), testNamespace)
+	tokenValue := "test-token"
+	amAccessSrt := newAMAccessorSecret(testNamespace, tokenValue)
+
+	// Create router CA secret in the user workload monitoring namespace
+	routerCASecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hubAmRouterCASecretName,
+			Namespace: testNamespace,
+		},
+		Data: map[string][]byte{
+			"service-ca.crt": []byte("test-ca-crt"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := []runtime.Object{hubInfoObj, amAccessSrt, routerCASecret}
+			if tt.UserWorkloadMonitoringConfigCMExist {
+				objs = append(objs, newUserWorkloadMonitoringConfigCM(tt.UserWorkloadMonitoringConfigDataYaml, tt.Manager))
+			}
+			testCreateOrUpdateUserWorkloadMonitoringConfig(t, hubInfo, fake.NewClientBuilder().WithRuntimeObjects(objs...).Build(), tt.ExpectedDeleteUserWorkloadMonitoringCM, tokenValue)
+		})
+	}
+}
+
+func newUserWorkloadMonitoringConfigCM(configDataStr string, mgr string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+			Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{
+					Manager:   mgr,
+					Operation: metav1.ManagedFieldsOperationUpdate,
+				},
+			},
+		},
+		Data: map[string]string{
+			"config.yaml": configDataStr,
+		},
+	}
+}
+
+func testCreateOrUpdateUserWorkloadMonitoringConfig(t *testing.T, hubInfo *operatorconfig.HubInfo, c client.Client, expectedCMDelete bool, tokenValue string) {
+	ctx := context.TODO()
+	err := createOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
+	if err != nil {
+		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
+	}
+
+	foundUserWorkloadMonitoringConfigMap := &corev1.ConfigMap{}
+	err = c.Get(ctx, types.NamespacedName{
+		Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+		Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+	}, foundUserWorkloadMonitoringConfigMap)
+	if err != nil {
+		t.Fatalf("failed to check configmap %s: %v", operatorconfig.OCPUserWorkloadMonitoringConfigMap, err)
+	}
+
+	foundUserWorkloadConfigurationYAML, ok := foundUserWorkloadMonitoringConfigMap.Data["config.yaml"]
+	if !ok {
+		t.Fatalf("configmap: %s doesn't contain key: config.yaml", operatorconfig.OCPUserWorkloadMonitoringConfigMap)
+	}
+	foundUserWorkloadConfigurationJSON, err := yamltool.YAMLToJSON([]byte(foundUserWorkloadConfigurationYAML))
+	if err != nil {
+		t.Fatalf("failed to transform YAML to JSON:\n%s\n", foundUserWorkloadConfigurationYAML)
+	}
+
+	foundUserWorkloadConfiguration := &cmomanifests.UserWorkloadConfiguration{}
+	if err := json.Unmarshal([]byte(foundUserWorkloadConfigurationJSON), foundUserWorkloadConfiguration); err != nil {
+		t.Fatalf("failed to marshal the user workload monitoring config: %v:\n%s\n", err, foundUserWorkloadConfigurationJSON)
+	}
+
+	if foundUserWorkloadConfiguration.Prometheus == nil {
+		t.Fatalf("empty prometheus in UserWorkloadConfiguration: %v", foundUserWorkloadConfiguration)
+	}
+
+	if foundUserWorkloadConfiguration.Prometheus.AlertmanagerConfigs == nil {
+		t.Fatalf("empty AlertmanagerConfigs in UserWorkloadConfiguration.Prometheus: %v", foundUserWorkloadConfiguration)
+	}
+
+	containsOCMAlertmanagerConfig := false
+	for _, v := range foundUserWorkloadConfiguration.Prometheus.AlertmanagerConfigs {
+		if v.TLSConfig != (cmomanifests.TLSConfig{}) &&
+			v.TLSConfig.CA != nil &&
+			v.TLSConfig.CA.LocalObjectReference != (corev1.LocalObjectReference{}) &&
+			v.TLSConfig.CA.LocalObjectReference.Name == hubAmRouterCASecretName &&
+			v.BearerToken != nil &&
+			v.BearerToken.LocalObjectReference != (corev1.LocalObjectReference{}) &&
+			v.BearerToken.LocalObjectReference.Name == hubAmAccessorSecretName {
+			containsOCMAlertmanagerConfig = true
+			foundHubAmAccessorSecret := &corev1.Secret{}
+			err = c.Get(ctx, types.NamespacedName{
+				Name:      v.BearerToken.LocalObjectReference.Name,
+				Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+			}, foundHubAmAccessorSecret)
+			if err != nil {
+				t.Fatalf("failed to check the observability-alertmanager-accessor secret %s: %v", operatorconfig.OCPUserWorkloadMonitoringConfigMap, err)
+			}
+			foundAmAccessorToken, ok := foundHubAmAccessorSecret.Data[hubAmAccessorSecretKey]
+			if !ok {
+				t.Fatalf("no key %s found in the observability-alertmanager-accessor secret", hubAmAccessorSecretKey)
+			}
+			if string(foundAmAccessorToken) != tokenValue {
+				t.Fatalf("incorrect token found in the observability-alertmanager-accessor secret, got token: %s, expected value %s", foundAmAccessorToken, tokenValue)
+			}
+		}
+	}
+
+	if containsOCMAlertmanagerConfig == false {
+		t.Fatalf("no AlertmanagerConfig for OCM in UserWorkloadConfiguration.Prometheus.AlertmanagerConfigs: %v", foundUserWorkloadConfiguration)
+	}
+
+	err = RevertUserWorkloadMonitoringConfig(ctx, c)
+	if err != nil {
+		t.Fatalf("Failed to revert user-workload-monitoring-config configmap: (%v)", err)
+	}
+
+	err = c.Get(ctx, types.NamespacedName{
+		Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+		Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+	}, foundUserWorkloadMonitoringConfigMap)
+	if expectedCMDelete {
+		if err == nil || !errors.IsNotFound(err) {
+			t.Fatalf("the configmap %s should be deleted", operatorconfig.OCPUserWorkloadMonitoringConfigMap)
+		}
+	}
+
+	foundHubAmAccessorSecret := &corev1.Secret{}
+	err = c.Get(ctx, types.NamespacedName{
+		Name:      hubAmAccessorSecretName,
+		Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+	}, foundHubAmAccessorSecret)
+	if err != nil {
+		t.Fatalf("the secret %s should not be deleted", hubAmAccessorSecretName)
+	}
+
+	foundHubAmRouterCASecret := &corev1.Secret{}
+	err = c.Get(ctx, types.NamespacedName{
+		Name:      hubAmRouterCASecretName,
+		Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+	}, foundHubAmRouterCASecret)
+	if err != nil {
+		t.Fatalf("the secret %s should not be deleted", hubAmRouterCASecretName)
+	}
+
+	err = RevertUserWorkloadMonitoringConfig(ctx, c)
+	if err != nil {
+		t.Fatalf("Run into error when try to revert user-workload-monitoring-config configmap twice: (%v)", err)
+	}
+}
+
+func TestUserWorkloadMonitoringConfigAlertsDisabled(t *testing.T) {
+	testNamespace := operatorconfig.OCPUserWorkloadMonitoringNamespace
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
+	ctx := context.TODO()
+
+	hubInfo := &operatorconfig.HubInfo{}
+	err := yaml.Unmarshal([]byte(hubInfoYAMLAlertsDisabled), &hubInfo)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal hubInfo: (%v)", err)
+	}
+	hubInfoObj := newHubInfoSecret([]byte(hubInfoYAMLAlertsDisabled), testNamespace)
+	amAccessSrt := newAMAccessorSecret(testNamespace, "test-token")
+
+	// Create router CA secret in the user workload monitoring namespace
+	routerCASecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hubAmRouterCASecretName,
+			Namespace: testNamespace,
+		},
+		Data: map[string][]byte{
+			"service-ca.crt": []byte("test-ca-crt"),
+		},
+	}
+
+	// Create user-workload-monitoring-config configmap with "manager: endpoint-monitoring-operator"
+	uwmConfig := newUserWorkloadMonitoringConfigCM(`
+prometheus:
+  alertmanagerConfigs:
+  - apiVersion: v2
+    bearerToken:
+      key: token
+      name: foo
+    pathPrefix: /
+    scheme: https
+    staticConfigs:
+    - test-host.com
+    tlsConfig:
+      insecureSkipVerify: true`, "endpoint-monitoring-operator")
+
+	objs := []runtime.Object{hubInfoObj, amAccessSrt, routerCASecret, uwmConfig}
+	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+
+	// Test disabling alert forwarding
+	err = createOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
+	if err != nil {
+		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
+	}
+
+	// Verify the configmap is updated correctly
+	foundUserWorkloadMonitoringConfigMap := &corev1.ConfigMap{}
+	err = c.Get(ctx, types.NamespacedName{
+		Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+		Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+	}, foundUserWorkloadMonitoringConfigMap)
+	if err != nil {
+		t.Fatalf("failed to check configmap %s: %v", operatorconfig.OCPUserWorkloadMonitoringConfigMap, err)
+	}
+
+	foundUserWorkloadConfigurationYAML, ok := foundUserWorkloadMonitoringConfigMap.Data["config.yaml"]
+	if !ok {
+		t.Fatalf("configmap: %s doesn't contain key: config.yaml", operatorconfig.OCPUserWorkloadMonitoringConfigMap)
+	}
+
+	foundUserWorkloadConfigurationJSON, err := yamltool.YAMLToJSON([]byte(foundUserWorkloadConfigurationYAML))
+	if err != nil {
+		t.Fatalf("failed to transform YAML to JSON:\n%s\n", foundUserWorkloadConfigurationYAML)
+	}
+
+	foundUserWorkloadConfiguration := &cmomanifests.UserWorkloadConfiguration{}
+	if err := json.Unmarshal([]byte(foundUserWorkloadConfigurationJSON), foundUserWorkloadConfiguration); err != nil {
+		t.Fatalf("failed to marshal the user workload monitoring config: %v:\n%s\n", err, foundUserWorkloadConfigurationJSON)
+	}
+
+	if foundUserWorkloadConfiguration.Prometheus == nil {
+		t.Fatalf("empty prometheus in UserWorkloadConfiguration: %v", foundUserWorkloadConfiguration)
+	}
+
+	if foundUserWorkloadConfiguration.Prometheus.AlertmanagerConfigs != nil && len(foundUserWorkloadConfiguration.Prometheus.AlertmanagerConfigs) > 0 {
+		t.Fatalf("AlertmanagerConfigs should be nil or empty when alerts are disabled, got: %v", foundUserWorkloadConfiguration.Prometheus.AlertmanagerConfigs)
+	}
+
+	// Test re-enabling alert forwarding
+	hubInfo = &operatorconfig.HubInfo{}
+	err = yaml.Unmarshal([]byte(hubInfoYAML), &hubInfo)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal hubInfo: (%v)", err)
+	}
+
+	err = createOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
+	if err != nil {
+		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
+	}
+
+	// Verify the configmap is updated correctly
+	err = c.Get(ctx, types.NamespacedName{
+		Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+		Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+	}, foundUserWorkloadMonitoringConfigMap)
+	if err != nil {
+		t.Fatalf("failed to check configmap %s: %v", operatorconfig.OCPUserWorkloadMonitoringConfigMap, err)
+	}
+
+	foundUserWorkloadConfigurationYAML, ok = foundUserWorkloadMonitoringConfigMap.Data["config.yaml"]
+	if !ok {
+		t.Fatalf("configmap: %s doesn't contain key: config.yaml", operatorconfig.OCPUserWorkloadMonitoringConfigMap)
+	}
+
+	foundUserWorkloadConfigurationJSON, err = yamltool.YAMLToJSON([]byte(foundUserWorkloadConfigurationYAML))
+	if err != nil {
+		t.Fatalf("failed to transform YAML to JSON:\n%s\n", foundUserWorkloadConfigurationYAML)
+	}
+
+	foundUserWorkloadConfiguration = &cmomanifests.UserWorkloadConfiguration{}
+	if err := json.Unmarshal([]byte(foundUserWorkloadConfigurationJSON), foundUserWorkloadConfiguration); err != nil {
+		t.Fatalf("failed to marshal the user workload monitoring config: %v:\n%s\n", err, foundUserWorkloadConfigurationJSON)
+	}
+
+	if foundUserWorkloadConfiguration.Prometheus == nil {
+		t.Fatalf("empty prometheus in UserWorkloadConfiguration: %v", foundUserWorkloadConfiguration)
+	}
+
+	if foundUserWorkloadConfiguration.Prometheus.AlertmanagerConfigs == nil {
+		t.Fatalf("AlertmanagerConfigs should not be nil when alerts are enabled")
+	}
+
+	containsOCMAlertmanagerConfig := false
+	for _, v := range foundUserWorkloadConfiguration.Prometheus.AlertmanagerConfigs {
+		if v.TLSConfig != (cmomanifests.TLSConfig{}) &&
+			v.TLSConfig.CA != nil &&
+			v.TLSConfig.CA.LocalObjectReference != (corev1.LocalObjectReference{}) &&
+			v.TLSConfig.CA.LocalObjectReference.Name == hubAmRouterCASecretName {
+			containsOCMAlertmanagerConfig = true
+		}
+	}
+
+	if !containsOCMAlertmanagerConfig {
+		t.Fatalf("AlertmanagerConfigs should contain OCM config when alerts are enabled")
 	}
 }

--- a/operators/pkg/config/config.go
+++ b/operators/pkg/config/config.go
@@ -30,10 +30,13 @@ const (
 )
 
 const (
-	OCPClusterMonitoringNamespace         = "openshift-monitoring"
-	OCPClusterMonitoringConfigMapName     = "cluster-monitoring-config"
-	OCPClusterMonitoringConfigMapKey      = "config.yaml"
-	OCPClusterMonitoringPrometheusService = "prometheus-k8s"
+	OCPClusterMonitoringNamespace              = "openshift-monitoring"
+	OCPClusterMonitoringConfigMapName          = "cluster-monitoring-config"
+	OCPClusterMonitoringConfigMapKey           = "config.yaml"
+	OCPClusterMonitoringPrometheusService      = "prometheus-k8s"
+	OCPUserWorkloadMonitoringNamespace         = "openshift-user-workload-monitoring"
+	OCPUserWorkloadMonitoringConfigMap         = "user-workload-monitoring-config"
+	OCPUserWorkloadMonitoringPrometheusService = "prometheus"
 )
 
 const (


### PR DESCRIPTION
Related to [ACM-1951](https://issues.redhat.com/browse/ACM-1951)

We now forward user workload alerts from a spoke cluster to hub alert manager. This happens when
1. Alert forwarding is enabled for Plaform
2. UWM is configured on Prometheus

When alert forwarding is disabled, Hub AlertManager CA and Certificate are still copied into UWM workspace on the spoke cluster with the expectation that an external policy could be used to enable UWM alert forwarding. This is identical to how  platform alerting can be configured via policy while disabling alerting from Observability stack.