### PR TITLE
e2e: retry on conflicts when apply

### DIFF
--- a/tests/pkg/tests/observability_alert_test.go
+++ b/tests/pkg/tests/observability_alert_test.go
@@ -206,7 +206,7 @@ var _ = Describe("", func() {
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(
-			utils.Apply(
+			utils.ApplyRetryOnConflict(
 				testOptions.HubCluster.ClusterServerURL,
 				testOptions.KubeConfig,
 				testOptions.HubCluster.KubeContext,
@@ -262,7 +262,7 @@ var _ = Describe("", func() {
 	// 	secret := utils.CreateCustomAlertConfigYaml(testOptions.HubCluster.BaseDomain)
 
 	// 	Expect(
-	// 		utils.Apply(
+	// 		utils.ApplyRetryOnConflict(
 	// 			testOptions.HubCluster.ClusterServerURL,
 	// 			testOptions.KubeConfig,
 	// 			testOptions.HubCluster.KubeContext,
@@ -278,7 +278,7 @@ var _ = Describe("", func() {
 			kustomize.Options{KustomizationPath: "../../../examples/alerts/custom_rules_invalid"},
 		)
 		Expect(
-			utils.Apply(
+			utils.ApplyRetryOnConflict(
 				testOptions.HubCluster.ClusterServerURL,
 				testOptions.KubeConfig,
 				testOptions.HubCluster.KubeContext,
@@ -418,7 +418,7 @@ var _ = Describe("", func() {
 			promRuleAdded := false
 			for idx, mc := range testOptions.ManagedClusters {
 				if mc.Name == ks {
-					err = utils.Apply(
+					err = utils.ApplyRetryOnConflict(
 						testOptions.ManagedClusters[idx].ClusterServerURL,
 						testOptions.ManagedClusters[idx].KubeConfig,
 						testOptions.ManagedClusters[idx].KubeContext,
@@ -557,7 +557,7 @@ var _ = Describe("", func() {
 		for _, ks := range expectedKSClusterNames {
 			for idx, mc := range testOptions.ManagedClusters {
 				if mc.Name == ks.Name {
-					err = utils.Apply(
+					err = utils.ApplyRetryOnConflict(
 						testOptions.ManagedClusters[idx].ClusterServerURL,
 						testOptions.ManagedClusters[idx].KubeConfig,
 						testOptions.ManagedClusters[idx].KubeContext,

--- a/tests/pkg/tests/observability_config_test.go
+++ b/tests/pkg/tests/observability_config_test.go
@@ -48,7 +48,7 @@ var _ = Describe("", func() {
 		yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: mcoPath})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(
-			utils.Apply(
+			utils.ApplyRetryOnConflict(
 				testOptions.HubCluster.ClusterServerURL,
 				testOptions.KubeConfig,
 				testOptions.HubCluster.KubeContext,
@@ -95,7 +95,7 @@ var _ = Describe("", func() {
 		yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: mcoPath})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(
-			utils.Apply(
+			utils.ApplyRetryOnConflict(
 				testOptions.HubCluster.ClusterServerURL,
 				testOptions.KubeConfig,
 				testOptions.HubCluster.KubeContext,
@@ -378,7 +378,7 @@ var _ = Describe("", func() {
 		yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: mcoPath})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(
-			utils.Apply(
+			utils.ApplyRetryOnConflict(
 				testOptions.HubCluster.ClusterServerURL,
 				testOptions.KubeConfig,
 				testOptions.HubCluster.KubeContext,
@@ -467,7 +467,7 @@ var _ = Describe("", func() {
 		yamlB, err = kustomize.Render(kustomize.Options{KustomizationPath: mcoPath})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(
-			utils.Apply(
+			utils.ApplyRetryOnConflict(
 				testOptions.HubCluster.ClusterServerURL,
 				testOptions.KubeConfig,
 				testOptions.HubCluster.KubeContext,

--- a/tests/pkg/tests/observability_dashboard_test.go
+++ b/tests/pkg/tests/observability_dashboard_test.go
@@ -39,7 +39,7 @@ var _ = Describe("", func() {
 			kustomize.Options{KustomizationPath: "../../../examples/dashboards/sample_custom_dashboard"},
 		)
 		Expect(
-			utils.Apply(
+			utils.ApplyRetryOnConflict(
 				testOptions.HubCluster.ClusterServerURL,
 				testOptions.KubeConfig,
 				testOptions.HubCluster.KubeContext,
@@ -56,7 +56,7 @@ var _ = Describe("", func() {
 			kustomize.Options{KustomizationPath: "../../../examples/dashboards/update_sample_custom_dashboard"},
 		)
 		Expect(
-			utils.Apply(
+			utils.ApplyRetryOnConflict(
 				testOptions.HubCluster.ClusterServerURL,
 				testOptions.KubeConfig,
 				testOptions.HubCluster.KubeContext,

--- a/tests/pkg/tests/observability_export_test.go
+++ b/tests/pkg/tests/observability_export_test.go
@@ -54,7 +54,7 @@ var _ = Describe("", func() {
 		yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: "../../../examples/export"})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(
-			utils.Apply(
+			utils.ApplyRetryOnConflict(
 				testOptions.HubCluster.ClusterServerURL,
 				testOptions.KubeConfig,
 				testOptions.HubCluster.KubeContext,
@@ -69,7 +69,7 @@ var _ = Describe("", func() {
 		yamlB, err = kustomize.Render(kustomize.Options{KustomizationPath: templatePath})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(
-			utils.Apply(
+			utils.ApplyRetryOnConflict(
 				testOptions.HubCluster.ClusterServerURL,
 				testOptions.KubeConfig,
 				testOptions.HubCluster.KubeContext,

--- a/tests/pkg/tests/observability_install_test.go
+++ b/tests/pkg/tests/observability_install_test.go
@@ -43,7 +43,7 @@ func installMCO() {
 			kustomize.Options{KustomizationPath: "../../../examples/configmapcmc/cluster-monitoring-config"},
 		)
 		Expect(
-			utils.Apply(
+			utils.ApplyRetryOnConflict(
 				testOptions.HubCluster.ClusterServerURL,
 				testOptions.KubeConfig,
 				testOptions.HubCluster.KubeContext,
@@ -84,14 +84,14 @@ func installMCO() {
 		//set resource quota and limit range for canary environment to avoid destruct the node
 		yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: "../../../examples/minio"})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(utils.Apply(testOptions.HubCluster.ClusterServerURL, testOptions.KubeConfig, testOptions.HubCluster.KubeContext, yamlB)).NotTo(HaveOccurred())
+		Expect(utils.ApplyRetryOnConflict(testOptions.HubCluster.ClusterServerURL, testOptions.KubeConfig, testOptions.HubCluster.KubeContext, yamlB)).NotTo(HaveOccurred())
 	}
 
 	//set resource quota and limit range for canary environment to avoid destruct the node
 	yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: "../../../examples/policy"})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(
-		utils.Apply(
+		utils.ApplyRetryOnConflict(
 			testOptions.HubCluster.ClusterServerURL,
 			testOptions.KubeConfig,
 			testOptions.HubCluster.KubeContext,
@@ -106,7 +106,7 @@ func installMCO() {
 		//set resource quota and limit range for canary environment to avoid destruct the node
 		yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: "../../../examples/minio-tls"})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(utils.Apply(testOptions.HubCluster.ClusterServerURL, testOptions.KubeConfig, testOptions.HubCluster.KubeContext, yamlB)).NotTo(HaveOccurred())
+		Expect(utils.ApplyRetryOnConflict(testOptions.HubCluster.ClusterServerURL, testOptions.KubeConfig, testOptions.HubCluster.KubeContext, yamlB)).NotTo(HaveOccurred())
 
 		By("Apply MCO instance of v1beta2")
 		v1beta2KustomizationPath := ""
@@ -119,7 +119,7 @@ func installMCO() {
 		Expect(err).NotTo(HaveOccurred())
 		// add retry for update mco object failure
 		Eventually(func() error {
-			return utils.Apply(
+			return utils.ApplyRetryOnConflict(
 				testOptions.HubCluster.ClusterServerURL,
 				testOptions.KubeConfig,
 				testOptions.HubCluster.KubeContext,
@@ -134,7 +134,7 @@ func installMCO() {
 		Expect(err).NotTo(HaveOccurred())
 		// add retry for update mco object failure
 		Eventually(func() error {
-			return utils.Apply(
+			return utils.ApplyRetryOnConflict(
 				testOptions.HubCluster.ClusterServerURL,
 				testOptions.KubeConfig,
 				testOptions.HubCluster.KubeContext,

--- a/tests/pkg/tests/observability_metrics_test.go
+++ b/tests/pkg/tests/observability_metrics_test.go
@@ -53,7 +53,7 @@ var _ = Describe("", func() {
 		yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: "../../../examples/metrics/allowlist"})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(
-			utils.Apply(
+			utils.ApplyRetryOnConflict(
 				testOptions.HubCluster.ClusterServerURL,
 				testOptions.KubeConfig,
 				testOptions.HubCluster.KubeContext,

--- a/tests/pkg/utils/utils.go
+++ b/tests/pkg/utils/utils.go
@@ -32,6 +32,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog"
 )
 
@@ -226,6 +227,13 @@ func LoadConfig(url, kubeconfig, ctx string) (*rest.Config, error) {
 	}
 
 	return nil, errors.New("could not create a valid kubeconfig")
+}
+
+func ApplyRetryOnConflict(url string, kubeconfig string, ctx string, yamlB []byte) error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		return Apply(url, kubeconfig, ctx, yamlB)
+	})
+	return err
 }
 
 // Apply a multi resources file to the cluster described by the url, kubeconfig and ctx.


### PR DESCRIPTION
Ensures that we retry on conflicts to ensure tests (especially the install) doesn't get stuck.