### PR TITLE
metrics-collector: copy URL to avoid racecondition

### DIFF
--- a/collectors/metrics/cmd/metrics-collector/main.go
+++ b/collectors/metrics/cmd/metrics-collector/main.go
@@ -688,10 +688,13 @@ func initShardedConfigs(o *Options, agent Agent) ([]*forwarder.Config, error) {
 
 		shardCfgs := make([]*forwarder.Config, len(shards))
 		for i, shard := range shards {
+			// make sure we copy the URL object so it's not shared between workers
+			fromCopy := *from
+			fromQueryCopy := *fromQuery
 			shardCfgs[i] = &forwarder.Config{
 				FromClientConfig: forwarder.FromClientConfig{
-					URL:       from,
-					QueryURL:  fromQuery,
+					URL:       &fromCopy,
+					QueryURL:  &fromQueryCopy,
 					Token:     o.FromToken,
 					TokenFile: o.FromTokenFile,
 					CAFile:    o.FromCAFile,


### PR DESCRIPTION
When creating different workers, we would pass on the same URL object to each worker. These worker would, in parallel, manipulate this object, causing a race condition.

In most cases, the effect of this, was that multiple workers would hit the same federate endpoint (which has the metrics to federate in the URL as GET parameters), and as a result we would send some metrics multiple times, and other metrics we would not send at all, causing loss of data.