### PR TITLE
Add configurable query timeout for Grafana and proxy

### DIFF
--- a/operators/endpointmetrics/pkg/rendering/renderer.go
+++ b/operators/endpointmetrics/pkg/rendering/renderer.go
@@ -68,7 +68,7 @@ func Render(
 	if err != nil {
 		return nil, err
 	}
-	resources, err := r.RenderTemplates(genericTemplates, namespace, map[string]string{})
+	resources, err := r.RenderTemplates(ctx, genericTemplates, namespace, map[string]string{})
 	if err != nil {
 		return nil, err
 	}

--- a/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
+++ b/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
@@ -360,6 +360,12 @@ type AdvancedConfig struct {
 	// For the alertmanager that runs in the hub this setting has no effect.
 	// +optional
 	CustomAlertmanagerHubURL observabilityshared.URL `json:"customAlertmanagerHubURL,omitempty"`
+	// QueryTimeout is the timeout for queries executed in Grafana.
+	// It is applied to the read path components from Grafana.
+	// Default is 300s.
+	// +optional
+	// +kubebuilder:validation:Pattern="^([0-9]+(ms|s|m|h))+$"
+	QueryTimeout string `json:"queryTimeout,omitempty"`
 	// The spec of the data retention configurations
 	// +optional
 	RetentionConfig *RetentionConfig `json:"retentionConfig,omitempty"`

--- a/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
+++ b/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
@@ -364,7 +364,7 @@ type AdvancedConfig struct {
 	// It is applied to the read path components from Grafana.
 	// Default is 300s.
 	// +optional
-	// +kubebuilder:validation:Pattern="^([0-9]+(ms|s|m|h))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$"
 	QueryTimeout string `json:"queryTimeout,omitempty"`
 	// The spec of the data retention configurations
 	// +optional

--- a/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
+++ b/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
@@ -364,7 +364,7 @@ type AdvancedConfig struct {
 	// It is applied to the read path components from Grafana.
 	// Default is 300s.
 	// +optional
-	// +kubebuilder:validation:Pattern="^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$"
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$`
 	QueryTimeout string `json:"queryTimeout,omitempty"`
 	// The spec of the data retention configurations
 	// +optional

--- a/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
+++ b/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
@@ -365,6 +365,7 @@ type AdvancedConfig struct {
 	// Default is 300s.
 	// +optional
 	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$`
+	// +kubebuilder:default="300s"
 	QueryTimeout string `json:"queryTimeout,omitempty"`
 	// The spec of the data retention configurations
 	// +optional

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -5593,6 +5593,13 @@ spec:
                             type: object
                         type: object
                     type: object
+                  queryTimeout:
+                    description: |-
+                      QueryTimeout is the timeout for queries executed in Grafana.
+                      It is applied to the read path components from Grafana.
+                      Default is 300s.
+                    pattern: ^([0-9]+(ms|s|m|h))+$
+                    type: string
                   rbacQueryProxy:
                     description: The spec of rbac-query-proxy
                     properties:

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -5598,7 +5598,7 @@ spec:
                       QueryTimeout is the timeout for queries executed in Grafana.
                       It is applied to the read path components from Grafana.
                       Default is 300s.
-                    pattern: ^([0-9]+(ms|s|m|h))+$
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                     type: string
                   rbacQueryProxy:
                     description: The spec of rbac-query-proxy

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -5594,6 +5594,7 @@ spec:
                         type: object
                     type: object
                   queryTimeout:
+                    default: 300s
                     description: |-
                       QueryTimeout is the timeout for queries executed in Grafana.
                       It is applied to the read path components from Grafana.

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -5583,7 +5583,7 @@ spec:
                       QueryTimeout is the timeout for queries executed in Grafana.
                       It is applied to the read path components from Grafana.
                       Default is 300s.
-                    pattern: ^([0-9]+(ms|s|m|h))+$
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                     type: string
                   rbacQueryProxy:
                     description: The spec of rbac-query-proxy

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -5579,6 +5579,7 @@ spec:
                         type: object
                     type: object
                   queryTimeout:
+                    default: 300s
                     description: |-
                       QueryTimeout is the timeout for queries executed in Grafana.
                       It is applied to the read path components from Grafana.

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -5578,6 +5578,13 @@ spec:
                             type: object
                         type: object
                     type: object
+                  queryTimeout:
+                    description: |-
+                      QueryTimeout is the timeout for queries executed in Grafana.
+                      It is applied to the read path components from Grafana.
+                      Default is 300s.
+                    pattern: ^([0-9]+(ms|s|m|h))+$
+                    type: string
                   rbacQueryProxy:
                     description: The spec of rbac-query-proxy
                     properties:

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/grafana.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/grafana.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -83,6 +84,13 @@ func GenerateGrafanaDataSource(
 	mco *mcov1beta2.MultiClusterObservability,
 ) (*ctrl.Result, error) {
 	DynamicTimeInterval := min(mco.Spec.ObservabilityAddonSpec.Interval, 30)
+	queryTimeout := config.GetGrafanaQueryTimeout()
+	// Robustly convert duration string to seconds string
+	duration, err := time.ParseDuration(queryTimeout)
+	if err != nil {
+		return &ctrl.Result{}, fmt.Errorf("failed to parse query timeout duration %s: %w", queryTimeout, err)
+	}
+	queryTimeoutSec := fmt.Sprintf("%.0f", duration.Seconds())
 
 	grafanaDatasources, err := yaml.Marshal(GrafanaDatasources{
 		APIVersion: 1,
@@ -99,7 +107,7 @@ func GenerateGrafanaDataSource(
 				),
 				UID: "000000001",
 				JSONData: &JsonData{
-					Timeout:               "300",
+					Timeout:               queryTimeoutSec,
 					CustomQueryParameters: "max_source_resolution=auto",
 					TimeInterval:          fmt.Sprintf("%ds", mco.Spec.ObservabilityAddonSpec.Interval),
 					ForwardHeaders:        []string{"X-Forwarded-Access-Token"},
@@ -117,7 +125,7 @@ func GenerateGrafanaDataSource(
 				),
 				UID: "000000002",
 				JSONData: &JsonData{
-					Timeout:               "300",
+					Timeout:               queryTimeoutSec,
 					CustomQueryParameters: "max_source_resolution=auto",
 					TimeInterval:          fmt.Sprintf("%ds", DynamicTimeInterval),
 					ForwardHeaders:        []string{"X-Forwarded-Access-Token"},
@@ -195,12 +203,14 @@ func GenerateGrafanaRoute(
 	c client.Client, scheme *runtime.Scheme,
 	mco *mcov1beta2.MultiClusterObservability,
 ) (*ctrl.Result, error) {
+	queryTimeout := config.GetGrafanaQueryTimeout()
+
 	grafanaRoute := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.GrafanaRouteName,
 			Namespace: config.GetDefaultNamespace(),
 			Annotations: map[string]string{
-				haProxyRouterTimeoutKey: defaultHaProxyRouterTimeout,
+				haProxyRouterTimeoutKey: queryTimeout,
 			},
 		},
 		Spec: routev1.RouteSpec{

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/grafana.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/grafana.go
@@ -84,7 +84,7 @@ func GenerateGrafanaDataSource(
 	mco *mcov1beta2.MultiClusterObservability,
 ) (*ctrl.Result, error) {
 	DynamicTimeInterval := min(mco.Spec.ObservabilityAddonSpec.Interval, 30)
-	queryTimeout := config.GetGrafanaQueryTimeout()
+	queryTimeout := config.GetGrafanaQueryTimeout(mco)
 	// Robustly convert duration string to seconds string
 	duration, err := time.ParseDuration(queryTimeout)
 	if err != nil {
@@ -203,7 +203,7 @@ func GenerateGrafanaRoute(
 	c client.Client, scheme *runtime.Scheme,
 	mco *mcov1beta2.MultiClusterObservability,
 ) (*ctrl.Result, error) {
-	queryTimeout := config.GetGrafanaQueryTimeout()
+	queryTimeout := config.GetGrafanaQueryTimeout(mco)
 
 	grafanaRoute := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/grafana.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/grafana.go
@@ -252,34 +252,35 @@ func GenerateGrafanaRoute(
 			return &ctrl.Result{}, err
 		}
 		return nil, nil
+	} else if err != nil {
+		return &ctrl.Result{}, err
 	}
 
-	// if no annotations are set, set the default timeout
+	updated := false
 	if found.Annotations == nil {
 		found.Annotations = map[string]string{}
-		found.Annotations[haProxyRouterTimeoutKey] = defaultHaProxyRouterTimeout
 	}
-
-	// if some annotations are set, but the timeout is not set, set the default timeout
-	// otherwise, use the existing timeout which allows for custom timeouts.
-	// we do not want to overwrite other labels that may be set.
-	if _, ok := found.Annotations[haProxyRouterTimeoutKey]; !ok {
-		found.Annotations[haProxyRouterTimeoutKey] = defaultHaProxyRouterTimeout
+	if found.Annotations[haProxyRouterTimeoutKey] != queryTimeout {
+		found.Annotations[haProxyRouterTimeoutKey] = queryTimeout
+		updated = true
 	}
 
 	if !reflect.DeepEqual(found.Spec, grafanaRoute.Spec) {
 		found.Spec = grafanaRoute.Spec
+		updated = true
 	}
 
-	err = c.Update(context.TODO(), found)
-	if err != nil {
-		log.Error(
-			err,
-			"failed update for Grafana Route",
-			"grafanaRoute.Name",
-			grafanaRoute.Name,
-		)
-		return &ctrl.Result{}, err
+	if updated {
+		err = c.Update(context.TODO(), found)
+		if err != nil {
+			log.Error(
+				err,
+				"failed update for Grafana Route",
+				"grafanaRoute.Name",
+				grafanaRoute.Name,
+			)
+			return &ctrl.Result{}, err
+		}
 	}
 	return nil, nil
 }

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/grafana.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/grafana.go
@@ -8,7 +8,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"reflect"
+	"strconv"
 	"time"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
@@ -79,6 +81,7 @@ type SecureJsonData struct {
 // GenerateGrafanaDataSource is used to generate the GrafanaDatasource as a secret.
 // the GrafanaDatasource points to observatorium api gateway service.
 func GenerateGrafanaDataSource(
+	ctx context.Context,
 	c client.Client,
 	scheme *runtime.Scheme,
 	mco *mcov1beta2.MultiClusterObservability,
@@ -90,7 +93,14 @@ func GenerateGrafanaDataSource(
 	if err != nil {
 		return &ctrl.Result{}, fmt.Errorf("failed to parse query timeout duration %s: %w", queryTimeout, err)
 	}
-	queryTimeoutSec := fmt.Sprintf("%.0f", duration.Seconds())
+
+	var secs int
+	if duration < time.Second {
+		secs = 1
+	} else {
+		secs = int(math.Ceil(duration.Seconds()))
+	}
+	queryTimeoutSec := strconv.Itoa(secs)
 
 	grafanaDatasources, err := yaml.Marshal(GrafanaDatasources{
 		APIVersion: 1,
@@ -156,7 +166,7 @@ func GenerateGrafanaDataSource(
 	// Check if this already exists
 	grafanaDSFound := &corev1.Secret{}
 	err = c.Get(
-		context.TODO(),
+		ctx,
 		types.NamespacedName{
 			Name:      dsSecret.Name,
 			Namespace: dsSecret.Namespace,
@@ -170,7 +180,7 @@ func GenerateGrafanaDataSource(
 			"dsSecret.Name", dsSecret.Name,
 		)
 
-		err = c.Create(context.TODO(), dsSecret)
+		err = c.Create(ctx, dsSecret)
 		if err != nil {
 			return &ctrl.Result{}, err
 		}
@@ -184,7 +194,7 @@ func GenerateGrafanaDataSource(
 		!bytes.Equal(grafanaDSFound.Data[datasourceKey], dsSecret.Data[datasourceKey])) ||
 		grafanaDSFound.Data[datasourceKey] == nil {
 		log.Info("Updating grafana datasource secret")
-		err = c.Update(context.TODO(), dsSecret)
+		err = c.Update(ctx, dsSecret)
 		if err != nil {
 			log.Error(err, "Failed to update grafana datasource secret")
 			return &ctrl.Result{}, err
@@ -200,6 +210,7 @@ func GenerateGrafanaDataSource(
 }
 
 func GenerateGrafanaRoute(
+	ctx context.Context,
 	c client.Client, scheme *runtime.Scheme,
 	mco *mcov1beta2.MultiClusterObservability,
 ) (*ctrl.Result, error) {
@@ -235,7 +246,7 @@ func GenerateGrafanaRoute(
 
 	found := &routev1.Route{}
 	err := c.Get(
-		context.TODO(),
+		ctx,
 		types.NamespacedName{Name: grafanaRoute.Name, Namespace: grafanaRoute.Namespace},
 		found,
 	)
@@ -247,7 +258,7 @@ func GenerateGrafanaRoute(
 			"grafanaRoute.Name",
 			grafanaRoute.Name,
 		)
-		err = c.Create(context.TODO(), grafanaRoute)
+		err = c.Create(ctx, grafanaRoute)
 		if err != nil {
 			return &ctrl.Result{}, err
 		}
@@ -271,7 +282,7 @@ func GenerateGrafanaRoute(
 	}
 
 	if updated {
-		err = c.Update(context.TODO(), found)
+		err = c.Update(ctx, found)
 		if err != nil {
 			log.Error(
 				err,
@@ -286,10 +297,11 @@ func GenerateGrafanaRoute(
 }
 
 func GenerateGrafanaOauthClient(
+	ctx context.Context,
 	c client.Client, scheme *runtime.Scheme,
 	mco *mcov1beta2.MultiClusterObservability,
 ) (*ctrl.Result, error) {
-	host, err := config.GetRouteHost(c, config.GrafanaRouteName, config.GetDefaultNamespace())
+	host, err := config.GetRouteHost(ctx, c, config.GrafanaRouteName, config.GetDefaultNamespace())
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +321,7 @@ func GenerateGrafanaOauthClient(
 
 	found := &oauthv1.OAuthClient{}
 	err = c.Get(
-		context.TODO(),
+		ctx,
 		types.NamespacedName{Name: config.GrafanaOauthClientName},
 		found,
 	)
@@ -319,7 +331,7 @@ func GenerateGrafanaOauthClient(
 			"GrafanaOauthClientName",
 			config.GrafanaOauthClientName,
 		)
-		err = c.Create(context.TODO(), oauthClient)
+		err = c.Create(ctx, oauthClient)
 		if err != nil {
 			return &ctrl.Result{}, err
 		}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/grafana_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/grafana_test.go
@@ -68,13 +68,13 @@ func TestGenerateGrafanaRoute(t *testing.T) {
 			c: fake.NewClientBuilder().WithScheme(clientScheme).Build(),
 		},
 		{
-			name: "Test update a Route if it has been modified",
+			name: "Test reconcile timeout annotation",
 			want: routev1.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      config.GrafanaRouteName,
 					Namespace: config.GetDefaultNamespace(),
 					Annotations: map[string]string{
-						haProxyRouterTimeoutKey: defaultHaProxyRouterTimeout,
+						haProxyRouterTimeoutKey: "600s",
 					},
 				},
 				Spec: routev1.RouteSpec{
@@ -93,9 +93,11 @@ func TestGenerateGrafanaRoute(t *testing.T) {
 			},
 			c: fake.NewClientBuilder().WithScheme(clientScheme).WithObjects(&routev1.Route{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        config.GrafanaRouteName,
-					Namespace:   config.GetDefaultNamespace(),
-					Annotations: map[string]string{},
+					Name:      config.GrafanaRouteName,
+					Namespace: config.GetDefaultNamespace(),
+					Annotations: map[string]string{
+						haProxyRouterTimeoutKey: "300s",
+					},
 				},
 				Spec: routev1.RouteSpec{
 					Port: &routev1.RoutePort{
@@ -103,7 +105,7 @@ func TestGenerateGrafanaRoute(t *testing.T) {
 					},
 					To: routev1.RouteTargetReference{
 						Kind: "Service",
-						Name: "modified",
+						Name: config.GrafanaServiceName,
 					},
 					TLS: &routev1.TLSConfig{
 						Termination:                   routev1.TLSTerminationReencrypt,
@@ -115,6 +117,13 @@ func TestGenerateGrafanaRoute(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "Test reconcile timeout annotation" {
+				instance.Spec.AdvancedConfig = &mcov1beta2.AdvancedConfig{
+					QueryTimeout: "600s",
+				}
+			} else {
+				instance.Spec.AdvancedConfig = nil
+			}
 			_, err := GenerateGrafanaRoute(tt.c, s, instance)
 			if err != nil {
 				t.Errorf("GenerateGrafanaDataSource() error = %v", err)
@@ -129,6 +138,9 @@ func TestGenerateGrafanaRoute(t *testing.T) {
 			}
 			if !reflect.DeepEqual(list.Items[0].Spec, tt.want.Spec) {
 				t.Fatalf("Expected route spec: %v, got %v", tt.want.Spec, list.Items[0].Spec)
+			}
+			if !reflect.DeepEqual(list.Items[0].ObjectMeta.Annotations, tt.want.ObjectMeta.Annotations) {
+				t.Fatalf("Expected route annotations: %v, got %v", tt.want.ObjectMeta.Annotations, list.Items[0].ObjectMeta.Annotations)
 			}
 		})
 	}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/grafana_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/grafana_test.go
@@ -124,7 +124,7 @@ func TestGenerateGrafanaRoute(t *testing.T) {
 			} else {
 				instance.Spec.AdvancedConfig = nil
 			}
-			_, err := GenerateGrafanaRoute(tt.c, s, instance)
+			_, err := GenerateGrafanaRoute(context.Background(), tt.c, s, instance)
 			if err != nil {
 				t.Errorf("GenerateGrafanaDataSource() error = %v", err)
 				return
@@ -199,19 +199,94 @@ func TestGenerateGrafanaDataSource(t *testing.T) {
 			},
 			expectedTimeout: "60",
 		},
+		{
+			name: "Custom timeout 500ms",
+			mco: &mcov1beta2.MultiClusterObservability{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mco"},
+				Spec: mcov1beta2.MultiClusterObservabilitySpec{
+					ObservabilityAddonSpec: &mcoshared.ObservabilityAddonSpec{
+						Interval: 300,
+					},
+					AdvancedConfig: &mcov1beta2.AdvancedConfig{
+						QueryTimeout: "500ms",
+					},
+				},
+			},
+			expectedTimeout: "1",
+		},
+		{
+			name: "Custom timeout 0s",
+			mco: &mcov1beta2.MultiClusterObservability{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mco"},
+				Spec: mcov1beta2.MultiClusterObservabilitySpec{
+					ObservabilityAddonSpec: &mcoshared.ObservabilityAddonSpec{
+						Interval: 300,
+					},
+					AdvancedConfig: &mcov1beta2.AdvancedConfig{
+						QueryTimeout: "0s",
+					},
+				},
+			},
+			expectedTimeout: "1",
+		},
+		{
+			name: "Custom timeout -5s",
+			mco: &mcov1beta2.MultiClusterObservability{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mco"},
+				Spec: mcov1beta2.MultiClusterObservabilitySpec{
+					ObservabilityAddonSpec: &mcoshared.ObservabilityAddonSpec{
+						Interval: 300,
+					},
+					AdvancedConfig: &mcov1beta2.AdvancedConfig{
+						QueryTimeout: "-5s",
+					},
+				},
+			},
+			expectedTimeout: "1",
+		},
+		{
+			name: "Custom timeout 1.2s",
+			mco: &mcov1beta2.MultiClusterObservability{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mco"},
+				Spec: mcov1beta2.MultiClusterObservabilitySpec{
+					ObservabilityAddonSpec: &mcoshared.ObservabilityAddonSpec{
+						Interval: 300,
+					},
+					AdvancedConfig: &mcov1beta2.AdvancedConfig{
+						QueryTimeout: "1.2s",
+					},
+				},
+			},
+			expectedTimeout: "2",
+		},
+		{
+			name: "Custom timeout 1s",
+			mco: &mcov1beta2.MultiClusterObservability{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mco"},
+				Spec: mcov1beta2.MultiClusterObservabilitySpec{
+					ObservabilityAddonSpec: &mcoshared.ObservabilityAddonSpec{
+						Interval: 300,
+					},
+					AdvancedConfig: &mcov1beta2.AdvancedConfig{
+						QueryTimeout: "1s",
+					},
+				},
+			},
+			expectedTimeout: "1",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := fake.NewClientBuilder().WithScheme(s).Build()
-			_, err := GenerateGrafanaDataSource(c, s, tt.mco)
+			_, err := GenerateGrafanaDataSource(context.Background(), c, s, tt.mco)
 			if err != nil {
 				t.Errorf("GenerateGrafanaDataSource() error = %v", err)
 				return
 			}
 
 			secret := &corev1.Secret{}
-			err = c.Get(context.TODO(), client.ObjectKey{
+			err = c.Get(context.Background(), client.ObjectKey{
 				Name:      "grafana-datasources",
 				Namespace: config.GetDefaultNamespace(),
 			}, secret)

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -381,11 +381,11 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 		}
 
 		// expose grafana through route
-		result, err = GenerateGrafanaRoute(r.Client, r.Scheme, instance)
+		result, err = GenerateGrafanaRoute(ctx, r.Client, r.Scheme, instance)
 		if result != nil {
 			return *result, fmt.Errorf("failed to generate Grafana route: %w", err)
 		}
-		result, err = GenerateGrafanaOauthClient(r.Client, r.Scheme, instance)
+		result, err = GenerateGrafanaOauthClient(ctx, r.Client, r.Scheme, instance)
 		if result != nil {
 			return *result, fmt.Errorf("failed to generate Grafana OAuth client: %w", err)
 		}
@@ -404,7 +404,7 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	}
 
 	// generate grafana datasource to point to observatorium api gateway
-	result, err = GenerateGrafanaDataSource(r.Client, r.Scheme, instance)
+	result, err = GenerateGrafanaDataSource(ctx, r.Client, r.Scheme, instance)
 	if result != nil {
 		return *result, fmt.Errorf("failed to generate Grafana data source: %w", err)
 	}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -281,7 +281,7 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 
 	// Render the templates with a specified CR
 	renderer := rendering.NewMCORenderer(instance, r.Client, r.ImageClient).WithRendererOptions(rendererOptions)
-	toDeploy, err := renderer.Render()
+	toDeploy, err := renderer.Render(ctx)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to render MCO templates for %s/%s: %w", instance.GetNamespace(), instance.GetName(), err)
 	}
@@ -339,7 +339,7 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 
 	if !rendering.MCOAEnabled(instance) {
 		namespace, labels := renderer.NamespaceAndLabels()
-		toDelete, err := renderer.MCOAResources(namespace, labels)
+		toDelete, err := renderer.MCOAResources(ctx, namespace, labels)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to list MCOA resources for deletion in namespace %s: %w", namespace, err)
 		}

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -395,7 +395,7 @@ func GetDefaultTenantName() string {
 // GetObsAPIRouteHost is used to Route's host for Observatorium API. This doesn't take into consideration
 // the `advanced.customObservabilityHubURL` configuration.
 func GetObsAPIRouteHost(ctx context.Context, client client.Client, namespace string) (string, error) {
-	return GetRouteHost(client, obsAPIGateway, namespace)
+	return GetRouteHost(ctx, client, obsAPIGateway, namespace)
 }
 
 // GetObsAPIExternalURL is used to get the frontend URL that should be used to reach the Observatorium API instance.
@@ -418,21 +418,22 @@ func GetObsAPIExternalURL(ctx context.Context, client client.Client, namespace s
 		}
 		return obsURL, nil
 	}
-	routeHost, err := GetRouteHost(client, obsAPIGateway, namespace)
+	routeHost, err := GetRouteHost(ctx, client, obsAPIGateway, namespace)
 	if err != nil {
 		return nil, err
 	}
 	return url.Parse(fmt.Sprintf("%s://%s", schemeHttps, routeHost))
 }
 
-func GetRouteHost(client client.Client, name string, namespace string) (string, error) {
+func GetRouteHost(ctx context.Context, client client.Client, name string, namespace string) (string, error) {
 	found := &routev1.Route{}
 
-	err := client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, found)
+	err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
 		// if the router is not created yet, fallback to get host
 		// from the domain of ingresscontroller
 		domain, err := getDomainForIngressController(
+			ctx,
 			client,
 			OpenshiftIngressOperatorCRName,
 			OpenshiftIngressOperatorNamespace,
@@ -479,6 +480,7 @@ func GetAlertmanagerURL(ctx context.Context, client client.Client, namespace str
 	if err != nil && errors.IsNotFound(err) {
 		// if the alertmanager router is not created yet, fallback to get host from the domain of ingresscontroller
 		domain, err := getDomainForIngressController(
+			ctx,
 			client,
 			OpenshiftIngressOperatorCRName,
 			OpenshiftIngressOperatorNamespace,
@@ -494,9 +496,9 @@ func GetAlertmanagerURL(ctx context.Context, client client.Client, namespace str
 }
 
 // getDomainForIngressController get the domain for the given ingresscontroller instance.
-func getDomainForIngressController(client client.Client, name, namespace string) (string, error) {
+func getDomainForIngressController(ctx context.Context, client client.Client, name, namespace string) (string, error) {
 	ingressOperatorInstance := &operatorv1.IngressController{}
-	err := client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, ingressOperatorInstance)
+	err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, ingressOperatorInstance)
 	if err != nil {
 		return "", err
 	}

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -718,7 +718,10 @@ func GetOperandName(name string) string {
 	return operandNames[name]
 }
 
-func GetGrafanaQueryTimeout() string {
+func GetGrafanaQueryTimeout(mco *observabilityv1beta2.MultiClusterObservability) string {
+	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.QueryTimeout != "" {
+		return mco.Spec.AdvancedConfig.QueryTimeout
+	}
 	return "300s"
 }
 

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -718,6 +718,10 @@ func GetOperandName(name string) string {
 	return operandNames[name]
 }
 
+func GetGrafanaQueryTimeout() string {
+	return "300s"
+}
+
 func SetOperandNames(c client.Client) error {
 	if len(operandNames) != 0 {
 		return nil

--- a/operators/multiclusterobservability/pkg/config/config_test.go
+++ b/operators/multiclusterobservability/pkg/config/config_test.go
@@ -910,3 +910,51 @@ func TestGetMCHVersions(t *testing.T) {
 		})
 	}
 }
+func TestGetGrafanaQueryTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		mco      *mcov1beta2.MultiClusterObservability
+		expected string
+	}{
+		{
+			name: "Nil AdvancedConfig",
+			mco: &mcov1beta2.MultiClusterObservability{
+				Spec: mcov1beta2.MultiClusterObservabilitySpec{
+					AdvancedConfig: nil,
+				},
+			},
+			expected: "300s",
+		},
+		{
+			name: "Empty QueryTimeout",
+			mco: &mcov1beta2.MultiClusterObservability{
+				Spec: mcov1beta2.MultiClusterObservabilitySpec{
+					AdvancedConfig: &mcov1beta2.AdvancedConfig{
+						QueryTimeout: "",
+					},
+				},
+			},
+			expected: "300s",
+		},
+		{
+			name: "Custom QueryTimeout",
+			mco: &mcov1beta2.MultiClusterObservability{
+				Spec: mcov1beta2.MultiClusterObservabilitySpec{
+					AdvancedConfig: &mcov1beta2.AdvancedConfig{
+						QueryTimeout: "5m",
+					},
+				},
+			},
+			expected: "5m",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetGrafanaQueryTimeout(tt.mco)
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}

--- a/operators/multiclusterobservability/pkg/config/config_test.go
+++ b/operators/multiclusterobservability/pkg/config/config_test.go
@@ -910,6 +910,7 @@ func TestGetMCHVersions(t *testing.T) {
 		})
 	}
 }
+
 func TestGetGrafanaQueryTimeout(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/operators/multiclusterobservability/pkg/rendering/renderer.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer.go
@@ -5,6 +5,8 @@
 package rendering
 
 import (
+	"context"
+
 	imagev1client "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	obv1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
@@ -60,14 +62,14 @@ func (r *MCORenderer) WithRendererOptions(options *RendererOptions) *MCORenderer
 	return r
 }
 
-func (r *MCORenderer) Render() ([]*unstructured.Unstructured, error) {
+func (r *MCORenderer) Render(ctx context.Context) ([]*unstructured.Unstructured, error) {
 	// load and render generic templates
 	genericTemplates, err := templates.GetOrLoadGenericTemplates(templatesutil.GetTemplateRenderer())
 	if err != nil {
 		return nil, err
 	}
 	namespace, labels := r.NamespaceAndLabels()
-	resources, err := r.renderer.RenderTemplates(genericTemplates, namespace, labels)
+	resources, err := r.renderer.RenderTemplates(ctx, genericTemplates, namespace, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +79,7 @@ func (r *MCORenderer) Render() ([]*unstructured.Unstructured, error) {
 	if err != nil {
 		return nil, err
 	}
-	grafanaResources, err := r.renderGrafanaTemplates(grafanaTemplates, namespace, labels)
+	grafanaResources, err := r.renderGrafanaTemplates(ctx, grafanaTemplates, namespace, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +90,7 @@ func (r *MCORenderer) Render() ([]*unstructured.Unstructured, error) {
 	if err != nil {
 		return nil, err
 	}
-	alertResources, err := r.renderAlertManagerTemplates(alertTemplates, namespace, labels)
+	alertResources, err := r.renderAlertManagerTemplates(ctx, alertTemplates, namespace, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +101,7 @@ func (r *MCORenderer) Render() ([]*unstructured.Unstructured, error) {
 	if err != nil {
 		return nil, err
 	}
-	thanosResources, err := r.renderThanosTemplates(thanosTemplates, namespace, labels)
+	thanosResources, err := r.renderThanosTemplates(ctx, thanosTemplates, namespace, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +112,7 @@ func (r *MCORenderer) Render() ([]*unstructured.Unstructured, error) {
 	if err != nil {
 		return nil, err
 	}
-	proxyResources, err := r.renderProxyTemplates(proxyTemplates, namespace, labels)
+	proxyResources, err := r.renderProxyTemplates(ctx, proxyTemplates, namespace, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +120,7 @@ func (r *MCORenderer) Render() ([]*unstructured.Unstructured, error) {
 
 	// load and render multicluster-observability-addon templates if capabilities is enabled
 	if MCOAEnabled(r.cr) {
-		mcoaResources, err := r.MCOAResources(namespace, labels)
+		mcoaResources, err := r.MCOAResources(ctx, namespace, labels)
 		if err != nil {
 			return nil, err
 		}
@@ -178,12 +180,12 @@ func (r *MCORenderer) NamespaceAndLabels() (string, map[string]string) {
 	return namespace, labels
 }
 
-func (r *MCORenderer) MCOAResources(namespace string, labels map[string]string) ([]*unstructured.Unstructured, error) {
+func (r *MCORenderer) MCOAResources(ctx context.Context, namespace string, labels map[string]string) ([]*unstructured.Unstructured, error) {
 	mcoaTemplates, err := templates.GetOrLoadMCOATemplates(templatesutil.GetTemplateRenderer())
 	if err != nil {
 		return nil, err
 	}
-	mcoaResources, err := r.renderMCOATemplates(mcoaTemplates, namespace, labels)
+	mcoaResources, err := r.renderMCOATemplates(ctx, mcoaTemplates, namespace, labels)
 	if err != nil {
 		return nil, err
 	}

--- a/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
@@ -39,8 +39,8 @@ func (r *MCORenderer) newAlertManagerRenderer() {
 	}
 }
 
-func (r *MCORenderer) renderAlertManagerStatefulSet(res *resource.Resource, namespace string, labels map[string]string) (*unstructured.Unstructured, error) {
-	u, err := r.renderer.RenderNamespace(res, namespace, labels)
+func (r *MCORenderer) renderAlertManagerStatefulSet(ctx context.Context, res *resource.Resource, namespace string, labels map[string]string) (*unstructured.Unstructured, error) {
+	u, err := r.renderer.RenderNamespace(ctx, res, namespace, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -155,10 +155,10 @@ func (r *MCORenderer) renderAlertManagerStatefulSet(res *resource.Resource, name
 	return &unstructured.Unstructured{Object: unstructuredObj}, nil
 }
 
-func (r *MCORenderer) renderAlertManagerSecret(res *resource.Resource,
+func (r *MCORenderer) renderAlertManagerSecret(ctx context.Context, res *resource.Resource,
 	namespace string, labels map[string]string,
 ) (*unstructured.Unstructured, error) {
-	u, err := r.renderer.RenderNamespace(res, namespace, labels)
+	u, err := r.renderer.RenderNamespace(ctx, res, namespace, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -185,10 +185,10 @@ func (r *MCORenderer) renderAlertManagerSecret(res *resource.Resource,
 	return u, nil
 }
 
-func (r *MCORenderer) renderAlertManagerConfigMap(res *resource.Resource,
+func (r *MCORenderer) renderAlertManagerConfigMap(ctx context.Context, res *resource.Resource,
 	namespace string, labels map[string]string,
 ) (*unstructured.Unstructured, error) {
-	u, err := r.renderer.RenderNamespace(res, namespace, labels)
+	u, err := r.renderer.RenderNamespace(ctx, res, namespace, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,7 @@ func (r *MCORenderer) renderAlertManagerConfigMap(res *resource.Resource,
 			Namespace: "kube-system",
 		}
 		sourceConfigMap := &corev1.ConfigMap{}
-		err = r.kubeClient.Get(context.Background(), namespacedName, sourceConfigMap)
+		err = r.kubeClient.Get(ctx, namespacedName, sourceConfigMap)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching source ConfigMap: %w", err)
 		}
@@ -235,7 +235,7 @@ func (r *MCORenderer) renderAlertManagerConfigMap(res *resource.Resource,
 	return u, nil
 }
 
-func (r *MCORenderer) renderAlertManagerTemplates(templates []*resource.Resource,
+func (r *MCORenderer) renderAlertManagerTemplates(ctx context.Context, templates []*resource.Resource,
 	namespace string, labels map[string]string,
 ) ([]*unstructured.Unstructured, error) {
 	uobjs := []*unstructured.Unstructured{}
@@ -249,7 +249,7 @@ func (r *MCORenderer) renderAlertManagerTemplates(templates []*resource.Resource
 			uobjs = append(uobjs, &unstructured.Unstructured{Object: m})
 			continue
 		}
-		uobj, err := render(template.DeepCopy(), namespace, labels)
+		uobj, err := render(ctx, template.DeepCopy(), namespace, labels)
 		if err != nil {
 			return []*unstructured.Unstructured{}, err
 		}

--- a/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager_test.go
@@ -5,7 +5,6 @@
 package rendering
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -312,7 +311,7 @@ func renderTemplates(t *testing.T, kubeClient client.Client, mco *mcov1beta2.Mul
 	config.ReadImageManifestConfigMap(kubeClient, "v1")
 
 	imageClient := &fakeimagev1client.FakeImageV1{Fake: &(fakeimageclient.NewSimpleClientset().Fake)}
-	_, err = imageClient.ImageStreams(config.OauthProxyImageStreamNamespace).Create(context.Background(),
+	_, err = imageClient.ImageStreams(config.OauthProxyImageStreamNamespace).Create(t.Context(),
 		&imagev1.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      config.OauthProxyImageStreamName,
@@ -339,7 +338,7 @@ func renderTemplates(t *testing.T, kubeClient client.Client, mco *mcov1beta2.Mul
 	// load and render alertmanager templates
 	alertTemplates, err := templates.GetOrLoadAlertManagerTemplates(templatesutil.GetTemplateRenderer())
 	assert.NoError(t, err)
-	alertResources, err := renderer.renderAlertManagerTemplates(alertTemplates, "namespace", map[string]string{"test": "test"})
+	alertResources, err := renderer.renderAlertManagerTemplates(t.Context(), alertTemplates, "namespace", map[string]string{"test": "test"})
 	assert.NoError(t, err)
 
 	return alertResources

--- a/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
@@ -5,6 +5,7 @@
 package rendering
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -42,10 +43,12 @@ func (r *MCORenderer) newGranfanaRenderer() {
 	}
 }
 
-func (r *MCORenderer) renderGrafanaDeployments(res *resource.Resource,
+func (r *MCORenderer) renderGrafanaDeployments(
+	ctx context.Context,
+	res *resource.Resource,
 	namespace string, labels map[string]string,
 ) (*unstructured.Unstructured, error) {
-	u, err := r.renderer.RenderDeployments(res, namespace, labels)
+	u, err := r.renderer.RenderDeployments(ctx, res, namespace, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +102,9 @@ func (r *MCORenderer) renderGrafanaDeployments(res *resource.Resource,
 	return &unstructured.Unstructured{Object: unstructuredObj}, nil
 }
 
-func (r *MCORenderer) renderGrafanaTemplates(templates []*resource.Resource,
+func (r *MCORenderer) renderGrafanaTemplates(
+	ctx context.Context,
+	templates []*resource.Resource,
 	namespace string, labels map[string]string,
 ) ([]*unstructured.Unstructured, error) {
 	uobjs := []*unstructured.Unstructured{}
@@ -150,7 +155,7 @@ func (r *MCORenderer) renderGrafanaTemplates(templates []*resource.Resource,
 			uobjs = append(uobjs, &unstructured.Unstructured{Object: m})
 			continue
 		}
-		uobj, err := render(template, namespace, labels)
+		uobj, err := render(ctx, template, namespace, labels)
 		if err != nil {
 			return []*unstructured.Unstructured{}, err
 		}

--- a/operators/multiclusterobservability/pkg/rendering/renderer_grafana_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_grafana_test.go
@@ -5,7 +5,6 @@
 package rendering
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -36,7 +35,7 @@ func TestRenderGrafana(t *testing.T) {
 	require.NoError(t, err)
 
 	imageClient := &fakeimagev1client.FakeImageV1{Fake: &(fakeimageclient.NewSimpleClientset().Fake)}
-	_, err = imageClient.ImageStreams(config.OauthProxyImageStreamNamespace).Create(context.Background(),
+	_, err = imageClient.ImageStreams(config.OauthProxyImageStreamNamespace).Create(t.Context(),
 		&imagev1.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      config.OauthProxyImageStreamName,
@@ -170,7 +169,7 @@ func TestRenderGrafana(t *testing.T) {
 
 			mcoRenderer.newGranfanaRenderer()
 			namespace := "myns"
-			grafanaResources, err := mcoRenderer.renderGrafanaTemplates(grafanaTemplates, namespace, nil)
+			grafanaResources, err := mcoRenderer.renderGrafanaTemplates(t.Context(), grafanaTemplates, namespace, nil)
 			require.NoError(t, err)
 			for _, r := range grafanaResources {
 				if r.GetKind() == "ClusterRole" {

--- a/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
@@ -5,6 +5,7 @@
 package rendering
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"net/url"
@@ -187,7 +188,7 @@ func (r *MCORenderer) renderClusterManagementAddOn(
 	u := &unstructured.Unstructured{Object: m}
 
 	// Add grafana link annotation
-	host, err := mcoconfig.GetRouteHost(r.kubeClient, mcoconfig.GrafanaRouteName, mcoconfig.GetDefaultNamespace())
+	host, err := mcoconfig.GetRouteHost(context.TODO(), r.kubeClient, mcoconfig.GrafanaRouteName, mcoconfig.GetDefaultNamespace())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get host route: %w", err)
 	}

--- a/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
@@ -61,11 +61,12 @@ func (r *MCORenderer) newMCOARenderer() {
 }
 
 func (r *MCORenderer) renderMCOADeployment(
+	ctx context.Context,
 	res *resource.Resource,
 	namespace string,
 	labels map[string]string,
 ) (*unstructured.Unstructured, error) {
-	u, err := r.renderer.RenderNamespace(res, namespace, labels)
+	u, err := r.renderer.RenderNamespace(ctx, res, namespace, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -177,6 +178,7 @@ func (r *MCORenderer) renderMCOADeployment(
 }
 
 func (r *MCORenderer) renderClusterManagementAddOn(
+	ctx context.Context,
 	res *resource.Resource,
 	namespace string,
 	labels map[string]string,
@@ -188,7 +190,7 @@ func (r *MCORenderer) renderClusterManagementAddOn(
 	u := &unstructured.Unstructured{Object: m}
 
 	// Add grafana link annotation
-	host, err := mcoconfig.GetRouteHost(context.TODO(), r.kubeClient, mcoconfig.GrafanaRouteName, mcoconfig.GetDefaultNamespace())
+	host, err := mcoconfig.GetRouteHost(ctx, r.kubeClient, mcoconfig.GrafanaRouteName, mcoconfig.GetDefaultNamespace())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get host route: %w", err)
 	}
@@ -216,11 +218,12 @@ func (r *MCORenderer) renderClusterManagementAddOn(
 }
 
 func (r *MCORenderer) renderAddonDeploymentConfig(
+	ctx context.Context,
 	res *resource.Resource,
 	namespace string,
 	labels map[string]string,
 ) (*unstructured.Unstructured, error) {
-	u, err := r.renderer.RenderNamespace(res, namespace, labels)
+	u, err := r.renderer.RenderNamespace(ctx, res, namespace, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -307,6 +310,7 @@ func (r *MCORenderer) renderAddonDeploymentConfig(
 }
 
 func (r *MCORenderer) renderMCOATemplates(
+	ctx context.Context,
 	templates []*resource.Resource,
 	namespace string,
 	labels map[string]string,
@@ -331,7 +335,7 @@ func (r *MCORenderer) renderMCOATemplates(
 			uobjs = append(uobjs, &unstructured.Unstructured{Object: m})
 			continue
 		}
-		uobj, err := render(template.DeepCopy(), namespace, labels)
+		uobj, err := render(ctx, template.DeepCopy(), namespace, labels)
 		if err != nil {
 			return []*unstructured.Unstructured{}, err
 		}

--- a/operators/multiclusterobservability/pkg/rendering/renderer_mcoa_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_mcoa_test.go
@@ -72,7 +72,7 @@ func TestRenderMCOADeployment(t *testing.T) {
 
 	renderer := &MCORenderer{cr: mco}
 
-	uobj, err := renderer.renderMCOADeployment(dp, "test", map[string]string{"key": "value"})
+	uobj, err := renderer.renderMCOADeployment(t.Context(), dp, "test", map[string]string{"key": "value"})
 	assert.NoError(t, err)
 	assert.NotNil(t, uobj)
 
@@ -111,7 +111,7 @@ func TestRenderMCOADeployment(t *testing.T) {
 			},
 		},
 	}
-	uobj, err = renderer.renderMCOADeployment(dp, "test", map[string]string{"key": "value"})
+	uobj, err = renderer.renderMCOADeployment(t.Context(), dp, "test", map[string]string{"key": "value"})
 	assert.NoError(t, err)
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(uobj.Object, got)
 	assert.NoError(t, err)
@@ -203,7 +203,7 @@ func TestRenderAddonDeploymentConfig(t *testing.T) {
 		},
 	}}
 
-	uobj, err := renderer.renderAddonDeploymentConfig(aodc, "test", map[string]string{"key": "value"})
+	uobj, err := renderer.renderAddonDeploymentConfig(t.Context(), aodc, "test", map[string]string{"key": "value"})
 	assert.NoError(t, err)
 	assert.NotNil(t, uobj)
 
@@ -455,7 +455,7 @@ func TestRenderMCOATemplates(t *testing.T) {
 				},
 			}
 
-			uobjs, err := renderer.renderMCOATemplates(mcoaTemplates, "test", map[string]string{"key": "value"})
+			uobjs, err := renderer.renderMCOATemplates(t.Context(), mcoaTemplates, "test", map[string]string{"key": "value"})
 			assert.NoError(t, err)
 			assert.NotNil(t, uobjs)
 

--- a/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
@@ -68,6 +68,8 @@ func (r *MCORenderer) renderProxyDeployment(res *resource.Resource,
 			1,
 		)
 	}
+	queryTimeout := mcoconfig.GetGrafanaQueryTimeout()
+	args0 = append(args0, fmt.Sprintf("--proxy-timeout=%s", queryTimeout))
 	spec.Containers[0].Args = args0
 	spec.Containers[0].Resources = mcoconfig.GetResources(mcoconfig.RBACQueryProxy, r.cr.Spec.InstanceSize, r.cr.Spec.AdvancedConfig)
 

--- a/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
@@ -68,7 +68,7 @@ func (r *MCORenderer) renderProxyDeployment(res *resource.Resource,
 			1,
 		)
 	}
-	queryTimeout := mcoconfig.GetGrafanaQueryTimeout()
+	queryTimeout := mcoconfig.GetGrafanaQueryTimeout(r.cr)
 	args0 = append(args0, fmt.Sprintf("--proxy-timeout=%s", queryTimeout))
 	spec.Containers[0].Args = args0
 	spec.Containers[0].Resources = mcoconfig.GetResources(mcoconfig.RBACQueryProxy, r.cr.Spec.InstanceSize, r.cr.Spec.AdvancedConfig)

--- a/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
@@ -5,6 +5,7 @@
 package rendering
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -34,10 +35,10 @@ func (r *MCORenderer) newProxyRenderer() {
 	}
 }
 
-func (r *MCORenderer) renderProxyDeployment(res *resource.Resource,
+func (r *MCORenderer) renderProxyDeployment(ctx context.Context, res *resource.Resource,
 	namespace string, labels map[string]string,
 ) (*unstructured.Unstructured, error) {
-	u, err := r.renderer.RenderDeployments(res, namespace, labels)
+	u, err := r.renderer.RenderDeployments(ctx, res, namespace, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -123,10 +124,10 @@ func (r *MCORenderer) renderProxyDeployment(res *resource.Resource,
 	return &unstructured.Unstructured{Object: unstructuredObj}, nil
 }
 
-func (r *MCORenderer) renderProxySecret(res *resource.Resource,
+func (r *MCORenderer) renderProxySecret(ctx context.Context, res *resource.Resource,
 	namespace string, labels map[string]string,
 ) (*unstructured.Unstructured, error) {
-	u, err := r.renderer.RenderNamespace(res, namespace, labels)
+	u, err := r.renderer.RenderNamespace(ctx, res, namespace, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +155,7 @@ func (r *MCORenderer) renderProxySecret(res *resource.Resource,
 	return u, nil
 }
 
-func (r *MCORenderer) renderProxyTemplates(templates []*resource.Resource,
+func (r *MCORenderer) renderProxyTemplates(ctx context.Context, templates []*resource.Resource,
 	namespace string, labels map[string]string,
 ) ([]*unstructured.Unstructured, error) {
 	uobjs := []*unstructured.Unstructured{}
@@ -168,7 +169,7 @@ func (r *MCORenderer) renderProxyTemplates(templates []*resource.Resource,
 			uobjs = append(uobjs, &unstructured.Unstructured{Object: m})
 			continue
 		}
-		uobj, err := render(template.DeepCopy(), namespace, labels)
+		uobj, err := render(ctx, template.DeepCopy(), namespace, labels)
 		if err != nil {
 			return []*unstructured.Unstructured{}, err
 		}

--- a/operators/multiclusterobservability/pkg/rendering/renderer_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_test.go
@@ -5,7 +5,6 @@
 package rendering
 
 import (
-	"context"
 	"os"
 	"path"
 	"testing"
@@ -65,7 +64,7 @@ func TestRender(t *testing.T) {
 	kubeClient := fake.NewClientBuilder().WithObjects(clientCa).Build()
 
 	imageClient := &fakeimagev1client.FakeImageV1{Fake: &(fakeimageclient.NewSimpleClientset().Fake)}
-	_, err = imageClient.ImageStreams(config.OauthProxyImageStreamNamespace).Create(context.Background(),
+	_, err = imageClient.ImageStreams(config.OauthProxyImageStreamNamespace).Create(t.Context(),
 		&imagev1.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      config.OauthProxyImageStreamName,
@@ -88,7 +87,7 @@ func TestRender(t *testing.T) {
 	}
 
 	renderer := NewMCORenderer(mchcr, kubeClient, imageClient)
-	_, err = renderer.Render()
+	_, err = renderer.Render(t.Context())
 	if err != nil {
 		t.Fatalf("failed to render MultiClusterObservability: %v", err)
 	}
@@ -96,7 +95,7 @@ func TestRender(t *testing.T) {
 
 func TestGetOauthProxyFromImageStreams(t *testing.T) {
 	imageClient := &fakeimagev1client.FakeImageV1{Fake: &(fakeimageclient.NewSimpleClientset().Fake)}
-	_, err := imageClient.ImageStreams(config.OauthProxyImageStreamNamespace).Create(context.Background(),
+	_, err := imageClient.ImageStreams(config.OauthProxyImageStreamNamespace).Create(t.Context(),
 		&imagev1.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      config.OauthProxyImageStreamName,

--- a/operators/multiclusterobservability/pkg/rendering/renderer_thanos.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_thanos.go
@@ -5,6 +5,7 @@
 package rendering
 
 import (
+	"context"
 	"strconv"
 
 	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
@@ -28,7 +29,7 @@ func (r *MCORenderer) newThanosRenderer() {
 	}
 }
 
-func (r *MCORenderer) renderThanosTemplates(templates []*resource.Resource,
+func (r *MCORenderer) renderThanosTemplates(ctx context.Context, templates []*resource.Resource,
 	namespace string, labels map[string]string,
 ) ([]*unstructured.Unstructured, error) {
 	uobjs := []*unstructured.Unstructured{}
@@ -42,7 +43,7 @@ func (r *MCORenderer) renderThanosTemplates(templates []*resource.Resource,
 			uobjs = append(uobjs, &unstructured.Unstructured{Object: m})
 			continue
 		}
-		uobj, err := render(template.DeepCopy(), namespace, labels)
+		uobj, err := render(ctx, template.DeepCopy(), namespace, labels)
 		if err != nil {
 			return []*unstructured.Unstructured{}, err
 		}
@@ -55,10 +56,10 @@ func (r *MCORenderer) renderThanosTemplates(templates []*resource.Resource,
 	return uobjs, nil
 }
 
-func (r *MCORenderer) RenderThanosConfig(res *resource.Resource,
+func (r *MCORenderer) RenderThanosConfig(ctx context.Context, res *resource.Resource,
 	namespace string, labels map[string]string,
 ) (*unstructured.Unstructured, error) {
-	u, err := r.renderer.RenderNamespace(res, namespace, labels)
+	u, err := r.renderer.RenderNamespace(ctx, res, namespace, labels)
 	if err != nil {
 		return nil, err
 	}

--- a/operators/multiclusterobservability/pkg/util/clustermanagementaddon.go
+++ b/operators/multiclusterobservability/pkg/util/clustermanagementaddon.go
@@ -33,7 +33,7 @@ type clusterManagementAddOnSpec struct {
 func CreateClusterManagementAddon(ctx context.Context, c client.Client) (
 	*addonv1alpha1.ClusterManagementAddOn, error,
 ) {
-	clusterManagementAddon, err := newClusterManagementAddon(c)
+	clusterManagementAddon, err := newClusterManagementAddon(ctx, c)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func DeleteClusterManagementAddon(ctx context.Context, client client.Client) err
 	return nil
 }
 
-func newClusterManagementAddon(c client.Client) (*addonv1alpha1.ClusterManagementAddOn, error) {
-	host, err := config.GetRouteHost(c, config.GrafanaRouteName, config.GetDefaultNamespace())
+func newClusterManagementAddon(ctx context.Context, c client.Client) (*addonv1alpha1.ClusterManagementAddOn, error) {
+	host, err := config.GetRouteHost(ctx, c, config.GrafanaRouteName, config.GetDefaultNamespace())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get host route: %w", err)
 	}

--- a/operators/multiclusterobservability/pkg/util/clustermanagementaddon_test.go
+++ b/operators/multiclusterobservability/pkg/util/clustermanagementaddon_test.go
@@ -43,7 +43,7 @@ func TestClusterManagmentAddon(t *testing.T) {
 		t.Fatalf("Failed to create clustermanagementaddon twice: (%v)", err)
 	}
 	addon := &addonv1alpha1.ClusterManagementAddOn{}
-	err = c.Get(context.TODO(),
+	err = c.Get(context.Background(),
 		types.NamespacedName{
 			Name: ObservabilityController,
 		},
@@ -68,7 +68,7 @@ func TestClusterManagmentAddon(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to delete clustermanagementaddon: (%v)", err)
 	}
-	err = c.Get(context.TODO(),
+	err = c.Get(context.Background(),
 		types.NamespacedName{
 			Name: ObservabilityController,
 		},
@@ -80,7 +80,7 @@ func TestClusterManagmentAddon(t *testing.T) {
 
 	// Test upgrade scenario: Create a CMA with the old lifecycle annotation
 	// The test expects the annotation to be removed during reconciliation.
-	clusterManagementAddon, err := newClusterManagementAddon(c)
+	clusterManagementAddon, err := newClusterManagementAddon(context.Background(), c)
 	if err != nil {
 		t.Fatalf("Failed to create new clustermanagementaddon: (%v)", err)
 	}
@@ -91,7 +91,7 @@ func TestClusterManagmentAddon(t *testing.T) {
 	}
 	clusterManagementAddon.ObjectMeta.Annotations[addonv1alpha1.AddonLifecycleAnnotationKey] = addonv1alpha1.AddonLifecycleSelfManageAnnotationValue
 
-	if err := c.Create(context.TODO(), clusterManagementAddon); err != nil {
+	if err := c.Create(context.Background(), clusterManagementAddon); err != nil {
 		t.Fatalf("Failed to create clustermanagementaddon: (%v)", err)
 	}
 
@@ -102,7 +102,7 @@ func TestClusterManagmentAddon(t *testing.T) {
 	}
 
 	// Retrieve the updated object
-	err = c.Get(context.TODO(),
+	err = c.Get(context.Background(),
 		types.NamespacedName{
 			Name: ObservabilityController,
 		},

--- a/operators/pkg/rendering/renderer.go
+++ b/operators/pkg/rendering/renderer.go
@@ -5,6 +5,7 @@
 package rendering
 
 import (
+	"context"
 	"errors"
 	"maps"
 	"strconv"
@@ -18,7 +19,7 @@ const (
 	nsUpdateAnnoKey = "update-namespace"
 )
 
-type RenderFn func(*resource.Resource, string, map[string]string) (*unstructured.Unstructured, error)
+type RenderFn func(context.Context, *resource.Resource, string, map[string]string) (*unstructured.Unstructured, error)
 
 type Renderer struct {
 	renderFns map[string]RenderFn
@@ -48,6 +49,7 @@ func NewRenderer() *Renderer {
 }
 
 func (r *Renderer) RenderTemplates(
+	ctx context.Context,
 	templates []*resource.Resource,
 	namespace string,
 	labels map[string]string,
@@ -63,7 +65,7 @@ func (r *Renderer) RenderTemplates(
 			uobjs = append(uobjs, &unstructured.Unstructured{Object: m})
 			continue
 		}
-		uobj, err := render(template.DeepCopy(), namespace, labels)
+		uobj, err := render(ctx, template.DeepCopy(), namespace, labels)
 		if err != nil {
 			return []*unstructured.Unstructured{}, err
 		}
@@ -77,6 +79,7 @@ func (r *Renderer) RenderTemplates(
 }
 
 func (r *Renderer) RenderDeployments(
+	ctx context.Context,
 	res *resource.Resource,
 	namespace string,
 	labels map[string]string,
@@ -98,6 +101,7 @@ func (r *Renderer) RenderDeployments(
 }
 
 func (r *Renderer) RenderNamespace(
+	ctx context.Context,
 	res *resource.Resource,
 	namespace string,
 	labels map[string]string,
@@ -118,6 +122,7 @@ func (r *Renderer) RenderNamespace(
 }
 
 func (r *Renderer) RenderClusterRole(
+	ctx context.Context,
 	res *resource.Resource,
 	namespace string,
 	labels map[string]string,
@@ -139,6 +144,7 @@ func (r *Renderer) RenderClusterRole(
 }
 
 func (r *Renderer) RenderClusterRoleBinding(
+	ctx context.Context,
 	res *resource.Resource,
 	namespace string,
 	labels map[string]string,

--- a/operators/pkg/util/util.go
+++ b/operators/pkg/util/util.go
@@ -16,6 +16,7 @@ import (
 	appv1 "k8s.io/api/apps/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -111,26 +112,31 @@ func RegisterDebugEndpoint(register func(string, http.Handler) error) error {
 }
 
 func UpdateDeployLabel(c client.Client, dName, namespace, label string) error {
-	dep := &appv1.Deployment{}
-	err := c.Get(context.TODO(), types.NamespacedName{
-		Name:      dName,
-		Namespace: namespace,
-	}, dep)
-	if err != nil {
-		if !k8serrors.IsNotFound(err) {
-			log.Error(err, "Failed to check the deployment", "name", dName)
-		}
-		return err
-	}
-	if dep.Status.ReadyReplicas != 0 {
-		dep.Spec.Template.Labels[label] = time.Now().Format("2006-1-2.150405")
-		err = c.Update(context.TODO(), dep)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		dep := &appv1.Deployment{}
+		err := c.Get(context.TODO(), types.NamespacedName{
+			Name:      dName,
+			Namespace: namespace,
+		}, dep)
 		if err != nil {
-			log.Error(err, "Failed to update the deployment", "name", dName)
+			if !k8serrors.IsNotFound(err) {
+				log.Error(err, "Failed to check the deployment", "name", dName)
+			}
 			return err
-		} else {
-			log.Info("Update deployment restart label", "name", dName)
 		}
-	}
-	return nil
+		if dep.Status.ReadyReplicas != 0 {
+			if dep.Spec.Template.Labels == nil {
+				dep.Spec.Template.Labels = map[string]string{}
+			}
+			dep.Spec.Template.Labels[label] = time.Now().Format("2006-1-2.150405")
+			err = c.Update(context.TODO(), dep)
+			if err != nil {
+				log.Error(err, "Failed to update the deployment", "name", dName)
+				return err
+			} else {
+				log.Info("Update deployment restart label", "name", dName)
+			}
+		}
+		return nil
+	})
 }

--- a/proxy/cmd/main.go
+++ b/proxy/cmd/main.go
@@ -38,6 +38,7 @@ type proxyConf struct {
 	tlsCaFile          string
 	tlsCertFile        string
 	tlsKeyFile         string
+	proxyTimeout       time.Duration
 }
 
 func main() {
@@ -62,6 +63,7 @@ func run() error {
 	flagset.StringVar(&cfg.tlsCaFile, "tls-ca-file", "/var/rbac_proxy/ca/ca.crt", "The path to the CA certificate file for connecting to the downstream server.")
 	flagset.StringVar(&cfg.tlsCertFile, "tls-cert-file", "/var/rbac_proxy/certs/tls.crt", "The path to the client certificate file for connecting to the downstream server.")
 	flagset.StringVar(&cfg.tlsKeyFile, "tls-key-file", "/var/rbac_proxy/certs/tls.key", "The path to the client key file for connecting to the downstream server.")
+	flagset.DurationVar(&cfg.proxyTimeout, "proxy-timeout", 5*time.Minute, "The timeout for the proxy to wait for the downstream server response.")
 
 	_ = flagset.Parse(os.Args[1:])
 
@@ -109,6 +111,7 @@ func run() error {
 		KeyFile:         cfg.tlsKeyFile,
 		CertFile:        cfg.tlsCertFile,
 		PollingInterval: 15 * time.Second,
+		ProxyTimeout:    cfg.proxyTimeout,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to set tls transport: %w", err)

--- a/proxy/cmd/main.go
+++ b/proxy/cmd/main.go
@@ -129,7 +129,7 @@ func run() error {
 		Handler:           handlers,
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       15 * time.Second,
-		WriteTimeout:      12 * time.Minute,
+		WriteTimeout:      cfg.proxyTimeout + 1*time.Minute,
 	}
 
 	// start the server in a goroutine

--- a/proxy/cmd/main.go
+++ b/proxy/cmd/main.go
@@ -67,6 +67,10 @@ func run() error {
 
 	_ = flagset.Parse(os.Args[1:])
 
+	if cfg.proxyTimeout <= 0 {
+		return fmt.Errorf("--proxy-timeout must be positive, got: %v", cfg.proxyTimeout)
+	}
+
 	// Kubeconfig flag
 	flagset.StringVar(&cfg.kubeconfigLocation, "kubeconfig", "",
 		"Path to a kubeconfig file. If unset, in-cluster configuration will be used")

--- a/proxy/pkg/proxy/tls.go
+++ b/proxy/pkg/proxy/tls.go
@@ -46,8 +46,9 @@ type reloadingTransport struct {
 
 // newReloadingTransport creates a new transport that can reload its TLS configuration.
 func newReloadingTransport(opts *TLSOptions) (*reloadingTransport, error) {
-	if opts.ProxyTimeout == 0 {
-		opts.ProxyTimeout = 300 * time.Second
+	proxyTimeout := opts.ProxyTimeout
+	if proxyTimeout == 0 {
+		proxyTimeout = 300 * time.Second
 	}
 	transport := &reloadingTransport{
 		opts:      opts,
@@ -59,7 +60,7 @@ func newReloadingTransport(opts *TLSOptions) (*reloadingTransport, error) {
 				KeepAlive: 300 * time.Second,
 			}).Dial,
 			TLSHandshakeTimeout:   30 * time.Second,
-			ResponseHeaderTimeout: opts.ProxyTimeout,
+			ResponseHeaderTimeout: proxyTimeout,
 		},
 	}
 


### PR DESCRIPTION
This PR introduces configurable query timeout management across the observability stack, allowing users to define a custom `queryTimeout` in the `MultiClusterObservability` CR. This ensures consistency between Grafana, the OpenShift Route (HAProxy), and the RBAC Query Proxy.

**Note:** The timeout remains at a fixed value of **5m** for other downstream components (Observatorium API, Thanos Query-Frontend).

#### Key Changes:

-   **API & CRD:**
    -   Added `QueryTimeout` to `AdvancedConfig` in the `v1beta2` API (defaulting to `300s`).
-   **Operator:**
    -   **Grafana:** Automatically updates Grafana DataSources with the configured timeout and applies the `haproxy.router.openshift.io/timeout` annotation to the Grafana Route.
    -   **Proxy Rendering:** Dynamically passes the configured timeout to the RBAC Query Proxy via the new `--proxy-timeout` flag.
-   **RBAC Query Proxy:**
    -   Introduced the `--proxy-timeout` command-line flag.
    -   Synchronized the HTTP server's `WriteTimeout` and the underlying transport's `ResponseHeaderTimeout` with the configured proxy timeout (adding a 1-minute buffer for the server timeout to allow graceful proxy failures).

This change improves reliability for long-running queries and provides a single point of configuration for timeout settings on the ingress path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable `queryTimeout` field to MultiClusterObservability spec (default: 300s) to control Grafana query timeouts on read-path components.
  * Added `--proxy-timeout` CLI flag to configure proxy timeout behavior (default: 5 minutes).

* **Improvements**
  * Enhanced timeout handling for Grafana operations and HTTP server write deadlines to align with proxy timeout configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->