### PR TITLE
[ACM-27632] Reenable e2e test

### DIFF
--- a/tests/pkg/tests/observability_addon_test.go
+++ b/tests/pkg/tests/observability_addon_test.go
@@ -197,51 +197,65 @@ var _ = Describe("", func() {
 	// And these enable/disable operations, when done quickly as in a test environment, are not well followed by OCM for this addon that is not
 	// managed by the addon framework. As a result, the hub-kubeconfig secret (bootstrapped asynchronously via the Registration Agent's CSR flow)
 	// is not always created on the managed cluster, making the rest of the test suite fail.
-	// Context("RHACM4K-7518: Observability: Disable the Observability by updating managed cluster label [P2][Sev2][Observability]@ocpInterop @non-ui-post-restore @non-ui-post-release @non-ui-pre-upgrade @non-ui-post-upgrade @post-upgrade @post-restore (addon/g1) -", func() {
-	// 	It("[Stable] Modifying managedcluster cr to disable observability", func() {
-	// 		Eventually(func() error {
-	// 			return utils.UpdateObservabilityFromManagedCluster(testOptions, false)
-	// 		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 
-	// 		klog.V(1).Infof("managedcluster number is <%d>", len(testOptions.ManagedClusters))
-	// 		if len(testOptions.ManagedClusters) > 0 {
-	// 			By("Waiting for MCO addon components scales to 0")
-	// 			Eventually(func() bool {
-	// 				err, obaNS := utils.GetNamespace(testOptions, false, MCO_ADDON_NAMESPACE)
-	// 				if err == nil && obaNS == nil {
-	// 					return true
-	// 				}
-	// 				return false
-	// 			}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(BeTrue())
-	// 		}
-	// 	})
+	// To avoid the timing issues associated with the removal of this managed cluster, we will
+	Context("RHACM4K-7518: Observability: Disable the Observability by updating managed cluster label [P2][Sev2][Observability]@ocpInterop @non-ui-post-restore @non-ui-post-release @non-ui-pre-upgrade @non-ui-post-upgrade @post-upgrade @post-restore (addon/g1) -", func() {
+		It("[Stable] Modifying managedcluster cr to disable observability", func() {
+			Eventually(func() error {
+				return utils.UpdateObservabilityFromManagedCluster(testOptions, false)
+			}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 
-	// 	It("[Stable] Remove disable observability label from the managed cluster", func() {
-	// 		By("Waiting for 1 minute to make sure the registration controller correctly takes into account the changes")
-	// 		time.Sleep(60 * time.Second)
-	// 		Eventually(func() error {
-	// 			return utils.UpdateObservabilityFromManagedCluster(testOptions, true)
-	// 		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
+			// add delay to ensure that the list of managed clusters in ManagedClusterList is updated before reconcile
+			By("Waiting for 20 seconds to make sure the list of managed clusters is updated")
+			time.Sleep(20 * time.Second)
 
-	// 		if len(testOptions.ManagedClusters) > 0 {
-	// 			By("Waiting for MCO addon components ready")
-	// 			Eventually(func() bool {
-	// 				err, podList := utils.GetPodList(
-	// 					testOptions,
-	// 					false,
-	// 					MCO_ADDON_NAMESPACE,
-	// 					"component=metrics-collector",
-	// 				)
-	// 				// starting with OCP 4.13, userWorkLoadMonitoring is enabled by default
-	// 				if len(podList.Items) >= 1 && err == nil {
-	// 					return true
-	// 				}
-	// 				return false
-	// 			}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(BeTrue())
-	// 		}
-	// 	})
-	// },
-	// )
+			// trigger reconcile here
+			err := utils.TriggerMCOReconcile(testOptions, true)
+			Expect(err).NotTo(HaveOccurred())
+
+			klog.V(1).Infof("managedcluster number is <%d>", len(testOptions.ManagedClusters))
+			if len(testOptions.ManagedClusters) > 0 {
+				By("Waiting for MCO addon components scales to 0")
+				Eventually(func() bool {
+					err, obaNS := utils.GetNamespace(testOptions, false, MCO_ADDON_NAMESPACE)
+					if err == nil && obaNS == nil {
+						return true
+					}
+					return false
+				}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(BeTrue())
+			}
+
+			// cleanup the trigger label
+			err = utils.TriggerMCOReconcile(testOptions, false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("[Stable] Remove disable observability label from the managed cluster", func() {
+			By("Waiting for 1 minute to make sure the registration controller correctly takes into account the changes")
+			time.Sleep(60 * time.Second)
+			Eventually(func() error {
+				return utils.UpdateObservabilityFromManagedCluster(testOptions, true)
+			}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
+
+			if len(testOptions.ManagedClusters) > 0 {
+				By("Waiting for MCO addon components ready")
+				Eventually(func() bool {
+					err, podList := utils.GetPodList(
+						testOptions,
+						false,
+						MCO_ADDON_NAMESPACE,
+						"component=metrics-collector",
+					)
+					// starting with OCP 4.13, userWorkLoadMonitoring is enabled by default
+					if len(podList.Items) >= 1 && err == nil {
+						return true
+					}
+					return false
+				}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(BeTrue())
+			}
+		})
+	},
+	)
 
 	JustAfterEach(func() {
 		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())

--- a/tests/pkg/tests/observability_addon_test.go
+++ b/tests/pkg/tests/observability_addon_test.go
@@ -216,10 +216,29 @@ var _ = Describe("", func() {
 				By("Waiting for MCO addon components scales to 0")
 				Eventually(func() bool {
 					err, obaNS := utils.GetNamespace(testOptions, false, MCO_ADDON_NAMESPACE)
-					if err == nil && obaNS == nil {
-						return true
+					if err != nil || obaNS != nil {
+						return false
 					}
-					return false
+
+					// check that the observability-addon is deleted from the managed cluster
+					err = utils.CheckOBADeletedOnManagedCluster(testOptions)
+					if err != nil {
+						return false
+					}
+
+					// check that the observability-addon is deleted from the hub cluster
+					err = utils.CheckOBADeletedOnHub(testOptions)
+					if err != nil {
+						return false
+					}
+
+					// check that the manifestwork is removed from hub
+					err = utils.CheckObsAddonManifestWorkDeleted(testOptions)
+					if err != nil {
+						return false
+					}
+
+					return true
 				}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(BeTrue())
 			}
 


### PR DESCRIPTION
Reenable e2e test that was commented out.
- Add delay after label added to managed cluster.
- Trigger a second reconcile.