### PR TITLE
Handle AM accessor token on redeploy/restart

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -163,6 +163,8 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			if err := DeleteHubMetricsCollectionDeployments(ctx, r.Client); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to delete hub metrics collection deployments and resources: %w", err)
 			}
+			// Also clear the amAccessorToken global var, to ensure it's not re-used on re-deploys
+			amAccessorTokenSecret = nil
 		}
 
 		// Don't return right away from here because the above cleanup is not complete and it requires


### PR DESCRIPTION
With this commit, we ensure that the AM accessor token is fetched from the existing secret if the global variable is empty, and we also make sure to clear this global variable Observability is removed.

Not doing this before caused the following sub-optimal behavior:
1) A new token is created every time MCO restarts, even if the actual token is not expired
2) If the Observability stack is re-deployed (i.e add the MCO CR, delete it again, then add it again), the MCO operator is not restarted and retains the information about the previous token. This us to try and create a new secret with the `resourceVersion` set, which led to an error, which caused the observability stack to not be created correctly.

We choose to retain the use of the global variable here, to ensure that we create as few as possible tokens. This is to handle the situation where a spoke might reconcile, and cause an a new token to be generated due to the expiry. In that case, if the hub reconciles closely after, if we didn't retain the global variable, we would once again create a new token. Further we currently do all expiry logic on the hub, so it's best to ensure the tokens are as aligned as possible.

Fixes: ACM-25717