### PR TITLE
tests: don't set storageclass

### DIFF
--- a/examples/export/v1beta2/custom-certs/observability.yaml
+++ b/examples/export/v1beta2/custom-certs/observability.yaml
@@ -124,5 +124,4 @@ spec:
       name: victoriametrics      
     receiveStorageSize: 10Gi
     ruleStorageSize: 1Gi
-    storageClass: gp2
     storeStorageSize: 1Gi

--- a/examples/export/v1beta2/observability.yaml
+++ b/examples/export/v1beta2/observability.yaml
@@ -122,5 +122,4 @@ spec:
       name: victoriametrics
     receiveStorageSize: 10Gi
     ruleStorageSize: 1Gi
-    storageClass: gp2
     storeStorageSize: 1Gi

--- a/examples/mco/e2e/v1beta2/custom-certs-kind/observability.yaml
+++ b/examples/mco/e2e/v1beta2/custom-certs-kind/observability.yaml
@@ -123,5 +123,4 @@ spec:
       tlsSecretName: minio-tls-secret
     receiveStorageSize: 1Gi
     ruleStorageSize: 1Gi
-    storageClass: gp2
     storeStorageSize: 1Gi

--- a/examples/mco/e2e/v1beta2/custom-certs/observability.yaml
+++ b/examples/mco/e2e/v1beta2/custom-certs/observability.yaml
@@ -123,5 +123,4 @@ spec:
       tlsSecretName: minio-tls-secret
     receiveStorageSize: 10Gi
     ruleStorageSize: 1Gi
-    storageClass: gp2
     storeStorageSize: 1Gi

--- a/examples/mco/e2e/v1beta2/observability.yaml
+++ b/examples/mco/e2e/v1beta2/observability.yaml
@@ -121,6 +121,5 @@ spec:
       name: thanos-object-storage
     receiveStorageSize: 10Gi
     ruleStorageSize: 1Gi
-    storageClass: gp2
     storeStorageSize: 1Gi
 

--- a/examples/updatemcocr/advancedmcoconfig/custom-certs/v1beta2-observability-custom-mco.yaml
+++ b/examples/updatemcocr/advancedmcoconfig/custom-certs/v1beta2-observability-custom-mco.yaml
@@ -157,5 +157,4 @@ spec:
       tlsSecretName: minio-tls-secret
     receiveStorageSize: 1Gi
     ruleStorageSize: 1Gi
-    storageClass: gp2
     storeStorageSize: 1Gi

--- a/examples/updatemcocr/advancedmcoconfig/v1beta2-observability-custom-mco.yaml
+++ b/examples/updatemcocr/advancedmcoconfig/v1beta2-observability-custom-mco.yaml
@@ -155,5 +155,4 @@ spec:
       name: thanos-object-storage
     receiveStorageSize: 1Gi
     ruleStorageSize: 1Gi
-    storageClass: gp2
     storeStorageSize: 1Gi

--- a/examples/updatemcocr/initialmcoconfig/custom-certs/v1beta2-observability-initial-mco.yaml
+++ b/examples/updatemcocr/initialmcoconfig/custom-certs/v1beta2-observability-initial-mco.yaml
@@ -123,5 +123,4 @@ spec:
       tlsSecretName: minio-tls-secret
     receiveStorageSize: 1Gi
     ruleStorageSize: 1Gi
-    storageClass: gp2
     storeStorageSize: 1Gi

--- a/examples/updatemcocr/initialmcoconfig/v1beta2-observability-initial-mco.yaml
+++ b/examples/updatemcocr/initialmcoconfig/v1beta2-observability-initial-mco.yaml
@@ -121,5 +121,4 @@ spec:
       name: thanos-object-storage
     receiveStorageSize: 1Gi
     ruleStorageSize: 1Gi
-    storageClass: gp2
     storeStorageSize: 1Gi


### PR DESCRIPTION
In some cases (unsure why) Observability components will be up, with a specific (probably the default) storage class. Later we attempt to change the storageClass to gp2 as set in our example files.

This causes the Observatorium operator to get stuck with the error below, making us unable to make any changes to these StatefulSets. This causes test-failures.

In this PR we remove the storageclass from the testing completely and rely on the default to avoid any issues.

```
 * failed to execute action (CreateOrUpdate): StatefulSet.apps
   "observability-thanos-receive-default" is invalid: spec: Forbidden:
   updates to statefulset spec for fields other than 'replicas',
   'ordinals', 'template', 'updateStrategy', 'revisionHistoryLimit',
   'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are
   forbidden
```