### PR TITLE
wip: feat(tls): implement dynamic TLS profile updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee
 	github.com/openshift/cluster-monitoring-operator v0.1.1-0.20251021084408-d3eba7e97d65
 	github.com/openshift/hypershift/api v0.0.0-20241119231618-9aca80837541
+	github.com/openshift/library-go v0.0.0-20250711143941-47604345e7ea
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.82.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.82.0
 	github.com/prometheus/alertmanager v0.28.1
@@ -154,7 +155,6 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/openshift/library-go v0.0.0-20250711143941-47604345e7ea // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	ocinfrav1 "github.com/openshift/api/config/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	imagev1client "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
@@ -203,6 +204,19 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 		return ctrl.Result{}, nil
 	}
 
+	apiServer := &ocinfrav1.APIServer{}
+	var tlsProfile *ocinfrav1.TLSSecurityProfile
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: "cluster"}, apiServer); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to get apiserver cluster config: %w", err)
+		}
+	} else {
+		tlsProfile = apiServer.Spec.TLSSecurityProfile
+	}
+
+	// Ensure the manager's metrics and webhook servers dynamically update their TLS configuration.
+	commonutil.SyncBaseTLSConfig(tlsProfile)
+
 	if _, ok := config.BackupResourceMap[instance.Spec.StorageConfig.MetricObjectStorage.Name]; !ok {
 		log.Info(infoAddingBackupLabel, "Secret", instance.Spec.StorageConfig.MetricObjectStorage.Name)
 		config.BackupResourceMap[instance.Spec.StorageConfig.MetricObjectStorage.Name] = config.ResourceTypeSecret
@@ -270,6 +284,7 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 
 	// Build render options
 	rendererOptions := &rendering.RendererOptions{
+		TLSProfile: tlsProfile,
 		MCOAOptions: rendering.MCOARendererOptions{
 			DisableCMAORender:              disableMCOACMAORender,
 			MetricsHubHostname:             obsAPIURL.Host,
@@ -552,7 +567,17 @@ func (r *MultiClusterObservabilityReconciler) SetupWithManager(mgr ctrl.Manager)
 				}
 				return nil
 			}), builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
-		Watches(&apiextensionsv1.CustomResourceDefinition{}, newMCOACRDEventHandler(c), builder.WithPredicates(mcoaCRDPred))
+		Watches(&apiextensionsv1.CustomResourceDefinition{}, newMCOACRDEventHandler(c), builder.WithPredicates(mcoaCRDPred)).
+		Watches(&ocinfrav1.APIServer{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
+			if a.GetName() == "cluster" {
+				return []reconcile.Request{
+					{NamespacedName: types.NamespacedName{
+						Name: config.GetMonitoringCRName(),
+					}},
+				}
+			}
+			return nil
+		}), builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}))
 
 	if _, err := mgr.GetRESTMapper().KindFor(schema.GroupVersionResource{
 		Group:    "image.openshift.io",

--- a/operators/multiclusterobservability/main.go
+++ b/operators/multiclusterobservability/main.go
@@ -5,10 +5,11 @@
 package main
 
 import (
-	"crypto/tls"
+	"context"
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/IBM/controller-filtered-cache/filteredcache"
 	ocinfrav1 "github.com/openshift/api/config/v1"
@@ -33,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -45,6 +47,7 @@ import (
 	workv1 "open-cluster-management.io/api/work/v1"
 	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	ctrlruntimescheme "sigs.k8s.io/controller-runtime/pkg/scheme"
@@ -244,20 +247,45 @@ func main() {
 		{LabelSelector: "owner==multicluster-observability-operator"},
 	}
 
+	directClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "unable to create client")
+		os.Exit(1)
+	}
+	apiServer := &ocinfrav1.APIServer{}
+	var tlsProfile *ocinfrav1.TLSSecurityProfile
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	if err := directClient.Get(ctx, client.ObjectKey{Name: "cluster"}, apiServer); err != nil {
+		cancel()
+		if !errors.IsNotFound(err) {
+			setupLog.Error(err, "unable to get apiserver cluster config")
+			os.Exit(1)
+		}
+		setupLog.Info("apiserver cluster config not found, using default TLS profile")
+	} else {
+		cancel()
+		tlsProfile = apiServer.Spec.TLSSecurityProfile
+		if tlsProfile != nil {
+			setupLog.Info("Detected TLS profile", "type", tlsProfile.Type)
+		} else {
+			setupLog.Info("No TLS profile configured on apiserver, using default")
+		}
+	}
+	operatorsutil.SyncBaseTLSConfig(tlsProfile)
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
-		Metrics:                server.Options{BindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort)},
+		Scheme: scheme,
+		Metrics: server.Options{
+			BindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+			TLSOpts:     operatorsutil.GetDynamicTLSConfig(),
+		},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "b9d51391.open-cluster-management.io",
 		NewCache:               filteredcache.NewEnhancedFilteredCacheBuilder(gvkLabelsMap),
 		WebhookServer: ctrlwebhook.NewServer(ctrlwebhook.Options{
-			Port: webhookPort,
-			TLSOpts: []func(*tls.Config){
-				func(t *tls.Config) {
-					t.MinVersion = tls.VersionTLS12
-				},
-			},
+			Port:    webhookPort,
+			TLSOpts: operatorsutil.GetDynamicTLSConfig(),
 		}),
 	})
 	if err != nil {

--- a/operators/multiclusterobservability/pkg/rendering/renderer.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer.go
@@ -5,6 +5,7 @@
 package rendering
 
 import (
+	ocinfrav1 "github.com/openshift/api/config/v1"
 	imagev1client "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	obv1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
@@ -25,6 +26,7 @@ var log = logf.Log.WithName("renderer")
 
 type RendererOptions struct {
 	MCOAOptions MCOARendererOptions
+	TLSProfile  *ocinfrav1.TLSSecurityProfile
 }
 
 type MCORenderer struct {
@@ -32,6 +34,7 @@ type MCORenderer struct {
 	imageClient           imagev1client.ImageV1Interface
 	renderer              *rendererutil.Renderer
 	cr                    *obv1beta2.MultiClusterObservability
+	tlsProfile            *ocinfrav1.TLSSecurityProfile
 	rendererOptions       *RendererOptions
 	renderGrafanaFns      map[string]rendererutil.RenderFn
 	renderAlertManagerFns map[string]rendererutil.RenderFn
@@ -40,7 +43,11 @@ type MCORenderer struct {
 	renderMCOAFns         map[string]rendererutil.RenderFn
 }
 
-func NewMCORenderer(multipleClusterMonitoring *obv1beta2.MultiClusterObservability, kubeClient client.Client, imageClient imagev1client.ImageV1Interface) *MCORenderer {
+func NewMCORenderer(
+	multipleClusterMonitoring *obv1beta2.MultiClusterObservability,
+	kubeClient client.Client,
+	imageClient imagev1client.ImageV1Interface,
+) *MCORenderer {
 	mcoRenderer := &MCORenderer{
 		renderer:    rendererutil.NewRenderer(),
 		cr:          multipleClusterMonitoring,
@@ -57,6 +64,9 @@ func NewMCORenderer(multipleClusterMonitoring *obv1beta2.MultiClusterObservabili
 
 func (r *MCORenderer) WithRendererOptions(options *RendererOptions) *MCORenderer {
 	r.rendererOptions = options
+	if options != nil {
+		r.tlsProfile = options.TLSProfile
+	}
 	return r
 }
 

--- a/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
@@ -137,11 +137,13 @@ func (r *MCORenderer) renderAlertManagerStatefulSet(res *resource.Resource, name
 		return nil, fmt.Errorf("failed to get OAuth image for alertmanager")
 	}
 	oauthProxyContainer.ImagePullPolicy = imagePullPolicy
+	oauthProxyContainer.Args = util.AppendOauthProxyTLSArgs(oauthProxyContainer.Args, r.tlsProfile)
 
 	if ok, image := mcoconfig.ReplaceImage(r.cr.Annotations, mcoconfig.DefaultImgRepository+"/"+mcoconfig.KubeRBACProxyImgName, mcoconfig.KubeRBACProxyKey); ok {
 		kubeRbacProxyContainer.Image = image
 	}
 	kubeRbacProxyContainer.ImagePullPolicy = imagePullPolicy
+	kubeRbacProxyContainer.Args = util.AppendKubeRBACProxyTLSArgs(kubeRbacProxyContainer.Args, r.tlsProfile)
 
 	// replace the volumeClaimTemplate
 	dep.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = &r.cr.Spec.StorageConfig.StorageClass

--- a/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
@@ -90,6 +90,7 @@ func (r *MCORenderer) renderGrafanaDeployments(res *resource.Resource,
 		return nil, fmt.Errorf("failed to get OAuth image for alertmanager")
 	}
 	spec.Containers[2].ImagePullPolicy = imagePullPolicy
+	spec.Containers[2].Args = util.AppendOauthProxyTLSArgs(spec.Containers[2].Args, r.tlsProfile)
 
 	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {

--- a/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_proxy.go
@@ -76,6 +76,7 @@ func (r *MCORenderer) renderProxyDeployment(res *resource.Resource,
 	for idx := range args1 {
 		args1[idx] = strings.Replace(args1[idx], "{{MCO_NAMESPACE}}", mcoconfig.GetDefaultNamespace(), 1)
 	}
+	args1 = util.AppendOauthProxyTLSArgs(args1, r.tlsProfile)
 	spec.Containers[1].Args = args1
 	spec.NodeSelector = r.cr.Spec.NodeSelector
 	spec.Tolerations = r.cr.Spec.Tolerations

--- a/operators/multiclusterobservability/pkg/rendering/renderer_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_test.go
@@ -8,18 +8,24 @@ import (
 	"context"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
+	ocinfrav1 "github.com/openshift/api/config/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	fakeimageclient "github.com/openshift/client-go/image/clientset/versioned/fake"
 	fakeimagev1client "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1/fake"
+	"github.com/openshift/library-go/pkg/crypto"
 	mcoshared "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/shared"
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	templatesutil "github.com/stolostron/multicluster-observability-operator/operators/pkg/rendering/templates"
+	obsv1alpha1 "github.com/stolostron/observatorium-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -29,8 +35,7 @@ func TestRender(t *testing.T) {
 		t.Fatalf("failed to get working dir %v", err)
 	}
 	templatesPath := path.Join(path.Dir(path.Dir(wd)), "manifests")
-	os.Setenv(templatesutil.TemplatesPathEnvVar, templatesPath)
-	defer os.Unsetenv(templatesutil.TemplatesPathEnvVar)
+	t.Setenv(templatesutil.TemplatesPathEnvVar, templatesPath)
 
 	mchcr := &mcov1beta2.MultiClusterObservability{
 		TypeMeta:   metav1.TypeMeta{Kind: "MultiClusterObservability"},
@@ -62,7 +67,10 @@ func TestRender(t *testing.T) {
 			"client-ca-file": "test",
 		},
 	}
-	kubeClient := fake.NewClientBuilder().WithObjects(clientCa).Build()
+	s := runtime.NewScheme()
+	corev1.AddToScheme(s)
+	obsv1alpha1.AddToScheme(s)
+	kubeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(clientCa).Build()
 
 	imageClient := &fakeimagev1client.FakeImageV1{Fake: &(fakeimageclient.NewSimpleClientset().Fake)}
 	_, err = imageClient.ImageStreams(config.OauthProxyImageStreamNamespace).Create(context.Background(),
@@ -91,6 +99,227 @@ func TestRender(t *testing.T) {
 	_, err = renderer.Render()
 	if err != nil {
 		t.Fatalf("failed to render MultiClusterObservability: %v", err)
+	}
+}
+
+func TestTLSProfilePropagation(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working dir %v", err)
+	}
+	templatesPath := path.Join(path.Dir(path.Dir(wd)), "manifests")
+	t.Setenv(templatesutil.TemplatesPathEnvVar, templatesPath)
+
+	mchcr := &mcov1beta2.MultiClusterObservability{
+		TypeMeta:   metav1.TypeMeta{Kind: "MultiClusterObservability"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"},
+		Spec: mcov1beta2.MultiClusterObservabilitySpec{
+			ImagePullPolicy: "IfNotPresent",
+			ImagePullSecret: "test",
+			StorageConfig: &mcov1beta2.StorageConfig{
+				MetricObjectStorage: &mcoshared.PreConfiguredStorage{
+					Key:  "test",
+					Name: "test",
+				},
+				StorageClass:            "gp2",
+				AlertmanagerStorageSize: "1Gi",
+				CompactStorageSize:      "1Gi",
+				RuleStorageSize:         "1Gi",
+				ReceiveStorageSize:      "1Gi",
+				StoreStorageSize:        "1Gi",
+			},
+		},
+	}
+
+	clientCa := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "extension-apiserver-authentication",
+			Namespace: "kube-system",
+		},
+		Data: map[string]string{
+			"client-ca-file": "test",
+		},
+	}
+	s := runtime.NewScheme()
+	corev1.AddToScheme(s)
+	obsv1alpha1.AddToScheme(s)
+	testClient := fake.NewClientBuilder().WithScheme(s).WithObjects(clientCa).Build()
+	err = config.SetOperandNames(testClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	imageClient := &fakeimagev1client.FakeImageV1{Fake: &(fakeimageclient.NewSimpleClientset().Fake)}
+	_, err = imageClient.ImageStreams("openshift").Create(context.Background(),
+		&imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{Name: "oauth-proxy", Namespace: "openshift"},
+			Spec: imagev1.ImageStreamSpec{
+				Tags: []imagev1.TagReference{
+					{
+						Name: "v4.4",
+						From: &corev1.ObjectReference{
+							Kind: "DockerImage",
+							Name: "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+						},
+					},
+				},
+			},
+		}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name          string
+		profile       *ocinfrav1.TLSSecurityProfile
+		expectedMin   string
+		expectedCiph  []string
+		expectedProxy string
+	}{
+		{
+			name:          "nil profile",
+			profile:       nil,
+			expectedMin:   "VersionTLS12",
+			expectedCiph:  crypto.OpenSSLToIANACipherSuites(ocinfrav1.TLSProfiles[ocinfrav1.TLSProfileIntermediateType].Ciphers),
+			expectedProxy: "TLSv1.2",
+		},
+		{
+			name: "old profile",
+			profile: &ocinfrav1.TLSSecurityProfile{
+				Type: ocinfrav1.TLSProfileOldType,
+			},
+			expectedMin:   "VersionTLS10",
+			expectedCiph:  crypto.OpenSSLToIANACipherSuites(ocinfrav1.TLSProfiles[ocinfrav1.TLSProfileOldType].Ciphers),
+			expectedProxy: "TLSv1.0",
+		},
+		{
+			name: "intermediate profile",
+			profile: &ocinfrav1.TLSSecurityProfile{
+				Type: ocinfrav1.TLSProfileIntermediateType,
+			},
+			expectedMin:   "VersionTLS12",
+			expectedCiph:  crypto.OpenSSLToIANACipherSuites(ocinfrav1.TLSProfiles[ocinfrav1.TLSProfileIntermediateType].Ciphers),
+			expectedProxy: "TLSv1.2",
+		},
+		{
+			// The modern profile uses TLS 1.3, which requires no cipher suites because TLS 1.3 cipher suites
+			// are not configurable in Go and are handled automatically.
+			name: "modern profile",
+			profile: &ocinfrav1.TLSSecurityProfile{
+				Type: ocinfrav1.TLSProfileModernType,
+			},
+			expectedMin:   "VersionTLS13",
+			expectedCiph:  nil,
+			expectedProxy: "TLSv1.3",
+		},
+		{
+			name: "custom profile",
+			profile: &ocinfrav1.TLSSecurityProfile{
+				Type: ocinfrav1.TLSProfileCustomType,
+				Custom: &ocinfrav1.CustomTLSProfile{
+					TLSProfileSpec: ocinfrav1.TLSProfileSpec{
+						MinTLSVersion: ocinfrav1.VersionTLS11,
+						Ciphers:       []string{"AES128-SHA"}, // OpenSSL format
+					},
+				},
+			},
+			expectedMin:   "VersionTLS11",
+			expectedCiph:  []string{"TLS_RSA_WITH_AES_128_CBC_SHA"}, // IANA format
+			expectedProxy: "TLSv1.1",
+		},
+		{
+			name: "custom profile with nil custom spec falls back to intermediate",
+			profile: &ocinfrav1.TLSSecurityProfile{
+				Type: ocinfrav1.TLSProfileCustomType,
+			},
+			expectedMin:   "VersionTLS12",
+			expectedCiph:  crypto.OpenSSLToIANACipherSuites(ocinfrav1.TLSProfiles[ocinfrav1.TLSProfileIntermediateType].Ciphers),
+			expectedProxy: "TLSv1.2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			renderer := NewMCORenderer(mchcr, testClient, imageClient)
+			renderer.WithRendererOptions(&RendererOptions{
+				TLSProfile: tt.profile,
+				MCOAOptions: MCOARendererOptions{
+					MetricsHubHostname:             "test",
+					MetricsHubAlertmanagerHostname: "test",
+				},
+			})
+			objs, err := renderer.Render()
+			assert.NoError(t, err)
+
+			var foundProxy, foundGrafana, foundAlertmanager bool
+
+			for _, obj := range objs {
+				if obj.GetKind() == "Deployment" && obj.GetName() == config.GetOperandName(config.RBACQueryProxy) {
+					foundProxy = true
+					var dep appsv1.Deployment
+					err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &dep)
+					assert.NoError(t, err)
+
+					args1 := dep.Spec.Template.Spec.Containers[1].Args
+					assert.Contains(t, args1, "--tls-min-version="+tt.expectedProxy)
+
+					if len(tt.expectedCiph) > 0 {
+						cipherArg := "--tls-cipher-suites=" + strings.Join(tt.expectedCiph, ",")
+						assert.Contains(t, args1, cipherArg)
+					} else {
+						for _, arg := range args1 {
+							assert.NotContains(t, arg, "--tls-cipher-suites=")
+						}
+					}
+				}
+				if obj.GetKind() == "Deployment" && obj.GetName() == config.GetOperandName(config.Grafana) {
+					foundGrafana = true
+					var dep appsv1.Deployment
+					err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &dep)
+					assert.NoError(t, err)
+
+					args2 := dep.Spec.Template.Spec.Containers[2].Args
+					assert.Contains(t, args2, "--tls-min-version="+tt.expectedProxy)
+
+					if len(tt.expectedCiph) > 0 {
+						cipherArg := "--tls-cipher-suites=" + strings.Join(tt.expectedCiph, ",")
+						assert.Contains(t, args2, cipherArg)
+					} else {
+						for _, arg := range args2 {
+							assert.NotContains(t, arg, "--tls-cipher-suites=")
+						}
+					}
+				}
+				if obj.GetKind() == "StatefulSet" && obj.GetName() == config.GetOperandName(config.Alertmanager) {
+					foundAlertmanager = true
+					var sts appsv1.StatefulSet
+					err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &sts)
+					assert.NoError(t, err)
+
+					args2 := sts.Spec.Template.Spec.Containers[2].Args
+					assert.Contains(t, args2, "--tls-min-version="+tt.expectedProxy)
+
+					args3 := sts.Spec.Template.Spec.Containers[3].Args
+					assert.Contains(t, args3, "--tls-min-version="+tt.expectedMin)
+
+					if len(tt.expectedCiph) > 0 {
+						cipherArg := "--tls-cipher-suites=" + strings.Join(tt.expectedCiph, ",")
+						assert.Contains(t, args2, cipherArg)
+						assert.Contains(t, args3, cipherArg)
+					} else {
+						for _, arg := range args2 {
+							assert.NotContains(t, arg, "--tls-cipher-suites=")
+						}
+						for _, arg := range args3 {
+							assert.NotContains(t, arg, "--tls-cipher-suites=")
+						}
+					}
+				}
+			}
+
+			assert.True(t, foundProxy, "RBAC Query Proxy deployment not found")
+			assert.True(t, foundGrafana, "Grafana deployment not found")
+			assert.True(t, foundAlertmanager, "Alertmanager statefulset not found")
+		})
 	}
 }
 

--- a/operators/pkg/util/tls.go
+++ b/operators/pkg/util/tls.go
@@ -1,0 +1,139 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package util
+
+import (
+	"crypto/tls"
+	"reflect"
+	"sync"
+
+	ocinfrav1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+var (
+	tlsProfileMu   sync.RWMutex
+	currentProfile *ocinfrav1.TLSSecurityProfile
+)
+
+// SyncBaseTLSConfig updates the cached TLS profile for dynamic configuration.
+func SyncBaseTLSConfig(profile *ocinfrav1.TLSSecurityProfile) {
+	tlsProfileMu.Lock()
+	defer tlsProfileMu.Unlock()
+
+	if !reflect.DeepEqual(currentProfile, profile) {
+		log.Info("TLS profile updated", "old", currentProfile, "new", profile)
+		currentProfile = profile
+	}
+}
+
+func normalizeProfile(profile *ocinfrav1.TLSSecurityProfile) *ocinfrav1.TLSSecurityProfile {
+	if profile == nil {
+		return &ocinfrav1.TLSSecurityProfile{
+			Type: ocinfrav1.TLSProfileIntermediateType,
+		}
+	}
+	return profile
+}
+
+// GetTLSProfileStringMinVersion returns the string representation of the minimum TLS version for a given profile.
+func GetTLSProfileStringMinVersion(profile *ocinfrav1.TLSSecurityProfile) string {
+	profile = normalizeProfile(profile)
+	switch profile.Type {
+	case ocinfrav1.TLSProfileOldType:
+		return string(ocinfrav1.TLSProfiles[ocinfrav1.TLSProfileOldType].MinTLSVersion)
+	case ocinfrav1.TLSProfileIntermediateType:
+		return string(ocinfrav1.TLSProfiles[ocinfrav1.TLSProfileIntermediateType].MinTLSVersion)
+	case ocinfrav1.TLSProfileModernType:
+		return string(ocinfrav1.TLSProfiles[ocinfrav1.TLSProfileModernType].MinTLSVersion)
+	case ocinfrav1.TLSProfileCustomType:
+		if profile.Custom != nil {
+			return string(profile.Custom.MinTLSVersion)
+		}
+	}
+	return string(ocinfrav1.TLSProfiles[ocinfrav1.TLSProfileIntermediateType].MinTLSVersion)
+}
+
+// GetTLSProfileCiphers returns the cipher suites for a given profile in OpenSSL format.
+// Note: TLS 1.3 ciphers are not configurable in Go, so this returns nil for the Modern profile.
+func GetTLSProfileCiphers(profile *ocinfrav1.TLSSecurityProfile) []string {
+	profile = normalizeProfile(profile)
+	switch profile.Type {
+	case ocinfrav1.TLSProfileOldType:
+		return ocinfrav1.TLSProfiles[ocinfrav1.TLSProfileOldType].Ciphers
+	case ocinfrav1.TLSProfileIntermediateType:
+		return ocinfrav1.TLSProfiles[ocinfrav1.TLSProfileIntermediateType].Ciphers
+	case ocinfrav1.TLSProfileModernType:
+		// TLS 1.3 ciphers are not configurable in Go
+		return nil
+	case ocinfrav1.TLSProfileCustomType:
+		if profile.Custom != nil {
+			return profile.Custom.Ciphers
+		}
+	}
+	return ocinfrav1.TLSProfiles[ocinfrav1.TLSProfileIntermediateType].Ciphers
+}
+
+// GetTLSProfileIANACiphers returns the cipher suites for a given profile in IANA format.
+func GetTLSProfileIANACiphers(profile *ocinfrav1.TLSSecurityProfile) []string {
+	ciphers := GetTLSProfileCiphers(profile)
+	if len(ciphers) == 0 {
+		return nil
+	}
+	return crypto.OpenSSLToIANACipherSuites(ciphers)
+}
+
+// GetOauthProxyTLSMinVersion maps the configv1.TLSProtocolVersion to the format expected by oauth-proxy (e.g. TLSv1.2).
+func GetOauthProxyTLSMinVersion(profile *ocinfrav1.TLSSecurityProfile) string {
+	minVersion := GetTLSProfileStringMinVersion(profile)
+	switch minVersion {
+	case string(ocinfrav1.VersionTLS10):
+		return "TLSv1.0"
+	case string(ocinfrav1.VersionTLS11):
+		return "TLSv1.1"
+	case string(ocinfrav1.VersionTLS12):
+		return "TLSv1.2"
+	case string(ocinfrav1.VersionTLS13):
+		return "TLSv1.3"
+	default:
+		return "TLSv1.2"
+	}
+}
+
+// GetSupportedTLSConfig returns the default TLS configuration for the given profile.
+func GetSupportedTLSConfig(profile *ocinfrav1.TLSSecurityProfile) []func(*tls.Config) {
+	minVersion := GetTLSProfileStringMinVersion(profile)
+	ciphers := GetTLSProfileCiphers(profile)
+
+	goMinVersion, err := crypto.TLSVersion(minVersion)
+	if err != nil {
+		goMinVersion = tls.VersionTLS12
+	}
+	var goCiphers []uint16
+	if len(ciphers) > 0 {
+		var anyErr bool
+		ianaCiphers := crypto.OpenSSLToIANACipherSuites(ciphers)
+		for _, cipher := range ianaCiphers {
+			goCipher, err := crypto.CipherSuite(cipher)
+			if err != nil {
+				anyErr = true
+			} else {
+				goCiphers = append(goCiphers, goCipher)
+			}
+		}
+		if anyErr {
+			goCiphers = nil
+		}
+	}
+
+	return []func(*tls.Config){
+		func(t *tls.Config) {
+			t.MinVersion = goMinVersion
+			if len(goCiphers) > 0 {
+				t.CipherSuites = goCiphers
+			}
+		},
+	}
+}

--- a/operators/pkg/util/tls_dynamic.go
+++ b/operators/pkg/util/tls_dynamic.go
@@ -1,0 +1,33 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package util
+
+import (
+	"crypto/tls"
+)
+
+// GetDynamicTLSConfig returns a TLS configuration function that dynamically reads
+// the latest TLS profile without requiring a pod restart.
+func GetDynamicTLSConfig() []func(*tls.Config) {
+	return []func(*tls.Config){
+		func(t *tls.Config) {
+			t.GetConfigForClient = func(hi *tls.ClientHelloInfo) (*tls.Config, error) {
+				tlsProfileMu.RLock()
+				profile := currentProfile
+				tlsProfileMu.RUnlock()
+
+				cfg := t.Clone()
+				cfg.GetConfigForClient = nil
+
+				// Re-apply the GetSupportedTLSConfig onto the cloned config
+				for _, f := range GetSupportedTLSConfig(profile) {
+					f(cfg)
+				}
+
+				return cfg, nil
+			}
+		},
+	}
+}

--- a/operators/pkg/util/tls_helpers.go
+++ b/operators/pkg/util/tls_helpers.go
@@ -1,0 +1,32 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	ocinfrav1 "github.com/openshift/api/config/v1"
+)
+
+// AppendOauthProxyTLSArgs adds the appropriate --tls-min-version and --tls-cipher-suites flags
+// to the provided args slice based on the TLS security profile.
+func AppendOauthProxyTLSArgs(args []string, profile *ocinfrav1.TLSSecurityProfile) []string {
+	args = append(args, fmt.Sprintf("--tls-min-version=%s", GetOauthProxyTLSMinVersion(profile)))
+	if ciphers := GetTLSProfileIANACiphers(profile); len(ciphers) > 0 {
+		args = append(args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(ciphers, ",")))
+	}
+	return args
+}
+
+// AppendKubeRBACProxyTLSArgs adds the appropriate --tls-min-version and --tls-cipher-suites flags
+// to the provided args slice based on the TLS security profile.
+func AppendKubeRBACProxyTLSArgs(args []string, profile *ocinfrav1.TLSSecurityProfile) []string {
+	args = append(args, fmt.Sprintf("--tls-min-version=%s", GetTLSProfileStringMinVersion(profile)))
+	if ciphers := GetTLSProfileIANACiphers(profile); len(ciphers) > 0 {
+		args = append(args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(ciphers, ",")))
+	}
+	return args
+}

--- a/operators/pkg/util/tls_test.go
+++ b/operators/pkg/util/tls_test.go
@@ -1,0 +1,149 @@
+package util
+
+import (
+	"crypto/tls"
+	"testing"
+
+	ocinfrav1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTLSProfileStringMinVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		profile  *ocinfrav1.TLSSecurityProfile
+		expected string
+	}{
+		{
+			name:     "nil profile",
+			profile:  nil,
+			expected: string(ocinfrav1.TLSProfiles[ocinfrav1.TLSProfileIntermediateType].MinTLSVersion),
+		},
+		{
+			name: "custom profile with nil custom spec",
+			profile: &ocinfrav1.TLSSecurityProfile{
+				Type: ocinfrav1.TLSProfileCustomType,
+			},
+			expected: string(ocinfrav1.TLSProfiles[ocinfrav1.TLSProfileIntermediateType].MinTLSVersion),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GetTLSProfileStringMinVersion(tt.profile))
+		})
+	}
+}
+
+func TestGetTLSProfileCiphers(t *testing.T) {
+	tests := []struct {
+		name     string
+		profile  *ocinfrav1.TLSSecurityProfile
+		expected []string
+	}{
+		{
+			name:     "nil profile",
+			profile:  nil,
+			expected: ocinfrav1.TLSProfiles[ocinfrav1.TLSProfileIntermediateType].Ciphers,
+		},
+		{
+			name: "custom profile with nil custom spec",
+			profile: &ocinfrav1.TLSSecurityProfile{
+				Type: ocinfrav1.TLSProfileCustomType,
+			},
+			expected: ocinfrav1.TLSProfiles[ocinfrav1.TLSProfileIntermediateType].Ciphers,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GetTLSProfileCiphers(tt.profile))
+		})
+	}
+}
+
+func TestGetSupportedTLSConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		profile         *ocinfrav1.TLSSecurityProfile
+		expectedMinVer  uint16
+		expectedCiphers int
+	}{
+		{
+			name: "valid custom profile",
+			profile: &ocinfrav1.TLSSecurityProfile{
+				Type: ocinfrav1.TLSProfileCustomType,
+				Custom: &ocinfrav1.CustomTLSProfile{
+					TLSProfileSpec: ocinfrav1.TLSProfileSpec{
+						MinTLSVersion: ocinfrav1.VersionTLS11,
+						Ciphers:       []string{"AES128-SHA"}, // valid
+					},
+				},
+			},
+			expectedMinVer:  tls.VersionTLS11,
+			expectedCiphers: 1, // Will map to one IANA cipher
+		},
+		{
+			name: "invalid TLS version falls back to TLS 1.2",
+			profile: &ocinfrav1.TLSSecurityProfile{
+				Type: ocinfrav1.TLSProfileCustomType,
+				Custom: &ocinfrav1.CustomTLSProfile{
+					TLSProfileSpec: ocinfrav1.TLSProfileSpec{
+						MinTLSVersion: "VersionTLS1.99", // invalid
+						Ciphers:       []string{"AES128-SHA"},
+					},
+				},
+			},
+			expectedMinVer:  tls.VersionTLS12,
+			expectedCiphers: 1,
+		},
+		{
+			name: "invalid ciphers fall back to nil",
+			profile: &ocinfrav1.TLSSecurityProfile{
+				Type: ocinfrav1.TLSProfileCustomType,
+				Custom: &ocinfrav1.CustomTLSProfile{
+					TLSProfileSpec: ocinfrav1.TLSProfileSpec{
+						MinTLSVersion: ocinfrav1.VersionTLS12,
+						Ciphers:       []string{"INVALID-CIPHER"}, // invalid
+					},
+				},
+			},
+			expectedMinVer:  tls.VersionTLS12,
+			expectedCiphers: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			funcs := GetSupportedTLSConfig(tt.profile)
+			assert.Len(t, funcs, 1)
+
+			cfg := &tls.Config{}
+			funcs[0](cfg)
+
+			assert.Equal(t, tt.expectedMinVer, cfg.MinVersion)
+			assert.Len(t, cfg.CipherSuites, tt.expectedCiphers)
+		})
+	}
+}
+
+func TestGetDynamicTLSConfig(t *testing.T) {
+	// Set a known profile
+	SyncBaseTLSConfig(&ocinfrav1.TLSSecurityProfile{Type: ocinfrav1.TLSProfileModernType})
+
+	funcs := GetDynamicTLSConfig()
+	base := &tls.Config{}
+	funcs[0](base)
+
+	// Simulate a handshake
+	cfg, err := base.GetConfigForClient(&tls.ClientHelloInfo{})
+	assert.NoError(t, err)
+	assert.Equal(t, uint16(tls.VersionTLS13), cfg.MinVersion)
+	assert.Nil(t, cfg.GetConfigForClient) // recursion guard
+
+	// Update profile and verify it takes effect without re-initialization
+	SyncBaseTLSConfig(&ocinfrav1.TLSSecurityProfile{Type: ocinfrav1.TLSProfileIntermediateType})
+	cfg2, err := base.GetConfigForClient(&tls.ClientHelloInfo{})
+	assert.NoError(t, err)
+	assert.Equal(t, uint16(tls.VersionTLS12), cfg2.MinVersion)
+}


### PR DESCRIPTION
Fetch APIServer TLS profile and dynamically configure the manager webhook and metrics servers. Propagate TLS configuration to operand containers (OAuth proxy, Kube RBAC proxy) using appropriate TLS min versions and cipher suites. Watch APIServer config for changes. Include unit tests for profile mapping and dynamic configuration.
