### PR TITLE
Add managed cluster to options.yaml for e2e testing

### DIFF
--- a/cicd-scripts/run-e2e-tests.sh
+++ b/cicd-scripts/run-e2e-tests.sh
@@ -65,13 +65,75 @@ if [[ -n ${IS_KIND_ENV} ]]; then
   printf "\n    grafanaHost: grafana-test" >>${OPTIONSFILE}
 fi
 printf "\n  clusters:" >>${OPTIONSFILE}
-printf "\n    - name: ${cluster_name}" >>${OPTIONSFILE}
-if [[ -n ${IS_KIND_ENV} ]]; then
-  printf "\n      clusterServerURL: ${clusterServerURL}" >>${OPTIONSFILE}
+
+# Check if there's a separate managed cluster (not local-cluster)
+# Priority order:
+# 1. CI clusterpool: ${SHARED_DIR}/managed-1.kc
+# 2. Explicit env vars: MANAGED_CLUSTER_KUBECONFIG or IMPORT_KUBECONFIG
+# 3. Fallback to local-cluster only
+
+managed_cluster_name=""
+managed_cluster_kubeconfig=""
+
+if [[ -n ${SHARED_DIR} ]] && [[ -f ${SHARED_DIR}/managed-1.kc ]]; then
+  # CI environment with clusterpool
+  managed_cluster_name="managed"
+  managed_cluster_kubeconfig="${SHARED_DIR}/managed-1.kc"
+  echo "Detected CI clusterpool environment: ${SHARED_DIR}/managed-1.kc"
+elif [[ -n ${MANAGED_CLUSTER_NAME} ]] && [[ ${MANAGED_CLUSTER_NAME} != "local-cluster" ]]; then
+  # Explicit environment variables
+  managed_cluster_name=${MANAGED_CLUSTER_NAME}
+  managed_cluster_kubeconfig=${MANAGED_CLUSTER_KUBECONFIG:-${IMPORT_KUBECONFIG}}
 fi
-printf "\n      baseDomain: ${base_domain}" >>${OPTIONSFILE}
-printf "\n      kubeconfig: ${kubeconfig_hub_path}" >>${OPTIONSFILE}
-printf "\n      kubecontext: ${kubecontext}" >>${OPTIONSFILE}
+
+if [[ -n ${managed_cluster_name} ]] && [[ -f ${managed_cluster_kubeconfig} ]]; then
+  # Add managed cluster as the first entry
+  managed_base_domain=${MANAGED_CLUSTER_BASE_DOMAIN:-""}
+  managed_api_url=${MANAGED_CLUSTER_API_URL:-""}
+
+  # Auto-extract API URL from kubeconfig if not provided
+  if [[ -z ${managed_api_url} ]]; then
+    managed_api_url=$(kubectl --kubeconfig=${managed_cluster_kubeconfig} config view -o jsonpath="{.clusters[0].cluster.server}" 2>/dev/null || echo "")
+    if [[ -n ${managed_api_url} ]]; then
+      echo "Extracted API URL from managed cluster kubeconfig: ${managed_api_url}"
+    fi
+  fi
+
+  # Auto-extract base domain from API URL
+  if [[ -z ${managed_base_domain} ]] && [[ -n ${managed_api_url} ]]; then
+    managed_base_domain=$(echo ${managed_api_url} | sed -E 's|https://api\.([^:]+).*|\1|')
+    if [[ -n ${managed_base_domain} ]]; then
+      echo "Extracted base domain from API URL: ${managed_base_domain}"
+    fi
+  fi
+
+  # construct API URL from base domain if we have it
+  if [[ -z ${managed_api_url} ]] && [[ -n ${managed_base_domain} ]]; then
+    managed_api_url="https://api.${managed_base_domain}:6443"
+  fi
+
+  printf "\n    - name: ${managed_cluster_name}" >>${OPTIONSFILE}
+  if [[ -n ${managed_api_url} ]]; then
+    printf "\n      clusterServerURL: ${managed_api_url}" >>${OPTIONSFILE}
+  fi
+  if [[ -n ${managed_base_domain} ]]; then
+    printf "\n      baseDomain: ${managed_base_domain}" >>${OPTIONSFILE}
+  fi
+  printf "\n      kubeconfig: ${managed_cluster_kubeconfig}" >>${OPTIONSFILE}
+
+  echo "Added managed cluster to options.yaml: ${managed_cluster_name} (kubeconfig: ${managed_cluster_kubeconfig})"
+else
+  # No separate managed cluster - add local-cluster only (for KinD or hub-only testing)
+  printf "\n    - name: ${cluster_name}" >>${OPTIONSFILE}
+  if [[ -n ${IS_KIND_ENV} ]]; then
+    printf "\n      clusterServerURL: ${clusterServerURL}" >>${OPTIONSFILE}
+  fi
+  printf "\n      baseDomain: ${base_domain}" >>${OPTIONSFILE}
+  printf "\n      kubeconfig: ${kubeconfig_hub_path}" >>${OPTIONSFILE}
+  printf "\n      kubecontext: ${kubecontext}" >>${OPTIONSFILE}
+
+  echo "No separate managed cluster found - addon tests will be skipped"
+fi
 
 if command -v ginkgo &>/dev/null; then
   GINKGO_CMD=ginkgo


### PR DESCRIPTION
Some test (e.g., addon based tests and others) rely on having a managed cluster other than `local-cluster` in options.yaml. 

```
  [SKIPPED] in [BeforeEach] - /go/src/github.com/stolostron/multicluster-observability-operator/tests/pkg/tests/observability_addon_test.go:33 @ 11/11/25 22:34:25.312
S [SKIPPED] [0.633 seconds]
  [SKIPPED] Skip the case for local-cluster since no observability addon
  [SKIPPED] in [BeforeEach] - /go/src/github.com/stolostron/multicluster-observability-operator/tests/pkg/tests/observability_addon_test.go:33 @ 11/11/25 22:34:25.949
S [SKIPPED] [0.635 seconds]
  [SKIPPED] Skip the case for local-cluster since no observability addon
  [SKIPPED] in [BeforeEach] - /go/src/github.com/stolostron/multicluster-observability-operator/tests/pkg/tests/observability_addon_test.go:33 @ 11/11/25 22:34:26.581
S [SKIPPED] [0.630 seconds]
  [SKIPPED] Skip the case for local-cluster since no observability addon
  [SKIPPED] in [BeforeEach] - /go/src/github.com/stolostron/multicluster-observability-operator/tests/pkg/tests/observa
```

The E2E framework currently adds a managed cluster to hub, but still creates a `local-cluster` as the default managed cluster. This PR will discover and inject managed cluster into options.yaml to ensure all managed cluster tests execute.