### PR TITLE
Clear MCOA error state if disabled

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_status.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_status.go
@@ -267,10 +267,12 @@ func updateAddonSpecStatus(
 
 func updateMCOAStatus(c client.Client, conds *[]mcoshared.Condition, mco *mcov1beta2.MultiClusterObservability) {
 	if mco.Spec.Capabilities == nil {
+		removeStatusCondition(conds, reasonMCOADegraded)
 		return
 	}
 
 	if mco.Spec.Capabilities.Platform == nil && mco.Spec.Capabilities.UserWorkloads == nil {
+		removeStatusCondition(conds, reasonMCOADegraded)
 		return
 	}
 
@@ -280,6 +282,7 @@ func updateMCOAStatus(c client.Client, conds *[]mcoshared.Condition, mco *mcov1b
 		!mco.Spec.Capabilities.Platform.Logs.Collection.Enabled &&
 		!mco.Spec.Capabilities.Platform.Metrics.Default.Enabled &&
 		!mco.Spec.Capabilities.Platform.Analytics.IncidentDetection.Enabled {
+		removeStatusCondition(conds, reasonMCOADegraded)
 		return
 	}
 


### PR DESCRIPTION
Make sure we clear MCOA Degraded state, if MCOA is disabled. The error state would before stick if one first enable MCOA, gets to an error state, and then disabled MCOA again.