### PR TITLE
ACM-27035: adding accelerator_card_info metric to the scrape config

### DIFF
--- a/cicd-scripts/metrics/Makefile
+++ b/cicd-scripts/metrics/Makefile
@@ -17,6 +17,7 @@ check-platform-metrics:
 	@echo "--> Checking platform metrics:"
 	@$(CURDIR)/scripts/extract-dashboards-metrics.sh -d $(PLATFORM_DASH_DIR) | tr '\n' ',' > $(TMPDIR)/dash-metrics
 	@go run cmd/dashcheck/main.go --scrape-configs=$(PLATFORM_DASH_DIR)/scrape-config.yaml \
+		--ignored-scrapeconfig-metrics=accelerator_card_info \
 		--dashboard-metrics=$$(cat $(TMPDIR)/dash-metrics)
 	@cat $(PLATFORM_DASH_DIR)/prometheus-rule.yaml | yq '.spec' | promtool check rules
 	@go run cmd/rulescheck/main.go --scrape-configs=$(PLATFORM_DASH_DIR)/scrape-config.yaml \

--- a/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
+++ b/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
@@ -6,6 +6,7 @@ data:
   metrics_list.yaml: |
     names:
       - :node_memory_MemAvailable_bytes:sum
+      - accelerator_card_info
       - acm_managed_cluster_labels
       - acm_rs:namespace:cpu_request_hard
       - acm_rs:namespace:cpu_request

--- a/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/scrape-config.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/scrape-config.yaml
@@ -14,6 +14,7 @@ spec:
   params:
     match[]:
     - '{__name__=":node_memory_MemAvailable_bytes:sum"}'
+    - '{__name__="accelerator_card_info"}'
     - '{__name__="acm_label_names"}' # metrics generated on the hub by MCE, needed for Grafana
     - '{__name__="acm_managed_cluster_labels"}' # metrics generated on the hub by MCE, needed for Grafana
     - '{__name__="active_streams_lease:grpc_server_handled_total:sum"}'


### PR DESCRIPTION
accelerator_card_info is needed by the fleet management UI to provide GPU cards info.