### PR TITLE
[release-2.15] Use cluster-id for alertmanager secrets

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/util"
 	oav1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
 	oav1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
+	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	"github.com/stolostron/multicluster-observability-operator/operators/pkg/deploying"
 	rendererutil "github.com/stolostron/multicluster-observability-operator/operators/pkg/rendering"
@@ -210,7 +211,7 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, fmt.Errorf("failed to check prometheus resource: %w", err)
 		}
 
-		clusterID, err = openshift.GetClusterID(ctx, r.Client)
+		clusterID, err = mcoconfig.GetClusterID(ctx, r.Client)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get cluster id: %w", err)
 		}

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
@@ -145,7 +145,7 @@ func createHubAmRouterCASecret(
 	client client.Client,
 	targetNamespace string) error {
 
-	hubAmRouterSecret := hubAmRouterCASecretName + "-" + hubInfo.HubClusterDomain
+	hubAmRouterSecret := hubAmRouterCASecretName + "-" + hubInfo.HubClusterID
 
 	hubAmRouterCA := hubInfo.AlertmanagerRouterCA
 	dataMap := map[string][]byte{hubAmRouterCASecretKey: []byte(hubAmRouterCA)}
@@ -193,7 +193,7 @@ func createHubAmAccessorTokenSecret(ctx context.Context, client client.Client, n
 		return fmt.Errorf("fail to get %s/%s secret: %w", namespace, hubAmAccessorSecretName, err)
 	}
 
-	hubAmAccessorSecret := hubAmAccessorSecretName + "-" + hubInfo.HubClusterDomain
+	hubAmAccessorSecret := hubAmAccessorSecretName + "-" + hubInfo.HubClusterID
 	dataMap := map[string][]byte{hubAmAccessorSecretKey: []byte(amAccessorToken)}
 	hubAmAccessorTokenSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -258,7 +258,7 @@ func newAdditionalAlertmanagerConfig(hubInfo *operatorconfig.HubInfo) cmomanifes
 		TLSConfig: cmomanifests.TLSConfig{
 			CA: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: hubAmRouterCASecretName + "-" + hubInfo.HubClusterDomain,
+					Name: hubAmRouterCASecretName + "-" + hubInfo.HubClusterID,
 				},
 				Key: hubAmRouterCASecretKey,
 			},
@@ -266,7 +266,7 @@ func newAdditionalAlertmanagerConfig(hubInfo *operatorconfig.HubInfo) cmomanifes
 		},
 		BearerToken: &corev1.SecretKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{
-				Name: hubAmAccessorSecretName + "-" + hubInfo.HubClusterDomain,
+				Name: hubAmAccessorSecretName + "-" + hubInfo.HubClusterID,
 			},
 			Key: hubAmAccessorSecretKey,
 		},
@@ -764,7 +764,7 @@ func inManagedFields(cm *corev1.ConfigMap) bool {
 
 // isManaged checks if the additional alertmanager config is managed by ACM
 func isManaged(amc cmomanifests.AdditionalAlertmanagerConfig, hubInfo *operatorconfig.HubInfo) bool {
-	if hubInfo != nil && amc.TLSConfig.CA != nil && amc.TLSConfig.CA.LocalObjectReference.Name == hubAmRouterCASecretName+"-"+hubInfo.HubClusterDomain {
+	if hubInfo != nil && amc.TLSConfig.CA != nil && amc.TLSConfig.CA.LocalObjectReference.Name == hubAmRouterCASecretName+"-"+hubInfo.HubClusterID {
 		return true
 	} else if hubInfo == nil && amc.TLSConfig.CA != nil && strings.Contains(amc.TLSConfig.CA.LocalObjectReference.Name, hubAmRouterCASecretName) {
 		//This is only for the CMO cleanup script to clean up old configs

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
@@ -145,7 +145,7 @@ prometheusK8s:
 		},
 	}
 
-	hubInfo := &operatorconfig.HubInfo{HubClusterDomain: "test-hub"}
+	hubInfo := &operatorconfig.HubInfo{HubClusterID: "1a9af6dc0801433cb28a200af81"}
 	err := yaml.Unmarshal([]byte(hubInfoYAML), &hubInfo)
 	if err != nil {
 		t.Fatalf("Failed to unmarshal hubInfo: (%v)", err)
@@ -173,7 +173,7 @@ func TestClusterMonitoringConfigUnchanged(t *testing.T) {
 		ClusterName:              "test-cluster",
 		ObservatoriumAPIEndpoint: "http://test-endpoint",
 		AlertmanagerEndpoint:     "http://test-alertamanger-endpoint",
-		HubClusterDomain:         "test-hub",
+		HubClusterID:             "1a9af6dc0801433cb28a200af81",
 	}
 	cmoCfg := newClusterMonitoringConfigCM(clusterMonitoringConfigDataYaml, endpointMonitoringOperatorMgr)
 	client := fake.NewClientBuilder().WithRuntimeObjects(newHubInfoSecret([]byte(hubInfoYAML), testNamespace), cmoCfg, amAccessSrt).Build()
@@ -337,10 +337,10 @@ func testCreateOrUpdateClusterMonitoringConfig(t *testing.T, hubInfo *operatorco
 		if v.TLSConfig != (cmomanifests.TLSConfig{}) &&
 			v.TLSConfig.CA != nil &&
 			v.TLSConfig.CA.LocalObjectReference != (corev1.LocalObjectReference{}) &&
-			v.TLSConfig.CA.LocalObjectReference.Name == hubAmRouterCASecretName+"-"+hubInfo.HubClusterDomain &&
+			v.TLSConfig.CA.LocalObjectReference.Name == hubAmRouterCASecretName+"-"+hubInfo.HubClusterID &&
 			v.BearerToken != nil &&
 			v.BearerToken.LocalObjectReference != (corev1.LocalObjectReference{}) &&
-			v.BearerToken.LocalObjectReference.Name == hubAmAccessorSecretName+"-"+hubInfo.HubClusterDomain {
+			v.BearerToken.LocalObjectReference.Name == hubAmAccessorSecretName+"-"+hubInfo.HubClusterID {
 			containsOCMAlertmanagerConfig = true
 			foundHubAmAccessorSecret := &corev1.Secret{}
 			err = c.Get(ctx, types.NamespacedName{Name: v.BearerToken.LocalObjectReference.Name,
@@ -376,17 +376,17 @@ func testCreateOrUpdateClusterMonitoringConfig(t *testing.T, hubInfo *operatorco
 	}
 
 	foundHubAmAccessorSecret := &corev1.Secret{}
-	err = c.Get(ctx, types.NamespacedName{Name: hubAmAccessorSecretName + "-" + hubInfo.HubClusterDomain,
+	err = c.Get(ctx, types.NamespacedName{Name: hubAmAccessorSecretName + "-" + hubInfo.HubClusterID,
 		Namespace: promNamespace}, foundHubAmAccessorSecret)
 	if err != nil {
-		t.Fatalf("the secret %s should not be deleted", hubAmAccessorSecretName+"-"+hubInfo.HubClusterDomain)
+		t.Fatalf("the secret %s should not be deleted", hubAmAccessorSecretName+"-"+hubInfo.HubClusterID)
 	}
 
 	foundHubAmRouterCASecret := &corev1.Secret{}
-	err = c.Get(ctx, types.NamespacedName{Name: hubAmRouterCASecretName + "-" + hubInfo.HubClusterDomain,
+	err = c.Get(ctx, types.NamespacedName{Name: hubAmRouterCASecretName + "-" + hubInfo.HubClusterID,
 		Namespace: promNamespace}, foundHubAmRouterCASecret)
 	if err != nil {
-		t.Fatalf("the secret %s should not be deleted", hubAmRouterCASecretName+"-"+hubInfo.HubClusterDomain)
+		t.Fatalf("the secret %s should not be deleted", hubAmRouterCASecretName+"-"+hubInfo.HubClusterID)
 	}
 
 	err = RevertClusterMonitoringConfig(ctx, c, hubInfo)
@@ -462,7 +462,7 @@ prometheus:
 		},
 	}
 
-	hubInfo := &operatorconfig.HubInfo{HubClusterDomain: "test-hub"}
+	hubInfo := &operatorconfig.HubInfo{HubClusterID: "1a9af6dc0801433cb28a200af81"}
 	err := yaml.Unmarshal([]byte(hubInfoYAML), &hubInfo)
 	if err != nil {
 		t.Fatalf("Failed to unmarshal hubInfo: (%v)", err)
@@ -474,7 +474,7 @@ prometheus:
 	// Create router CA secret in the user workload monitoring namespace
 	routerCASecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hubAmRouterCASecretName + "-" + hubInfo.HubClusterDomain,
+			Name:      hubAmRouterCASecretName + "-" + hubInfo.HubClusterID,
 			Namespace: uwlTestNamespace,
 		},
 		Data: map[string][]byte{
@@ -484,7 +484,7 @@ prometheus:
 
 	uwlAccessSrt := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hubAmAccessorSecretName + "-" + hubInfo.HubClusterDomain,
+			Name:      hubAmAccessorSecretName + "-" + hubInfo.HubClusterID,
 			Namespace: uwlTestNamespace,
 		},
 		Data: map[string][]byte{
@@ -564,10 +564,10 @@ func testCreateOrUpdateUserWorkloadMonitoringConfig(t *testing.T, hubInfo *opera
 		if v.TLSConfig != (cmomanifests.TLSConfig{}) &&
 			v.TLSConfig.CA != nil &&
 			v.TLSConfig.CA.LocalObjectReference != (corev1.LocalObjectReference{}) &&
-			v.TLSConfig.CA.LocalObjectReference.Name == hubAmRouterCASecretName+"-"+hubInfo.HubClusterDomain &&
+			v.TLSConfig.CA.LocalObjectReference.Name == hubAmRouterCASecretName+"-"+hubInfo.HubClusterID &&
 			v.BearerToken != nil &&
 			v.BearerToken.LocalObjectReference != (corev1.LocalObjectReference{}) &&
-			v.BearerToken.LocalObjectReference.Name == hubAmAccessorSecretName+"-"+hubInfo.HubClusterDomain {
+			v.BearerToken.LocalObjectReference.Name == hubAmAccessorSecretName+"-"+hubInfo.HubClusterID {
 			containsOCMAlertmanagerConfig = true
 			foundHubAmAccessorSecret := &corev1.Secret{}
 			err = c.Get(ctx, types.NamespacedName{
@@ -608,20 +608,20 @@ func testCreateOrUpdateUserWorkloadMonitoringConfig(t *testing.T, hubInfo *opera
 
 	foundHubAmAccessorSecret := &corev1.Secret{}
 	err = c.Get(ctx, types.NamespacedName{
-		Name:      hubAmAccessorSecretName + "-" + hubInfo.HubClusterDomain,
+		Name:      hubAmAccessorSecretName + "-" + hubInfo.HubClusterID,
 		Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
 	}, foundHubAmAccessorSecret)
 	if err != nil {
-		t.Fatalf("the secret %s should not be deleted", hubAmAccessorSecretName+"-"+hubInfo.HubClusterDomain)
+		t.Fatalf("the secret %s should not be deleted", hubAmAccessorSecretName+"-"+hubInfo.HubClusterID)
 	}
 
 	foundHubAmRouterCASecret := &corev1.Secret{}
 	err = c.Get(ctx, types.NamespacedName{
-		Name:      hubAmRouterCASecretName + "-" + hubInfo.HubClusterDomain,
+		Name:      hubAmRouterCASecretName + "-" + hubInfo.HubClusterID,
 		Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
 	}, foundHubAmRouterCASecret)
 	if err != nil {
-		t.Fatalf("the secret %s should not be deleted", hubAmRouterCASecretName+"-"+hubInfo.HubClusterDomain)
+		t.Fatalf("the secret %s should not be deleted", hubAmRouterCASecretName+"-"+hubInfo.HubClusterID)
 	}
 
 	err = RevertUserWorkloadMonitoringConfig(ctx, c, hubInfo)
@@ -760,7 +760,7 @@ prometheus:
 		if v.TLSConfig != (cmomanifests.TLSConfig{}) &&
 			v.TLSConfig.CA != nil &&
 			v.TLSConfig.CA.LocalObjectReference != (corev1.LocalObjectReference{}) &&
-			v.TLSConfig.CA.LocalObjectReference.Name == hubAmRouterCASecretName+"-"+hubInfo.HubClusterDomain {
+			v.TLSConfig.CA.LocalObjectReference.Name == hubAmRouterCASecretName+"-"+hubInfo.HubClusterID {
 			containsOCMAlertmanagerConfig = true
 		}
 	}
@@ -776,7 +776,7 @@ func TestUserWorkloadMonitoringConfigUWMAlertsDisabled(t *testing.T) {
 	ctx := context.TODO()
 
 	// Test with UWM alerting disabled but global alerting enabled
-	hubInfo := &operatorconfig.HubInfo{HubClusterDomain: "test-hub"}
+	hubInfo := &operatorconfig.HubInfo{HubClusterID: "test-hub"}
 	err := yaml.Unmarshal([]byte(hubInfoYAMLUWMAlertsDisabled), &hubInfo)
 	if err != nil {
 		t.Fatalf("Failed to unmarshal hubInfo: (%v)", err)
@@ -787,7 +787,7 @@ func TestUserWorkloadMonitoringConfigUWMAlertsDisabled(t *testing.T) {
 	// Create router CA secret in the user workload monitoring namespace
 	routerCASecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hubAmRouterCASecretName + "-" + hubInfo.HubClusterDomain,
+			Name:      hubAmRouterCASecretName + "-" + hubInfo.HubClusterID,
 			Namespace: testNamespace,
 		},
 		Data: map[string][]byte{
@@ -901,7 +901,7 @@ prometheus:
 		if v.TLSConfig != (cmomanifests.TLSConfig{}) &&
 			v.TLSConfig.CA != nil &&
 			v.TLSConfig.CA.LocalObjectReference != (corev1.LocalObjectReference{}) &&
-			v.TLSConfig.CA.LocalObjectReference.Name == hubAmRouterCASecretName+"-"+hubInfo.HubClusterDomain {
+			v.TLSConfig.CA.LocalObjectReference.Name == hubAmRouterCASecretName+"-"+hubInfo.HubClusterID {
 			containsOCMAlertmanagerConfig = true
 		}
 	}
@@ -918,7 +918,7 @@ func TestUWLMonitoringDisableScenario(t *testing.T) {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
 
 	// Create hub info with alerts enabled (but UWL disabled)
-	hubInfo := &operatorconfig.HubInfo{HubClusterDomain: "test-hub"}
+	hubInfo := &operatorconfig.HubInfo{HubClusterID: "test-hub"}
 	err := yaml.Unmarshal([]byte(hubInfoYAML), &hubInfo)
 	if err != nil {
 		t.Fatalf("Failed to unmarshal hubInfo: (%v)", err)
@@ -1017,7 +1017,7 @@ userWorkloadEnabled: false
 			// Check if the configmap still contains ACM alertmanager configuration
 			if parsed.Prometheus != nil && parsed.Prometheus.AlertmanagerConfigs != nil {
 				for _, config := range parsed.Prometheus.AlertmanagerConfigs {
-					if config.TLSConfig.CA != nil && config.TLSConfig.CA.LocalObjectReference.Name == hubAmRouterCASecretName+"-"+hubInfo.HubClusterDomain {
+					if config.TLSConfig.CA != nil && config.TLSConfig.CA.LocalObjectReference.Name == hubAmRouterCASecretName+"-"+hubInfo.HubClusterID {
 						t.Fatalf("UWL configmap still contains ACM alertmanager configuration when it should be cleaned up")
 					}
 				}
@@ -1042,7 +1042,7 @@ func TestUWLMonitoringEnableScenario(t *testing.T) {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
 
 	// Create hub info with alerts enabled (but UWL disabled)
-	hubInfo := &operatorconfig.HubInfo{HubClusterDomain: "test-hub"}
+	hubInfo := &operatorconfig.HubInfo{HubClusterID: "test-hub"}
 	err := yaml.Unmarshal([]byte(hubInfoYAML), &hubInfo)
 	if err != nil {
 		t.Fatalf("Failed to unmarshal hubInfo: (%v)", err)
@@ -1131,7 +1131,7 @@ enableUserWorkload: true
 
 	// Verify that the ACM alertmanager configuration is present by checking for the CA secret
 	// The configuration should reference the hub alertmanager router CA secret
-	if !strings.Contains(configYAML, hubAmRouterCASecretName+"-"+hubInfo.HubClusterDomain) {
+	if !strings.Contains(configYAML, hubAmRouterCASecretName+"-"+hubInfo.HubClusterID) {
 		t.Fatalf("UWL configmap should contain ACM alertmanager configuration with CA secret reference")
 	}
 

--- a/operators/endpointmetrics/pkg/openshift/openshift.go
+++ b/operators/endpointmetrics/pkg/openshift/openshift.go
@@ -144,16 +144,6 @@ func CreateCAConfigmap(ctx context.Context, client client.Client, namespace stri
 	return nil
 }
 
-// getClusterID is used to get the cluster uid
-func GetClusterID(ctx context.Context, c client.Client) (string, error) {
-	clusterVersion := &ocinfrav1.ClusterVersion{}
-	if err := c.Get(ctx, types.NamespacedName{Name: "version"}, clusterVersion); err != nil {
-		return "", fmt.Errorf("failed to get clusterVersion: %w", err)
-	}
-
-	return string(clusterVersion.Spec.ClusterID), nil
-}
-
 func IsSNO(ctx context.Context, c client.Client) (bool, error) {
 	infraConfig := &ocinfrav1.Infrastructure{}
 	if err := c.Get(ctx, types.NamespacedName{Name: "cluster"}, infraConfig); err != nil {

--- a/operators/endpointmetrics/pkg/openshift/openshift_test.go
+++ b/operators/endpointmetrics/pkg/openshift/openshift_test.go
@@ -9,13 +9,11 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	ocinfrav1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/openshift"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -24,15 +22,6 @@ const (
 	testClusterID         = "kind-cluster-id"
 	hostedClusterName     = "test-hosted-cluster"
 	hosteClusterNamespace = "clusters"
-)
-
-var (
-	cv = &ocinfrav1.ClusterVersion{
-		ObjectMeta: metav1.ObjectMeta{Name: "version"},
-		Spec: ocinfrav1.ClusterVersionSpec{
-			ClusterID: testClusterID,
-		},
-	}
 )
 
 func init() {
@@ -104,19 +93,5 @@ func TestCreateDeleteMonitoringClusterRoleBinding(t *testing.T) {
 	err = openshift.DeleteMonitoringClusterRoleBinding(ctx, c, false)
 	if err != nil {
 		t.Fatalf("Run into error when try to delete delete clusterrolebinding twice: (%v)", err)
-	}
-}
-
-func TestGetClusterID(t *testing.T) {
-	ctx := context.TODO()
-	scheme := runtime.NewScheme()
-	ocinfrav1.Install(scheme)
-	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(cv).Build()
-	found, err := openshift.GetClusterID(ctx, c)
-	if err != nil {
-		t.Fatalf("Failed to get clusterversion: (%v)", err)
-	}
-	if found != testClusterID {
-		t.Fatalf("Got wrong cluster id: %s", found)
 	}
 }

--- a/operators/endpointmetrics/pkg/rendering/renderer.go
+++ b/operators/endpointmetrics/pkg/rendering/renderer.go
@@ -178,7 +178,7 @@ func Render(
 					},
 					Key: "alertmanager.yaml",
 				}
-				spec.Secrets = []string{"hub-alertmanager-router-ca" + "-" + hubInfo.HubClusterDomain, "observability-alertmanager-accessor" + "-" + hubInfo.HubClusterDomain}
+				spec.Secrets = []string{"hub-alertmanager-router-ca" + "-" + hubInfo.HubClusterID, "observability-alertmanager-accessor" + "-" + hubInfo.HubClusterID}
 			}
 
 			unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
@@ -260,9 +260,9 @@ func Render(
 			hubAmEp := strings.TrimPrefix(hubInfo.AlertmanagerEndpoint, "https://")
 			amConfig = strings.ReplaceAll(amConfig, "_ALERTMANAGER_ENDPOINT_", hubAmEp)
 			amConfig = strings.ReplaceAll(amConfig, "credentials_file: /etc/prometheus/secrets/observability-alertmanager-accessor/token",
-				fmt.Sprintf("credentials_file: /etc/prometheus/secrets/observability-alertmanager-accessor-%s/token", hubInfo.HubClusterDomain))
+				fmt.Sprintf("credentials_file: /etc/prometheus/secrets/observability-alertmanager-accessor-%s/token", hubInfo.HubClusterID))
 			amConfig = strings.ReplaceAll(amConfig, "ca_file: /etc/prometheus/secrets/hub-alertmanager-router-ca/service-ca.crt",
-				fmt.Sprintf("ca_file: /etc/prometheus/secrets/hub-alertmanager-router-ca-%s/service-ca.crt", hubInfo.HubClusterDomain))
+				fmt.Sprintf("ca_file: /etc/prometheus/secrets/hub-alertmanager-router-ca-%s/service-ca.crt", hubInfo.HubClusterID))
 			s.StringData["alertmanager.yaml"] = amConfig
 
 			unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)

--- a/operators/multiclusterobservability/controllers/placementrule/hub_info_secret_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_info_secret_test.go
@@ -194,7 +194,7 @@ func TestNewSecret(t *testing.T) {
 		t.Fatalf("Failed to unmarshal data in hub info secret (%v)", err)
 	}
 	if !strings.HasPrefix(hub.ObservatoriumAPIEndpoint, "https://observatorium-api-open-cluster-management-observability.apps.test-host") ||
-		hub.AlertmanagerEndpoint != "https://"+routeHost || hub.AlertmanagerRouterCA != routerCA {
+		hub.AlertmanagerEndpoint != "https://"+routeHost || hub.AlertmanagerRouterCA != routerCA || hub.HubClusterID != "1a9af6dc0801433cb28a200af81" {
 		t.Fatalf("Wrong content in hub info secret: \ngot: "+hub.ObservatoriumAPIEndpoint+" "+hub.AlertmanagerEndpoint+" "+hub.AlertmanagerRouterCA, clusterName+" "+"https://test-host"+" "+"test-host"+" "+routerCA)
 	}
 

--- a/operators/multiclusterobservability/controllers/placementrule/hub_ocp_monitoring_util.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_ocp_monitoring_util.go
@@ -95,7 +95,7 @@ func RevertHubClusterMonitoringConfig(ctx context.Context, client client.Client)
 		copiedAlertmanagerConfigs := make([]cmomanifests.AdditionalAlertmanagerConfig, 0)
 		for _, v := range foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs {
 			if v.TLSConfig == (cmomanifests.TLSConfig{}) ||
-				(v.TLSConfig.CA != nil && v.TLSConfig.CA.LocalObjectReference.Name != hubAmRouterCASecretName+"-"+hubInfo.HubClusterDomain) {
+				(v.TLSConfig.CA != nil && v.TLSConfig.CA.LocalObjectReference.Name != hubAmRouterCASecretName+"-"+hubInfo.HubClusterID) {
 				copiedAlertmanagerConfigs = append(copiedAlertmanagerConfigs, v)
 			}
 		}

--- a/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
+++ b/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
@@ -88,3 +88,6 @@
     - apiGroups: [operator.openshift.io]
       resources: [ingresscontrollers]
       verbs: ["get", "list", "watch"]
+    - apiGroups: ["config.openshift.io"]
+      resources: [clusterversions]
+      verbs: ["get", "list", "watch"]

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -20,7 +20,6 @@ import (
 	ocinfrav1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
-	ocpClientSet "github.com/openshift/client-go/config/clientset/versioned"
 	obsv1alpha1 "github.com/stolostron/observatorium-operator/api/v1alpha1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -598,11 +597,10 @@ func GetKubeAPIServerAddress(client client.Client) (string, error) {
 }
 
 // GetClusterID is used to get the cluster uid.
-func GetClusterID(ocpClient ocpClientSet.Interface) (string, error) {
-	clusterVersion, err := ocpClient.ConfigV1().ClusterVersions().Get(context.TODO(), "version", v1.GetOptions{})
-	if err != nil {
-		log.Error(err, "Failed to get clusterVersion")
-		return "", err
+func GetClusterID(ctx context.Context, c client.Client) (string, error) {
+	clusterVersion := &ocinfrav1.ClusterVersion{}
+	if err := c.Get(ctx, types.NamespacedName{Name: "version"}, clusterVersion); err != nil {
+		return "", fmt.Errorf("failed to get clusterVersion: %w", err)
 	}
 
 	return string(clusterVersion.Spec.ClusterID), nil
@@ -939,19 +937,21 @@ func GetCachedImageManifestData() (map[string]string, bool) {
 	return nil, false
 }
 
-func GetClusterName(obsApiURL string) string {
-	u, err := url.Parse(obsApiURL)
+func GetTrimmedClusterID(c client.Client) (string, error) {
+	id, err := GetClusterID(context.TODO(), c)
 	if err != nil {
-		log.Error(err, "Failed to parse obsApiURL", "obsApiURL", obsApiURL)
-		return ""
+		return "", err
 	}
-	hostParts := strings.Split(u.Hostname(), ".")
-	if len(hostParts) < 3 {
-		log.Error(err, "Failed to get cluster name from obsApiURL", "obsApiURL", obsApiURL)
-		return ""
-	}
-	clusterName := hostParts[2]
-	return clusterName
+	// We use this ID later to postfix the follow secrets:
+	// hub-alertmanager-router-ca
+	// observability-alertmanager-accessor
+	//
+	// when prom-opreator mounts these secrets to the prometheus-k8s pod
+	// it will take the name of the secret, and prepend `secret-` to the
+	// volume mount name. However since this is volume mount name is a label
+	// that must be at most 63 chars. Therefore we trim it here to 19 chars.
+	idTrim := strings.ReplaceAll(id, "-", "")
+	return fmt.Sprintf("%.19s", idTrim), nil
 }
 
 // KindOrder is a map that defines the deployment order for Kubernetes resource kinds.

--- a/operators/pkg/config/types.go
+++ b/operators/pkg/config/types.go
@@ -18,7 +18,7 @@ type HubInfo struct {
 	AlertmanagerEndpoint     string `yaml:"alertmanager-endpoint"`
 	AlertmanagerRouterCA     string `yaml:"alertmanager-router-ca"`
 	UWMAlertingDisabled      bool   `yaml:"uwm-alerting-disabled"`
-	HubClusterDomain         string `yaml:"hub-cluster-domain"`
+	HubClusterID             string `yaml:"hub-cluster-id"`
 }
 
 type RecordingRule struct {

--- a/scripts/bootstrap-kind-env.sh
+++ b/scripts/bootstrap-kind-env.sh
@@ -41,12 +41,21 @@ deploy_openshift_router() {
   kubectl apply -f ${WORKDIR}/router/
 }
 
+deploy_cluster_version() {
+  kubectl apply -f ${WORKDIR}/clusterversion/clusterversion-crd.yaml
+  # need a sleep otherwise we get error:
+  # Error from server (NotFound): error when creating "clusterversion.yaml": the server could not find the requested resource (post clusterversions.config.openshift.io)
+  sleep 2
+  kubectl apply -f ${WORKDIR}/clusterversion/clusterversion.yaml
+}
+
 run() {
   create_kind_cluster hub
   deploy_crds
   deploy_templates
   deploy_service_ca_operator
   deploy_openshift_router
+  deploy_cluster_version
 }
 
 run

--- a/tests/run-in-kind/clusterversion/clusterversion-crd.yaml
+++ b/tests/run-in-kind/clusterversion/clusterversion-crd.yaml
@@ -1,0 +1,776 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/495
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: Default
+  name: clusterversions.config.openshift.io
+spec:
+  conversion:
+    strategy: None
+  group: config.openshift.io
+  names:
+    kind: ClusterVersion
+    listKind: ClusterVersionList
+    plural: clusterversions
+    singular: clusterversion
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.history[?(@.state=="Completed")].version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].lastTransitionTime
+      name: Since
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterVersion is the configuration for the ClusterVersionOperator. This is where
+          parameters related to automatic updates can be set.
+
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              spec is the desired state of the cluster version - the operator will work
+              to ensure that the desired version is applied to the cluster.
+            properties:
+              capabilities:
+                description: |-
+                  capabilities configures the installation of optional, core
+                  cluster components.  A null value here is identical to an
+                  empty object; see the child properties for default semantics.
+                properties:
+                  additionalEnabledCapabilities:
+                    description: |-
+                      additionalEnabledCapabilities extends the set of managed
+                      capabilities beyond the baseline defined in
+                      baselineCapabilitySet.  The default is an empty set.
+                    items:
+                      description: ClusterVersionCapability enumerates optional, core
+                        cluster components.
+                      enum:
+                      - openshift-samples
+                      - baremetal
+                      - marketplace
+                      - Console
+                      - Insights
+                      - Storage
+                      - CSISnapshot
+                      - NodeTuning
+                      - MachineAPI
+                      - Build
+                      - DeploymentConfig
+                      - ImageRegistry
+                      - OperatorLifecycleManager
+                      - CloudCredential
+                      - Ingress
+                      - CloudControllerManager
+                      - OperatorLifecycleManagerV1
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  baselineCapabilitySet:
+                    description: |-
+                      baselineCapabilitySet selects an initial set of
+                      optional capabilities to enable, which can be extended via
+                      additionalEnabledCapabilities.  If unset, the cluster will
+                      choose a default, and the default may change over time.
+                      The current default is vCurrent.
+                    enum:
+                    - None
+                    - v4.11
+                    - v4.12
+                    - v4.13
+                    - v4.14
+                    - v4.15
+                    - v4.16
+                    - v4.17
+                    - v4.18
+                    - vCurrent
+                    type: string
+                type: object
+              channel:
+                description: |-
+                  channel is an identifier for explicitly requesting a non-default set
+                  of updates to be applied to this cluster. The default channel will
+                  contain stable updates that are appropriate for production clusters.
+                type: string
+              clusterID:
+                description: |-
+                  clusterID uniquely identifies this cluster. This is expected to be
+                  an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in
+                  hexadecimal values). This is a required field.
+                type: string
+              desiredUpdate:
+                description: |-
+                  desiredUpdate is an optional field that indicates the desired value of
+                  the cluster version. Setting this value will trigger an upgrade (if
+                  the current version does not match the desired version). The set of
+                  recommended update values is listed as part of available updates in
+                  status, and setting values outside that range may cause the upgrade
+                  to fail.
+
+                  Some of the fields are inter-related with restrictions and meanings described here.
+                  1. image is specified, version is specified, architecture is specified. API validation error.
+                  2. image is specified, version is specified, architecture is not specified. The version extracted from the referenced image must match the specified version.
+                  3. image is specified, version is not specified, architecture is specified. API validation error.
+                  4. image is specified, version is not specified, architecture is not specified. image is used.
+                  5. image is not specified, version is specified, architecture is specified. version and desired architecture are used to select an image.
+                  6. image is not specified, version is specified, architecture is not specified. version and current architecture are used to select an image.
+                  7. image is not specified, version is not specified, architecture is specified. API validation error.
+                  8. image is not specified, version is not specified, architecture is not specified. API validation error.
+
+                  If an upgrade fails the operator will halt and report status
+                  about the failing component. Setting the desired update value back to
+                  the previous version will cause a rollback to be attempted. Not all
+                  rollbacks will succeed.
+                properties:
+                  architecture:
+                    description: |-
+                      architecture is an optional field that indicates the desired
+                      value of the cluster architecture. In this context cluster
+                      architecture means either a single architecture or a multi
+                      architecture. architecture can only be set to Multi thereby
+                      only allowing updates from single to multi architecture. If
+                      architecture is set, image cannot be set and version must be
+                      set.
+                      Valid values are 'Multi' and empty.
+                    enum:
+                    - Multi
+                    - ""
+                    type: string
+                  force:
+                    description: |-
+                      force allows an administrator to update to an image that has failed
+                      verification or upgradeable checks. This option should only
+                      be used when the authenticity of the provided image has been verified out
+                      of band because the provided image will run with full administrative access
+                      to the cluster. Do not use this flag with images that comes from unknown
+                      or potentially malicious sources.
+                    type: boolean
+                  image:
+                    description: |-
+                      image is a container image location that contains the update.
+                      image should be used when the desired version does not exist in availableUpdates or history.
+                      When image is set, architecture cannot be specified.
+                      If both version and image are set, the version extracted from the referenced image must match the specified version.
+                    type: string
+                  version:
+                    description: |-
+                      version is a semantic version identifying the update version.
+                      version is required if architecture is specified.
+                      If both version and image are set, the version extracted from the referenced image must match the specified version.
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: cannot set both Architecture and Image
+                  rule: 'has(self.architecture) && has(self.image) ? (self.architecture
+                    == "" || self.image == "") : true'
+                - message: Version must be set if Architecture is set
+                  rule: 'has(self.architecture) && self.architecture != "" ? self.version
+                    != "" : true'
+              overrides:
+                description: |-
+                  overrides is list of overides for components that are managed by
+                  cluster version operator. Marking a component unmanaged will prevent
+                  the operator from creating or updating the object.
+                items:
+                  description: |-
+                    ComponentOverride allows overriding cluster version operator's behavior
+                    for a component.
+                  properties:
+                    group:
+                      description: group identifies the API group that the kind is
+                        in.
+                      type: string
+                    kind:
+                      description: kind indentifies which object to override.
+                      type: string
+                    name:
+                      description: name is the component's name.
+                      type: string
+                    namespace:
+                      description: |-
+                        namespace is the component's namespace. If the resource is cluster
+                        scoped, the namespace should be empty.
+                      type: string
+                    unmanaged:
+                      description: |-
+                        unmanaged controls if cluster version operator should stop managing the
+                        resources in this cluster.
+                        Default: false
+                      type: boolean
+                  required:
+                  - group
+                  - kind
+                  - name
+                  - namespace
+                  - unmanaged
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - kind
+                - group
+                - namespace
+                - name
+                x-kubernetes-list-type: map
+              upstream:
+                description: |-
+                  upstream may be used to specify the preferred update server. By default
+                  it will use the appropriate update server for the cluster and region.
+                type: string
+            required:
+            - clusterID
+            type: object
+          status:
+            description: |-
+              status contains information about the available updates and any in-progress
+              updates.
+            properties:
+              availableUpdates:
+                description: |-
+                  availableUpdates contains updates recommended for this
+                  cluster. Updates which appear in conditionalUpdates but not in
+                  availableUpdates may expose this cluster to known issues. This list
+                  may be empty if no updates are recommended, if the update service
+                  is unavailable, or if an invalid channel has been specified.
+                items:
+                  description: Release represents an OpenShift release image and associated
+                    metadata.
+                  properties:
+                    channels:
+                      description: |-
+                        channels is the set of Cincinnati channels to which the release
+                        currently belongs.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    image:
+                      description: |-
+                        image is a container image location that contains the update. When this
+                        field is part of spec, image is optional if version is specified and the
+                        availableUpdates field contains a matching version.
+                      type: string
+                    url:
+                      description: |-
+                        url contains information about this release. This URL is set by
+                        the 'url' metadata property on a release or the metadata returned by
+                        the update API and should be displayed as a link in user
+                        interfaces. The URL field may not be set for test or nightly
+                        releases.
+                      type: string
+                    version:
+                      description: |-
+                        version is a semantic version identifying the update version. When this
+                        field is part of spec, version is optional if image is specified.
+                      type: string
+                  required:
+                  - image
+                  - version
+                  type: object
+                nullable: true
+                type: array
+                x-kubernetes-list-type: atomic
+              capabilities:
+                description: capabilities describes the state of optional, core cluster
+                  components.
+                properties:
+                  enabledCapabilities:
+                    description: enabledCapabilities lists all the capabilities that
+                      are currently managed.
+                    items:
+                      description: ClusterVersionCapability enumerates optional, core
+                        cluster components.
+                      enum:
+                      - openshift-samples
+                      - baremetal
+                      - marketplace
+                      - Console
+                      - Insights
+                      - Storage
+                      - CSISnapshot
+                      - NodeTuning
+                      - MachineAPI
+                      - Build
+                      - DeploymentConfig
+                      - ImageRegistry
+                      - OperatorLifecycleManager
+                      - CloudCredential
+                      - Ingress
+                      - CloudControllerManager
+                      - OperatorLifecycleManagerV1
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  knownCapabilities:
+                    description: knownCapabilities lists all the capabilities known
+                      to the current cluster.
+                    items:
+                      description: ClusterVersionCapability enumerates optional, core
+                        cluster components.
+                      enum:
+                      - openshift-samples
+                      - baremetal
+                      - marketplace
+                      - Console
+                      - Insights
+                      - Storage
+                      - CSISnapshot
+                      - NodeTuning
+                      - MachineAPI
+                      - Build
+                      - DeploymentConfig
+                      - ImageRegistry
+                      - OperatorLifecycleManager
+                      - CloudCredential
+                      - Ingress
+                      - CloudControllerManager
+                      - OperatorLifecycleManagerV1
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+              conditionalUpdates:
+                description: |-
+                  conditionalUpdates contains the list of updates that may be
+                  recommended for this cluster if it meets specific required
+                  conditions. Consumers interested in the set of updates that are
+                  actually recommended for this cluster should use
+                  availableUpdates. This list may be empty if no updates are
+                  recommended, if the update service is unavailable, or if an empty
+                  or invalid channel has been specified.
+                items:
+                  description: |-
+                    ConditionalUpdate represents an update which is recommended to some
+                    clusters on the version the current cluster is reconciling, but which
+                    may not be recommended for the current cluster.
+                  properties:
+                    conditions:
+                      description: |-
+                        conditions represents the observations of the conditional update's
+                        current status. Known types are:
+                        * Recommended, for whether the update is recommended for the current cluster.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    release:
+                      description: release is the target of the update.
+                      properties:
+                        channels:
+                          description: |-
+                            channels is the set of Cincinnati channels to which the release
+                            currently belongs.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        image:
+                          description: |-
+                            image is a container image location that contains the update. When this
+                            field is part of spec, image is optional if version is specified and the
+                            availableUpdates field contains a matching version.
+                          type: string
+                        url:
+                          description: |-
+                            url contains information about this release. This URL is set by
+                            the 'url' metadata property on a release or the metadata returned by
+                            the update API and should be displayed as a link in user
+                            interfaces. The URL field may not be set for test or nightly
+                            releases.
+                          type: string
+                        version:
+                          description: |-
+                            version is a semantic version identifying the update version. When this
+                            field is part of spec, version is optional if image is specified.
+                          type: string
+                      required:
+                      - image
+                      - version
+                      type: object
+                    risks:
+                      description: |-
+                        risks represents the range of issues associated with
+                        updating to the target release. The cluster-version
+                        operator will evaluate all entries, and only recommend the
+                        update if there is at least one entry and all entries
+                        recommend the update.
+                      items:
+                        description: |-
+                          ConditionalUpdateRisk represents a reason and cluster-state
+                          for not recommending a conditional update.
+                        properties:
+                          matchingRules:
+                            description: |-
+                              matchingRules is a slice of conditions for deciding which
+                              clusters match the risk and which do not. The slice is
+                              ordered by decreasing precedence. The cluster-version
+                              operator will walk the slice in order, and stop after the
+                              first it can successfully evaluate. If no condition can be
+                              successfully evaluated, the update will not be recommended.
+                            items:
+                              description: |-
+                                ClusterCondition is a union of typed cluster conditions.  The 'type'
+                                property determines which of the type-specific properties are relevant.
+                                When evaluated on a cluster, the condition may match, not match, or
+                                fail to evaluate.
+                              properties:
+                                promql:
+                                  description: promql represents a cluster condition
+                                    based on PromQL.
+                                  properties:
+                                    promql:
+                                      description: |-
+                                        promql is a PromQL query classifying clusters. This query
+                                        query should return a 1 in the match case and a 0 in the
+                                        does-not-match case. Queries which return no time
+                                        series, or which return values besides 0 or 1, are
+                                        evaluation failures.
+                                      type: string
+                                  required:
+                                  - promql
+                                  type: object
+                                type:
+                                  description: |-
+                                    type represents the cluster-condition type. This defines
+                                    the members and semantics of any additional properties.
+                                  enum:
+                                  - Always
+                                  - PromQL
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          message:
+                            description: |-
+                              message provides additional information about the risk of
+                              updating, in the event that matchingRules match the cluster
+                              state. This is only to be consumed by humans. It may
+                              contain Line Feed characters (U+000A), which should be
+                              rendered as new lines.
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              name is the CamelCase reason for not recommending a
+                              conditional update, in the event that matchingRules match the
+                              cluster state.
+                            minLength: 1
+                            type: string
+                          url:
+                            description: url contains information about this risk.
+                            format: uri
+                            minLength: 1
+                            type: string
+                        required:
+                        - matchingRules
+                        - message
+                        - name
+                        - url
+                        type: object
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                  required:
+                  - release
+                  - risks
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              conditions:
+                description: |-
+                  conditions provides information about the cluster version. The condition
+                  "Available" is set to true if the desiredUpdate has been reached. The
+                  condition "Progressing" is set to true if an update is being applied.
+                  The condition "Degraded" is set to true if an update is currently blocked
+                  by a temporary or permanent error. Conditions are only valid for the
+                  current desiredUpdate when metadata.generation is equal to
+                  status.generation.
+                items:
+                  description: |-
+                    ClusterOperatorStatusCondition represents the state of the operator's
+                    managed and monitored components.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the time of the last update
+                        to the current status property.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message provides additional information about the current condition.
+                        This is only to be consumed by humans.  It may contain Line Feed
+                        characters (U+000A), which should be rendered as new lines.
+                      type: string
+                    reason:
+                      description: reason is the CamelCase reason for the condition's
+                        current status.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type specifies the aspect reported by this condition.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              desired:
+                description: |-
+                  desired is the version that the cluster is reconciling towards.
+                  If the cluster is not yet fully initialized desired will be set
+                  with the information available, which may be an image or a tag.
+                properties:
+                  channels:
+                    description: |-
+                      channels is the set of Cincinnati channels to which the release
+                      currently belongs.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                  image:
+                    description: |-
+                      image is a container image location that contains the update. When this
+                      field is part of spec, image is optional if version is specified and the
+                      availableUpdates field contains a matching version.
+                    type: string
+                  url:
+                    description: |-
+                      url contains information about this release. This URL is set by
+                      the 'url' metadata property on a release or the metadata returned by
+                      the update API and should be displayed as a link in user
+                      interfaces. The URL field may not be set for test or nightly
+                      releases.
+                    type: string
+                  version:
+                    description: |-
+                      version is a semantic version identifying the update version. When this
+                      field is part of spec, version is optional if image is specified.
+                    type: string
+                required:
+                - image
+                - version
+                type: object
+              history:
+                description: |-
+                  history contains a list of the most recent versions applied to the cluster.
+                  This value may be empty during cluster startup, and then will be updated
+                  when a new update is being applied. The newest update is first in the
+                  list and it is ordered by recency. Updates in the history have state
+                  Completed if the rollout completed - if an update was failing or halfway
+                  applied the state will be Partial. Only a limited amount of update history
+                  is preserved.
+                items:
+                  description: UpdateHistory is a single attempted update to the cluster.
+                  properties:
+                    acceptedRisks:
+                      description: |-
+                        acceptedRisks records risks which were accepted to initiate the update.
+                        For example, it may menition an Upgradeable=False or missing signature
+                        that was overridden via desiredUpdate.force, or an update that was
+                        initiated despite not being in the availableUpdates set of recommended
+                        update targets.
+                      type: string
+                    completionTime:
+                      description: |-
+                        completionTime, if set, is when the update was fully applied. The update
+                        that is currently being applied will have a null completion time.
+                        Completion time will always be set for entries that are not the current
+                        update (usually to the started time of the next update).
+                      format: date-time
+                      nullable: true
+                      type: string
+                    image:
+                      description: |-
+                        image is a container image location that contains the update. This value
+                        is always populated.
+                      type: string
+                    startedTime:
+                      description: startedTime is the time at which the update was
+                        started.
+                      format: date-time
+                      type: string
+                    state:
+                      description: |-
+                        state reflects whether the update was fully applied. The Partial state
+                        indicates the update is not fully applied, while the Completed state
+                        indicates the update was successfully rolled out at least once (all
+                        parts of the update successfully applied).
+                      type: string
+                    verified:
+                      description: |-
+                        verified indicates whether the provided update was properly verified
+                        before it was installed. If this is false the cluster may not be trusted.
+                        Verified does not cover upgradeable checks that depend on the cluster
+                        state at the time when the update target was accepted.
+                      type: boolean
+                    version:
+                      description: |-
+                        version is a semantic version identifying the update version. If the
+                        requested image does not define a version, or if a failure occurs
+                        retrieving the image, this value may be empty.
+                      type: string
+                  required:
+                  - completionTime
+                  - image
+                  - startedTime
+                  - state
+                  - verified
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              observedGeneration:
+                description: |-
+                  observedGeneration reports which version of the spec is being synced.
+                  If this value is not equal to metadata.generation, then the desired
+                  and conditions fields may represent a previous version.
+                format: int64
+                type: integer
+              versionHash:
+                description: |-
+                  versionHash is a fingerprint of the content that the cluster will be
+                  updated with. It is used by the operator to avoid unnecessary work
+                  and is for internal use only.
+                type: string
+            required:
+            - availableUpdates
+            - desired
+            - observedGeneration
+            - versionHash
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: the `marketplace` capability requires the `OperatorLifecycleManager`
+            capability, which is neither explicitly or implicitly enabled in this
+            cluster, please enable the `OperatorLifecycleManager` capability
+          rule: 'has(self.spec.capabilities) && has(self.spec.capabilities.additionalEnabledCapabilities)
+            && self.spec.capabilities.baselineCapabilitySet == ''None'' && ''marketplace''
+            in self.spec.capabilities.additionalEnabledCapabilities ? ''OperatorLifecycleManager''
+            in self.spec.capabilities.additionalEnabledCapabilities || (has(self.status)
+            && has(self.status.capabilities) && has(self.status.capabilities.enabledCapabilities)
+            && ''OperatorLifecycleManager'' in self.status.capabilities.enabledCapabilities)
+            : true'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ClusterVersion
+    listKind: ClusterVersionList
+    plural: clusterversions
+    singular: clusterversion
+  conditions:
+  - lastTransitionTime: "2025-12-08T19:58:08Z"
+    message: no conflicts found
+    reason: NoConflicts
+    status: "True"
+    type: NamesAccepted
+  - lastTransitionTime: "2025-12-08T19:58:08Z"
+    message: the initial names have been accepted
+    reason: InitialNamesAccepted
+    status: "True"
+    type: Established
+  storedVersions:
+  - v1

--- a/tests/run-in-kind/clusterversion/clusterversion.yaml
+++ b/tests/run-in-kind/clusterversion/clusterversion.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+items:
+- apiVersion: config.openshift.io/v1
+  kind: ClusterVersion
+  metadata:
+    name: version
+  spec:
+    channel: stable-4.20
+    clusterID: 1a9af6dc-0801-433c-b28a-200af81e8eef
+kind: List
+metadata:
+  resourceVersion: ""


### PR DESCRIPTION
manual backport of https://github.com/stolostron/multicluster-observability-operator/pull/2275