### PR TITLE
Add MCO operator permissions for clustermanagementaddons/status

### DIFF
--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -49,7 +49,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-10-07T17:35:44Z"
+    createdAt: "2025-11-19T13:19:24Z"
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-observability-operator.v0.1.0
@@ -313,6 +313,7 @@ spec:
           resources:
           - clustermanagementaddons
           - clustermanagementaddons/finalizers
+          - clustermanagementaddons/status
           verbs:
           - create
           - update

--- a/operators/multiclusterobservability/config/rbac/mco_role.yaml
+++ b/operators/multiclusterobservability/config/rbac/mco_role.yaml
@@ -229,6 +229,7 @@ rules:
   resources:
   - clustermanagementaddons
   - clustermanagementaddons/finalizers
+  - clustermanagementaddons/status
   verbs:
   - create
   - update


### PR DESCRIPTION
Since observability-addon is registering in self-managed mode, the embedded addon-framework controllers need permission to update the status when a addonDeploymentConfig is registered through ClusterManagementAddon object. 

This PR is a prerequisite for https://github.com/stolostron/multicluster-observability-operator/pull/2240

Adding for posterity.  It is currently a two-step process for any feature to update MCO cluster role permissions.

First, create a PR by doing 
1. Update to [mco_role.yaml](https://github.com/stolostron/multicluster-observability-operator/blob/main/operators/multiclusterobservability/config/rbac/mco_role.yaml)
2. Run `make bundle` to update csv file

Once the PR is merged, ACM build will picks up the `csv` change to create a new build that deploys MCO with new permissions.

At this point, the feature needing the ClusterRole change can be e2e tested, as long as the test can pick up the ACM build with the updated permissions. 

in e2e environments, it is currently not possible to `patch` ClusterRole permissions used by MCO operator. The closest alternative is to patch permissions by injecting an additional `multicluster-observability-operator-e2e-testing` ClusterRole and ClusterRoleBinding and  as done in the CICD pipeline [here](https://github.com/openshift/release/blob/master/ci-operator/config/stolostron/multicluster-observability-operator/stolostron-multicluster-observability-operator-main.yaml#L195-L219) 
