### PR TITLE
wip: tests: fix e2e mcoa failure by waiting for config hash in CMA update

### DIFF
--- a/tests/pkg/tests/observability_mcoa_test.go
+++ b/tests/pkg/tests/observability_mcoa_test.go
@@ -120,6 +120,7 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 					Expect(utils.CreateScrapeConfig(testOptions, customScrapeConfigCR, "platform-metrics-collector", []string{fmt.Sprintf(`{__name__="%s"}`, customMetricName)})).NotTo(HaveOccurred())
 					Expect(
 						utils.AddConfigToPlacementInClusterManagementAddon(
+							ctx,
 							testOptions,
 							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
 							globalPlacementName,
@@ -166,6 +167,7 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 					Expect(utils.CreatePrometheusRule(testOptions, ruleName, utils.MCO_NAMESPACE, "platform-metrics-collector", ruleMetricName, "")).NotTo(HaveOccurred())
 					Expect(
 						utils.AddConfigToPlacementInClusterManagementAddon(
+							context.Background(),
 							testOptions,
 							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
 							globalPlacementName,
@@ -180,6 +182,7 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 					Expect(utils.CreateScrapeConfig(testOptions, scrapeConfigName, "platform-metrics-collector", []string{fmt.Sprintf(`{__name__="%s"}`, ruleMetricName)})).NotTo(HaveOccurred())
 					Expect(
 						utils.AddConfigToPlacementInClusterManagementAddon(
+							context.Background(),
 							testOptions,
 							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
 							globalPlacementName,
@@ -269,6 +272,7 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 					Expect(utils.CreatePrometheusRule(testOptions, ruleName, utils.MCO_NAMESPACE, "user-workload-metrics-collector", ruleMetricName, "default")).NotTo(HaveOccurred())
 					Expect(
 						utils.AddConfigToPlacementInClusterManagementAddon(
+							ctx,
 							testOptions,
 							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
 							globalPlacementName,
@@ -283,6 +287,7 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 					Expect(utils.CreateScrapeConfig(testOptions, scrapeConfigName, "user-workload-metrics-collector", []string{fmt.Sprintf(`{__name__="%s"}`, ruleMetricName)})).NotTo(HaveOccurred())
 					Expect(
 						utils.AddConfigToPlacementInClusterManagementAddon(
+							ctx,
 							testOptions,
 							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
 							globalPlacementName,

--- a/tests/pkg/utils/clustermanagementaddon.go
+++ b/tests/pkg/utils/clustermanagementaddon.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -34,6 +35,7 @@ var (
 )
 
 func AddConfigToPlacementInClusterManagementAddon(
+	ctx context.Context,
 	opt TestOptions,
 	name string,
 	placementName string,
@@ -50,7 +52,7 @@ func AddConfigToPlacementInClusterManagementAddon(
 		// Cap:      10 * time.Second,
 	}
 	retryErr := retry.RetryOnConflict(backoffConfig, func() error {
-		cma, err := clientDynamic.Resource(clusterManagementAddonGVR).Get(context.TODO(), name, metav1.GetOptions{})
+		cma, err := clientDynamic.Resource(clusterManagementAddonGVR).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to get ClusterManagementAddon %s: %w", name, err)
 		}
@@ -104,7 +106,7 @@ func AddConfigToPlacementInClusterManagementAddon(
 			return fmt.Errorf("failed to set installStrategy in ClusterManagementAddon: %w", err)
 		}
 
-		_, err = clientDynamic.Resource(clusterManagementAddonGVR).Update(context.TODO(), cma, metav1.UpdateOptions{})
+		_, err = clientDynamic.Resource(clusterManagementAddonGVR).Update(ctx, cma, metav1.UpdateOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to update ClusterManagementAddon: %w", err)
 		}
@@ -124,7 +126,7 @@ func AddConfigToPlacementInClusterManagementAddon(
 	// Waiting for the newly added config's hash to be populated confirms that the
 	// addonconfig-controller completed its pass and all hashes — including AddOnDeploymentConfig
 	// — are populated again.
-	return waitForConfigHashPopulated(context.Background(), opt, name, configGVR, configName, configNamespace)
+	return waitForConfigHashPopulated(ctx, opt, name, configGVR, configName, configNamespace)
 }
 
 const (
@@ -154,7 +156,13 @@ func waitForConfigHashPopulated(ctx context.Context, opt TestOptions, addonName 
 				Namespace(cluster.Name).
 				Get(ctx, addonName, metav1.GetOptions{})
 			if err != nil {
-				return false, nil // transient, retry
+				if apierrors.IsNotFound(err) ||
+					apierrors.IsTimeout(err) ||
+					apierrors.IsServerTimeout(err) ||
+					apierrors.IsTooManyRequests(err) {
+					return false, nil // transient, retry
+				}
+				return false, err // permanent error (Forbidden, Unauthorized, BadRequest, …), stop polling
 			}
 
 			configRefs, found, err := unstructured.NestedSlice(mca.Object, "status", "configReferences")

--- a/tests/pkg/utils/clustermanagementaddon.go
+++ b/tests/pkg/utils/clustermanagementaddon.go
@@ -49,7 +49,7 @@ func AddConfigToPlacementInClusterManagementAddon(
 		Jitter:   0.1,
 		// Cap:      10 * time.Second,
 	}
-	return retry.RetryOnConflict(backoffConfig, func() error {
+	retryErr := retry.RetryOnConflict(backoffConfig, func() error {
 		cma, err := clientDynamic.Resource(clusterManagementAddonGVR).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to get ClusterManagementAddon %s: %w", name, err)
@@ -110,6 +110,88 @@ func AddConfigToPlacementInClusterManagementAddon(
 		}
 
 		return nil
+	})
+	if retryErr != nil {
+		return retryErr
+	}
+
+	// When a config is added to the CMA, the OCM hub controller fully replaces
+	// MCA.Status.ConfigReferences with a new list that includes the added config but has every
+	// DesiredConfig.SpecHash set to "". The addonconfig-controller then repopulates all hashes
+	// asynchronously. Until it does, any controller reading the AddOnDeploymentConfig hash
+	// (addon-registration-controller, addon-deploy-controller) errors with "deployment config
+	// desired spec hash is empty" and keeps requeuing, preventing config propagation to spokes.
+	// Waiting for the newly added config's hash to be populated confirms that the
+	// addonconfig-controller completed its pass and all hashes — including AddOnDeploymentConfig
+	// — are populated again.
+	return waitForConfigHashPopulated(context.Background(), opt, name, configGVR, configName, configNamespace)
+}
+
+const (
+	addonConfigHashPollInterval = 2 * time.Second
+	addonConfigHashPollTimeout  = 2 * time.Minute
+)
+
+// waitForConfigHashPopulated polls until the given config appears with a non-empty
+// desiredConfig.specHash in the status.configReferences of every ManagedClusterAddon for the
+// given addon. This signals that the addonconfig-controller has fully processed the CMA update
+// and all spec hashes in MCA.Status.ConfigReferences have been repopulated.
+func waitForConfigHashPopulated(ctx context.Context, opt TestOptions, addonName string, configGVR schema.GroupVersionResource, configName, configNamespace string) error {
+	clientDynamic := GetKubeClientDynamic(opt, true)
+	mcaGVR := NewMCOManagedClusterAddonsGVR()
+
+	return wait.PollUntilContextTimeout(ctx, addonConfigHashPollInterval, addonConfigHashPollTimeout, true, func(ctx context.Context) (bool, error) {
+		managedClusters, err := GetAvailableManagedClusters(opt)
+		if err != nil {
+			return false, nil // transient, retry
+		}
+		if len(managedClusters) == 0 {
+			return false, nil // no clusters registered yet, retry
+		}
+
+		for _, cluster := range managedClusters {
+			mca, err := clientDynamic.Resource(mcaGVR).
+				Namespace(cluster.Name).
+				Get(ctx, addonName, metav1.GetOptions{})
+			if err != nil {
+				return false, nil // transient, retry
+			}
+
+			configRefs, found, err := unstructured.NestedSlice(mca.Object, "status", "configReferences")
+			if err != nil {
+				return false, fmt.Errorf("failed to read status.configReferences from ManagedClusterAddon %s/%s: %w", cluster.Name, addonName, err)
+			}
+			if !found {
+				return false, nil // status not yet written, retry
+			}
+
+			newConfigFound := false
+			for _, ref := range configRefs {
+				refMap, ok := ref.(map[string]any)
+				if !ok {
+					continue
+				}
+				// All hashes must be non-empty: the OCM hub controller wipes every
+				// DesiredConfig.SpecHash when it rewrites MCA.Status.ConfigReferences, so any
+				// empty hash means the addonconfig-controller hasn't finished its pass yet.
+				specHash, _, _ := unstructured.NestedString(refMap, "desiredConfig", "specHash")
+				if specHash == "" {
+					return false, nil // at least one hash still empty, retry
+				}
+				group, _, _ := unstructured.NestedString(refMap, "group")
+				resource, _, _ := unstructured.NestedString(refMap, "resource")
+				name, _, _ := unstructured.NestedString(refMap, "desiredConfig", "name")
+				namespace, _, _ := unstructured.NestedString(refMap, "desiredConfig", "namespace")
+				if group == configGVR.Group && resource == configGVR.Resource && name == configName && namespace == configNamespace {
+					newConfigFound = true
+				}
+			}
+			if !newConfigFound {
+				return false, nil // newly added config not yet in MCA status, retry
+			}
+		}
+
+		return true, nil
 	})
 }
 


### PR DESCRIPTION
Ensure AddConfigToPlacementInClusterManagementAddon waits for the addonconfig-controller to repopulate spec hashes in MCA status. This prevents race conditions where empty hashes cause propagation failures to managed clusters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened addon configuration tests to verify updates are fully propagated and confirmed across all managed clusters, including validation that per-cluster config references are populated.
  * Made test invocations more consistent and robust by passing explicit context to relevant operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->