### PR TITLE
Add Konflux rebuild bot

### DIFF
--- a/.github/workflows/konflux-rebuild-bot.sh
+++ b/.github/workflows/konflux-rebuild-bot.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# args: $1: git-sha $2: branch-name
+add_commit_comment() {
+  SHA=$1
+  BRANCH=$2
+
+  jq -nc "{\"body\": \"/retest branch:$BRANCH\"}" |
+    curl -sL -X POST -d @- \
+      -H "Content-Type: application/json" \
+      -H "Authorization: token $GITHUB_TOKEN" \
+      "https://api.github.com/repos/$GITHUB_REPOSITORY/commits/$SHA/comments"
+}
+
+DEFAULT_BRANCH=$2
+GITHUB_TOKEN=$1
+
+# handle main/default branch separately
+git checkout "$DEFAULT_BRANCH"
+SHA=$(git log -n 1 --pretty=format:"%H" "$DEFAULT_BRANCH")
+add_commit_comment "$SHA" "$DEFAULT_BRANCH"
+
+# run on the last 4 branches expect the default one
+LATEST_RELEASE=$(git branch -a | grep -o "release-[[:digit:]].\([[:digit:]]*\)" | sed -e "s/^release-//" | sort -V | tail -n 1)
+CUR_REL=$LATEST_RELEASE
+for _ in {1..4}; do
+  CUR_REL=$(echo "$CUR_REL" | awk -F. -v OFS=. '{$NF -= 1 ; print}')
+  git checkout release-"$CUR_REL"
+  SHA=$(git log -n 1 --pretty=format:"%H" release-"$CUR_REL")
+  add_commit_comment "$SHA" "release-$CUR_REL"
+done

--- a/.github/workflows/konflux-rebuild-bot.yaml
+++ b/.github/workflows/konflux-rebuild-bot.yaml
@@ -1,0 +1,15 @@
+name: Konflux periodic build bot
+on:
+  schedule:
+    - cron: '0 0 * * Sat' # Github Actions job run in UTC.
+  workflow_dispatch:
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Add comments
+        run: bash .github/workflows/konflux-rebuild-bot.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
We need Konflux builds on a regular basis. However Konflux doesn't support regular/daily builds at the moment.

This commit adds a new GitHub workflow, which on a schedule, comments on the latest commit with a build command, in all of the relevant branches. This should ensure we get regular builds, even when there have been no activity for a while.

Since we migrated to the ACM common build pipeline for the konflux tasks, we will likely have various release branches with very low activity, necessitating this workflow.