### PR TITLE
fix: Clean up user-workload-monitoring-config configmap properly

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
@@ -567,8 +567,6 @@ func createOrUpdateCMOConfig(
 		return false, fmt.Errorf("failed to unmarshal existing CMO config: %w", err)
 	}
 
-	// Try to manually check for userWorkloadEnabled in the YAML
-
 	updatedCMOCfg := &cmomanifests.ClusterMonitoringConfiguration{}
 	if err := yaml.Unmarshal([]byte(currentYAML), updatedCMOCfg); err != nil {
 		return false, fmt.Errorf("failed to unmarshal updated CMO config: %w", err)


### PR DESCRIPTION
Related to [ACM-21697](https://issues.redhat.com/browse/ACM-21697) 

Clean up/revert user-workload-monitoring-config configmap when user disables userWorkloadMonitoring on a managed cluster.