### PR TITLE
Update alerts federation

### DIFF
--- a/operators/multiclusterobservability/manifests/base/grafana/alerts/scrape-config.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/alerts/scrape-config.yaml
@@ -13,7 +13,8 @@ spec:
   metricsPath: /federate
   params:
     match[]:
-    - '{__name__="ALERTS"}'
+    - '{__name__="ALERTS",alertname!="PodDisruptionBudgetAtLimit"}'
+    - '{__name__="ALERTS",alertname="PodDisruptionBudgetAtLimit",poddisruptionbudget!~"kubevirt-disruption-budget-.*"}'
   metricRelabelings:
   - action: labeldrop
     regex: managed_cluster|id


### PR DESCRIPTION
Do not Federate PodDisruptionBudgetAtLimit when
poddisruptionbudget=~"kubevirt-disruption-budget-.*"

These alerts are silenced on the clusters by default and should not be federated.

Signed-off-by: Shirly Radco <sradco@redhat.com>