### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for grafana-dashboard-loader-acm-214

### DIFF
--- a/loaders/dashboards/Containerfile.operator
+++ b/loaders/dashboards/Containerfile.operator
@@ -26,13 +26,14 @@ ARG IMAGE_OPENSHIFT_TAGS
 
 LABEL org.label-schema.vendor="Red Hat" \
     com.redhat.component="grafana-dashboard" \
+    cpe="cpe:/a:redhat:acm:2.14::el9" \
     org.label-schema.name="$IMAGE_NAME_ARCH" \
     org.label-schema.description="$IMAGE_DESCRIPTION" \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=$VCS_URL \
     org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
     org.label-schema.schema-version="1.0" \
-    name="$IMAGE_NAME" \
+    name="rhacm2/grafana-dashboard-loader-rhel9" \
     maintainer="$IMAGE_MAINTAINER" \
     version="$IMAGE_VERSION" \
     release="$IMAGE_RELEASE" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
