### PR TITLE
Don't crash when UWM is enabled on spokes

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
@@ -654,7 +654,11 @@ func createOrUpdateUserWorkloadMonitoringConfig(
 
 	existingYAML, ok := existing.Data["config.yaml"]
 	if !ok {
-		existing.Data["config.yaml"] = string(yamlBytes)
+		if existing.Data == nil {
+			existing.Data = map[string]string{"config.yaml": string(yamlBytes)}
+		} else {
+			existing.Data["config.yaml"] = string(yamlBytes)
+		}
 		log.Info("user workload monitoring configmap missing config.yaml, updating")
 		return client.Update(ctx, existing)
 	}


### PR DESCRIPTION
We would crash due to the `data` map being nil, when first importing a spoke that has UWM enabled.