### PR TITLE
Jenkins: allow setting different hub name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     }
     agent {
         docker {
-	    image 'quay.io/vboulos/acmqe-automation/go:go1.21-ginkgo2.17.1'
+	    image 'quay.io/vboulos/acmqe-automation/go:go1.25-ginkgo2.23.0'
             args '--network host -u 0:0'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,9 @@ pipeline {
                 set -x
                 export OC_HUB_CLUSTER_API_URL="${params.OC_HUB_CLUSTER_API_URL}"
                 BASE_DOMAIN=\$(echo \${OC_HUB_CLUSTER_API_URL} | awk -F'https://|:' '{gsub(/^api\\./, "", \$2); print \$2}')
-                HUB_CLUSTER_NAME=\$(echo \$BASE_DOMAIN | cut -d'.' -f1)
+                if [[ -z "${params.HUB_CLUSTER_NAME}" ]]; then
+                    HUB_CLUSTER_NAME=\$(echo \$BASE_DOMAIN | cut -d'.' -f1)
+                fi
                 echo "BASE_DOMAIN: \$BASE_DOMAIN"
                 echo "HUB_CLUSTER_NAME: \$HUB_CLUSTER_NAME"
                 export HUB_CLUSTER_NAME="\$HUB_CLUSTER_NAME"


### PR DESCRIPTION
Use the hub name set in the Jenkins args if set, otheruse extract it from the base url (as done before).

/cherry-pick release-2.16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI pipeline runtime image to a newer Go/Ginkgo build image.
  * Build configuration now respects a manually provided cluster name: if supplied it’s used unchanged; otherwise the system derives it from the base domain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->