### PR TITLE
Fix for observability addon e2e tests

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -578,9 +578,9 @@ func createAllRelatedRes(
 			continue
 		}
 
-		if err := deleteObsAddon(ctx, c, ep.Namespace); err != nil {
-			allErrors = append(allErrors, fmt.Errorf("failed to deleteObsAddon: %w", err))
-			log.Error(err, "Failed to delete observabilityaddon", "namespace", ep.Namespace)
+		if err := deleteManagedClusterRes(c, ep.Namespace); err != nil {
+			allErrors = append(allErrors, fmt.Errorf("failed to delete managed cluster resources: %w", err))
+			log.Error(err, "Failed to delete managed cluster resources", "namespace", ep.Namespace)
 		}
 	}
 

--- a/tests/pkg/tests/observability_addon_test.go
+++ b/tests/pkg/tests/observability_addon_test.go
@@ -128,7 +128,7 @@ var _ = Describe("", func() {
 					return err
 				}
 				return nil
-			}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
+			}, EventuallyTimeoutMinute*6, EventuallyIntervalSecond*5).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
Fix for RHACM4K-7518, that fails frequently in e2e tests. The expected scenario:
1. Add "observability=disabled" label to managed cluster
2. observability addon resources for the managed cluster are removed
3. The `endpoint-observability-operator` and `metrics-collector-deployment` pods are removed from the "open-cluster-management-addon-observability" namespace

The failing scenario in RHACM4K-7518 test this PR addresses:
1. Add "observability=disabled" label to managed cluster
2. The `metrics-collector-deployment` pod is removed along with related secrets
3. The `endpoint-observability-operator` and the "open-cluster-management-addon-observability" namespace still exist
4.  The `endpoint-observability-operator` has error `failed to get ObservabilityAddon in hub cluster`
