### PR TITLE
Fix log verbosity setting for MCOA

### DIFF
--- a/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
@@ -152,7 +152,9 @@ func (r *MCORenderer) renderMCOADeployment(
 
 	if r.cr.Spec.Capabilities != nil && r.cr.Spec.Capabilities.AddonManager != nil {
 		if r.cr.Spec.Capabilities.AddonManager.LogVerbosity != nil {
-			patchContainer.Args = append(patchContainer.Args, fmt.Sprintf("--log-verbosity=%d", *r.cr.Spec.Capabilities.AddonManager.LogVerbosity))
+			if len(obj.Spec.Template.Spec.Containers) > 0 {
+				obj.Spec.Template.Spec.Containers[0].Args = append(obj.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--log-verbosity=%d", *r.cr.Spec.Capabilities.AddonManager.LogVerbosity))
+			}
 		}
 	}
 

--- a/operators/multiclusterobservability/pkg/rendering/renderer_mcoa_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_mcoa_test.go
@@ -118,6 +118,7 @@ func TestRenderMCOADeployment(t *testing.T) {
 	container = got.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, *mco.Spec.Capabilities.AddonManager.Resources, container.Resources)
 	assert.Contains(t, container.Args, "--log-verbosity=5")
+	assert.Contains(t, container.Args, "controller")
 }
 
 func TestRenderAddonDeploymentConfig(t *testing.T) {


### PR DESCRIPTION
The previous version was overriding all args.