### PR TITLE
ACM-21373: fix addon status update

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -181,6 +181,7 @@ func createManifestwork(ctx context.Context, c client.Client, work *workv1.Manif
 	}
 
 	log.Info("Updating manifestwork", "namespace", namespace, "name", name)
+	found.SetLabels(work.Labels)
 	found.Spec.Workload.Manifests = work.Spec.Workload.Manifests
 	err = c.Update(ctx, found)
 	if err != nil {

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -106,7 +106,8 @@ func newManifestwork(name string, namespace string) *workv1.ManifestWork {
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				ownerLabelKey: ownerLabelValue,
+				ownerLabelKey:               ownerLabelValue,
+				addonv1alpha1.AddonLabelKey: "observability-controller",
 			},
 			Annotations: map[string]string{
 				// Add the postpone delete annotation for manifestwork so that the observabilityaddon can be

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -106,8 +106,9 @@ func newManifestwork(name string, namespace string) *workv1.ManifestWork {
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				ownerLabelKey:               ownerLabelValue,
-				addonv1alpha1.AddonLabelKey: "observability-controller",
+				ownerLabelKey: ownerLabelValue,
+				// Add label expected by OCM to retrieve manifestWork belonging to the addon and update its status
+				addonv1alpha1.AddonLabelKey: config.ManagedClusterAddonName,
 			},
 			Annotations: map[string]string{
 				// Add the postpone delete annotation for manifestwork so that the observabilityaddon can be

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
@@ -389,7 +389,7 @@ func TestManifestWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create manifestworks: (%v)", err)
 	}
-	if err := createManifestwork(c, manWork); err != nil {
+	if err := createManifestwork(context.Background(), c, manWork); err != nil {
 		t.Fatalf("Failed to apply manifestworks: (%v)", err)
 	}
 
@@ -427,7 +427,7 @@ func TestManifestWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create manifestworks: (%v)", err)
 	}
-	if err := createManifestwork(c, manWork); err != nil {
+	if err := createManifestwork(context.Background(), c, manWork); err != nil {
 		t.Fatalf("Failed to apply manifestworks: (%v)", err)
 	}
 	err = c.Get(context.TODO(), types.NamespacedName{Name: workName, Namespace: namespace}, found)
@@ -443,7 +443,7 @@ func TestManifestWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create manifestworks with updated namespace: (%v)", err)
 	}
-	if err := createManifestwork(c, manWork); err != nil {
+	if err := createManifestwork(context.Background(), c, manWork); err != nil {
 		t.Fatalf("Failed to apply manifestworks: (%v)", err)
 	}
 
@@ -475,7 +475,7 @@ func TestManifestWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create manifestworks: (%v)", err)
 	}
-	if err := createManifestwork(c, manWork); err != nil {
+	if err := createManifestwork(context.Background(), c, manWork); err != nil {
 		t.Fatalf("Failed to apply manifestworks: (%v)", err)
 	}
 	found = &workv1.ManifestWork{}

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -530,7 +530,7 @@ func createAllRelatedRes(
 			}
 		} else {
 			retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				return createManifestwork(c, manifestWork)
+				return createManifestwork(ctx, c, manifestWork)
 			})
 			if retryErr != nil {
 				allErrors = append(allErrors, fmt.Errorf("failed to create manifestwork: %w", retryErr))

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -641,7 +641,7 @@ func createManagedClusterRes(ctx context.Context, c client.Client, mco *mcov1bet
 		return nil, fmt.Errorf("failed to create role bindings: %w", err)
 	}
 
-	addon, err := util.CreateManagedClusterAddonCR(c, namespace, ownerLabelKey, ownerLabelValue)
+	addon, err := util.CreateManagedClusterAddonCR(ctx, c, namespace, ownerLabelKey, ownerLabelValue)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ManagedClusterAddon: %w", err)
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -689,7 +689,7 @@ func createManagedClusterRes(ctx context.Context, c client.Client, mco *mcov1bet
 func deleteManagedClusterRes(c client.Client, namespace string) error {
 	managedclusteraddon := &addonv1alpha1.ManagedClusterAddOn{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      util.ManagedClusterAddonName,
+			Name:      config.ManagedClusterAddonName,
 			Namespace: namespace,
 		},
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -509,6 +509,7 @@ func createAllRelatedRes(
 		}
 		manifestWork, err := createManifestWorks(c, namespace, mci, mco, works, metricsAllowlistConfigMap, crdv1Work, endpointMetricsOperatorDeploy, hubInfoSecret.DeepCopy(), addonDeployCfg, installProm)
 		if err != nil {
+			allErrors = append(allErrors, fmt.Errorf("failed to create manifestworks: %w", err))
 			log.Error(err, "Failed to create manifestworks: %w", err)
 			continue
 		}
@@ -518,6 +519,7 @@ func createAllRelatedRes(
 			// install the endpoint operator into open-cluster-management-observability namespace for the hub cluster
 			log.Info("Creating resource for hub metrics collection", "cluster", managedCluster)
 			if err := ensureResourcesForHubMetricsCollection(ctx, c, mco, manifestWork.Spec.Workload.Manifests); err != nil {
+				allErrors = append(allErrors, fmt.Errorf("failed to ensure resources for hub metrics collection: %w", err))
 				log.Error(err, "Failed to ensure resources for hub metrics collection")
 				continue
 			}
@@ -526,6 +528,7 @@ func createAllRelatedRes(
 				return createManifestwork(c, manifestWork)
 			})
 			if retryErr != nil {
+				allErrors = append(allErrors, fmt.Errorf("failed to create manifestwork: %w", retryErr))
 				log.Error(retryErr, "Failed to create manifestwork")
 				continue
 			}

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -543,7 +543,12 @@ func createAllRelatedRes(
 	// which are no longer to be managed and therefore needs deletion
 	managedClustersNamespaces := make(map[string]struct{}, len(managedClusterList))
 	for _, mc := range managedClusterList {
-		managedClustersNamespaces[mc.Name] = struct{}{}
+		if mc.IsLocalCluster {
+			// local cluster resources live in a different namespace than the ManagedClusterName
+			managedClustersNamespaces[config.GetDefaultNamespace()] = struct{}{}
+		} else {
+			managedClustersNamespaces[mc.Name] = struct{}{}
+		}
 	}
 
 	for _, ep := range obsAddonList.Items {

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -267,6 +267,11 @@ func (r *PlacementRuleReconciler) cleanOrphanResources(ctx context.Context, req 
 			continue
 		}
 
+		if ns == config.GetDefaultNamespace() {
+			// Local cluster has no ObservabilityAddon, skip if the namespace matches
+			continue
+		}
+
 		log.Info("Deleting orphaned ManagedCluster resources", "namespace", ns)
 		if err := deleteManagedClusterRes(r.Client, ns); err != nil {
 			return fmt.Errorf("failed to delete managed cluster resources in namespace %q: %w", ns, err)

--- a/operators/multiclusterobservability/controllers/placementrule/predict_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predict_func.go
@@ -51,10 +51,10 @@ func getClusterMgmtAddonPredFunc() predicate.Funcs {
 func getMgClusterAddonPredFunc() predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return e.Object.GetName() == util.ManagedClusterAddonName
+			return e.Object.GetName() == config.ManagedClusterAddonName
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			if e.ObjectOld.GetName() != util.ManagedClusterAddonName {
+			if e.ObjectOld.GetName() != config.ManagedClusterAddonName {
 				return false
 			}
 			oldConfig := addonv1alpha1.ConfigReferent{}

--- a/operators/multiclusterobservability/controllers/placementrule/predict_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predict_func.go
@@ -51,7 +51,7 @@ func getClusterMgmtAddonPredFunc() predicate.Funcs {
 func getMgClusterAddonPredFunc() predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return false
+			return e.Object.GetName() == util.ManagedClusterAddonName
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			if e.ObjectOld.GetName() != util.ManagedClusterAddonName {

--- a/operators/multiclusterobservability/controllers/placementrule/predict_func_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predict_func_test.go
@@ -61,7 +61,13 @@ func TestGetMgClusterAddonPredFunc(t *testing.T) {
 	ce := event.CreateEvent{
 		Object: newManagedClusterAddon(),
 	}
-	if pred.CreateFunc(ce) {
+	if !pred.CreateFunc(ce) {
+		t.Fatal("reconcile failed to trigger for managedclusteraddon create event")
+	}
+
+	invalidAddon := newManagedClusterAddon()
+	invalidAddon.Name = "another-addon"
+	if pred.CreateFunc(event.CreateEvent{Object: invalidAddon}) {
 		t.Fatal("reconcile triggered for managedclusteraddon create event")
 	}
 

--- a/operators/multiclusterobservability/controllers/placementrule/status.go
+++ b/operators/multiclusterobservability/controllers/placementrule/status.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mcov1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
-	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/util"
+	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	"k8s.io/apimachinery/pkg/api/meta"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 )
@@ -34,15 +34,15 @@ func updateAddonStatus(ctx context.Context, c client.Client, addonList mcov1beta
 		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			managedclusteraddon := &addonv1alpha1.ManagedClusterAddOn{}
 			err := c.Get(ctx, types.NamespacedName{
-				Name:      util.ManagedClusterAddonName,
+				Name:      config.ManagedClusterAddonName,
 				Namespace: addon.ObjectMeta.Namespace,
 			}, managedclusteraddon)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
-					log.Info("managedclusteraddon does not exist", "namespace", addon.ObjectMeta.Namespace, "name", util.ManagedClusterAddonName)
+					log.Info("managedclusteraddon does not exist", "namespace", addon.ObjectMeta.Namespace, "name", config.ManagedClusterAddonName)
 					return nil
 				}
-				log.Error(err, "Failed to get managedclusteraddon", "namespace", addon.ObjectMeta.Namespace, "name", util.ManagedClusterAddonName)
+				log.Error(err, "Failed to get managedclusteraddon", "namespace", addon.ObjectMeta.Namespace, "name", config.ManagedClusterAddonName)
 				return err
 			}
 

--- a/operators/multiclusterobservability/controllers/placementrule/status.go
+++ b/operators/multiclusterobservability/controllers/placementrule/status.go
@@ -57,7 +57,7 @@ func updateAddonStatus(ctx context.Context, c client.Client, addonList mcov1beta
 			}
 
 			isUpdated = true
-			return c.Status().Patch(ctx, desiredAddon, client.StrategicMergeFrom(managedclusteraddon))
+			return c.Status().Patch(ctx, desiredAddon, client.MergeFrom(managedclusteraddon))
 		})
 		if retryErr != nil {
 			log.Error(retryErr, "Failed to update status for managedclusteraddon", "namespace", addon.ObjectMeta.Namespace)

--- a/operators/multiclusterobservability/controllers/placementrule/status_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/status_test.go
@@ -18,7 +18,7 @@ import (
 
 	mcov1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
-	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/util"
+	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -116,7 +116,7 @@ func TestUpdateAddonStatus(t *testing.T) {
 
 			clusterAddon := &addonv1alpha1.ManagedClusterAddOn{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      util.ManagedClusterAddonName,
+					Name:      config.ManagedClusterAddonName,
 					Namespace: namespace,
 				},
 				Status: addonv1alpha1.ManagedClusterAddOnStatus{
@@ -150,7 +150,7 @@ func TestUpdateAddonStatus(t *testing.T) {
 
 			foundClusterAddon := &addonv1alpha1.ManagedClusterAddOn{}
 			if err := c.Get(context.Background(), types.NamespacedName{
-				Name:      util.ManagedClusterAddonName,
+				Name:      config.ManagedClusterAddonName,
 				Namespace: namespace,
 			}, foundClusterAddon); err != nil {
 				t.Fatalf("Failed to get managedclusteraddon: (%v)", err)
@@ -163,7 +163,7 @@ func TestUpdateAddonStatus(t *testing.T) {
 			}
 
 			if err := c.Get(context.Background(), types.NamespacedName{
-				Name:      util.ManagedClusterAddonName,
+				Name:      config.ManagedClusterAddonName,
 				Namespace: namespace,
 			}, foundClusterAddon); err != nil {
 				t.Fatalf("Failed to get managedclusteraddon: (%v)", err)

--- a/operators/multiclusterobservability/main.go
+++ b/operators/multiclusterobservability/main.go
@@ -212,7 +212,7 @@ func main() {
 			{FieldSelector: fmt.Sprintf("metadata.name=%s", util.ObservabilityController)},
 		},
 		addonv1alpha1.SchemeGroupVersion.WithKind("ManagedClusterAddOn"): {
-			{FieldSelector: fmt.Sprintf("metadata.name=%s", util.ManagedClusterAddonName)},
+			{FieldSelector: fmt.Sprintf("metadata.name=%s", config.ManagedClusterAddonName)},
 		},
 	}
 

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -184,6 +184,7 @@ const (
 	MetricsCollector               = "metrics-collector"
 	Observatorium                  = "observatorium"
 	MultiClusterObservabilityAddon = "multicluster-observability-addon"
+	ManagedClusterAddonName        = "observability-controller"
 
 	RetentionResolutionRaw = "365d"
 	RetentionResolution5m  = "365d"

--- a/operators/multiclusterobservability/pkg/util/managedclusteraddon.go
+++ b/operators/multiclusterobservability/pkg/util/managedclusteraddon.go
@@ -49,8 +49,7 @@ func CreateManagedClusterAddonCR(ctx context.Context, c client.Client, namespace
 				return nil, fmt.Errorf("failed to create managedclusteraddon for namespace %s: %w", namespace, err)
 			}
 
-			log.Info("Successfully created ManagedClusterAddOn. Waiting for next reconcile to update status.", "name", addon.Name, "namespace", addon.Namespace)
-			return addon, nil
+			log.Info("Successfully created ManagedClusterAddOn.", "name", addon.Name, "namespace", addon.Namespace)
 		} else {
 			return nil, fmt.Errorf("failed to get the managedClusterAddon: %w", err)
 		}
@@ -58,7 +57,7 @@ func CreateManagedClusterAddonCR(ctx context.Context, c client.Client, namespace
 
 	// Update its status
 	if managedClusterAddon, err = updateManagedClusterAddOnStatus(ctx, c, namespace); err != nil {
-		return nil, fmt.Errorf("failed to update newly created managedClusterAddonStatus: %w", err)
+		return nil, fmt.Errorf("failed to update the managedClusterAddon status: %w", err)
 	}
 
 	return managedClusterAddon, nil

--- a/operators/multiclusterobservability/pkg/util/managedclusteraddon.go
+++ b/operators/multiclusterobservability/pkg/util/managedclusteraddon.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -22,7 +23,6 @@ import (
 )
 
 const (
-	ManagedClusterAddonName  = "observability-controller" // #nosec G101 -- Not a hardcoded credential.
 	progressingConditionType = "Progressing"
 	availableConditionType   = "Available"
 	degradedConditionType    = "Degraded"
@@ -37,7 +37,7 @@ func CreateManagedClusterAddonCR(ctx context.Context, c client.Client, namespace
 	// check if managedClusterAddon exists
 	managedClusterAddon := &addonv1alpha1.ManagedClusterAddOn{}
 	objectKey := types.NamespacedName{
-		Name:      ManagedClusterAddonName,
+		Name:      config.ManagedClusterAddonName,
 		Namespace: namespace,
 	}
 	err := c.Get(ctx, objectKey, managedClusterAddon)
@@ -70,7 +70,7 @@ func createManagedClusterAddOn(ctx context.Context, c client.Client, namespace, 
 			Kind:       "ManagedClusterAddOn",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ManagedClusterAddonName,
+			Name:      config.ManagedClusterAddonName,
 			Namespace: namespace,
 			Labels: map[string]string{
 				labelKey: labelValue,
@@ -91,7 +91,7 @@ func updateManagedClusterAddOnStatus(ctx context.Context, c client.Client, names
 	existingManagedClusterAddon := &addonv1alpha1.ManagedClusterAddOn{}
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		objectKey := types.NamespacedName{
-			Name:      ManagedClusterAddonName,
+			Name:      config.ManagedClusterAddonName,
 			Namespace: namespace,
 		}
 		if err := c.Get(ctx, objectKey, existingManagedClusterAddon); err != nil {

--- a/operators/multiclusterobservability/pkg/util/managedclusteraddon_test.go
+++ b/operators/multiclusterobservability/pkg/util/managedclusteraddon_test.go
@@ -24,7 +24,7 @@ func TestManagedClusterAddon(t *testing.T) {
 	s := scheme.Scheme
 	addonv1alpha1.AddToScheme(s)
 	c := fake.NewClientBuilder().WithStatusSubresource(&addonv1alpha1.ManagedClusterAddOn{}).Build()
-	_, err := CreateManagedClusterAddonCR(c, namespace, "testKey", "value")
+	_, err := CreateManagedClusterAddonCR(context.Background(), c, namespace, "testKey", "value")
 	if err != nil {
 		t.Fatalf("Failed to create managedclusteraddon: (%v)", err)
 	}

--- a/operators/multiclusterobservability/pkg/util/managedclusteraddon_test.go
+++ b/operators/multiclusterobservability/pkg/util/managedclusteraddon_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -31,7 +32,7 @@ func TestManagedClusterAddon(t *testing.T) {
 	addon := &addonv1alpha1.ManagedClusterAddOn{}
 	err = c.Get(context.TODO(),
 		types.NamespacedName{
-			Name:      ManagedClusterAddonName,
+			Name:      config.ManagedClusterAddonName,
 			Namespace: namespace,
 		},
 		addon,


### PR DESCRIPTION
- Fixes a reconcile loop triggered by invalid resources cleaning in the placement rule controller for the hub
- Improves multi error handling
- Retry status update on conflict
- Improve conditions update