### PR TITLE
fix grafana dashboards reloader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,8 +154,12 @@ integration-test-operators: ## Run operators integration tests.
 integration-test-proxy: ## Run proxy integration tests.
 	go test -tags=integration ./proxy/...
 
+.PHONY: integration-test-loaders
+integration-test-loaders: ## Run loaders integration tests.
+	go test -tags=integration ./loaders/...
+
 .PHONY: integration-test
-integration-test: integration-test-operators integration-test-proxy ## Run all integration tests.
+integration-test: integration-test-operators integration-test-proxy integration-test-loaders ## Run all integration tests.
 
 .PHONY: e2e-tests
 e2e-tests: tools ## Run E2E tests.

--- a/dev-scripts/manifests/storage/minio-deployment.yaml
+++ b/dev-scripts/manifests/storage/minio-deployment.yaml
@@ -14,8 +14,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
-        fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/dev-scripts/teardown-acm.sh
+++ b/dev-scripts/teardown-acm.sh
@@ -88,12 +88,15 @@ fi
 # Remove cluster-scoped artifacts that can block namespace deletion if the MCH
 # operator did not fully clean them up (e.g. on an aborted previous teardown).
 # These are safe to delete unconditionally — they are recreated on reinstall.
-log_info "Removing cluster-scoped MCE artifacts..."
+log_info "Removing cluster-scoped MCE/ACM artifacts..."
 oc delete apiservice \
   v1.admission.cluster.open-cluster-management.io \
   v1.admission.work.open-cluster-management.io \
   --ignore-not-found
-oc delete validatingwebhookconfiguration multiclusterengines.multicluster.openshift.io \
+# Validating webhooks can block namespace deletion if the underlying service is gone.
+oc delete validatingwebhookconfiguration \
+  multiclusterengines.multicluster.openshift.io \
+  multiclusterhub.validating-webhook.open-cluster-management.io \
   --ignore-not-found
 oc delete mce --all --ignore-not-found --wait=false
 
@@ -137,6 +140,13 @@ if command -v jq &>/dev/null; then
     jq -r '.items[] | select(.metadata.deletionTimestamp != null) | .metadata.name')
 fi
 
+# MultiClusterHub finalizer can get stuck if the webhook is gone.
+if $mch_exists; then
+  log_info "Ensuring MultiClusterHub finalizers are cleared..."
+  oc patch multiclusterhub multiclusterhub -n "${ACM_NS}" \
+    --type=merge -p '{"metadata":{"finalizers":null}}' 2>/dev/null || true
+fi
+
 # Now tell OLM to stop managing both operators.
 log_info "Removing ACM OLM resources (CSV and Subscription)..."
 oc delete csv --all -n "${ACM_NS}" --ignore-not-found
@@ -165,5 +175,15 @@ wait_for_deletion namespace open-cluster-management-agent "" 120
 wait_for_deletion namespace open-cluster-management-agent-addon "" 120
 wait_for_deletion namespace open-cluster-management-policies "" 60
 wait_for_deletion namespace hypershift "" 120
+
+# Final safety check: if namespaces are still stuck in Terminating, force-strip finalizers.
+for _ns in "${_acm_namespaces[@]}"; do
+  if oc get namespace "$_ns" 2>/dev/null | grep -q Terminating; then
+    log_warn "Namespace $_ns is stuck in Terminating. Forcefully stripping finalizers..."
+    oc get namespace "$_ns" -o json | jq '.spec.finalizers = []' >"/tmp/finalize-$_ns.json"
+    oc replace --raw "/api/v1/namespaces/$_ns/finalize" -f "/tmp/finalize-$_ns.json" &>/dev/null || true
+    rm "/tmp/finalize-$_ns.json"
+  fi
+done
 
 log_info "ACM removed."

--- a/loaders/dashboards/README.md
+++ b/loaders/dashboards/README.md
@@ -1,17 +1,45 @@
-# grafana-dashboard-loader
+# Grafana Dashboard Loader
 
-Sidecar proxy to load grafana dashboards from configmaps.
+The Grafana Dashboard Loader is a high-performance, stateless sidecar that synchronizes Kubernetes ConfigMaps containing Grafana JSON definitions into a local Grafana instance. It implements an **Exclusive Ownership** model where Kubernetes is the absolute source of truth.
 
-## Prerequisites
+## Core Features
 
-- You must install [Open Cluster Management Observabilty](https://github.com/stolostron/multicluster-observability-operator)
+- **Kubernetes-Native Architecture**: Uses a Kubernetes workqueue with exponential backoff for robust, resilient synchronization.
+- **Exclusive Ownership**: The loader assumes total control over the Grafana instance's dashboard space.
+- **Dynamic Folder Management**: Supports moving dashboards between folders using the `observability.open-cluster-management.io/dashboard-folder` annotation.
+- **Hybrid Deletion Model**: Combines immediate in-memory tracking for responsive deletions with a 10-minute "Total Sweep" safety net for correctness.
+- **Home Dashboard Sync**: Automatically sets a specific dashboard as the Grafana "Home" page based on ConfigMap annotations.
 
-## How to build image
+## How it works (Source of Truth)
 
+Unlike traditional loaders that rely on tagging or external databases, this loader treats the **Kubernetes API** as the absolute source of truth.
+
+1.  **Deterministic UIDs**: Every dashboard is assigned a stable UID derived from its source ConfigMap (`namespace/name/key`). This ensures that dashboards maintain their identity and URL even if the loader restarts.
+2.  **Total Control**: The loader periodically lists *all* dashboards in the Grafana instance. Any dashboard that does not have a corresponding ConfigMap in Kubernetes is considered an "orphan" and is automatically deleted.
+3.  **Always Overwrite**: To ensure consistency, the loader always overwrites existing dashboards in Grafana with the content from Kubernetes. Manual changes made in the Grafana UI are intentionally disregarded and will be reverted on the next sync cycle.
+
+### ⚠️ Operational Warning
+Because this loader assumes **Exclusive Ownership**, any dashboard created manually in the Grafana UI (without a corresponding ConfigMap) will be deleted during the periodic "Total Sweep" cycle. Always manage your dashboards via Kubernetes manifests.
+
+## Configuration
+
+### Desired ConfigMaps
+The loader watches for ConfigMaps that match **either** of the following criteria:
+1. Label `grafana-custom-dashboard: "true"` is present.
+2. The ConfigMap is owned by a `MultiClusterObservability` resource and its name contains `grafana-dashboard`.
+
+### Supported Annotations & Labels
+- `observability.open-cluster-management.io/dashboard-folder`: (Annotation) The title of the Grafana folder where the dashboard should be placed. Defaults to `Custom`.
+- `general-folder: "true"`: (Label) If set to true, the dashboard is placed in the "General" folder (ID 0).
+- `set-home-dashboard: "true"`: (Annotation) If set on the ConfigMap, the loader will attempt to set the primary dashboard in this CM as the Grafana Home page.
+
+## Development
+
+### How to build image
 ```bash
-docker build -f Dockerfile.prow -t grafana-dashboard-loader:latest .
+make docker-build-local  # Targeted at the loader component
 ```
 
-Now, you can use this image to replace the grafana-dashboard-loader component and verify your PRs.
-
-Rebuild Image: Thu Aug 18 15:00:45 EDT 2022
+### Running Tests
+- **Unit Tests**: `go test ./loaders/dashboards/pkg/controller/...`
+- **Integration Tests**: `make integration-test-loaders` (Uses `envtest` to run against a real control plane).

--- a/loaders/dashboards/cmd/main.go
+++ b/loaders/dashboards/cmd/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 	"os/signal"
@@ -12,25 +13,48 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/stolostron/multicluster-observability-operator/loaders/dashboards/pkg/controller"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 )
 
 func main() {
+	// Initialize klog flags using a separate FlagSet to avoid polluting the global one.
 	klogFlags := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	klog.InitFlags(klogFlags)
+
+	// Set up pflag and bridge the klog flags into it.
 	flagset := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
 	flagset.AddGoFlagSet(klogFlags)
 
-	// use a channel to synchronize the finalization for a graceful shutdown
-	stop := make(chan struct{})
-	defer close(stop)
+	var grafanaURI string
+	flagset.StringVar(&grafanaURI, "grafana-uri", "http://127.0.0.1:3001", "The URI of the Grafana server.")
 
-	controller.RunGrafanaDashboardController(stop)
+	// Parse flags
+	if err := flagset.Parse(os.Args[1:]); err != nil {
+		klog.Fatalf("failed to parse flags: %v", err)
+	}
 
-	// use a channel to handle OS signals to terminate and gracefully shut
-	// down processing
-	sigTerm := make(chan os.Signal, 1)
-	signal.Notify(sigTerm, syscall.SIGTERM)
-	signal.Notify(sigTerm, syscall.SIGINT)
-	<-sigTerm
+	// Set up context that is canceled on OS signals
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	// Build kubeconfig and client
+	config, err := clientcmd.BuildConfigFromFlags("", "")
+	if err != nil {
+		klog.Fatalf("failed to get cluster config: %v", err)
+	}
+	kubeClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		klog.Fatalf("failed to build kubeclient: %v", err)
+	}
+
+	// Initialize and run the controller
+	c, err := controller.NewGrafanaDashboardController(kubeClient.CoreV1(), grafanaURI)
+	if err != nil {
+		klog.Fatalf("failed to create controller: %v", err)
+	}
+	if err := c.Run(ctx); err != nil {
+		klog.Fatalf("controller failed: %v", err)
+	}
 }

--- a/loaders/dashboards/pkg/controller/dashboard_controller.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller.go
@@ -189,7 +189,7 @@ func (c *GrafanaDashboardController) processNextItem(ctx context.Context, queue 
 	}
 
 	if queue.NumRequeues(obj) < c.maxDashboardRetry {
-		klog.V(1).InfoS("syncing dashboard failed, retrying", "object", obj, "error", err)
+		klog.ErrorS(err, "syncing dashboard failed, retrying", "object", obj)
 		queue.AddRateLimited(obj)
 		return true
 	}

--- a/loaders/dashboards/pkg/controller/dashboard_controller.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller.go
@@ -48,6 +48,7 @@ const (
 	permissionsRetryDelay    = 5 * time.Second
 	defaultMaxDashboardRetry = 40
 	resyncPeriod             = 10 * time.Minute
+	reconcileTimeout         = 2 * time.Minute
 )
 
 type trackedState struct {
@@ -66,7 +67,12 @@ type GrafanaDashboardController struct {
 	// uidMap tracks which Grafana UIDs and folders are associated with a given ConfigMap (key).
 	// This allows for immediate deletion of dashboards and empty folders when a ConfigMap is removed or moved.
 	uidMap map[string]trackedState
-	mapMu  sync.RWMutex
+
+	// reconcileMu ensures that only one reconciliation operation (ConfigMap update, deletion,
+	// or total orphan sweep) interacts with the Grafana API and the internal state at a time.
+	// This prevents race conditions between the incremental worker and the periodic sweep.
+	// We use a channel as a semaphore to support context-aware locking and timeouts.
+	reconcileMu chan struct{}
 }
 
 // NewGrafanaDashboardController creates a new GrafanaDashboardController
@@ -87,13 +93,16 @@ func NewGrafanaDashboardController(kubeClient corev1client.CoreV1Interface, uri 
 		ns = "open-cluster-management-observability"
 		klog.InfoS("POD_NAMESPACE environment variable is empty. Defaulting to standard observability namespace.", "namespace", ns)
 	}
-	return &GrafanaDashboardController{
+	c := &GrafanaDashboardController{
 		kubeClient:        kubeClient,
 		grafana:           &grafanaClient{uri: uri},
 		maxDashboardRetry: defaultMaxDashboardRetry,
 		watchedNS:         ns,
 		uidMap:            make(map[string]trackedState),
-	}, nil
+		reconcileMu:       make(chan struct{}, 1),
+	}
+	c.reconcileMu <- struct{}{}
+	return c, nil
 }
 
 // Run runs the controller until the context is canceled.
@@ -144,7 +153,9 @@ func (c *GrafanaDashboardController) Run(ctx context.Context) error {
 	// Periodically run orphan cleanup to catch any missed deletions and ghost folders.
 	wg.Go(func() {
 		wait.UntilWithContext(ctx, func(ctx context.Context) {
-			if err := c.cleanupOrphanDashboards(ctx, c.indexer); err != nil {
+			tCtx, cancel := context.WithTimeout(ctx, reconcileTimeout)
+			defer cancel()
+			if err := c.cleanupOrphanDashboards(tCtx, c.indexer); err != nil {
 				klog.ErrorS(err, "periodic orphan cleanup failed")
 			}
 		}, resyncPeriod)
@@ -167,7 +178,10 @@ func (c *GrafanaDashboardController) processNextItem(ctx context.Context, queue 
 	}
 	defer queue.Done(obj)
 
-	err := c.syncHandler(ctx, obj, indexer)
+	tCtx, cancel := context.WithTimeout(ctx, reconcileTimeout)
+	defer cancel()
+
+	err := c.syncHandler(tCtx, obj, indexer)
 	if err == nil {
 		queue.Forget(obj)
 		return true
@@ -215,12 +229,31 @@ func (c *GrafanaDashboardController) syncHandler(ctx context.Context, item any, 
 	return c.updateDashboard(ctx, cm)
 }
 
-func (c *GrafanaDashboardController) deleteTrackedUIDs(ctx context.Context, key string) error {
-	c.mapMu.Lock()
-	state, exists := c.uidMap[key]
-	// We don't delete from map immediately. We only delete if all UIDs are successfully removed.
-	c.mapMu.Unlock()
+func (c *GrafanaDashboardController) lockReconcile(ctx context.Context) error {
+	select {
+	case <-c.reconcileMu:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
 
+func (c *GrafanaDashboardController) unlockReconcile() {
+	select {
+	case c.reconcileMu <- struct{}{}:
+	default:
+		// Should not happen if used correctly
+		klog.Error("reconcileMu semaphore already full during unlock")
+	}
+}
+
+func (c *GrafanaDashboardController) deleteTrackedUIDs(ctx context.Context, key string) error {
+	if err := c.lockReconcile(ctx); err != nil {
+		return err
+	}
+	defer c.unlockReconcile()
+
+	state, exists := c.uidMap[key]
 	if !exists {
 		return nil
 	}
@@ -238,19 +271,15 @@ func (c *GrafanaDashboardController) deleteTrackedUIDs(ctx context.Context, key 
 
 	if len(failedUIDs) > 0 {
 		// Update the map to only track what's left
-		c.mapMu.Lock()
 		c.uidMap[key] = trackedState{
 			uids:   failedUIDs,
 			folder: state.folder,
 		}
-		c.mapMu.Unlock()
 		return errors.Join(errs...)
 	}
 
 	// All deleted successfully
-	c.mapMu.Lock()
 	delete(c.uidMap, key)
-	c.mapMu.Unlock()
 
 	if state.folder != "" {
 		c.cleanupFolderIfEmpty(ctx, state.folder)
@@ -322,6 +351,11 @@ func (c *GrafanaDashboardController) shouldEnqueue(oldCm, newCm *corev1.ConfigMa
 }
 
 func (c *GrafanaDashboardController) cleanupOrphanDashboards(ctx context.Context, indexer cache.Indexer) error {
+	if err := c.lockReconcile(ctx); err != nil {
+		return err
+	}
+	defer c.unlockReconcile()
+
 	klog.InfoS("scanning for orphan dashboards in Grafana")
 	dashboards, err := c.grafana.ListAllDashboards(ctx)
 	if err != nil {
@@ -378,15 +412,27 @@ func (c *GrafanaDashboardController) cleanupOrphanDashboards(ctx context.Context
 	}
 
 	// Update the controller's map with the fresh state discovered from Kubernetes.
-	// Note on Map Overwrite Race: This performs a full overwrite of c.uidMap, which could
-	// theoretically overwrite a concurrent syncHandler update. However, because this
-	// runs periodically and rebuilds state from the informer cache, the worst-case
-	// scenario is that an immediate deletion is delayed until the next sweep (10 minutes).
-	// This is an acceptable tradeoff for the simplicity of the current implementation.
-	c.mapMu.Lock()
-	c.uidMap = newUIDMap
-	c.mapMu.Unlock()
+	// We perform a surgical update instead of a full overwrite to minimize the risk
+	// of overwriting a concurrent syncHandler update for a specific ConfigMap.
+	// 1. Remove keys from the map that are no longer present in Kubernetes as desired dashboards.
+	for key := range c.uidMap {
+		if _, exists := newUIDMap[key]; !exists {
+			delete(c.uidMap, key)
+		}
+	}
+	// 2. Update/Add keys from the fresh scan.
+	// We only overwrite the state for a ConfigMap if the desired UIDs or folder changed.
+	// This preserves any "failed deletions" (extra UIDs) that updateDashboard might
+	// be tracking, ensuring they continue to be retried until they successfully
+	// vanish from Grafana.
+	for key, newState := range newUIDMap {
+		oldState, exists := c.uidMap[key]
+		if !exists || oldState.folder != newState.folder || !uidsMatch(oldState.uids, newState.uids) {
+			c.uidMap[key] = newState
+		}
+	}
 
+	folderUIDsWithDashboards := make(map[string]struct{})
 	for _, d := range dashboards {
 		select {
 		case <-ctx.Done():
@@ -398,11 +444,13 @@ func (c *GrafanaDashboardController) cleanupOrphanDashboards(ctx context.Context
 			if err := c.grafana.DeleteDashboard(ctx, d.UID); err != nil {
 				klog.ErrorS(err, "failed to delete orphan dashboard", "uid", d.UID)
 			}
+		} else if d.FolderUID != "" {
+			folderUIDsWithDashboards[d.FolderUID] = struct{}{}
 		}
 	}
 
 	// orphan deletion may leave folders empty; this is a catch-all sweep.
-	c.cleanupAllEmptyFolders(ctx)
+	c.cleanupAllEmptyFolders(ctx, folderUIDsWithDashboards)
 	return nil
 }
 
@@ -445,7 +493,11 @@ func (c *GrafanaDashboardController) createCustomFolder(ctx context.Context, fol
 
 	// check permissions
 	hasPerm, err := c.grafana.HasPermissions(ctx, folder.UID)
-	if err == nil && !hasPerm {
+	if err != nil {
+		klog.ErrorS(err, "failed to check folder permissions", "folderTitle", folderTitle)
+		return 0
+	}
+	if !hasPerm {
 		klog.InfoS("failed to set permissions for folder. Deleting folder and retrying later.", "folderTitle", folderTitle)
 		select {
 		case <-ctx.Done():
@@ -485,7 +537,7 @@ func (c *GrafanaDashboardController) cleanupFolderIfEmpty(ctx context.Context, f
 		if empty {
 			klog.InfoS("deleting empty folder", "title", folderTitle, "uid", folder.UID)
 			if err := c.grafana.DeleteFolder(ctx, folder.UID); err != nil {
-				klog.ErrorS(err, "failed to cleanup empty folder", "folderTitle", folderTitle)
+				klog.ErrorS(err, "failed to cleanup empty folder", "folderTitle", folderTitle, "folderUID", folder.UID)
 			}
 			return true, nil
 		}
@@ -497,7 +549,7 @@ func (c *GrafanaDashboardController) cleanupFolderIfEmpty(ctx context.Context, f
 	}
 }
 
-func (c *GrafanaDashboardController) cleanupAllEmptyFolders(ctx context.Context) {
+func (c *GrafanaDashboardController) cleanupAllEmptyFolders(ctx context.Context, folderUIDsWithDashboards map[string]struct{}) {
 	klog.InfoS("scanning for empty folders in Grafana")
 	folders, err := c.grafana.ListFolders(ctx)
 	if err != nil {
@@ -510,11 +562,10 @@ func (c *GrafanaDashboardController) cleanupAllEmptyFolders(ctx context.Context)
 			continue
 		}
 
-		empty, err := c.grafana.IsEmpty(ctx, folder.UID)
-		if err == nil && empty {
+		if _, hasDashboards := folderUIDsWithDashboards[folder.UID]; !hasDashboards {
 			klog.InfoS("deleting empty folder during total sweep", "folderTitle", folder.Title, "uid", folder.UID)
 			if err := c.grafana.DeleteFolder(ctx, folder.UID); err != nil {
-				klog.ErrorS(err, "failed to delete empty folder", "folderTitle", folder.Title)
+				klog.ErrorS(err, "failed to delete empty folder", "folderTitle", folder.Title, "folderUID", folder.UID)
 			}
 		}
 	}
@@ -538,7 +589,10 @@ func (c *GrafanaDashboardController) resolveDashboardUID(dashboard map[string]an
 	// 1. If key matches CM name (common case), use CM name to keep legacy UID.
 	// 2. Otherwise, use name-key to ensure uniqueness.
 	nameArg := cm.GetName()
-	keyBase := strings.TrimSuffix(key, ".json")
+	keyBase := key
+	for _, suffix := range []string{".json", ".yaml", ".yml"} {
+		keyBase = strings.TrimSuffix(keyBase, suffix)
+	}
 	if keyBase != cm.GetName() && !strings.Contains(cm.GetName(), keyBase) {
 		nameArg = cm.GetName() + "-" + keyBase
 	}
@@ -556,6 +610,11 @@ func (c *GrafanaDashboardController) resolveDashboardUID(dashboard map[string]an
 // pattern while still supporting multi-dashboard ConfigMaps by accumulating errors and
 // ensuring sibling dashboards are not blocked by a failure in one.
 func (c *GrafanaDashboardController) updateDashboard(ctx context.Context, newObj *corev1.ConfigMap) error {
+	if err := c.lockReconcile(ctx); err != nil {
+		return err
+	}
+	defer c.unlockReconcile()
+
 	var folderID int64
 	folderTitle := getDashboardCustomFolderTitle(newObj)
 	if folderTitle != "" {
@@ -604,7 +663,7 @@ func (c *GrafanaDashboardController) updateDashboard(ctx context.Context, newObj
 		// by the cleanup phase below.
 		currentUIDs = append(currentUIDs, uid)
 		dashboard["uid"] = uid
-		dashboard["id"] = nil
+		delete(dashboard, "id")
 
 		id, err := c.grafana.CreateOrUpdateDashboard(ctx, dashboard, folderID)
 		if err != nil {
@@ -634,9 +693,7 @@ func (c *GrafanaDashboardController) updateDashboard(ctx context.Context, newObj
 	// Immediate cleanup for keys removed from this ConfigMap.
 	// We compare the UIDs we just identified as desired (currentUIDs) against
 	// the UIDs we knew about from the previous successful reconcile (oldUIDs).
-	c.mapMu.RLock()
 	oldState := c.uidMap[cmKey]
-	c.mapMu.RUnlock()
 
 	// Find UIDs that were in the map but are not in the current ConfigMap data
 	currentSet := make(map[string]struct{}, len(currentUIDs))
@@ -659,16 +716,14 @@ func (c *GrafanaDashboardController) updateDashboard(ctx context.Context, newObj
 	}
 
 	// Update the map with current state + those that failed to delete.
-	c.mapMu.Lock()
 	c.uidMap[cmKey] = trackedState{
 		uids:   append(currentUIDs, failedDeletions...),
 		folder: folderTitle,
 	}
-	c.mapMu.Unlock()
 
 	// Perform immediate folder cleanup.
 	// 1. Check the CURRENT folder (in case all dashboards were removed from it but CM still exists)
-	if folderTitle != "" {
+	if folderTitle != "" && len(currentUIDs) == 0 {
 		c.cleanupFolderIfEmpty(ctx, folderTitle)
 	}
 	// 2. Check the OLD folder (if it changed)
@@ -725,4 +780,24 @@ func getDashboardCustomFolderTitle(cm *corev1.ConfigMap) string {
 	}
 
 	return DefaultCustomFolder
+}
+
+// uidsMatch returns true if all UIDs in the new set are already present in the old set.
+// This is used to detect if the "Desired" state from Kubernetes has changed, while
+// allowing the "Old" state to contain additional UIDs (failed deletions) that
+// we want to preserve.
+func uidsMatch(oldUIDs, newUIDs []string) bool {
+	if len(newUIDs) > len(oldUIDs) {
+		return false
+	}
+	oldSet := make(map[string]struct{}, len(oldUIDs))
+	for _, u := range oldUIDs {
+		oldSet[u] = struct{}{}
+	}
+	for _, u := range newUIDs {
+		if _, exists := oldSet[u]; !exists {
+			return false
+		}
+	}
+	return true
 }

--- a/loaders/dashboards/pkg/controller/dashboard_controller.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller.go
@@ -5,76 +5,647 @@
 package controller
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
+	"net/url"
 	"os"
-	"regexp"
-	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/stolostron/multicluster-observability-operator/loaders/dashboards/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 )
 
 const (
-	unmarshallErrMsg    = "Failed to unmarshall response body"
-	customFolderKey     = "observability.open-cluster-management.io/dashboard-folder"
-	generalFolderKey    = "general-folder"
-	defaultCustomFolder = "Custom"
-	homeDashboardTitle  = "ACM - Clusters Overview"
-	homeDashboardUIDKey = "home-dashboard-uid"
-	setHomeDashboardKey = "set-home-dashboard"
+	// Annotation and Label keys
+	CustomFolderKey     = "observability.open-cluster-management.io/dashboard-folder"
+	GeneralFolderKey    = "general-folder"
+	DefaultCustomFolder = "Custom"
+	HomeDashboardUIDKey = "home-dashboard-uid"
+	SetHomeDashboardKey = "set-home-dashboard"
+
+	// CustomDashboardLabelKey is the label used to identify Grafana custom dashboards
+	CustomDashboardLabelKey = "grafana-custom-dashboard"
+
+	// ARCHITECTURAL NOTE: This controller assumes EXCLUSIVE ownership of the Grafana instance's
+	// dashboard space. Any dashboard found in Grafana that does not have a corresponding
+	// ConfigMap in the watched namespace will be deleted during the periodic orphan cleanup.
+	// This ensures that Kubernetes remains the absolute source of truth.
+
+	// Timing and Retries
+	folderCreationDelay      = 1 * time.Second
+	permissionsRetryDelay    = 5 * time.Second
+	defaultMaxDashboardRetry = 40
+	resyncPeriod             = 10 * time.Minute
 )
 
-var (
-	grafanaURI = "http://127.0.0.1:3001"
-	// Retry on errors.
-	maxHttpRetry      = 10
-	maxDashboardRetry = 40
-)
-
-// RunGrafanaDashboardController ...
-func RunGrafanaDashboardController(stop <-chan struct{}) {
-	config, err := clientcmd.BuildConfigFromFlags("", "")
-	if err != nil {
-		klog.Error("failed to get cluster config", "error", err)
-	}
-	// Build kubeclient client and informer for managed cluster
-	kubeClient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		klog.Fatal("failed to build kubeclient", "error", err)
-	}
-
-	informer, err := newKubeInformer(kubeClient.CoreV1())
-	if err != nil {
-		klog.Fatal("failed to get informer", "error", err)
-	}
-
-	go informer.Run(stop)
-	<-stop
+type trackedState struct {
+	uids   []string
+	folder string
 }
 
-func isDesiredDashboardConfigmap(obj any) bool {
+// GrafanaDashboardController manages the lifecycle of Grafana dashboards
+type GrafanaDashboardController struct {
+	kubeClient        corev1client.CoreV1Interface
+	grafana           GrafanaClient
+	maxDashboardRetry int
+	watchedNS         string
+	indexer           cache.Indexer
+
+	// uidMap tracks which Grafana UIDs and folders are associated with a given ConfigMap (key).
+	// This allows for immediate deletion of dashboards and empty folders when a ConfigMap is removed or moved.
+	uidMap map[string]trackedState
+	mapMu  sync.RWMutex
+}
+
+// NewGrafanaDashboardController creates a new GrafanaDashboardController
+func NewGrafanaDashboardController(kubeClient corev1client.CoreV1Interface, uri string) (*GrafanaDashboardController, error) {
+	if uri == "" {
+		return nil, errors.New("grafana URI is required")
+	}
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("invalid grafana URI %q: %w", uri, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("invalid grafana URI %q: scheme and host are required", uri)
+	}
+
+	ns := os.Getenv("POD_NAMESPACE")
+	if ns == "" {
+		klog.Warning("POD_NAMESPACE environment variable is empty. The controller will watch all namespaces.")
+	}
+	return &GrafanaDashboardController{
+		kubeClient:        kubeClient,
+		grafana:           &grafanaClient{uri: uri},
+		maxDashboardRetry: defaultMaxDashboardRetry,
+		watchedNS:         ns,
+		uidMap:            make(map[string]trackedState),
+	}, nil
+}
+
+// Run runs the controller until the context is canceled.
+func (c *GrafanaDashboardController) Run(ctx context.Context) error {
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]())
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	defer queue.ShutDown()
+
+	informer, err := c.newKubeInformer(queue)
+	if err != nil {
+		return fmt.Errorf("failed to get informer: %w", err)
+	}
+
+	go informer.Run(ctx.Done())
+
+	klog.Info("waiting for informer caches to sync")
+	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		if ctx.Err() != nil {
+			return fmt.Errorf("context canceled while waiting for cache sync: %w", ctx.Err())
+		}
+		return fmt.Errorf("failed to sync cache")
+	}
+
+	c.indexer = informer.GetIndexer()
+
+	klog.InfoS("performing initial orphan cleanup")
+	c.cleanupOrphanDashboards(ctx, c.indexer)
+
+	klog.Info("starting worker")
+	wg.Go(func() {
+		wait.UntilWithContext(ctx, func(ctx context.Context) { c.runWorker(ctx, queue, c.indexer) }, time.Second)
+	})
+
+	// Periodically run orphan cleanup to catch any missed deletions and ghost folders.
+	wg.Go(func() {
+		wait.UntilWithContext(ctx, func(ctx context.Context) { c.cleanupOrphanDashboards(ctx, c.indexer) }, resyncPeriod)
+	})
+
+	<-ctx.Done()
+	klog.Info("stopping controller")
+	return nil
+}
+
+func (c *GrafanaDashboardController) runWorker(ctx context.Context, queue workqueue.TypedRateLimitingInterface[any], indexer cache.Indexer) {
+	for c.processNextItem(ctx, queue, indexer) {
+	}
+}
+
+func (c *GrafanaDashboardController) processNextItem(ctx context.Context, queue workqueue.TypedRateLimitingInterface[any], indexer cache.Indexer) bool {
+	obj, quit := queue.Get()
+	if quit {
+		return false
+	}
+	defer queue.Done(obj)
+
+	err := c.syncHandler(ctx, obj, indexer)
+	if err == nil {
+		queue.Forget(obj)
+		return true
+	}
+
+	if queue.NumRequeues(obj) < c.maxDashboardRetry {
+		klog.V(1).InfoS("syncing dashboard failed, retrying", "object", obj, "error", err)
+		queue.AddRateLimited(obj)
+		return true
+	}
+
+	queue.Forget(obj)
+	klog.ErrorS(err, "dashboard could not be processed after maximum retries", "object", obj, "maxRetries", c.maxDashboardRetry)
+	return true
+}
+
+func (c *GrafanaDashboardController) syncHandler(ctx context.Context, item any, indexer cache.Indexer) error {
+	key, ok := item.(string)
+	if !ok {
+		klog.ErrorS(fmt.Errorf("unexpected item type: %T", item), "dropping invalid queue item")
+		return nil
+	}
+
+	obj, exists, err := indexer.GetByKey(key)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		klog.InfoS("ConfigMap deleted, performing immediate cleanup from Grafana", "key", key)
+		return c.deleteTrackedUIDs(ctx, key)
+	}
+
 	cm, ok := obj.(*corev1.ConfigMap)
-	if !ok || cm == nil {
+	if !ok {
+		return fmt.Errorf("unexpected type in cache: %T for key %s", obj, key)
+	}
+
+	if !isDesiredDashboardConfigmap(cm) {
+		klog.InfoS("ConfigMap no longer a desired dashboard, performing immediate cleanup from Grafana", "namespace", cm.Namespace, "name", cm.Name)
+		return c.deleteTrackedUIDs(ctx, key)
+	}
+
+	klog.InfoS("syncing dashboard", "namespace", cm.Namespace, "name", cm.Name)
+	return c.updateDashboard(ctx, cm)
+}
+
+func (c *GrafanaDashboardController) deleteTrackedUIDs(ctx context.Context, key string) error {
+	c.mapMu.Lock()
+	state, exists := c.uidMap[key]
+	// We don't delete from map immediately. We only delete if all UIDs are successfully removed.
+	c.mapMu.Unlock()
+
+	if !exists {
+		return nil
+	}
+
+	var errs []error
+	var failedUIDs []string
+	for _, uid := range state.uids {
+		klog.InfoS("deleting tracked dashboard from Grafana", "key", key, "uid", uid)
+		if err := c.grafana.DeleteDashboard(ctx, uid); err != nil {
+			klog.ErrorS(err, "failed to delete tracked dashboard", "uid", uid)
+			errs = append(errs, err)
+			failedUIDs = append(failedUIDs, uid)
+		}
+	}
+
+	if len(failedUIDs) > 0 {
+		// Update the map to only track what's left
+		c.mapMu.Lock()
+		c.uidMap[key] = trackedState{
+			uids:   failedUIDs,
+			folder: state.folder,
+		}
+		c.mapMu.Unlock()
+		return errors.Join(errs...)
+	}
+
+	// All deleted successfully
+	c.mapMu.Lock()
+	delete(c.uidMap, key)
+	c.mapMu.Unlock()
+
+	if state.folder != "" {
+		c.cleanupFolderIfEmpty(ctx, state.folder)
+	}
+
+	return nil
+}
+
+func (c *GrafanaDashboardController) newKubeInformer(queue workqueue.TypedRateLimitingInterface[any]) (cache.SharedIndexInformer, error) {
+	watchlist := &cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (k8sruntime.Object, error) {
+			return c.kubeClient.ConfigMaps(c.watchedNS).List(ctx, opts)
+		},
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+			return c.kubeClient.ConfigMaps(c.watchedNS).Watch(ctx, opts)
+		},
+	}
+	kubeInformer := cache.NewSharedIndexInformer(
+		watchlist,
+		&corev1.ConfigMap{},
+		resyncPeriod,
+		cache.Indexers{},
+	)
+
+	_, err := kubeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			if cm, ok := obj.(*corev1.ConfigMap); ok && c.shouldEnqueue(nil, cm) {
+				key, err := cache.MetaNamespaceKeyFunc(obj)
+				if err == nil {
+					queue.Add(key)
+				}
+			}
+		},
+		UpdateFunc: func(oldObj, newObj any) {
+			oldCm, _ := oldObj.(*corev1.ConfigMap)
+			newCm, okNew := newObj.(*corev1.ConfigMap)
+			if okNew && c.shouldEnqueue(oldCm, newCm) {
+				key, err := cache.MetaNamespaceKeyFunc(newObj)
+				if err == nil {
+					queue.Add(key)
+				}
+			}
+		},
+		DeleteFunc: func(obj any) {
+			// Always enqueue deletions to ensure tracked UIDs are cleaned up.
+			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+			if err == nil {
+				queue.Add(key)
+			}
+		},
+	})
+	return kubeInformer, err
+}
+
+// shouldEnqueue determines if a ConfigMap change should be added to the workqueue.
+func (c *GrafanaDashboardController) shouldEnqueue(oldCm, newCm *corev1.ConfigMap) bool {
+	if newCm == nil {
+		return false
+	}
+	// Enqueue if the new state is a desired dashboard
+	if isDesiredDashboardConfigmap(newCm) {
+		return true
+	}
+	// Enqueue if it WAS a desired dashboard (to trigger immediate cleanup)
+	if oldCm != nil && isDesiredDashboardConfigmap(oldCm) {
+		return true
+	}
+	return false
+}
+
+func (c *GrafanaDashboardController) cleanupOrphanDashboards(ctx context.Context, indexer cache.Indexer) {
+	klog.Info("scanning for orphan dashboards in Grafana")
+	dashboards, err := c.grafana.ListAllDashboards(ctx)
+	if err != nil {
+		klog.ErrorS(err, "failed to list dashboards for cleanup")
+		return
+	}
+	klog.InfoS("found dashboards in Grafana", "count", len(dashboards))
+
+	if ctx.Err() != nil {
+		return
+	}
+
+	// Build a set of all expected UIDs from ConfigMaps in the indexer.
+	// Also populate the in-memory uidMap for immediate deletion support.
+	list := indexer.List()
+	expectedUIDs := make(map[string]struct{}, len(list))
+	newUIDMap := make(map[string]trackedState, len(list))
+
+	for _, obj := range list {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		cm, ok := obj.(*corev1.ConfigMap)
+		if !ok {
+			klog.V(4).InfoS("unexpected object type during cleanup", "type", fmt.Sprintf("%T", obj))
+			continue
+		}
+		if isDesiredDashboardConfigmap(cm) {
+			cmKey, err := cache.MetaNamespaceKeyFunc(cm)
+			if err != nil {
+				klog.ErrorS(err, "failed to get key for ConfigMap during cleanup", "namespace", cm.Namespace, "name", cm.Name)
+				continue
+			}
+			folder := getDashboardCustomFolderTitle(cm)
+			state := trackedState{folder: folder}
+			for key, val := range cm.Data {
+				dashboard := map[string]any{}
+				if err := json.Unmarshal([]byte(val), &dashboard); err != nil {
+					klog.ErrorS(err, "failed to unmarshal dashboard during cleanup, falling back to name-based UID", "namespace", cm.Namespace, "name", cm.Name, "key", key)
+					dashboard = nil
+				}
+				uid, err := c.resolveDashboardUID(dashboard, cm, key)
+				if err == nil {
+					expectedUIDs[uid] = struct{}{}
+					state.uids = append(state.uids, uid)
+				} else {
+					klog.ErrorS(err, "failed to resolve UID for dashboard key during cleanup", "namespace", cm.Namespace, "name", cm.Name, "key", key)
+				}
+			}
+			newUIDMap[cmKey] = state
+		}
+	}
+
+	// Update the controller's map with the fresh state discovered from Kubernetes.
+	// Note on Map Overwrite Race: This performs a full overwrite of c.uidMap, which could
+	// theoretically overwrite a concurrent syncHandler update. However, because this
+	// runs periodically and rebuilds state from the informer cache, the worst-case
+	// scenario is that an immediate deletion is delayed until the next sweep (10 minutes).
+	// This is an acceptable tradeoff for the simplicity of the current implementation.
+	c.mapMu.Lock()
+	c.uidMap = newUIDMap
+	c.mapMu.Unlock()
+
+	for _, d := range dashboards {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		if _, expected := expectedUIDs[d.UID]; !expected {
+			klog.InfoS("deleting orphan dashboard", "uid", d.UID)
+			if err := c.grafana.DeleteDashboard(ctx, d.UID); err != nil {
+				klog.ErrorS(err, "failed to delete orphan dashboard", "uid", d.UID)
+			}
+		}
+	}
+
+	// orphan deletion may leave folders empty; this is a catch-all sweep.
+	c.cleanupAllEmptyFolders(ctx)
+}
+
+func (c *GrafanaDashboardController) findCustomFolderID(ctx context.Context, folderTitle string) int64 {
+	folders, err := c.grafana.ListFolders(ctx)
+	if err != nil {
+		klog.ErrorS(err, "failed to list folders")
+		return 0
+	}
+
+	for _, folder := range folders {
+		if folder.Title == folderTitle {
+			return folder.ID
+		}
+	}
+	return 0
+}
+
+func (c *GrafanaDashboardController) createCustomFolder(ctx context.Context, folderTitle string) int64 {
+	folderID := c.findCustomFolderID(ctx, folderTitle)
+	if folderID != 0 {
+		return folderID
+	}
+
+	folder, err := c.grafana.CreateFolder(ctx, folderTitle)
+	if err != nil {
+		// Handle race condition
+		if retryID := c.findCustomFolderID(ctx, folderTitle); retryID != 0 {
+			return retryID
+		}
+		klog.ErrorS(err, "failed to create custom folder", "folderTitle", folderTitle)
+		return 0
+	}
+
+	select {
+	case <-ctx.Done():
+		return 0
+	case <-time.After(folderCreationDelay):
+	}
+
+	// check permissions
+	hasPerm, err := c.grafana.HasPermissions(ctx, folder.UID)
+	if err == nil && !hasPerm {
+		klog.InfoS("failed to set permissions for folder. Deleting folder and retrying later.", "folderTitle", folderTitle)
+		select {
+		case <-ctx.Done():
+			return 0
+		case <-time.After(permissionsRetryDelay):
+		}
+		if err := c.grafana.DeleteFolder(ctx, folder.UID); err != nil {
+			klog.ErrorS(err, "failed to delete folder during retry", "folderUID", folder.UID)
+		}
+		return 0
+	}
+
+	return folder.ID
+}
+
+func (c *GrafanaDashboardController) cleanupFolderIfEmpty(ctx context.Context, folderTitle string) {
+	if folderTitle == "" {
+		return
+	}
+	folderID := c.findCustomFolderID(ctx, folderTitle)
+	if folderID == 0 {
+		return
+	}
+	folder, err := c.grafana.GetFolderByID(ctx, folderID)
+	if err != nil {
+		return
+	}
+	empty, err := c.grafana.IsEmpty(ctx, folder.UID)
+	if err == nil && empty {
+		klog.InfoS("deleting empty folder", "title", folderTitle, "uid", folder.UID)
+		if err := c.grafana.DeleteFolder(ctx, folder.UID); err != nil {
+			klog.ErrorS(err, "failed to cleanup empty folder", "folderTitle", folderTitle)
+		}
+	}
+}
+
+func (c *GrafanaDashboardController) cleanupAllEmptyFolders(ctx context.Context) {
+	klog.InfoS("scanning for empty folders in Grafana")
+	folders, err := c.grafana.ListFolders(ctx)
+	if err != nil {
+		klog.ErrorS(err, "failed to list folders for cleanup")
+		return
+	}
+
+	for _, folder := range folders {
+		if folder.ID == 0 || folder.UID == "" {
+			continue
+		}
+
+		empty, err := c.grafana.IsEmpty(ctx, folder.UID)
+		if err == nil && empty {
+			klog.InfoS("deleting empty folder during total sweep", "folderTitle", folder.Title, "uid", folder.UID)
+			if err := c.grafana.DeleteFolder(ctx, folder.UID); err != nil {
+				klog.ErrorS(err, "failed to delete empty folder", "folderTitle", folder.Title)
+			}
+		}
+	}
+}
+
+// resolveDashboardUID extracts the UID from the dashboard JSON or generates a unique fallback.
+// If dashboard is nil, it skips JSON extraction and directly generates the fallback UID.
+func (c *GrafanaDashboardController) resolveDashboardUID(dashboard map[string]any, cm *corev1.ConfigMap, key string) (string, error) {
+	if dashboard != nil {
+		if uidVal, ok := dashboard["uid"]; ok && uidVal != nil {
+			uidStr, ok := uidVal.(string)
+			if ok && uidStr != "" {
+				return uidStr, nil
+			}
+		}
+	}
+
+	uid, err := util.GenerateUID(cm.GetNamespace(), cm.GetName()+"-"+key)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate fallback dashboard UID for key %s: %w", key, err)
+	}
+	klog.V(2).InfoS("dashboard UID not set in JSON, using generated fallback", "uid", uid, "key", key)
+	return uid, nil
+}
+
+// updateDashboard handles the synchronization of dashboards from a ConfigMap to Grafana.
+// Note: In most use cases, a ConfigMap contains a single dashboard key. We optimize for this
+// pattern while still supporting multi-dashboard ConfigMaps by accumulating errors and
+// ensuring sibling dashboards are not blocked by a failure in one.
+func (c *GrafanaDashboardController) updateDashboard(ctx context.Context, newObj *corev1.ConfigMap) error {
+	var folderID int64
+	folderTitle := getDashboardCustomFolderTitle(newObj)
+	if folderTitle != "" {
+		folderID = c.createCustomFolder(ctx, folderTitle)
+		if folderID == 0 {
+			return errors.New("failed to get folder id")
+		}
+	}
+
+	homeDashboardUID := ""
+	labels := newObj.Labels
+	annotations := newObj.Annotations
+	if strings.ToLower(annotations[SetHomeDashboardKey]) == "true" && labels[HomeDashboardUIDKey] != "" {
+		homeDashboardUID = labels[HomeDashboardUIDKey]
+	}
+
+	cmKey, err := cache.MetaNamespaceKeyFunc(newObj)
+	if err != nil {
+		return fmt.Errorf("failed to get key for ConfigMap: %w", err)
+	}
+
+	var errs []error
+	currentUIDs := make([]string, 0, len(newObj.Data))
+
+	for key, value := range newObj.Data {
+		dashboard := map[string]any{}
+		err := json.Unmarshal([]byte(value), &dashboard)
+		if err != nil {
+			// Unmarshal errors are terminal user input issues. We log and ignore them
+			// to avoid endless workqueue retries, while letting other valid dashboards
+			// in the same ConfigMap proceed.
+			klog.ErrorS(err, "failed to unmarshal dashboard data, skipping", "namespace", newObj.Namespace, "name", newObj.Name, "key", key)
+			continue
+		}
+
+		uid, err := c.resolveDashboardUID(dashboard, newObj, key)
+		if err != nil {
+			// UID resolution errors are also considered terminal input errors.
+			klog.ErrorS(err, "failed to resolve dashboard UID, skipping", "namespace", newObj.Namespace, "name", newObj.Name, "key", key)
+			continue
+		}
+
+		// We record the UID as part of the "desired state" (currentUIDs) BEFORE the API call.
+		// This ensures that if the API call fails, we still "remember" this dashboard
+		// belongs to this ConfigMap, protecting it from being erroneously deleted
+		// by the cleanup phase below.
+		currentUIDs = append(currentUIDs, uid)
+		dashboard["uid"] = uid
+		dashboard["id"] = nil
+
+		id, err := c.grafana.CreateOrUpdateDashboard(ctx, dashboard, folderID)
+		if err != nil {
+			var gErr *GrafanaError
+			if errors.As(err, &gErr) {
+				if gErr.IsNameExists() {
+					errs = append(errs, fmt.Errorf("the dashboard name already existed"))
+					continue
+				}
+			}
+			errs = append(errs, err)
+			continue
+		}
+
+		if homeDashboardUID != "" && uid == homeDashboardUID && id != 0 {
+			klog.InfoS("Setting home dashboard", "title", dashboard["title"])
+			if err := c.grafana.SetHomeDashboard(ctx, id); err != nil {
+				klog.ErrorS(err, "failed to set home dashboard", "title", dashboard["title"])
+				errs = append(errs, err)
+			} else {
+				klog.InfoS("home dashboard set successfully", "title", dashboard["title"], "id", id)
+			}
+		}
+		klog.InfoS("dashboard created/updated successfully", "name", newObj.Name, "uid", uid)
+	}
+
+	// Immediate cleanup for keys removed from this ConfigMap.
+	// We compare the UIDs we just identified as desired (currentUIDs) against
+	// the UIDs we knew about from the previous successful reconcile (oldUIDs).
+	c.mapMu.RLock()
+	oldState := c.uidMap[cmKey]
+	c.mapMu.RUnlock()
+
+	// Find UIDs that were in the map but are not in the current ConfigMap data
+	currentSet := make(map[string]struct{}, len(currentUIDs))
+	for _, uid := range currentUIDs {
+		currentSet[uid] = struct{}{}
+	}
+
+	var failedDeletions []string
+	for _, oldUID := range oldState.uids {
+		if _, exists := currentSet[oldUID]; !exists {
+			klog.InfoS("dashboard key removed from ConfigMap, deleting from Grafana", "namespace", newObj.Namespace, "name", newObj.Name, "uid", oldUID)
+			if err := c.grafana.DeleteDashboard(ctx, oldUID); err != nil {
+				klog.ErrorS(err, "failed to delete removed dashboard", "uid", oldUID)
+				errs = append(errs, err)
+				// We keep failed deletions in our tracking to retry them in the next cycle
+				// or let the Total Sweep handle them, ensuring we don't lose track of orphans.
+				failedDeletions = append(failedDeletions, oldUID)
+			}
+		}
+	}
+
+	// Update the map with current state + those that failed to delete.
+	c.mapMu.Lock()
+	c.uidMap[cmKey] = trackedState{
+		uids:   append(currentUIDs, failedDeletions...),
+		folder: folderTitle,
+	}
+	c.mapMu.Unlock()
+
+	// Perform immediate folder cleanup.
+	// 1. Check the CURRENT folder (in case all dashboards were removed from it but CM still exists)
+	if folderTitle != "" {
+		c.cleanupFolderIfEmpty(ctx, folderTitle)
+	}
+	// 2. Check the OLD folder (if it changed)
+	if oldState.folder != "" && oldState.folder != folderTitle {
+		c.cleanupFolderIfEmpty(ctx, oldState.folder)
+	}
+	// For immediate UX, the sweep is 10m away, which is acceptable for an empty folder.
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
+func isDesiredDashboardConfigmap(cm *corev1.ConfigMap) bool {
+	if cm == nil {
 		return false
 	}
 
 	labels := cm.Labels
-	if strings.ToLower(labels["grafana-custom-dashboard"]) == "true" {
+	if strings.ToLower(labels[CustomDashboardLabelKey]) == "true" {
 		return true
 	}
 
@@ -88,362 +659,20 @@ func isDesiredDashboardConfigmap(obj any) bool {
 	return false
 }
 
-func newKubeInformer(coreClient corev1client.CoreV1Interface) (cache.SharedIndexInformer, error) {
-	// get watched namespace
-	watchedNS := os.Getenv("POD_NAMESPACE")
-	watchlist := &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-			return coreClient.ConfigMaps(watchedNS).List(context.TODO(), metav1.ListOptions{})
-		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-			return coreClient.ConfigMaps(watchedNS).Watch(context.TODO(), metav1.ListOptions{})
-		},
-	}
-	kubeInformer := cache.NewSharedIndexInformer(
-		watchlist,
-		&corev1.ConfigMap{},
-		time.Second*0,
-		cache.Indexers{},
-	)
-
-	_, err := kubeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
-			if !isDesiredDashboardConfigmap(obj) {
-				return
-			}
-			klog.Infof("detect there is a new dashboard %v created", obj.(*corev1.ConfigMap).Name)
-			err := updateDashboard(nil, obj, false)
-
-			times := 0
-			for {
-				if err == nil {
-					break
-				} else if times == maxDashboardRetry {
-					klog.Errorf("dashboard: %s could not be created after retrying %v times", obj.(*corev1.ConfigMap).Name, maxDashboardRetry)
-					break
-				}
-
-				klog.Warningf("creation of dashboard: %v failed. Retrying in 10s. Error: %v", obj.(*corev1.ConfigMap).Name, err)
-				time.Sleep(time.Second * 10)
-				err = updateDashboard(nil, obj, false)
-
-				times++
-			}
-		},
-		UpdateFunc: func(old, newObj any) {
-			if old.(*corev1.ConfigMap).ResourceVersion == newObj.(*corev1.ConfigMap).ResourceVersion {
-				return
-			}
-			if !isDesiredDashboardConfigmap(newObj) {
-				return
-			}
-			klog.Infof("detect there is a dashboard %v updated", newObj.(*corev1.ConfigMap).Name)
-			err := updateDashboard(old, newObj, false)
-
-			times := 0
-			for {
-				if err == nil {
-					break
-				} else if times == maxDashboardRetry {
-					klog.Errorf("dashboard: %s could not be created after retrying %v times", newObj.(*corev1.ConfigMap).Name, maxDashboardRetry)
-					break
-				}
-
-				klog.Warningf("updating of dashboard: %v failed. Retrying in 10s. Error: %v", newObj.(*corev1.ConfigMap).Name, err)
-				time.Sleep(time.Second * 10)
-
-				err = updateDashboard(old, newObj, false)
-
-				times++
-			}
-		},
-		DeleteFunc: func(obj any) {
-			if !isDesiredDashboardConfigmap(obj) {
-				return
-			}
-			klog.Infof("detect there is a dashboard %v deleted", obj.(*corev1.ConfigMap).Name)
-			deleteDashboard(obj)
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return kubeInformer, nil
-}
-
-func hasCustomFolder(folderTitle string) float64 {
-	grafanaURL := grafanaURI + "/api/folders"
-	body, _ := util.SetRequest("GET", grafanaURL, nil, maxHttpRetry)
-
-	folders := []map[string]any{}
-	err := json.Unmarshal(body, &folders)
-	if err != nil {
-		klog.Error(unmarshallErrMsg, "error", err)
-		return 0
-	}
-
-	for _, folder := range folders {
-		if folder["title"] == folderTitle {
-			return folder["id"].(float64)
-		}
-	}
-	return 0
-}
-
-func createCustomFolder(folderTitle string) float64 {
-	folderID := hasCustomFolder(folderTitle)
-	if folderID == 0 {
-		// Create the folder
-		grafanaURL := grafanaURI + "/api/folders"
-		body, _ := util.SetRequest("POST", grafanaURL, strings.NewReader("{\"title\":\""+folderTitle+"\"}"), maxHttpRetry)
-		folder := map[string]any{}
-		err := json.Unmarshal(body, &folder)
-		if err != nil {
-			klog.Error(unmarshallErrMsg, "error", err)
-			return 0
-		}
-
-		time.Sleep(time.Second * 1)
-		// check if permissions were set correctly as sometimes this silently fails in Grafana
-		grafanaURL = grafanaURI + "/api/folders/" + folder["uid"].(string) + "/permissions"
-		body, _ = util.SetRequest("GET", grafanaURL, nil, maxHttpRetry)
-		if string(body) == "[]" {
-			// if this fails no permissions are set. In which case we want to delete the folder and try again...
-			klog.Warningf("failed to set permissions for folder: %v. Deleting folder and retrying later.", folderTitle)
-
-			time.Sleep(time.Second * 5)
-			deleteCustomFolder(folder["id"].(float64))
-			return 0
-		}
-		return folder["id"].(float64)
-	}
-	return folderID
-}
-
-func getCustomFolderUID(folderID float64) string {
-	grafanaURL := grafanaURI + "/api/folders/id/" + fmt.Sprint(folderID)
-	body, _ := util.SetRequest("GET", grafanaURL, nil, maxHttpRetry)
-	folder := map[string]any{}
-	err := json.Unmarshal(body, &folder)
-	if err != nil {
-		klog.Error(unmarshallErrMsg, "error", err)
-		return ""
-	}
-	uid, ok := folder["uid"]
-	if ok {
-		return uid.(string)
-	}
-
-	return ""
-}
-
-func isEmptyFolder(folderID float64) bool {
-	if folderID == 0 {
-		return false
-	}
-
-	grafanaURL := grafanaURI + "/api/search?folderIds=" + fmt.Sprint(folderID)
-	body, _ := util.SetRequest("GET", grafanaURL, nil, maxHttpRetry)
-	dashboards := []map[string]any{}
-	err := json.Unmarshal(body, &dashboards)
-	if err != nil {
-		klog.Error(unmarshallErrMsg, "error", err)
-		return false
-	}
-
-	if len(dashboards) == 0 {
-		klog.Infof("folder %v is empty", folderID)
-		return true
-	}
-
-	return false
-}
-
-func deleteCustomFolder(folderID float64) bool {
-	if folderID == 0 {
-		return false
-	}
-
-	uid := getCustomFolderUID(folderID)
-	if uid == "" {
-		klog.Error("failed to get custom folder UID")
-		return false
-	}
-
-	grafanaURL := grafanaURI + "/api/folders/" + uid
-	_, respStatusCode := util.SetRequest("DELETE", grafanaURL, nil, maxHttpRetry)
-	if respStatusCode != http.StatusOK {
-		klog.Errorf("failed to delete custom folder %v with %v", folderID, respStatusCode)
-		return false
-	}
-
-	klog.Infof("custom folder %v deleted", folderID)
-	return true
-}
-
-func getDashboardCustomFolderTitle(obj any) string {
-	cm, ok := obj.(*corev1.ConfigMap)
-	if !ok || cm == nil {
-		return ""
+func getDashboardCustomFolderTitle(cm *corev1.ConfigMap) string {
+	if cm == nil {
+		return DefaultCustomFolder
 	}
 
 	labels := cm.Labels
-	if labels[generalFolderKey] == "" || strings.ToLower(labels[generalFolderKey]) != "true" {
-		annotations := cm.Annotations
-		customFolder, ok := annotations[customFolderKey]
-		if !ok || customFolder == "" {
-			customFolder = defaultCustomFolder
-		}
-		return customFolder
-	}
-	return ""
-}
-
-// updateDashboard is used to update the customized dashboards via calling grafana api.
-func updateDashboard(old, newObj any, overwrite bool) error {
-	folderID := 0.0
-	folderTitle := getDashboardCustomFolderTitle(newObj)
-	if folderTitle != "" {
-		folderID = createCustomFolder(folderTitle)
-		if folderID == 0 {
-			return errors.New("failed to get folder id")
-		}
+	if labels[GeneralFolderKey] == "true" {
+		return ""
 	}
 
-	cm, ok := newObj.(*corev1.ConfigMap)
-	if !ok || cm == nil {
-		return fmt.Errorf("failed to get dashboard configmap")
-	}
-
-	homeDashboardUID := ""
-	labels := cm.Labels
 	annotations := cm.Annotations
-	if strings.ToLower(annotations[setHomeDashboardKey]) == "true" && labels[homeDashboardUIDKey] != "" {
-		homeDashboardUID = labels[homeDashboardUIDKey]
+	if annotations[CustomFolderKey] != "" {
+		return annotations[CustomFolderKey]
 	}
 
-	for _, value := range newObj.(*corev1.ConfigMap).Data {
-		dashboard := map[string]any{}
-		err := json.Unmarshal([]byte(value), &dashboard)
-		if err != nil {
-			return fmt.Errorf("failed to unmarshall data: %v", err)
-		}
-		if dashboard["uid"] == nil || dashboard["uid"] == "" {
-			dashboard["uid"], _ = util.GenerateUID(newObj.(*corev1.ConfigMap).GetName(),
-				newObj.(*corev1.ConfigMap).GetNamespace())
-			klog.Infof("dashboard uid is not set, generating a default: %s", dashboard["uid"])
-		}
-		dashboard["id"] = nil
-		data := map[string]any{
-			"folderId":  folderID,
-			"overwrite": overwrite,
-			"dashboard": dashboard,
-		}
-
-		b, err := json.Marshal(data)
-		if err != nil {
-			return fmt.Errorf("failed to marshal body: %v", err)
-		}
-
-		grafanaURL := grafanaURI + "/api/dashboards/db"
-		body, respStatusCode := util.SetRequest("POST", grafanaURL, bytes.NewBuffer(b), maxHttpRetry)
-
-		if respStatusCode != http.StatusOK {
-			if respStatusCode == http.StatusPreconditionFailed {
-				switch {
-				case strings.Contains(string(body), "version-mismatch"):
-					return updateDashboard(nil, newObj, true)
-				case strings.Contains(string(body), "name-exists"):
-					return fmt.Errorf("the dashboard name already existed")
-				default:
-					return fmt.Errorf("failed to create/update dashboard: %v", respStatusCode)
-				}
-			} else {
-				return fmt.Errorf("failed to create/update dashboard: %v", respStatusCode)
-			}
-		}
-
-		if homeDashboardUID != "" && dashboard["uid"] == homeDashboardUID {
-			// get "id" value from response
-			re := regexp.MustCompile("\"id\":(\\d+),")
-			result := re.FindSubmatch(body)
-			if len(result) != 2 {
-				klog.Infof("failed to retrieve dashboard id")
-			} else {
-				id, err := strconv.Atoi(strings.Trim(string(result[1]), " "))
-				if err != nil {
-					return fmt.Errorf("failed to parse dashboard id: %v", err)
-				} else {
-					klog.Infof("Setting dashboard: %v as home dashboard", dashboard["title"])
-					setHomeDashboard(id)
-				}
-			}
-		}
-		klog.Infof("dashboard: %v created/updated successfully", cm.Name)
-	}
-
-	folderTitle = getDashboardCustomFolderTitle(old)
-	folderID = hasCustomFolder(folderTitle)
-	if isEmptyFolder(folderID) {
-		if !deleteCustomFolder(folderID) {
-			return errors.New("failed to delete custom folder")
-		}
-	}
-	return nil
-}
-
-// DeleteDashboard ...
-func deleteDashboard(obj any) {
-	for _, value := range obj.(*corev1.ConfigMap).Data {
-		dashboard := map[string]any{}
-		err := json.Unmarshal([]byte(value), &dashboard)
-		if err != nil {
-			klog.Error("failed to unmarshall data", "error", err)
-			return
-		}
-
-		uid, _ := util.GenerateUID(obj.(*corev1.ConfigMap).Name, obj.(*corev1.ConfigMap).Namespace)
-		if dashboard["uid"] != nil {
-			uid = dashboard["uid"].(string)
-		}
-
-		grafanaURL := grafanaURI + "/api/dashboards/uid/" + uid
-
-		_, respStatusCode := util.SetRequest("DELETE", grafanaURL, nil, maxHttpRetry)
-		if respStatusCode != http.StatusOK {
-			klog.Errorf("failed to delete dashboard %v with %v", obj.(*corev1.ConfigMap).Name, respStatusCode)
-		} else {
-			klog.Info("dashboard deleted")
-		}
-
-		folderTitle := getDashboardCustomFolderTitle(obj)
-		folderID := hasCustomFolder(folderTitle)
-		if isEmptyFolder(folderID) {
-			if !deleteCustomFolder(folderID) {
-				klog.Errorf("failed to delete custom folder")
-				return
-			}
-		}
-	}
-}
-
-func setHomeDashboard(id int) {
-	data := map[string]int{
-		"homeDashboardId": id,
-	}
-
-	b, err := json.Marshal(data)
-	if err != nil {
-		klog.Error("failed to marshal body", "error", err)
-		return
-	}
-	grafanaURL := grafanaURI + "/api/org/preferences"
-	_, respStatusCode := util.SetRequest("PUT", grafanaURL, bytes.NewBuffer(b), maxHttpRetry)
-
-	if respStatusCode != http.StatusOK {
-		klog.Infof("failed to set home dashboard: %v", respStatusCode)
-	} else {
-		klog.Info("home dashboard is set")
-	}
+	return DefaultCustomFolder
 }

--- a/loaders/dashboards/pkg/controller/dashboard_controller.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller.go
@@ -435,11 +435,6 @@ func (c *GrafanaDashboardController) cleanupOrphanDashboards(ctx context.Context
 
 	folderUIDsWithDashboards := make(map[string]struct{})
 	for _, d := range dashboards {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
 		if _, expected := expectedUIDs[d.UID]; !expected {
 			klog.InfoS("deleting orphan dashboard", "uid", d.UID)
 			if err := c.grafana.DeleteDashboard(ctx, d.UID); err != nil {
@@ -505,6 +500,7 @@ func (c *GrafanaDashboardController) createCustomFolder(ctx context.Context, fol
 			return 0
 		case <-time.After(permissionsRetryDelay):
 		}
+
 		if err := c.grafana.DeleteFolder(ctx, folder.UID); err != nil {
 			klog.ErrorS(err, "failed to delete folder during retry", "folderUID", folder.UID)
 		}
@@ -531,28 +527,20 @@ func (c *GrafanaDashboardController) cleanupFolderIfEmpty(ctx context.Context, f
 		return fmt.Errorf("failed to check folder status in Grafana: %w", err)
 	}
 
-	// Wait up to 10 seconds for Grafana's search index to reflect the change.
-	// If it takes longer, we return an error to trigger a rate-limited retry in the workqueue.
-	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
-		empty, err := c.grafana.IsEmpty(ctx, folder.UID)
-		if err != nil {
-			klog.V(4).InfoS("failed to check if folder is empty during poll, retrying", "folder", folderTitle, "error", err)
-			return false, nil // retry
-		}
-		if empty {
-			klog.InfoS("deleting empty folder", "title", folderTitle, "uid", folder.UID)
-			if err := c.grafana.DeleteFolder(ctx, folder.UID); err != nil {
-				klog.ErrorS(err, "failed to cleanup empty folder", "folderTitle", folderTitle, "folderUID", folder.UID)
-			}
-			return true, nil
-		}
-		return false, nil // not empty yet, retry
-	})
+	// Check if the folder is empty. Grafana's search index is eventually consistent,
+	// so if this check fails because dashboards are still being indexed as "present",
+	// we return an error to trigger a rate-limited retry in the workqueue.
+	empty, err := c.grafana.IsEmpty(ctx, folder.UID)
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return fmt.Errorf("folder %q is not empty yet in Grafana index; will retry cleanup", folderTitle)
-		}
-		return err
+		return fmt.Errorf("failed to check folder emptiness: %w", err)
+	}
+	if !empty {
+		return fmt.Errorf("folder %q is not empty yet in Grafana index; will retry cleanup", folderTitle)
+	}
+
+	klog.InfoS("deleting empty folder", "title", folderTitle, "uid", folder.UID)
+	if err := c.grafana.DeleteFolder(ctx, folder.UID); err != nil {
+		return fmt.Errorf("failed to delete empty folder: %w", err)
 	}
 	return nil
 }
@@ -651,10 +639,10 @@ func (c *GrafanaDashboardController) updateDashboard(ctx context.Context, newObj
 		dashboard := map[string]any{}
 		err := json.Unmarshal([]byte(value), &dashboard)
 		if err != nil {
-			// Unmarshal errors are terminal user input issues. We log at V(2) and ignore them
-			// to avoid endless workqueue retries, while letting other valid dashboards
-			// in the same ConfigMap proceed.
-			klog.V(2).InfoS("failed to unmarshal dashboard data, skipping", "namespace", newObj.Namespace, "name", newObj.Name, "key", key, "error", err)
+			// Unmarshal errors are terminal user input issues. We log them as errors
+			// for visibility but skip the entry to avoid endless workqueue retries,
+			// while letting other valid dashboards in the same ConfigMap proceed.
+			klog.ErrorS(err, "failed to unmarshal dashboard data, skipping", "namespace", newObj.Namespace, "name", newObj.Name, "key", key)
 			continue
 		}
 

--- a/loaders/dashboards/pkg/controller/dashboard_controller.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -282,7 +283,7 @@ func (c *GrafanaDashboardController) deleteTrackedUIDs(ctx context.Context, key 
 	delete(c.uidMap, key)
 
 	if state.folder != "" {
-		c.cleanupFolderIfEmpty(ctx, state.folder)
+		return c.cleanupFolderIfEmpty(ctx, state.folder)
 	}
 
 	return nil
@@ -513,22 +514,26 @@ func (c *GrafanaDashboardController) createCustomFolder(ctx context.Context, fol
 	return folder.ID
 }
 
-func (c *GrafanaDashboardController) cleanupFolderIfEmpty(ctx context.Context, folderTitle string) {
+func (c *GrafanaDashboardController) cleanupFolderIfEmpty(ctx context.Context, folderTitle string) error {
 	if folderTitle == "" {
-		return
+		return nil
 	}
 	folderID := c.findCustomFolderID(ctx, folderTitle)
 	if folderID == 0 {
-		return
+		return nil
 	}
 	folder, err := c.grafana.GetFolderByID(ctx, folderID)
 	if err != nil {
-		return
+		var gErr *GrafanaError
+		if errors.As(err, &gErr) && gErr.Status == http.StatusNotFound {
+			return nil // Folder already gone, nothing to clean
+		}
+		return fmt.Errorf("failed to check folder status in Grafana: %w", err)
 	}
 
-	// Wait up to 5 seconds for Grafana's search index to reflect the change.
-	// This is an optimization for immediate UX during move/delete operations.
-	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+	// Wait up to 10 seconds for Grafana's search index to reflect the change.
+	// If it takes longer, we return an error to trigger a rate-limited retry in the workqueue.
+	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		empty, err := c.grafana.IsEmpty(ctx, folder.UID)
 		if err != nil {
 			klog.V(4).InfoS("failed to check if folder is empty during poll, retrying", "folder", folderTitle, "error", err)
@@ -543,10 +548,13 @@ func (c *GrafanaDashboardController) cleanupFolderIfEmpty(ctx context.Context, f
 		}
 		return false, nil // not empty yet, retry
 	})
-
-	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
-		klog.V(2).InfoS("folder not empty yet, leaving for periodic sweep", "folderTitle", folderTitle)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("folder %q is not empty yet in Grafana index; will retry cleanup", folderTitle)
+		}
+		return err
 	}
+	return nil
 }
 
 func (c *GrafanaDashboardController) cleanupAllEmptyFolders(ctx context.Context, folderUIDsWithDashboards map[string]struct{}) {
@@ -724,11 +732,15 @@ func (c *GrafanaDashboardController) updateDashboard(ctx context.Context, newObj
 	// Perform immediate folder cleanup.
 	// 1. Check the CURRENT folder (in case all dashboards were removed from it but CM still exists)
 	if folderTitle != "" && len(currentUIDs) == 0 {
-		c.cleanupFolderIfEmpty(ctx, folderTitle)
+		if err := c.cleanupFolderIfEmpty(ctx, folderTitle); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	// 2. Check the OLD folder (if it changed)
 	if oldState.folder != "" && oldState.folder != folderTitle {
-		c.cleanupFolderIfEmpty(ctx, oldState.folder)
+		if err := c.cleanupFolderIfEmpty(ctx, oldState.folder); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	// For immediate UX, the sweep is 10m away, which is acceptable for an empty folder.
 

--- a/loaders/dashboards/pkg/controller/dashboard_controller.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller.go
@@ -84,7 +84,8 @@ func NewGrafanaDashboardController(kubeClient corev1client.CoreV1Interface, uri 
 
 	ns := os.Getenv("POD_NAMESPACE")
 	if ns == "" {
-		klog.Warning("POD_NAMESPACE environment variable is empty. The controller will watch all namespaces.")
+		ns = "open-cluster-management-observability"
+		klog.InfoS("POD_NAMESPACE environment variable is empty. Defaulting to standard observability namespace.", "namespace", ns)
 	}
 	return &GrafanaDashboardController{
 		kubeClient:        kubeClient,
@@ -120,7 +121,20 @@ func (c *GrafanaDashboardController) Run(ctx context.Context) error {
 	c.indexer = informer.GetIndexer()
 
 	klog.InfoS("performing initial orphan cleanup")
-	c.cleanupOrphanDashboards(ctx, c.indexer)
+	// Retry the initial sweep for up to 1 minute to allow Grafana to start.
+	// This ensures we discover existing UIDs and don't start with a blank state
+	// which would cause the first delete event to be ignored.
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
+		err := c.cleanupOrphanDashboards(ctx, c.indexer)
+		if err != nil {
+			klog.InfoS("waiting for Grafana to be ready", "error", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("initial orphan cleanup failed after 1 minute timeout: %w", err)
+	}
 
 	klog.Info("starting worker")
 	wg.Go(func() {
@@ -129,7 +143,11 @@ func (c *GrafanaDashboardController) Run(ctx context.Context) error {
 
 	// Periodically run orphan cleanup to catch any missed deletions and ghost folders.
 	wg.Go(func() {
-		wait.UntilWithContext(ctx, func(ctx context.Context) { c.cleanupOrphanDashboards(ctx, c.indexer) }, resyncPeriod)
+		wait.UntilWithContext(ctx, func(ctx context.Context) {
+			if err := c.cleanupOrphanDashboards(ctx, c.indexer); err != nil {
+				klog.ErrorS(err, "periodic orphan cleanup failed")
+			}
+		}, resyncPeriod)
 	})
 
 	<-ctx.Done()
@@ -303,17 +321,17 @@ func (c *GrafanaDashboardController) shouldEnqueue(oldCm, newCm *corev1.ConfigMa
 	return false
 }
 
-func (c *GrafanaDashboardController) cleanupOrphanDashboards(ctx context.Context, indexer cache.Indexer) {
-	klog.Info("scanning for orphan dashboards in Grafana")
+func (c *GrafanaDashboardController) cleanupOrphanDashboards(ctx context.Context, indexer cache.Indexer) error {
+	klog.InfoS("scanning for orphan dashboards in Grafana")
 	dashboards, err := c.grafana.ListAllDashboards(ctx)
 	if err != nil {
-		klog.ErrorS(err, "failed to list dashboards for cleanup")
-		return
+		return fmt.Errorf("failed to list dashboards for cleanup: %w", err)
 	}
+
 	klog.InfoS("found dashboards in Grafana", "count", len(dashboards))
 
 	if ctx.Err() != nil {
-		return
+		return ctx.Err()
 	}
 
 	// Build a set of all expected UIDs from ConfigMaps in the indexer.
@@ -325,7 +343,7 @@ func (c *GrafanaDashboardController) cleanupOrphanDashboards(ctx context.Context
 	for _, obj := range list {
 		select {
 		case <-ctx.Done():
-			return
+			return ctx.Err()
 		default:
 		}
 		cm, ok := obj.(*corev1.ConfigMap)
@@ -344,7 +362,7 @@ func (c *GrafanaDashboardController) cleanupOrphanDashboards(ctx context.Context
 			for key, val := range cm.Data {
 				dashboard := map[string]any{}
 				if err := json.Unmarshal([]byte(val), &dashboard); err != nil {
-					klog.ErrorS(err, "failed to unmarshal dashboard during cleanup, falling back to name-based UID", "namespace", cm.Namespace, "name", cm.Name, "key", key)
+					klog.V(2).InfoS("failed to unmarshal dashboard during cleanup, falling back to name-based UID", "namespace", cm.Namespace, "name", cm.Name, "key", key)
 					dashboard = nil
 				}
 				uid, err := c.resolveDashboardUID(dashboard, cm, key)
@@ -372,7 +390,7 @@ func (c *GrafanaDashboardController) cleanupOrphanDashboards(ctx context.Context
 	for _, d := range dashboards {
 		select {
 		case <-ctx.Done():
-			return
+			return ctx.Err()
 		default:
 		}
 		if _, expected := expectedUIDs[d.UID]; !expected {
@@ -385,6 +403,7 @@ func (c *GrafanaDashboardController) cleanupOrphanDashboards(ctx context.Context
 
 	// orphan deletion may leave folders empty; this is a catch-all sweep.
 	c.cleanupAllEmptyFolders(ctx)
+	return nil
 }
 
 func (c *GrafanaDashboardController) findCustomFolderID(ctx context.Context, folderTitle string) int64 {
@@ -454,12 +473,27 @@ func (c *GrafanaDashboardController) cleanupFolderIfEmpty(ctx context.Context, f
 	if err != nil {
 		return
 	}
-	empty, err := c.grafana.IsEmpty(ctx, folder.UID)
-	if err == nil && empty {
-		klog.InfoS("deleting empty folder", "title", folderTitle, "uid", folder.UID)
-		if err := c.grafana.DeleteFolder(ctx, folder.UID); err != nil {
-			klog.ErrorS(err, "failed to cleanup empty folder", "folderTitle", folderTitle)
+
+	// Wait up to 5 seconds for Grafana's search index to reflect the change.
+	// This is an optimization for immediate UX during move/delete operations.
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		empty, err := c.grafana.IsEmpty(ctx, folder.UID)
+		if err != nil {
+			klog.V(4).InfoS("failed to check if folder is empty during poll, retrying", "folder", folderTitle, "error", err)
+			return false, nil // retry
 		}
+		if empty {
+			klog.InfoS("deleting empty folder", "title", folderTitle, "uid", folder.UID)
+			if err := c.grafana.DeleteFolder(ctx, folder.UID); err != nil {
+				klog.ErrorS(err, "failed to cleanup empty folder", "folderTitle", folderTitle)
+			}
+			return true, nil
+		}
+		return false, nil // not empty yet, retry
+	})
+
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		klog.V(2).InfoS("folder not empty yet, leaving for periodic sweep", "folderTitle", folderTitle)
 	}
 }
 
@@ -498,7 +532,18 @@ func (c *GrafanaDashboardController) resolveDashboardUID(dashboard map[string]an
 		}
 	}
 
-	uid, err := util.GenerateUID(cm.GetNamespace(), cm.GetName()+"-"+key)
+	// Fallback UID generation logic (Legacy Compatibility)
+	// The old loader used: util.GenerateUID(cm.Name, cm.Namespace) -> "name-namespace"
+	// To support multi-dashboard CMs without breaking existing single-dashboard CMs:
+	// 1. If key matches CM name (common case), use CM name to keep legacy UID.
+	// 2. Otherwise, use name-key to ensure uniqueness.
+	nameArg := cm.GetName()
+	keyBase := strings.TrimSuffix(key, ".json")
+	if keyBase != cm.GetName() && !strings.Contains(cm.GetName(), keyBase) {
+		nameArg = cm.GetName() + "-" + keyBase
+	}
+
+	uid, err := util.GenerateUID(nameArg, cm.GetNamespace())
 	if err != nil {
 		return "", fmt.Errorf("failed to generate fallback dashboard UID for key %s: %w", key, err)
 	}
@@ -539,10 +584,10 @@ func (c *GrafanaDashboardController) updateDashboard(ctx context.Context, newObj
 		dashboard := map[string]any{}
 		err := json.Unmarshal([]byte(value), &dashboard)
 		if err != nil {
-			// Unmarshal errors are terminal user input issues. We log and ignore them
+			// Unmarshal errors are terminal user input issues. We log at V(2) and ignore them
 			// to avoid endless workqueue retries, while letting other valid dashboards
 			// in the same ConfigMap proceed.
-			klog.ErrorS(err, "failed to unmarshal dashboard data, skipping", "namespace", newObj.Namespace, "name", newObj.Name, "key", key)
+			klog.V(2).InfoS("failed to unmarshal dashboard data, skipping", "namespace", newObj.Namespace, "name", newObj.Name, "key", key, "error", err)
 			continue
 		}
 
@@ -648,10 +693,15 @@ func isDesiredDashboardConfigmap(cm *corev1.ConfigMap) bool {
 	if strings.ToLower(labels[CustomDashboardLabelKey]) == "true" {
 		return true
 	}
+	if strings.ToLower(labels[GeneralFolderKey]) == "true" {
+		return true
+	}
 
+	// Platform dashboards are created by the MCO operator and typically follow this naming convention.
+	// We check both ownerRef and name prefix to avoid processing unrelated MCO resources like configs.
 	owners := cm.GetOwnerReferences()
 	for _, owner := range owners {
-		if strings.Contains(cm.Name, "grafana-dashboard") && owner.Kind == "MultiClusterObservability" {
+		if owner.Kind == "MultiClusterObservability" && strings.HasPrefix(cm.Name, "grafana-dashboard-") {
 			return true
 		}
 	}

--- a/loaders/dashboards/pkg/controller/dashboard_controller_integration_test.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller_integration_test.go
@@ -1,0 +1,294 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+//go:build integration
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+func TestIntegrationGrafanaDashboardController(t *testing.T) {
+	testEnv := &envtest.Environment{
+		ControlPlaneStopTimeout: 2 * time.Minute,
+	}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("failed to start envtest: %v", err)
+	}
+	defer testEnv.Stop()
+
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("failed to create kubeClient: %v", err)
+	}
+
+	var mu sync.Mutex
+	recordedRequests := make(map[string]int)
+	dashboards := make(map[string]map[string]any)
+	folders := make(map[int64]string)
+
+	resetState := func() {
+		mu.Lock()
+		defer mu.Unlock()
+		recordedRequests = make(map[string]int)
+		dashboards = make(map[string]map[string]any)
+		folders = map[int64]string{1: "General"}
+	}
+	resetState()
+
+	mockGrafana := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		key := fmt.Sprintf("%s %s", r.Method, r.URL.Path)
+		recordedRequests[key]++
+
+		if r.URL.Path == "/api/folders" {
+			if r.Method == "GET" {
+				var res []map[string]any
+				for id, title := range folders {
+					res = append(res, map[string]any{"id": id, "uid": fmt.Sprintf("uid-%d", id), "title": title})
+				}
+				json.NewEncoder(w).Encode(res)
+				return
+			}
+			if r.Method == "POST" {
+				var body map[string]string
+				json.NewDecoder(r.Body).Decode(&body)
+				id := int64(time.Now().UnixNano())
+				folders[id] = body["title"]
+				json.NewEncoder(w).Encode(map[string]any{"id": id, "uid": fmt.Sprintf("uid-%d", id), "title": body["title"]})
+				return
+			}
+		}
+
+		if strings.HasPrefix(r.URL.Path, "/api/folders/id/") {
+			var id int64
+			fmt.Sscanf(r.URL.Path, "/api/folders/id/%d", &id)
+			if title, ok := folders[id]; ok {
+				json.NewEncoder(w).Encode(map[string]any{"id": id, "uid": fmt.Sprintf("uid-%d", id), "title": title})
+				return
+			}
+		}
+
+		if strings.HasPrefix(r.URL.Path, "/api/folders/uid-") {
+			uid := r.URL.Path[len("/api/folders/"):]
+			if r.Method == "DELETE" {
+				var id int64
+				fmt.Sscanf(uid, "uid-%d", &id)
+				delete(folders, id)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			if strings.HasSuffix(r.URL.Path, "/permissions") {
+				w.Write([]byte("[{\"id\": 1}]"))
+				return
+			}
+		}
+
+		if r.URL.Path == "/api/org/preferences" && r.Method == "PUT" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		if r.URL.Path == "/api/search" {
+			var res []map[string]any
+			folderUIDs := r.URL.Query().Get("folderUids")
+			for uid, dash := range dashboards {
+				match := true
+				if folderUIDs != "" {
+					match = false
+					dashFolderID, _ := dash["folderId"].(int64)
+					if fmt.Sprintf("uid-%d", dashFolderID) == folderUIDs {
+						match = true
+					}
+				}
+				if match {
+					res = append(res, map[string]any{"uid": uid, "tags": dash["tags"]})
+				}
+			}
+			json.NewEncoder(w).Encode(res)
+			return
+		}
+
+		if r.URL.Path == "/api/dashboards/db" && r.Method == "POST" {
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			dash, _ := body["dashboard"].(map[string]any)
+			uid := dash["uid"].(string)
+			folderID := int64(body["folderId"].(float64))
+			dash["folderId"] = folderID
+			dashboards[uid] = dash
+			json.NewEncoder(w).Encode(map[string]any{"id": 100, "uid": uid, "status": "success"})
+			return
+		}
+
+		if strings.HasPrefix(r.URL.Path, "/api/dashboards/uid/") {
+			uid := r.URL.Path[len("/api/dashboards/uid/"):]
+			if r.Method == "DELETE" {
+				delete(dashboards, uid)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer mockGrafana.Close()
+
+	ns := "test-dashboards"
+	t.Setenv("POD_NAMESPACE", ns)
+	kubeClient.CoreV1().Namespaces().Create(t.Context(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+
+	t.Run("Scenario 1: Initial Orphan Cleanup", func(t *testing.T) {
+		resetState()
+		mu.Lock()
+		dashboards["zombie-uid"] = map[string]any{
+			"uid": "zombie-uid",
+		}
+		mu.Unlock()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		c, err := NewGrafanaDashboardController(kubeClient.CoreV1(), mockGrafana.URL)
+		if err != nil {
+			t.Fatalf("failed to create controller: %v", err)
+		}
+		go c.Run(ctx)
+
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 15*time.Second, true, func(ctx context.Context) (bool, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			_, exists := dashboards["zombie-uid"]
+			return !exists, nil
+		})
+		if err != nil {
+			t.Errorf("zombie dashboard was not cleaned up: %v", err)
+		}
+	})
+
+	t.Run("Scenario 2: Dashboard Lifecycle", func(t *testing.T) {
+		resetState()
+		mu.Lock()
+		folders[100] = "OldFolder"
+		mu.Unlock()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		c, err := NewGrafanaDashboardController(kubeClient.CoreV1(), mockGrafana.URL)
+		if err != nil {
+			t.Fatalf("failed to create controller: %v", err)
+		}
+		go c.Run(ctx)
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-dash", Namespace: ns,
+				Labels:      map[string]string{CustomDashboardLabelKey: "true", HomeDashboardUIDKey: "my-uid"},
+				Annotations: map[string]string{CustomFolderKey: "OldFolder", SetHomeDashboardKey: "true"},
+			},
+			Data: map[string]string{"dash.json": "{\"title\": \"My Dash\", \"uid\": \"my-uid\"}"},
+		}
+		kubeClient.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
+
+		// Verify Create + Home Preference
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			// SetHomeDashboard failures trigger a workqueue retry, but don't block
+			// the processing of other dashboards in the same ConfigMap.
+			return dashboards["my-uid"] != nil && recordedRequests["PUT /api/org/preferences"] > 0, nil
+		})
+		if err != nil {
+			t.Errorf("dashboard creation or home preference failed: %v", err)
+		}
+
+		// Scenario 3: Folder Move
+		cm.Annotations[CustomFolderKey] = "NewFolder"
+		_, err = kubeClient.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
+		if err != nil {
+			t.Fatalf("failed to update configmap for move: %v", err)
+		}
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			foundNew, foundOld := false, false
+			for _, title := range folders {
+				if title == "NewFolder" {
+					foundNew = true
+				}
+				if title == "OldFolder" {
+					foundOld = true
+				}
+			}
+			return foundNew && !foundOld, nil
+		})
+		if err != nil {
+			t.Errorf("folder move failed: %v", err)
+		}
+
+		// Scenario 4: Deletion
+		err = kubeClient.CoreV1().ConfigMaps(ns).Delete(ctx, cm.Name, metav1.DeleteOptions{})
+		if err != nil {
+			t.Fatalf("failed to delete configmap: %v", err)
+		}
+
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			return dashboards["my-uid"] == nil, nil
+		})
+		if err != nil {
+			t.Errorf("dashboard deletion failed: %v", err)
+		}
+
+		// Scenario 5: Update Transition (Remove Label)
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "transition-dash", Namespace: ns,
+				Labels: map[string]string{CustomDashboardLabelKey: "true"},
+			},
+			Data: map[string]string{"dash.json": "{\"title\": \"Transition Dash\", \"uid\": \"trans-uid\"}"},
+		}
+		kubeClient.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			return dashboards["trans-uid"] != nil, nil
+		})
+		if err != nil {
+			t.Errorf("failed to create transition dashboard: %v", err)
+		}
+
+		// Remove label
+		cm.Labels = map[string]string{}
+		_, err = kubeClient.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
+		if err != nil {
+			t.Fatalf("failed to update configmap to remove label: %v", err)
+		}
+
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			return dashboards["trans-uid"] == nil, nil
+		})
+		if err != nil {
+			t.Errorf("dashboard not deleted after removing label: %v", err)
+		}
+	})
+}

--- a/loaders/dashboards/pkg/controller/dashboard_controller_integration_test.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller_integration_test.go
@@ -109,7 +109,12 @@ func TestIntegrationGrafanaDashboardController(t *testing.T) {
 
 		if r.URL.Path == "/api/search" {
 			var res []map[string]any
-			folderUIDs := r.URL.Query().Get("folderUids")
+			// Handle both documented and legacy casing
+			folderUIDs := r.URL.Query().Get("folderUIDs")
+			if folderUIDs == "" {
+				folderUIDs = r.URL.Query().Get("folderUids")
+			}
+
 			for uid, dash := range dashboards {
 				match := true
 				if folderUIDs != "" {
@@ -123,6 +128,12 @@ func TestIntegrationGrafanaDashboardController(t *testing.T) {
 					res = append(res, map[string]any{"uid": uid, "tags": dash["tags"]})
 				}
 			}
+
+			// Respect limit=1 optimization
+			if r.URL.Query().Get("limit") == "1" && len(res) > 1 {
+				res = res[:1]
+			}
+
 			json.NewEncoder(w).Encode(res)
 			return
 		}
@@ -224,7 +235,8 @@ func TestIntegrationGrafanaDashboardController(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to update configmap for move: %v", err)
 		}
-		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		// Increased timeout (30s) to allow for the workqueue rate-limited retry of the folder cleanup.
+		err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			foundNew, foundOld := false, false

--- a/loaders/dashboards/pkg/controller/dashboard_controller_test.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller_test.go
@@ -6,296 +6,756 @@ package controller
 
 import (
 	"context"
-	stdlog "log"
+	"errors"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
-	"time"
 
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 )
 
-var hasFakeServer bool = false
+type mockGrafanaClient struct {
+	dashboards []grafanaDashboard
+	folders    []grafanaFolder
+
+	deleteDashCalled   map[string]int
+	deleteFolderCalled map[string]int
+	createDashCalled   int
+	setHomeCalled      int
+
+	searchErr     error
+	createErr     error
+	createErrFunc func() error
+	setHomeErr    error
+
+	folderErr     error // Dedicated error for folder operations
+	listErr       error
+	deleteDashErr error
+	deleteFoldErr error
+	permErr       error
+	emptyErr      error
+
+	permResp  bool
+	emptyResp map[string]bool
+
+	lastDashboard map[string]any
+}
+
+func newMockGrafanaClient() *mockGrafanaClient {
+	return &mockGrafanaClient{
+		deleteDashCalled:   make(map[string]int),
+		deleteFolderCalled: make(map[string]int),
+		emptyResp:          make(map[string]bool),
+		permResp:           true,
+	}
+}
+
+func (m *mockGrafanaClient) ListAllDashboards(ctx context.Context) ([]grafanaDashboard, error) {
+	return m.dashboards, m.searchErr
+}
+
+func (m *mockGrafanaClient) DeleteDashboard(ctx context.Context, uid string) error {
+	m.deleteDashCalled[uid]++
+	return m.deleteDashErr
+}
+
+func (m *mockGrafanaClient) CreateOrUpdateDashboard(ctx context.Context, dashboard map[string]any, folderID int64) (int64, error) {
+	m.createDashCalled++
+	m.lastDashboard = dashboard
+	if m.createErrFunc != nil {
+		return 100, m.createErrFunc()
+	}
+	return 100, m.createErr
+}
+
+func (m *mockGrafanaClient) SetHomeDashboard(ctx context.Context, id int64) error {
+	m.setHomeCalled++
+	return m.setHomeErr
+}
+
+func (m *mockGrafanaClient) ListFolders(ctx context.Context) ([]grafanaFolder, error) {
+	return m.folders, m.listErr
+}
+
+func (m *mockGrafanaClient) GetFolderByID(ctx context.Context, id int64) (*grafanaFolder, error) {
+	for _, f := range m.folders {
+		if f.ID == id {
+			return &f, nil
+		}
+	}
+	return nil, errors.New("not found")
+}
+
+func (m *mockGrafanaClient) CreateFolder(ctx context.Context, title string) (*grafanaFolder, error) {
+	if m.folderErr != nil {
+		return nil, m.folderErr
+	}
+	f := grafanaFolder{ID: 1, UID: "test", Title: title}
+	m.folders = append(m.folders, f)
+	return &f, nil
+}
+
+func (m *mockGrafanaClient) DeleteFolder(ctx context.Context, uid string) error {
+	m.deleteFolderCalled[uid]++
+	return m.deleteFoldErr
+}
+
+func (m *mockGrafanaClient) HasPermissions(ctx context.Context, uid string) (bool, error) {
+	return m.permResp, m.permErr
+}
+
+func (m *mockGrafanaClient) IsEmpty(ctx context.Context, uid string) (bool, error) {
+	return m.emptyResp[uid], m.emptyErr
+}
 
 func createDashboard() (*corev1.ConfigMap, error) {
-	// read the whole file at once
 	data, err := os.ReadFile("../../examples/k8s-dashboard.yaml")
 	if err != nil {
 		panic(err)
 	}
-
 	var cm corev1.ConfigMap
 	err = yaml.Unmarshal(data, &cm)
 	return &cm, err
 }
 
-func createFakeServer(t *testing.T) {
-	hasFakeServer = true
-	server3001 := http.NewServeMux()
-	server3001.HandleFunc("/api/folders",
-		func(w http.ResponseWriter, req *http.Request) {
-			w.Write([]byte("[{\"id\": 1,\"uid\": \"test\",\"title\": \"Custom\"}, {\"id\": 2, \"title\": \"noServer\",\"uid\": \"noServer\"}, {\"id\": 3,\"title\": \"noUID\"}]"))
-		},
-	)
-
-	server3001.HandleFunc("/api/folders/id/1",
-		func(w http.ResponseWriter, req *http.Request) {
-			w.Write([]byte("{\"uid\": \"test\"}"))
-		},
-	)
-
-	server3001.HandleFunc("/api/folders/id/2",
-		func(w http.ResponseWriter, req *http.Request) {
-			w.Write([]byte("{\"uid\": \"noServer\"}"))
-		},
-	)
-
-	server3001.HandleFunc("/api/folders/id/3",
-		func(w http.ResponseWriter, req *http.Request) {
-			w.Write([]byte("{}"))
-		},
-	)
-
-	server3001.HandleFunc("/api/folders/test",
-		func(w http.ResponseWriter, req *http.Request) {
-			w.Write([]byte("{}"))
-		},
-	)
-
-	server3001.HandleFunc("/api/search",
-		func(w http.ResponseWriter, req *http.Request) {
-			w.Write([]byte("[]"))
-		},
-	)
-
-	server3001.HandleFunc("/api/dashboards/db",
-		func(w http.ResponseWriter, req *http.Request) {
-			w.Write([]byte("done"))
-		},
-	)
-
-	server3001.HandleFunc("/api/dashboards/uid/ff635a025bcfea7bc3dd4f508990a3e8",
-		func(w http.ResponseWriter, req *http.Request) {
-			w.Write([]byte("done"))
-		},
-	)
-
-	err := http.ListenAndServe(":3001", server3001)
-	if err != nil {
-		stdlog.Fatal("fail to create internal server at 3001")
+func newTestController(t *testing.T, ns string) (*GrafanaDashboardController, *mockGrafanaClient) {
+	t.Setenv("POD_NAMESPACE", ns)
+	coreClient := fake.NewClientset().CoreV1()
+	mock := newMockGrafanaClient()
+	c := &GrafanaDashboardController{
+		kubeClient:        coreClient,
+		grafana:           mock,
+		maxDashboardRetry: defaultMaxDashboardRetry,
+		watchedNS:         ns,
+		uidMap:            make(map[string]trackedState),
 	}
+	return c, mock
+}
+
+func newTestQueue() workqueue.TypedRateLimitingInterface[any] {
+	return workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]())
+}
+
+func newTestIndexer() cache.Indexer {
+	return cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 }
 
 func TestGrafanaDashboardController(t *testing.T) {
-	coreClient := fake.NewSimpleClientset().CoreV1()
-	stop := make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
 
-	go createFakeServer(t)
-	maxHttpRetry = 1
+	c, mock := newTestController(t, "ns2")
+	mock.folders = append(mock.folders, grafanaFolder{ID: 1, UID: "test", Title: "Custom"})
 
-	os.Setenv("POD_NAMESPACE", "ns2")
+	cm, err := createDashboard()
+	if err != nil {
+		t.Fatalf("failed to create dashboard: %v", err)
+	}
+	_, err = c.kubeClient.ConfigMaps("ns2").Create(ctx, cm, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("fail to create configmap with %v", err)
+	}
 
-	informer, err := newKubeInformer(coreClient)
+	queue := newTestQueue()
+	informer, err := c.newKubeInformer(queue)
 	if err != nil {
 		t.Fatalf("failed to create informer with %v", err)
 	}
-	go informer.Run(stop)
+	go informer.Run(ctx.Done())
 
-	cm, err := createDashboard()
-	if err == nil {
-		_, err := coreClient.ConfigMaps("ns2").Create(context.TODO(), cm, metav1.CreateOptions{})
-		if err != nil {
-			t.Fatalf("fail to create configmap with %v", err)
-		}
-		// wait for 2 second to trigger AddFunc of informer
-		time.Sleep(time.Second * 2)
-		updateDashboard(nil, cm, false)
-
-		cm.Data = map[string]string{}
-		_, err = coreClient.ConfigMaps("ns2").Update(context.TODO(), cm, metav1.UpdateOptions{})
-		if err != nil {
-			t.Fatalf("fail to update configmap with %v", err)
-		}
-		// wait for 2 second to trigger UpdateFunc of informer
-		time.Sleep(time.Second * 2)
-		updateDashboard(nil, cm, false)
-
-		cm, _ := createDashboard()
-		_, err = coreClient.ConfigMaps("ns2").Update(context.TODO(), cm, metav1.UpdateOptions{})
-		if err != nil {
-			t.Fatalf("fail to update configmap with %v", err)
-		}
-
-		// wait for 2 second to trigger UpdateFunc of informer
-		time.Sleep(time.Second * 2)
-		updateDashboard(nil, cm, false)
-
-		coreClient.ConfigMaps("ns2").Delete(context.TODO(), cm.GetName(), metav1.DeleteOptions{})
-		time.Sleep(time.Second * 2)
-		deleteDashboard(cm)
-
+	if err := c.updateDashboard(ctx, cm); err != nil {
+		t.Errorf("failed to update dashboard: %v", err)
 	}
 
-	close(stop)
-	<-stop
+	cm.Data = map[string]string{}
+	_, err = c.kubeClient.ConfigMaps("ns2").Update(ctx, cm, metav1.UpdateOptions{})
+	if err := c.updateDashboard(ctx, cm); err != nil {
+		t.Errorf("failed to update dashboard with empty data: %v", err)
+	}
+
+	cm, _ = createDashboard()
+	_, err = c.kubeClient.ConfigMaps("ns2").Update(ctx, cm, metav1.UpdateOptions{})
+	if err := c.updateDashboard(ctx, cm); err != nil {
+		t.Errorf("failed to update dashboard: %v", err)
+	}
+
+	c.kubeClient.ConfigMaps("ns2").Delete(ctx, cm.GetName(), metav1.DeleteOptions{})
+	key, _ := cache.MetaNamespaceKeyFunc(cm)
+	if err := c.deleteTrackedUIDs(ctx, key); err != nil {
+		t.Errorf("failed to delete tracked uids: %v", err)
+	}
+}
+
+func TestDeleteTrackedUIDs(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("retry on deletion failure", func(t *testing.T) {
+		c, mock := newTestController(t, "default")
+		key := "default/my-dash"
+		c.uidMap[key] = trackedState{uids: []string{"uid1", "uid2"}, folder: "Custom"}
+
+		// Fail deletion for uid1
+		mock.deleteDashErr = errors.New("transient error")
+
+		err := c.deleteTrackedUIDs(ctx, key)
+		if err == nil {
+			t.Error("expected error on deletion failure")
+		}
+
+		c.mapMu.RLock()
+		state, exists := c.uidMap[key]
+		c.mapMu.RUnlock()
+
+		if !exists {
+			t.Error("expected state to remain in map on failure")
+		}
+		if len(state.uids) != 2 {
+			t.Errorf("expected both UIDs to remain (or at least the failed one), got %v", state.uids)
+		}
+
+		// Now succeed
+		mock.deleteDashErr = nil
+		err = c.deleteTrackedUIDs(ctx, key)
+		if err != nil {
+			t.Errorf("expected nil error on second attempt, got %v", err)
+		}
+
+		c.mapMu.RLock()
+		_, exists = c.uidMap[key]
+		c.mapMu.RUnlock()
+		if exists {
+			t.Error("expected state to be removed from map after successful deletion")
+		}
+	})
+}
+
+func TestNewKubeInformer_Filtering(t *testing.T) {
+	c := &GrafanaDashboardController{}
+
+	dashCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{CustomDashboardLabelKey: "true"}},
+	}
+	regularCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "regular"},
+	}
+
+	t.Run("enqueue new dashboard", func(t *testing.T) {
+		if !c.shouldEnqueue(nil, dashCM) {
+			t.Error("expected to enqueue new dashboard")
+		}
+	})
+
+	t.Run("ignore new regular ConfigMap", func(t *testing.T) {
+		if c.shouldEnqueue(nil, regularCM) {
+			t.Error("should not enqueue regular ConfigMap")
+		}
+	})
+
+	t.Run("enqueue when dashboard becomes regular CM (cleanup)", func(t *testing.T) {
+		if !c.shouldEnqueue(dashCM, regularCM) {
+			t.Error("expected to enqueue for immediate cleanup")
+		}
+	})
+
+	t.Run("ignore regular CM update", func(t *testing.T) {
+		if c.shouldEnqueue(regularCM, regularCM) {
+			t.Error("should not enqueue regular CM update")
+		}
+	})
+}
+
+func TestCleanupOrphanDashboards_MapPopulation(t *testing.T) {
+	ctx := t.Context()
+	c, mock := newTestController(t, "default")
+
+	// 1. Pre-existing ConfigMap in Kubernetes
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "pre-existing", Namespace: "default", Labels: map[string]string{CustomDashboardLabelKey: "true"}},
+		Data:       map[string]string{"dash.json": "{\"title\": \"Pre\", \"uid\": \"explicit-uid\"}"},
+	}
+	indexer := newTestIndexer()
+	indexer.Add(cm)
+
+	// 2. Grafana has this dashboard + an orphan
+	mock.dashboards = []grafanaDashboard{
+		{UID: "explicit-uid"},
+		{UID: "zombie-uid"},
+	}
+
+	// Run cleanup
+	c.cleanupOrphanDashboards(ctx, indexer)
+
+	// Verify zombie was deleted
+	if mock.deleteDashCalled["zombie-uid"] != 1 {
+		t.Error("expected zombie to be deleted")
+	}
+
+	// CRITICAL: Verify uidMap was populated during cleanup!
+	c.mapMu.RLock()
+	state, exists := c.uidMap["default/pre-existing"]
+	c.mapMu.RUnlock()
+
+	if !exists {
+		t.Fatal("expected uidMap to be populated during initial scan")
+	}
+	if len(state.uids) != 1 || state.uids[0] != "explicit-uid" {
+		t.Errorf("expected explicit-uid to be tracked, got %v", state.uids)
+	}
 }
 
 func TestIsDesiredDashboardConfigmap(t *testing.T) {
-	os.Setenv("POD_NAMESPACE", "test")
 	testCaseList := []struct {
 		name     string
 		cm       *corev1.ConfigMap
 		expected bool
 	}{
 		{
-			"invalid cm",
-			nil,
+			"custom dashboard",
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{CustomDashboardLabelKey: "true"}}},
+			true,
+		},
+		{
+			"not custom dashboard",
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{CustomDashboardLabelKey: "false"}}},
 			false,
 		},
-
 		{
-			"valid label",
+			"mco dashboard",
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-					Labels:    map[string]string{"grafana-custom-dashboard": "true"},
+					Name:            "grafana-dashboard-test",
+					OwnerReferences: []metav1.OwnerReference{{Kind: "MultiClusterObservability"}},
 				},
 			},
 			true,
 		},
-
 		{
-			"valid name",
+			"not mco dashboard (wrong name)",
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "grafana-dashboard",
-					Namespace: "test",
-					OwnerReferences: []metav1.OwnerReference{
-						{Kind: "MultiClusterObservability"},
-					},
-				},
-			},
-			true,
-		},
-
-		{
-			"invalid label",
-			&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-					Labels:    map[string]string{"grafana-custom-dashboard": "false"},
+					Name:            "not-grafana",
+					OwnerReferences: []metav1.OwnerReference{{Kind: "MultiClusterObservability"}},
 				},
 			},
 			false,
 		},
-
 		{
-			"invalid name",
+			"not mco dashboard (wrong owner)",
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-					OwnerReferences: []metav1.OwnerReference{
-						{Kind: "MultiClusterObservability"},
-					},
-				},
-			},
-			false,
-		},
-
-		{
-			"invalid owner references",
-			&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-					OwnerReferences: []metav1.OwnerReference{
-						{Kind: "test"},
-					},
+					Name:            "grafana-dashboard-test",
+					OwnerReferences: []metav1.OwnerReference{{Kind: "Pod"}},
 				},
 			},
 			false,
 		},
 	}
 
-	for _, c := range testCaseList {
-		output := isDesiredDashboardConfigmap(c.cm)
-		if output != c.expected {
-			t.Errorf("case (%v) output: (%v) is not the expected: (%v)", c.name, output, c.expected)
-		}
+	for _, tc := range testCaseList {
+		t.Run(tc.name, func(t *testing.T) {
+			if isDesiredDashboardConfigmap(tc.cm) != tc.expected {
+				t.Errorf("failed %s", tc.name)
+			}
+		})
 	}
 }
 
-func TestGetCustomFolderUID(t *testing.T) {
-	if !hasFakeServer {
-		go createFakeServer(t)
-		maxHttpRetry = 1
-	}
+func TestFindCustomFolderID(t *testing.T) {
+	c, mock := newTestController(t, "default")
+	mock.folders = []grafanaFolder{{ID: 1, Title: "Custom"}}
 
-	testCaseList := []struct {
-		name     string
-		id       float64
-		expected string
-	}{
-		{
-			"valid folder",
-			1,
-			"test",
-		},
-		{
-			"invalid folder",
-			0,
-			"",
-		},
-		{
-			"no uid field",
-			3,
-			"",
-		},
+	if c.findCustomFolderID(t.Context(), "Custom") != 1 {
+		t.Error("expected 1")
 	}
-	for _, c := range testCaseList {
-		output := getCustomFolderUID(c.id)
-		if output != c.expected {
-			t.Errorf("case (%v) output: (%v) is not the expected: (%v)", c.name, output, c.expected)
-		}
+	if c.findCustomFolderID(t.Context(), "Unknown") != 0 {
+		t.Error("expected 0")
 	}
 }
 
-func TestIsEmptyFolder(t *testing.T) {
-	if !hasFakeServer {
-		go createFakeServer(t)
-		maxHttpRetry = 1
-	}
+func TestSyncHandler(t *testing.T) {
+	ctx := t.Context()
+	c, _ := newTestController(t, "default")
 
-	testCaseList := []struct {
-		name     string
-		folderID float64
-		expected bool
+	t.Run("sync existing dashboard", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "m",
+				Namespace: "default",
+				Labels:    map[string]string{CustomDashboardLabelKey: "true"},
+			},
+			Data: map[string]string{"d": "{}"},
+		}
+		indexer := newTestIndexer()
+		indexer.Add(cm)
+		if err := c.syncHandler(ctx, "default/m", indexer); err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("non-existent key returns nil", func(t *testing.T) {
+		if err := c.syncHandler(ctx, "default/missing", newTestIndexer()); err != nil {
+			t.Error(err)
+		}
+	})
+}
+
+func TestCleanupOrphanDashboards(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("happy path", func(t *testing.T) {
+		c, mock := newTestController(t, "default")
+		// Resolve the expected UID for the existing CM
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "exists", Namespace: "default", Labels: map[string]string{CustomDashboardLabelKey: "true"}},
+			Data:       map[string]string{"key1": "{}"},
+		}
+		expectedUID, _ := c.resolveDashboardUID(nil, cm, "key1")
+
+		mock.dashboards = []grafanaDashboard{
+			{UID: expectedUID},
+			{UID: "orphan"},
+		}
+		mock.folders = []grafanaFolder{{ID: 10, UID: "empty-uid", Title: "Empty"}}
+		mock.emptyResp["empty-uid"] = true
+
+		indexer := newTestIndexer()
+		indexer.Add(cm)
+
+		c.cleanupOrphanDashboards(ctx, indexer)
+
+		if mock.deleteDashCalled["orphan"] != 1 {
+			t.Error("orphan not deleted")
+		}
+		if mock.deleteDashCalled[expectedUID] != 0 {
+			t.Error("valid dashboard should not be deleted")
+		}
+		if mock.deleteFolderCalled["empty-uid"] != 1 {
+			t.Error("empty folder not deleted")
+		}
+	})
+
+	t.Run("search error returns early", func(t *testing.T) {
+		c, mock := newTestController(t, "default")
+		mock.searchErr = errors.New("search fail")
+		mock.dashboards = []grafanaDashboard{{UID: "any"}}
+		c.cleanupOrphanDashboards(ctx, newTestIndexer())
+		if len(mock.deleteDashCalled) > 0 {
+			t.Error("should not have deleted anything on search error")
+		}
+	})
+
+	t.Run("non-dashboard CM does not protect dashboards", func(t *testing.T) {
+		c, mock := newTestController(t, "default")
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "regular", Namespace: "default"},
+			Data:       map[string]string{"key1": "{}"},
+		}
+		uid, _ := c.resolveDashboardUID(nil, cm, "key1")
+		mock.dashboards = []grafanaDashboard{{UID: uid}}
+		indexer := newTestIndexer()
+		indexer.Add(cm)
+		c.cleanupOrphanDashboards(ctx, indexer)
+		if mock.deleteDashCalled[uid] != 1 {
+			t.Error("dashboard from non-dashboard CM should be deleted")
+		}
+	})
+
+	t.Run("multi-key CM protects all its dashboards", func(t *testing.T) {
+		c, mock := newTestController(t, "default")
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "multi", Namespace: "default", Labels: map[string]string{CustomDashboardLabelKey: "true"}},
+			Data:       map[string]string{"k1": "{}", "k2": "{}"},
+		}
+		u1, _ := c.resolveDashboardUID(nil, cm, "k1")
+		u2, _ := c.resolveDashboardUID(nil, cm, "k2")
+		mock.dashboards = []grafanaDashboard{{UID: u1}, {UID: u2}}
+		indexer := newTestIndexer()
+		indexer.Add(cm)
+		c.cleanupOrphanDashboards(ctx, indexer)
+		if mock.deleteDashCalled[u1] != 0 || mock.deleteDashCalled[u2] != 0 {
+			t.Error("dashboards from multi-key CM should be protected")
+		}
+	})
+}
+
+func TestResolveDashboardUID(t *testing.T) {
+	c := &GrafanaDashboardController{}
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "my-cm", Namespace: "my-ns"}}
+
+	t.Run("uid exists", func(t *testing.T) {
+		dash := map[string]any{"uid": "existing-uid"}
+		uid, _ := c.resolveDashboardUID(dash, cm, "key1")
+		if uid != "existing-uid" {
+			t.Errorf("got %s", uid)
+		}
+	})
+	t.Run("fallback", func(t *testing.T) {
+		dash := map[string]any{"uid": ""}
+		uid, _ := c.resolveDashboardUID(dash, cm, "key1")
+		// Fallback should be namespace-name-key
+		if uid != "my-ns-my-cm-key1" {
+			t.Errorf("expected my-ns-my-cm-key1, got %s", uid)
+		}
+	})
+
+	t.Run("nil dashboard generates fallback UID", func(t *testing.T) {
+		uid, err := c.resolveDashboardUID(nil, cm, "key1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if uid == "" {
+			t.Error("expected non-empty generated UID")
+		}
+		uid2, _ := c.resolveDashboardUID(nil, cm, "key1")
+		if uid != uid2 {
+			t.Error("UID must be deterministic")
+		}
+	})
+
+	t.Run("multi-dashboard uniqueness", func(t *testing.T) {
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "multi", Namespace: "ns"}}
+		u1, _ := c.resolveDashboardUID(nil, cm, "k1")
+		u2, _ := c.resolveDashboardUID(nil, cm, "k2")
+		if u1 == u2 {
+			t.Errorf("expected unique UIDs for different keys, both got %s", u1)
+		}
+		if !strings.Contains(u1, "k1") || !strings.Contains(u2, "k2") {
+			t.Errorf("UIDs should contain the key name: %s, %s", u1, u2)
+		}
+	})
+}
+
+func TestCreateCustomFolder_PermissionsRetry(t *testing.T) {
+	ctx := t.Context()
+	c, mock := newTestController(t, "default")
+	mock.permResp = false // Force permission failure
+
+	id := c.createCustomFolder(ctx, "RetryFolder")
+	if id != 0 {
+		t.Errorf("expected 0 ID, got %v", id)
+	}
+	if mock.deleteFolderCalled["test"] != 1 {
+		t.Error("expected folder deletion on permission failure")
+	}
+}
+
+func TestUpdateDashboard_GrafanaErrors(t *testing.T) {
+	ctx := t.Context()
+
+	testCases := []struct {
+		name           string
+		err            error
+		expectedErrSub string
 	}{
 		{
-			"invalid ID",
-			0,
-			false,
-		},
-
-		{
-			"empty folder",
-			1,
-			true,
+			"name exists",
+			&GrafanaError{Status: http.StatusPreconditionFailed, Body: "name-exists"},
+			"the dashboard name already existed",
 		},
 	}
 
-	for _, c := range testCaseList {
-		output := isEmptyFolder(c.folderID)
-		if output != c.expected {
-			t.Errorf("case (%v) output: (%v) is not the expected: (%v)", c.name, output, c.expected)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, mock := newTestController(t, "default")
+			mock.createErr = tc.err
+
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "err-cm", Namespace: "default", Labels: map[string]string{CustomDashboardLabelKey: "true"}},
+				Data:       map[string]string{"k": "{}"},
+			}
+			err := c.updateDashboard(ctx, cm)
+			if err == nil || !strings.Contains(err.Error(), tc.expectedErrSub) {
+				t.Errorf("expected %q, got %v", tc.expectedErrSub, err)
+			}
+		})
+	}
+
+	t.Run("SetHomeDashboard failure should not block other dashboards and trigger retry", func(t *testing.T) {
+		c, mock := newTestController(t, "default")
+		mock.setHomeErr = errors.New("api failure")
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "multi-dash", Namespace: "default",
+				Labels: map[string]string{
+					CustomDashboardLabelKey: "true",
+					HomeDashboardUIDKey:     "uid1",
+				},
+				Annotations: map[string]string{
+					SetHomeDashboardKey: "true",
+				},
+			},
+			Data: map[string]string{
+				"dash1.json": "{\"title\": \"D1\", \"uid\": \"uid1\"}",
+				"dash2.json": "{\"title\": \"D2\", \"uid\": \"uid2\"}",
+			},
 		}
-	}
+
+		err := c.updateDashboard(ctx, cm)
+		if err == nil || !strings.Contains(err.Error(), "api failure") {
+			t.Errorf("expected error from SetHomeDashboard failure, got %v", err)
+		}
+
+		if mock.createDashCalled != 2 {
+			t.Errorf("expected 2 dashboards created, got %d", mock.createDashCalled)
+		}
+		if mock.setHomeCalled != 1 {
+			t.Errorf("expected 1 setHome call, got %d", mock.setHomeCalled)
+		}
+
+		c.mapMu.RLock()
+		state := c.uidMap["default/multi-dash"]
+		c.mapMu.RUnlock()
+		if len(state.uids) != 2 {
+			t.Errorf("expected 2 UIDs in map, got %v", state.uids)
+		}
+		// Verify content
+		found1, found2 := false, false
+		for _, u := range state.uids {
+			if u == "uid1" {
+				found1 = true
+			}
+			if u == "uid2" {
+				found2 = true
+			}
+		}
+		if !found1 || !found2 {
+			t.Errorf("missing UIDs in map: %v", state.uids)
+		}
+	})
+
+	t.Run("partial success: one fails creation, sibling succeeds. Both tracked in map.", func(t *testing.T) {
+		c, mock := newTestController(t, "default")
+		// Fail only on first call
+		callCount := 0
+		mock.createErrFunc = func() error {
+			callCount++
+			if callCount == 1 {
+				return errors.New("creation fail")
+			}
+			return nil
+		}
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "partial", Namespace: "default", Labels: map[string]string{CustomDashboardLabelKey: "true"}},
+			Data: map[string]string{
+				"dash1.json": "{\"title\": \"D1\", \"uid\": \"uid1\"}",
+				"dash2.json": "{\"title\": \"D2\", \"uid\": \"uid2\"}",
+			},
+		}
+
+		err := c.updateDashboard(ctx, cm)
+		if err == nil || !strings.Contains(err.Error(), "creation fail") {
+			t.Errorf("expected creation fail error, got %v", err)
+		}
+
+		if mock.createDashCalled != 2 {
+			t.Errorf("expected 2 create attempts, got %d", mock.createDashCalled)
+		}
+
+		c.mapMu.RLock()
+		state := c.uidMap["default/partial"]
+		c.mapMu.RUnlock()
+		// BOTH should be in the map to protect the failing one from accidental deletion
+		if len(state.uids) != 2 {
+			t.Errorf("expected 2 UIDs in map (including failing one), got %v", state.uids)
+		}
+	})
+
+	t.Run("unmarshal failure on one key does not block cleanup for orphans", func(t *testing.T) {
+		c, mock := newTestController(t, "default")
+		// Pre-populate map with an "old" UID that SHOULD be deleted
+		c.uidMap["default/unmarshal"] = trackedState{uids: []string{"old-orphan", "good-uid"}, folder: "Custom"}
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "unmarshal", Namespace: "default", Labels: map[string]string{CustomDashboardLabelKey: "true"}},
+			Data: map[string]string{
+				"bad.json":  "{",
+				"good.json": "{\"title\": \"Good\", \"uid\": \"good-uid\"}",
+			},
+		}
+
+		err := c.updateDashboard(ctx, cm)
+		if err != nil {
+			t.Errorf("expected nil error for unmarshal failure (best-effort), got %v", err)
+		}
+
+		// Verify cleanup RAN: old-orphan should be deleted
+		if mock.deleteDashCalled["old-orphan"] != 1 {
+			t.Error("expected cleanup to run despite unmarshal failure on a different key")
+		}
+
+		c.mapMu.RLock()
+		state := c.uidMap["default/unmarshal"]
+		c.mapMu.RUnlock()
+		// Map should only contain good-uid because currentUIDs is the new truth
+		if len(state.uids) != 1 || state.uids[0] != "good-uid" {
+			t.Errorf("expected only good-uid in map, got %v", state.uids)
+		}
+	})
+
+	t.Run("creation + deletion errors combined", func(t *testing.T) {
+		c, mock := newTestController(t, "default")
+		c.uidMap["default/combined"] = trackedState{uids: []string{"old-orphan"}, folder: "Custom"}
+		mock.createErr = errors.New("create fail")
+		mock.deleteDashErr = errors.New("delete fail")
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "combined", Namespace: "default", Labels: map[string]string{CustomDashboardLabelKey: "true"}},
+			Data: map[string]string{
+				"new.json": "{\"title\": \"New\", \"uid\": \"new-uid\"}",
+			},
+		}
+
+		err := c.updateDashboard(ctx, cm)
+		if err == nil {
+			t.Fatal("expected errors")
+		}
+		if !strings.Contains(err.Error(), "create fail") || !strings.Contains(err.Error(), "delete fail") {
+			t.Errorf("expected combined errors, got: %v", err)
+		}
+	})
+
+	t.Run("name exists on one key does not block others", func(t *testing.T) {
+		c, mock := newTestController(t, "default")
+		// Fail only on one specific title
+		mock.createErrFunc = func() error {
+			if mock.lastDashboard["title"] == "Bad" {
+				return &GrafanaError{Status: http.StatusPreconditionFailed, Body: "name-exists"}
+			}
+			return nil
+		}
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "name-exists", Namespace: "default", Labels: map[string]string{CustomDashboardLabelKey: "true"}},
+			Data: map[string]string{
+				"bad.json":  "{\"title\": \"Bad\", \"uid\": \"bad-uid\"}",
+				"good.json": "{\"title\": \"Good\", \"uid\": \"good-uid\"}",
+			},
+		}
+
+		err := c.updateDashboard(ctx, cm)
+		if err == nil || !strings.Contains(err.Error(), "the dashboard name already existed") {
+			t.Errorf("expected name exists error, got %v", err)
+		}
+
+		if mock.createDashCalled != 2 {
+			t.Errorf("expected 2 create attempts, got %d", mock.createDashCalled)
+		}
+
+		c.mapMu.RLock()
+		state := c.uidMap["default/name-exists"]
+		c.mapMu.RUnlock()
+		if len(state.uids) != 2 {
+			t.Errorf("expected both UIDs in map (protection logic), got %v", state.uids)
+		}
+	})
 }
 
 func TestGetDashboardCustomFolderTitle(t *testing.T) {
@@ -304,84 +764,75 @@ func TestGetDashboardCustomFolderTitle(t *testing.T) {
 		cm       *corev1.ConfigMap
 		expected string
 	}{
-		{
-			"invalid cm",
-			nil,
-			"",
-		},
-
-		{
-			"default folder",
-			&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "grafana-dashboard",
-					Namespace: "test",
-				},
-			},
-			"Custom",
-		},
-
-		{
-			"general folder",
-			&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "grafana-dashboard",
-					Namespace: "test",
-					Labels:    map[string]string{"general-folder": "true"},
-				},
-			},
-			"",
-		},
+		{"nil cm", nil, "Custom"},
+		{"default", &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test"}}, "Custom"},
+		{"custom", &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{CustomFolderKey: "my-folder"}}}, "my-folder"},
+		{"general", &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{GeneralFolderKey: "true"}}}, ""},
 	}
-
-	for _, c := range testCaseList {
-		output := getDashboardCustomFolderTitle(c.cm)
-		if output != c.expected {
-			t.Errorf("case (%v) output: (%v) is not the expected: (%v)", c.name, output, c.expected)
-		}
+	for _, tc := range testCaseList {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := getDashboardCustomFolderTitle(tc.cm); got != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, got)
+			}
+		})
 	}
 }
 
-func TestDeleteCustomFolder(t *testing.T) {
-	if !hasFakeServer {
-		go createFakeServer(t)
-		maxHttpRetry = 1
-	}
+func TestProcessNextItem(t *testing.T) {
+	ctx := t.Context()
+	c, _ := newTestController(t, "default")
 
-	testCaseList := []struct {
-		name     string
-		folderID float64
-		expected bool
-	}{
-		{
-			"invalid ID",
-			0,
-			false,
-		},
-
-		{
-			"no UID",
-			3,
-			false,
-		},
-
-		{
-			"request error",
-			2,
-			false,
-		},
-
-		{
-			"valid name",
-			1,
-			true,
-		},
-	}
-
-	for _, c := range testCaseList {
-		output := deleteCustomFolder(c.folderID)
-		if output != c.expected {
-			t.Errorf("case (%v) output: (%v) is not the expected: (%v)", c.name, output, c.expected)
+	t.Run("quit", func(t *testing.T) {
+		q := newTestQueue()
+		q.ShutDown()
+		if c.processNextItem(ctx, q, newTestIndexer()) {
+			t.Error("expected false")
 		}
-	}
+	})
+
+	t.Run("retry and exhaustion", func(t *testing.T) {
+		q := newTestQueue()
+		indexer := newTestIndexer()
+		c, mock := newTestController(t, "default")
+		// Case 1: Unmarshal error - Logged and Ignored (no retry)
+		cmBad := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "bad", Namespace: "default", Labels: map[string]string{CustomDashboardLabelKey: "true"}},
+			Data:       map[string]string{"k": "{"},
+		}
+		indexer.Add(cmBad)
+		q.Add("default/bad")
+		if !c.processNextItem(ctx, q, indexer) {
+			t.Fatal("expected true")
+		}
+		if q.NumRequeues("default/bad") != 0 {
+			t.Errorf("expected 0 requeues for unmarshal error, got %d", q.NumRequeues("default/bad"))
+		}
+
+		// Case 2: API error - Retried
+		mock.createErr = errors.New("api fail")
+		cmRetry := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "retry", Namespace: "default", Labels: map[string]string{CustomDashboardLabelKey: "true"}},
+			Data:       map[string]string{"k": "{}"},
+		}
+		indexer.Add(cmRetry)
+		q.Add("default/retry")
+
+		if !c.processNextItem(ctx, q, indexer) {
+			t.Fatal("expected true")
+		}
+		if q.NumRequeues("default/retry") != 1 {
+			t.Error("expected 1 requeue for API error")
+		}
+
+		// Exhaust retries for Case 2
+		for i := 1; i < c.maxDashboardRetry; i++ {
+			q.AddRateLimited("default/retry")
+		}
+		if !c.processNextItem(ctx, q, indexer) {
+			t.Fatal("expected true")
+		}
+		if q.NumRequeues("default/retry") != 0 {
+			t.Error("expected dropped after exhaustion")
+		}
+	})
 }

--- a/loaders/dashboards/pkg/controller/dashboard_controller_test.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller_test.go
@@ -134,7 +134,9 @@ func newTestController(t *testing.T, ns string) (*GrafanaDashboardController, *m
 		maxDashboardRetry: defaultMaxDashboardRetry,
 		watchedNS:         ns,
 		uidMap:            make(map[string]trackedState),
+		reconcileMu:       make(chan struct{}, 1),
 	}
+	c.reconcileMu <- struct{}{}
 	return c, mock
 }
 
@@ -208,9 +210,7 @@ func TestDeleteTrackedUIDs(t *testing.T) {
 			t.Error("expected error on deletion failure")
 		}
 
-		c.mapMu.RLock()
 		state, exists := c.uidMap[key]
-		c.mapMu.RUnlock()
 
 		if !exists {
 			t.Error("expected state to remain in map on failure")
@@ -226,9 +226,7 @@ func TestDeleteTrackedUIDs(t *testing.T) {
 			t.Errorf("expected nil error on second attempt, got %v", err)
 		}
 
-		c.mapMu.RLock()
 		_, exists = c.uidMap[key]
-		c.mapMu.RUnlock()
 		if exists {
 			t.Error("expected state to be removed from map after successful deletion")
 		}
@@ -297,9 +295,7 @@ func TestCleanupOrphanDashboards_MapPopulation(t *testing.T) {
 	}
 
 	// CRITICAL: Verify uidMap was populated during cleanup!
-	c.mapMu.RLock()
 	state, exists := c.uidMap["default/pre-existing"]
-	c.mapMu.RUnlock()
 
 	if !exists {
 		t.Fatal("expected uidMap to be populated during initial scan")
@@ -535,6 +531,30 @@ func TestResolveDashboardUID(t *testing.T) {
 	})
 }
 
+func TestResolveDashboardUID_Extensions(t *testing.T) {
+	c := &GrafanaDashboardController{}
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "my-dash", Namespace: "ns"}}
+
+	testCases := []struct {
+		key      string
+		expected string
+	}{
+		{"my-dash.json", "my-dash-ns"},
+		{"my-dash.yaml", "my-dash-ns"},
+		{"my-dash.yml", "my-dash-ns"},
+		{"other.json", "my-dash-other-ns"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.key, func(t *testing.T) {
+			uid, _ := c.resolveDashboardUID(nil, cm, tc.key)
+			if uid != tc.expected {
+				t.Errorf("for key %q: expected %q, got %q", tc.key, tc.expected, uid)
+			}
+		})
+	}
+}
+
 func TestCreateCustomFolder_PermissionsRetry(t *testing.T) {
 	ctx := t.Context()
 	c, mock := newTestController(t, "default")
@@ -613,9 +633,7 @@ func TestUpdateDashboard_GrafanaErrors(t *testing.T) {
 			t.Errorf("expected 1 setHome call, got %d", mock.setHomeCalled)
 		}
 
-		c.mapMu.RLock()
 		state := c.uidMap["default/multi-dash"]
-		c.mapMu.RUnlock()
 		if len(state.uids) != 2 {
 			t.Errorf("expected 2 UIDs in map, got %v", state.uids)
 		}
@@ -663,9 +681,7 @@ func TestUpdateDashboard_GrafanaErrors(t *testing.T) {
 			t.Errorf("expected 2 create attempts, got %d", mock.createDashCalled)
 		}
 
-		c.mapMu.RLock()
 		state := c.uidMap["default/partial"]
-		c.mapMu.RUnlock()
 		// BOTH should be in the map to protect the failing one from accidental deletion
 		if len(state.uids) != 2 {
 			t.Errorf("expected 2 UIDs in map (including failing one), got %v", state.uids)
@@ -695,9 +711,7 @@ func TestUpdateDashboard_GrafanaErrors(t *testing.T) {
 			t.Error("expected cleanup to run despite unmarshal failure on a different key")
 		}
 
-		c.mapMu.RLock()
 		state := c.uidMap["default/unmarshal"]
-		c.mapMu.RUnlock()
 		// Map should only contain good-uid because currentUIDs is the new truth
 		if len(state.uids) != 1 || state.uids[0] != "good-uid" {
 			t.Errorf("expected only good-uid in map, got %v", state.uids)
@@ -753,9 +767,7 @@ func TestUpdateDashboard_GrafanaErrors(t *testing.T) {
 			t.Errorf("expected 2 create attempts, got %d", mock.createDashCalled)
 		}
 
-		c.mapMu.RLock()
 		state := c.uidMap["default/name-exists"]
-		c.mapMu.RUnlock()
 		if len(state.uids) != 2 {
 			t.Errorf("expected both UIDs in map (protection logic), got %v", state.uids)
 		}

--- a/loaders/dashboards/pkg/controller/dashboard_controller_test.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller_test.go
@@ -89,7 +89,7 @@ func (m *mockGrafanaClient) GetFolderByID(ctx context.Context, id int64) (*grafa
 			return &f, nil
 		}
 	}
-	return nil, errors.New("not found")
+	return nil, &GrafanaError{Status: http.StatusNotFound, Body: "not found"}
 }
 
 func (m *mockGrafanaClient) CreateFolder(ctx context.Context, title string) (*grafanaFolder, error) {
@@ -111,7 +111,10 @@ func (m *mockGrafanaClient) HasPermissions(ctx context.Context, uid string) (boo
 }
 
 func (m *mockGrafanaClient) IsEmpty(ctx context.Context, uid string) (bool, error) {
-	return m.emptyResp[uid], m.emptyErr
+	if val, ok := m.emptyResp[uid]; ok {
+		return val, m.emptyErr
+	}
+	return true, m.emptyErr
 }
 
 func createDashboard() (*corev1.ConfigMap, error) {

--- a/loaders/dashboards/pkg/controller/dashboard_controller_test.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller_test.go
@@ -777,6 +777,38 @@ func TestUpdateDashboard_GrafanaErrors(t *testing.T) {
 	})
 }
 
+func TestCleanupFolder_APIErrorRetries(t *testing.T) {
+	ctx := t.Context()
+	c, mock := newTestController(t, "default")
+
+	// Setup a custom folder
+	mock.folders = []grafanaFolder{{ID: 1, UID: "folder-uid", Title: "Custom"}}
+	// Force the IsEmpty check to return a transient API error
+	mock.emptyErr = errors.New("transient grafana 500 error")
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "default", Labels: map[string]string{CustomDashboardLabelKey: "true"}},
+		Data:       map[string]string{}, // Empty data triggers immediate folder cleanup in updateDashboard
+	}
+	cm.Annotations = map[string]string{CustomFolderKey: "Custom"}
+	c.uidMap["default/test-cm"] = trackedState{folder: "Custom"}
+
+	err := c.updateDashboard(ctx, cm)
+
+	if err == nil {
+		t.Fatal("expected an error due to the transient API failure during cleanup")
+	}
+
+	if !strings.Contains(err.Error(), "transient grafana 500 error") {
+		t.Errorf("expected the API error to bubble up, got: %v", err)
+	}
+
+	// Verify that the poller aborted immediately and didn't attempt to delete the folder
+	if mock.deleteFolderCalled["folder-uid"] > 0 {
+		t.Error("expected folder deletion to be skipped when the emptiness check fails")
+	}
+}
+
 func TestGetDashboardCustomFolderTitle(t *testing.T) {
 	testCaseList := []struct {
 		name     string

--- a/loaders/dashboards/pkg/controller/dashboard_controller_test.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller_test.go
@@ -321,6 +321,11 @@ func TestIsDesiredDashboardConfigmap(t *testing.T) {
 			true,
 		},
 		{
+			"general folder dashboard",
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{GeneralFolderKey: "true"}}},
+			true,
+		},
+		{
 			"not custom dashboard",
 			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{CustomDashboardLabelKey: "false"}}},
 			false,
@@ -329,21 +334,11 @@ func TestIsDesiredDashboardConfigmap(t *testing.T) {
 			"mco dashboard",
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            "grafana-dashboard-test",
+					Name:            "grafana-dashboard-mco",
 					OwnerReferences: []metav1.OwnerReference{{Kind: "MultiClusterObservability"}},
 				},
 			},
 			true,
-		},
-		{
-			"not mco dashboard (wrong name)",
-			&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "not-grafana",
-					OwnerReferences: []metav1.OwnerReference{{Kind: "MultiClusterObservability"}},
-				},
-			},
-			false,
 		},
 		{
 			"not mco dashboard (wrong owner)",
@@ -498,9 +493,18 @@ func TestResolveDashboardUID(t *testing.T) {
 	t.Run("fallback", func(t *testing.T) {
 		dash := map[string]any{"uid": ""}
 		uid, _ := c.resolveDashboardUID(dash, cm, "key1")
-		// Fallback should be namespace-name-key
-		if uid != "my-ns-my-cm-key1" {
-			t.Errorf("expected my-ns-my-cm-key1, got %s", uid)
+		// Fallback should be name-namespace (legacy)
+		// Since key1 is NOT in my-cm, it should be my-cm-key1-my-ns
+		if uid != "my-cm-key1-my-ns" {
+			t.Errorf("expected my-cm-key1-my-ns, got %s", uid)
+		}
+	})
+
+	t.Run("legacy fallback (key matches name)", func(t *testing.T) {
+		cm2 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "my-dash", Namespace: "ns"}}
+		uid, _ := c.resolveDashboardUID(nil, cm2, "my-dash.json")
+		if uid != "my-dash-ns" {
+			t.Errorf("expected my-dash-ns, got %s", uid)
 		}
 	})
 
@@ -525,7 +529,7 @@ func TestResolveDashboardUID(t *testing.T) {
 		if u1 == u2 {
 			t.Errorf("expected unique UIDs for different keys, both got %s", u1)
 		}
-		if !strings.Contains(u1, "k1") || !strings.Contains(u2, "k2") {
+		if !strings.Contains(u1, "multi-k1") || !strings.Contains(u2, "multi-k2") {
 			t.Errorf("UIDs should contain the key name: %s, %s", u1, u2)
 		}
 	})

--- a/loaders/dashboards/pkg/controller/grafana_client.go
+++ b/loaders/dashboards/pkg/controller/grafana_client.go
@@ -1,0 +1,256 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package controller
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/stolostron/multicluster-observability-operator/loaders/dashboards/pkg/util"
+)
+
+const (
+	// Grafana API Paths
+	apiSearch               = "/api/search"
+	apiDashboards           = "/api/dashboards/db"
+	apiDashUID              = "/api/dashboards/uid/"
+	apiFolders              = "/api/folders"
+	apiFoldersID            = "/api/folders/id/"
+	folderPermissionsSuffix = "/permissions"
+	apiPreferences          = "/api/org/preferences"
+
+	// Grafana Error Messages
+	errVersionMismatch = "version-mismatch"
+	errNameExists      = "name-exists"
+)
+
+// GrafanaError captures details of a failed Grafana API call
+type GrafanaError struct {
+	Status int
+	Body   string
+}
+
+func (e *GrafanaError) Error() string {
+	return fmt.Sprintf("grafana error (status %d): %s", e.Status, e.Body)
+}
+
+type grafanaErrorResponse struct {
+	Message string `json:"message"`
+}
+
+func (e *GrafanaError) bodyMatches(keyword string) bool {
+	if e.Status != http.StatusPreconditionFailed {
+		return false
+	}
+	if e.Body == keyword {
+		return true
+	}
+	var resp grafanaErrorResponse
+	if err := json.Unmarshal([]byte(e.Body), &resp); err == nil {
+		return resp.Message == keyword
+	}
+	return false
+}
+
+// IsVersionMismatch returns true if the error is a Grafana 412 version mismatch
+func (e *GrafanaError) IsVersionMismatch() bool {
+	return e.bodyMatches(errVersionMismatch)
+}
+
+// IsNameExists returns true if the error indicates a dashboard name collision
+func (e *GrafanaError) IsNameExists() bool {
+	return e.bodyMatches(errNameExists)
+}
+
+// grafanaDashboard represents the structure returned by Grafana search
+type grafanaDashboard struct {
+	UID  string `json:"uid"`
+	Tags []any  `json:"tags"`
+}
+
+// grafanaFolder represents a Grafana folder
+type grafanaFolder struct {
+	ID    int64  `json:"id"`
+	UID   string `json:"uid"`
+	Title string `json:"title"`
+}
+
+// GrafanaClient defines the interface for interacting with Grafana
+type GrafanaClient interface {
+	ListAllDashboards(ctx context.Context) ([]grafanaDashboard, error)
+	DeleteDashboard(ctx context.Context, uid string) error
+	CreateOrUpdateDashboard(ctx context.Context, dashboard map[string]any, folderID int64) (int64, error)
+	SetHomeDashboard(ctx context.Context, id int64) error
+
+	ListFolders(ctx context.Context) ([]grafanaFolder, error)
+	GetFolderByID(ctx context.Context, id int64) (*grafanaFolder, error)
+	CreateFolder(ctx context.Context, title string) (*grafanaFolder, error)
+	DeleteFolder(ctx context.Context, uid string) error
+	HasPermissions(ctx context.Context, uid string) (bool, error)
+	IsEmpty(ctx context.Context, uid string) (bool, error)
+}
+
+type grafanaClient struct {
+	uri string
+}
+
+func (g *grafanaClient) ListAllDashboards(ctx context.Context) ([]grafanaDashboard, error) {
+	params := url.Values{}
+	params.Add("type", "dash-db")
+	targetURL := g.uri + apiSearch + "?" + params.Encode()
+	body, status := util.SendRequest(ctx, nil, http.MethodGet, targetURL, nil)
+	if status != http.StatusOK {
+		return nil, &GrafanaError{Status: status, Body: string(body)}
+	}
+	var res []grafanaDashboard
+	if err := json.Unmarshal(body, &res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (g *grafanaClient) DeleteDashboard(ctx context.Context, uid string) error {
+	targetURL := g.uri + apiDashUID + uid
+	body, status := util.SendRequest(ctx, nil, http.MethodDelete, targetURL, nil)
+	if status != http.StatusOK && status != http.StatusNotFound {
+		return &GrafanaError{Status: status, Body: string(body)}
+	}
+	return nil
+}
+
+func (g *grafanaClient) CreateOrUpdateDashboard(ctx context.Context, dashboard map[string]any, folderID int64) (int64, error) {
+	data := map[string]any{
+		"folderId": folderID,
+		// We always overwrite to enforce the "Stateless Exclusive Ownership" model.
+		// Kubernetes is the absolute source of truth; any manual changes in the
+		// Grafana UI are intentionally disregarded and overwritten.
+		"overwrite": true,
+		"dashboard": dashboard,
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal dashboard payload: %w", err)
+	}
+	targetURL := g.uri + apiDashboards
+	body, status := util.SendRequest(ctx, nil, http.MethodPost, targetURL, bytes.NewBuffer(b))
+	if status != http.StatusOK {
+		return 0, &GrafanaError{Status: status, Body: string(body)}
+	}
+	var resp struct {
+		ID *int64 `json:"id"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return 0, fmt.Errorf("failed to unmarshal Grafana response: %w (body: %s)", err, truncate(string(body), 256))
+	}
+	if resp.ID == nil {
+		return 0, fmt.Errorf("invalid Grafana dashboard response: missing id (body: %s)", truncate(string(body), 256))
+	}
+	return *resp.ID, nil
+}
+
+func (g *grafanaClient) SetHomeDashboard(ctx context.Context, id int64) error {
+	data := map[string]int64{"homeDashboardId": id}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal preferences payload: %w", err)
+	}
+	targetURL := g.uri + apiPreferences
+	body, status := util.SendRequest(ctx, nil, http.MethodPut, targetURL, bytes.NewBuffer(b))
+	if status != http.StatusOK {
+		return &GrafanaError{Status: status, Body: string(body)}
+	}
+	return nil
+}
+
+func (g *grafanaClient) ListFolders(ctx context.Context) ([]grafanaFolder, error) {
+	targetURL := g.uri + apiFolders
+	body, status := util.SendRequest(ctx, nil, http.MethodGet, targetURL, nil)
+	if status != http.StatusOK {
+		return nil, &GrafanaError{Status: status, Body: string(body)}
+	}
+	var res []grafanaFolder
+	if err := json.Unmarshal(body, &res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (g *grafanaClient) GetFolderByID(ctx context.Context, id int64) (*grafanaFolder, error) {
+	targetURL := fmt.Sprintf("%s%s%d", g.uri, apiFoldersID, id)
+	body, status := util.SendRequest(ctx, nil, http.MethodGet, targetURL, nil)
+	if status != http.StatusOK {
+		return nil, &GrafanaError{Status: status, Body: string(body)}
+	}
+	var res grafanaFolder
+	if err := json.Unmarshal(body, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+func (g *grafanaClient) CreateFolder(ctx context.Context, title string) (*grafanaFolder, error) {
+	payload, err := json.Marshal(map[string]string{"title": title})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal folder payload: %w", err)
+	}
+	targetURL := g.uri + apiFolders
+	body, status := util.SendRequest(ctx, nil, http.MethodPost, targetURL, bytes.NewReader(payload))
+	if status != http.StatusOK {
+		return nil, &GrafanaError{Status: status, Body: string(body)}
+	}
+	var res grafanaFolder
+	if err := json.Unmarshal(body, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+func (g *grafanaClient) DeleteFolder(ctx context.Context, uid string) error {
+	targetURL := g.uri + apiFolders + "/" + uid
+	body, status := util.SendRequest(ctx, nil, http.MethodDelete, targetURL, nil)
+	if status != http.StatusOK {
+		return &GrafanaError{Status: status, Body: string(body)}
+	}
+	return nil
+}
+
+func (g *grafanaClient) HasPermissions(ctx context.Context, uid string) (bool, error) {
+	targetURL := g.uri + apiFolders + "/" + uid + folderPermissionsSuffix
+	body, status := util.SendRequest(ctx, nil, http.MethodGet, targetURL, nil)
+	if status != http.StatusOK {
+		return false, &GrafanaError{Status: status, Body: string(body)}
+	}
+	var res []any
+	if err := json.Unmarshal(body, &res); err != nil {
+		return false, err
+	}
+	return len(res) > 0, nil
+}
+
+func (g *grafanaClient) IsEmpty(ctx context.Context, uid string) (bool, error) {
+	params := url.Values{}
+	params.Add("folderUids", uid)
+	targetURL := g.uri + apiSearch + "?" + params.Encode()
+	body, status := util.SendRequest(ctx, nil, http.MethodGet, targetURL, nil)
+	if status != http.StatusOK {
+		return false, &GrafanaError{Status: status, Body: string(body)}
+	}
+	var res []any
+	if err := json.Unmarshal(body, &res); err != nil {
+		return false, err
+	}
+	return len(res) == 0, nil
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/loaders/dashboards/pkg/controller/grafana_client.go
+++ b/loaders/dashboards/pkg/controller/grafana_client.go
@@ -235,8 +235,9 @@ func (g *grafanaClient) HasPermissions(ctx context.Context, uid string) (bool, e
 
 func (g *grafanaClient) IsEmpty(ctx context.Context, uid string) (bool, error) {
 	params := url.Values{}
-	params.Add("folderUids", uid)
+	params.Add("folderUIDs", uid)
 	params.Add("type", "dash-db")
+	params.Add("limit", "1") // We only need to know if at least one dashboard exists
 	targetURL := g.uri + apiSearch + "?" + params.Encode()
 	body, status := util.SendRequest(ctx, nil, http.MethodGet, targetURL, nil)
 	if status != http.StatusOK {

--- a/loaders/dashboards/pkg/controller/grafana_client.go
+++ b/loaders/dashboards/pkg/controller/grafana_client.go
@@ -70,8 +70,8 @@ func (e *GrafanaError) IsNameExists() bool {
 
 // grafanaDashboard represents the structure returned by Grafana search
 type grafanaDashboard struct {
-	UID  string `json:"uid"`
-	Tags []any  `json:"tags"`
+	UID       string `json:"uid"`
+	FolderUID string `json:"folderUid"`
 }
 
 // grafanaFolder represents a Grafana folder

--- a/loaders/dashboards/pkg/controller/grafana_client.go
+++ b/loaders/dashboards/pkg/controller/grafana_client.go
@@ -236,6 +236,7 @@ func (g *grafanaClient) HasPermissions(ctx context.Context, uid string) (bool, e
 func (g *grafanaClient) IsEmpty(ctx context.Context, uid string) (bool, error) {
 	params := url.Values{}
 	params.Add("folderUids", uid)
+	params.Add("type", "dash-db")
 	targetURL := g.uri + apiSearch + "?" + params.Encode()
 	body, status := util.SendRequest(ctx, nil, http.MethodGet, targetURL, nil)
 	if status != http.StatusOK {

--- a/loaders/dashboards/pkg/controller/grafana_client_test.go
+++ b/loaders/dashboards/pkg/controller/grafana_client_test.go
@@ -1,0 +1,197 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package controller
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGrafanaClient(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ListAllDashboards success", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != apiSearch || r.URL.Query().Get("type") != "dash-db" {
+				t.Errorf("unexpected path or query: %v", r.URL)
+			}
+			w.Write([]byte("[{\"uid\": \"d1\", \"tags\": [\"t1\"]}]"))
+		}))
+		defer ts.Close()
+
+		client := &grafanaClient{uri: ts.URL}
+		dashboards, err := client.ListAllDashboards(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(dashboards) != 1 || dashboards[0].UID != "d1" {
+			t.Errorf("unexpected dashboards: %v", dashboards)
+		}
+	})
+
+	t.Run("DeleteDashboard cases", func(t *testing.T) {
+		t.Run("success 200", func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer ts.Close()
+			client := &grafanaClient{uri: ts.URL}
+			if err := client.DeleteDashboard(ctx, "d1"); err != nil {
+				t.Errorf("expected nil error on 200, got %v", err)
+			}
+		})
+		t.Run("success 404", func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer ts.Close()
+			client := &grafanaClient{uri: ts.URL}
+			if err := client.DeleteDashboard(ctx, "d1"); err != nil {
+				t.Errorf("expected nil error on 404, got %v", err)
+			}
+		})
+		t.Run("failure 500", func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("internal error"))
+			}))
+			defer ts.Close()
+			client := &grafanaClient{uri: ts.URL}
+			err := client.DeleteDashboard(ctx, "d1")
+			if err == nil {
+				t.Fatal("expected error on 500")
+			}
+			gErr, _ := err.(*GrafanaError)
+			if gErr.Status != 500 {
+				t.Errorf("expected 500 status, got %d", gErr.Status)
+			}
+		})
+	})
+
+	t.Run("CreateOrUpdateDashboard error handling", func(t *testing.T) {
+		t.Run("raw string error", func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusPreconditionFailed)
+				w.Write([]byte("version-mismatch"))
+			}))
+			defer ts.Close()
+
+			client := &grafanaClient{uri: ts.URL}
+			_, err := client.CreateOrUpdateDashboard(ctx, map[string]any{}, 0)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			gErr, ok := err.(*GrafanaError)
+			if !ok || !gErr.IsVersionMismatch() {
+				t.Errorf("expected version mismatch error, got %v", err)
+			}
+		})
+
+		t.Run("json response error", func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusPreconditionFailed)
+				w.Write([]byte("{\"message\":\"name-exists\"}"))
+			}))
+			defer ts.Close()
+
+			client := &grafanaClient{uri: ts.URL}
+			_, err := client.CreateOrUpdateDashboard(ctx, map[string]any{}, 0)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			gErr, ok := err.(*GrafanaError)
+			if !ok || !gErr.IsNameExists() {
+				t.Errorf("expected name exists error, got %v", err)
+			}
+		})
+	})
+
+	t.Run("SetHomeDashboard", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPut || r.URL.Path != apiPreferences {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+		client := &grafanaClient{uri: ts.URL}
+		if err := client.SetHomeDashboard(ctx, 42); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("Folder operations", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case apiFolders:
+				if r.Method == http.MethodPost {
+					w.Write([]byte("{\"id\": 10, \"uid\": \"f10\", \"title\": \"New\"}"))
+				} else {
+					w.Write([]byte("[{\"id\": 1, \"uid\": \"f1\", \"title\": \"General\"}]"))
+				}
+			case apiFoldersID + "1":
+				w.Write([]byte("{\"id\": 1, \"uid\": \"f1\", \"title\": \"General\"}"))
+			case "/api/folders/f1" + folderPermissionsSuffix:
+				w.Write([]byte("[{\"id\": 1}]"))
+			case "/api/folders/f2" + folderPermissionsSuffix:
+				w.Write([]byte("[]"))
+			case apiSearch:
+				if r.URL.Query().Get("folderUids") == "f_empty" {
+					w.Write([]byte("[]"))
+				} else {
+					w.Write([]byte("[{}]"))
+				}
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer ts.Close()
+
+		client := &grafanaClient{uri: ts.URL}
+
+		folders, _ := client.ListFolders(ctx)
+		if len(folders) != 1 || folders[0].ID != 1 {
+			t.Errorf("list folders failed")
+		}
+
+		f, _ := client.GetFolderByID(ctx, 1)
+		if f.UID != "f1" {
+			t.Errorf("get folder by ID failed")
+		}
+
+		newF, _ := client.CreateFolder(ctx, "New")
+		if newF.ID != 10 {
+			t.Errorf("create folder failed")
+		}
+
+		hasPerm, _ := client.HasPermissions(ctx, "f1")
+		if !hasPerm {
+			t.Errorf("expected permissions")
+		}
+		hasPerm2, _ := client.HasPermissions(ctx, "f2")
+		if hasPerm2 {
+			t.Errorf("expected no permissions")
+		}
+
+		empty, _ := client.IsEmpty(ctx, "f_empty")
+		if !empty {
+			t.Errorf("expected empty")
+		}
+		empty2, _ := client.IsEmpty(ctx, "f_full")
+		if empty2 {
+			t.Errorf("expected not empty")
+		}
+	})
+}
+
+func TestGrafanaError(t *testing.T) {
+	err := &GrafanaError{Status: 404, Body: "not found"}
+	expected := "grafana error (status 404): not found"
+	if err.Error() != expected {
+		t.Errorf("expected %q, got %q", expected, err.Error())
+	}
+}

--- a/loaders/dashboards/pkg/controller/grafana_client_test.go
+++ b/loaders/dashboards/pkg/controller/grafana_client_test.go
@@ -140,7 +140,11 @@ func TestGrafanaClient(t *testing.T) {
 			case "/api/folders/f2" + folderPermissionsSuffix:
 				w.Write([]byte("[]"))
 			case apiSearch:
-				if r.URL.Query().Get("folderUids") == "f_empty" {
+				fUID := r.URL.Query().Get("folderUIDs")
+				if fUID == "" {
+					fUID = r.URL.Query().Get("folderUids")
+				}
+				if fUID == "f_empty" {
 					w.Write([]byte("[]"))
 				} else {
 					w.Write([]byte("[{}]"))

--- a/loaders/dashboards/pkg/util/grafana_util.go
+++ b/loaders/dashboards/pkg/util/grafana_util.go
@@ -5,10 +5,14 @@
 package util
 
 import (
+	"bytes"
+	"context"
 	"encoding/hex"
+	"errors"
 	"hash/fnv"
 	"io"
 	"net/http"
+	"sync"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -16,12 +20,21 @@ import (
 
 const (
 	defaultAdmin = "WHAT_YOU_ARE_DOING_IS_VOIDING_SUPPORT_0000000000000000000000000000000000000000000000000000000000000000"
+	// maxDashboardSize limits the size of the dashboard JSON we are willing to buffer in memory (10MB).
+	maxDashboardSize = 10 * 1024 * 1024
+	// grafanaUIDMaxLength is the maximum length allowed for a Grafana dashboard UID.
+	grafanaUIDMaxLength = 40
+)
+
+var (
+	httpClient *http.Client
+	once       sync.Once
 )
 
 // GenerateUID generates UID for customized dashboard.
 func GenerateUID(namespace string, name string) (string, error) {
 	uid := namespace + "-" + name
-	if len(uid) > 40 {
+	if len(uid) > grafanaUIDMaxLength {
 		hasher := fnv.New128a()
 		_, err := hasher.Write([]byte(uid))
 		if err != nil {
@@ -32,47 +45,78 @@ func GenerateUID(namespace string, name string) (string, error) {
 	return uid, nil
 }
 
-// GetHTTPClient returns http client.
+// getHTTPClient returns a singleton http client.
 func getHTTPClient() *http.Client {
-	transport := &http.Transport{}
-	client := &http.Client{Transport: transport}
-	return client
+	once.Do(func() {
+		httpClient = &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:          100,
+				IdleConnTimeout:       90 * time.Second,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ResponseHeaderTimeout: 10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
+		}
+	})
+	return httpClient
 }
 
-// SetRequest ...
-func SetRequest(method string, url string, body io.Reader, retry int) ([]byte, int) {
-	req, _ := http.NewRequest(method, url, body)
+// SendRequest sends an HTTP request with context support.
+func SendRequest(ctx context.Context, client *http.Client, method string, url string, body io.Reader) ([]byte, int) {
+	if client == nil {
+		client = getHTTPClient()
+	}
+
+	var payload []byte
+	if body != nil {
+		var err error
+		// Read up to maxDashboardSize + 1 to detect if the payload is too large.
+		payload, err = io.ReadAll(io.LimitReader(body, maxDashboardSize+1))
+		if err != nil {
+			klog.ErrorS(err, "failed to read request body")
+			return nil, http.StatusInternalServerError
+		}
+		if len(payload) > maxDashboardSize {
+			klog.ErrorS(errors.New("payload too large"), "dashboard payload exceeds size limit", "limit", maxDashboardSize)
+			return nil, http.StatusRequestEntityTooLarge
+		}
+	}
+
+	var reqBody io.Reader
+	if payload != nil {
+		reqBody = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+	if err != nil {
+		klog.ErrorS(err, "failed to create HTTP request", "method", method, "url", url)
+		return nil, http.StatusInternalServerError
+	}
+
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Forwarded-User", defaultAdmin)
 
-	resp, err := getHTTPClient().Do(req)
-	times := 0
-	for err != nil {
-		klog.Error("failed to send HTTP request. Retry in 5 seconds ", "error ", err)
-		time.Sleep(time.Second * 5)
-		times++
-		if times == retry {
-			klog.Errorf("failed to send HTTP request after retrying %v times", retry)
-			break
+	resp, err := client.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, http.StatusRequestTimeout
 		}
-		resp, err = getHTTPClient().Do(req)
-	}
-
-	if resp == nil {
-		return nil, http.StatusNotFound
+		klog.ErrorS(err, "failed to send HTTP request", "method", method, "url", url)
+		return nil, http.StatusServiceUnavailable
 	}
 
 	defer func() {
-		err := resp.Body.Close()
-		if err != nil {
-			klog.Info("failed to close response body ", "error ", err)
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			klog.V(2).InfoS("failed to close response body", "error", closeErr)
 		}
 	}()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		klog.Info("failed to parse response body ", "error ", err)
+		klog.ErrorS(err, "failed to read response body")
 		return nil, resp.StatusCode
 	}
+
 	return respBody, resp.StatusCode
 }

--- a/loaders/dashboards/pkg/util/grafana_util_test.go
+++ b/loaders/dashboards/pkg/util/grafana_util_test.go
@@ -5,42 +5,91 @@
 package util
 
 import (
-	stdlog "log"
+	"bytes"
+	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
-	"time"
 )
 
 func TestGenerateUID(t *testing.T) {
-	uid, _ := GenerateUID("open-cluster-management", "test")
-	if uid != "open-cluster-management-test" {
-		t.Fatalf("the uid %v is not the expected %v", uid, "open-cluster-management-test")
-	}
+	t.Parallel()
+	t.Run("legacy compatibility", func(t *testing.T) {
+		// Verify name-namespace order produces stable prefix
+		// Using short strings to avoid hashing trigger (> 40 chars)
+		name := "my-dash"
+		namespace := "mco"
+		uid, _ := GenerateUID(name, namespace)
+		if uid != "my-dash-mco" {
+			t.Fatalf("expected legacy prefix to be stable, got %v", uid)
+		}
+	})
 
-	uid, _ = GenerateUID("open-cluster-management-observability", "test")
-	if uid != "4e20548bdba37201faabf30d1c419981" {
-		t.Fatalf("the uid %v should not equal to %v", uid, "4e20548bdba37201faabf30d1c419981")
-	}
+	t.Run("multi-dashboard uniqueness", func(t *testing.T) {
+		// Verify that different keys in the same ConfigMap produce unique UIDs
+		name := "my-dashboard"
+		namespace := "open-cluster-management-observability"
+		key1 := "dash1.json"
+		key2 := "dash2.json"
+
+		uid1, _ := GenerateUID(name, namespace+"-"+key1)
+		uid2, _ := GenerateUID(name, namespace+"-"+key2)
+
+		if uid1 == uid2 {
+			t.Fatal("UIDs for different keys should be unique")
+		}
+	})
+
+	t.Run("hashing for long UIDs", func(t *testing.T) {
+		uid, _ := GenerateUID("very-long-dashboard-name-that-exceeds-the-limit", "very-long-namespace-name-that-also-exceeds-the-limit")
+		if len(uid) != 32 { // hex encoded fnv128 is 32 chars
+			t.Fatalf("expected hashed UID to be 32 characters, got %d", len(uid))
+		}
+	})
 }
 
-func createFakeServer(t *testing.T) {
-	server3002 := http.NewServeMux()
-	server3002.HandleFunc("/",
-		func(w http.ResponseWriter, req *http.Request) {
+func TestSendRequest(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("done"))
-		},
-	)
-	err := http.ListenAndServe(":3002", server3002)
-	if err != nil {
-		stdlog.Fatal("fail to create internal server at 3002")
-	}
-}
+		}))
+		defer ts.Close()
 
-func TestSetRequest(t *testing.T) {
-	go createFakeServer(t)
-	time.Sleep(time.Second)
-	_, responseCode := SetRequest("GET", "http://127.0.0.1:3002", nil, 1)
-	if responseCode == http.StatusNotFound {
-		t.Fatalf("cannot send request to server: %v", responseCode)
-	}
+		_, responseCode := SendRequest(t.Context(), nil, "GET", ts.URL, nil)
+		if responseCode != http.StatusOK {
+			t.Fatalf("expected 200 OK, got: %v", responseCode)
+		}
+	})
+
+	t.Run("payload too large", func(t *testing.T) {
+		// Create a large body (maxDashboardSize + 1)
+		largeBody := bytes.NewReader(make([]byte, maxDashboardSize+1))
+		_, responseCode := SendRequest(t.Context(), nil, "POST", "http://127.0.0.1:1", largeBody)
+		if responseCode != http.StatusRequestEntityTooLarge {
+			t.Fatalf("expected 413 Payload Too Large, got: %v", responseCode)
+		}
+	})
+
+	t.Run("max retries exceeded", func(t *testing.T) {
+		// Create a server and close it immediately to get a guaranteed unused dynamic port
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		unusedURL := ts.URL
+		ts.Close()
+
+		_, responseCode := SendRequest(t.Context(), nil, "GET", unusedURL, nil)
+		if responseCode != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503 for connection failure, got: %v", responseCode)
+		}
+	})
+
+	t.Run("context cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel() // immediately cancel
+
+		_, responseCode := SendRequest(ctx, nil, "GET", "http://127.0.0.1:1", nil)
+		if responseCode != http.StatusRequestTimeout {
+			t.Fatalf("expected 408 Request Timeout, got: %v", responseCode)
+		}
+	})
 }

--- a/tests/grafana-dev-test.sh
+++ b/tests/grafana-dev-test.sh
@@ -34,6 +34,12 @@ wait_for_condition() {
   fail "Timeout waiting for $desc after $max_attempts attempts"
 }
 
+cleanup() {
+  log "Cleaning up Grafana dev environment"
+  ./setup-grafana-dev.sh --clean || log "Warning: Failed to clean up Grafana dev environment"
+}
+trap cleanup EXIT
+
 # Ensure working directory
 BASE_DIR="$(cd "$(dirname "$0")/.." && pwd -P)"
 cd "$BASE_DIR/tools" || fail "Failed to change to tools directory"
@@ -53,7 +59,7 @@ POD_NAME=$(kubectl get pods -n "$OBS_NAMESPACE" -l "$GRAFANA_POD_LABEL" \
 log "Creating test user"
 create_test_user_cmd="
   kubectl -n \"$OBS_NAMESPACE\" exec \"$POD_NAME\" -c grafana-dashboard-loader -- /usr/bin/curl \
-    -XPOST -s \
+    -XPOST -fsS \
     -H \"Content-Type: application/json\" \
     -H \"X-Forwarded-User: WHAT_YOU_ARE_DOING_IS_VOIDING_SUPPORT_0000000000000000000000000000000000000000000000000000000000000000\" \
     -d '{ \"name\":\"$TEST_USER\", \"email\":\"$TEST_USER\", \"login\":\"$TEST_USER\", \"password\":\"$TEST_USER\" }' \
@@ -63,24 +69,20 @@ create_test_user_cmd="
 wait_for_condition \
   "$create_test_user_cmd" \
   "Creating test user" \
-  10 \
-  2
+  30 \
+  5
 
 # Switch to admin and generate dashboard
 wait_for_condition \
   "./switch-to-grafana-admin.sh \"$TEST_USER\"" \
   "switching to Grafana admin" \
-  10 \
-  2
+  30 \
+  5
 
 wait_for_condition \
   "./generate-dashboard-configmap-yaml.sh -f 'Alerts' 'Alert Analysis'" \
   "generating dashboard configmap" \
-  10 \
-  2
-
-# Cleanup
-log "Cleaning up Grafana dev environment"
-./setup-grafana-dev.sh --clean || fail "Failed to clean up Grafana dev environment"
+  30 \
+  5
 
 log "Script completed successfully"

--- a/tests/pkg/tests/observability_dashboard_test.go
+++ b/tests/pkg/tests/observability_dashboard_test.go
@@ -111,8 +111,9 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 					testOptions.HubCluster.KubeContext,
 					yamlB)).NotTo(HaveOccurred())
 
-			Eventually(func() bool {
-				result, _ := utils.ContainDashboard(testOptions, dashboardTitle)
+			Eventually(func(g Gomega) bool {
+				result, err := utils.ContainDashboard(testOptions, dashboardTitle)
+				g.Expect(err).ToNot(HaveOccurred())
 				return result
 			}, cleanupTimeout, cleanupInterval).Should(BeFalse())
 
@@ -142,8 +143,9 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 			err = utils.DeleteConfigMap(testOptions, true, dashboardName, MCO_NAMESPACE)
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(func() bool {
-				result, _ := utils.ContainDashboard(testOptions, dashboardTitle)
+			Eventually(func(g Gomega) bool {
+				result, err := utils.ContainDashboard(testOptions, dashboardTitle)
+				g.Expect(err).ToNot(HaveOccurred())
 				return result
 			}, syncTimeout, syncInterval).Should(BeFalse())
 		},
@@ -209,18 +211,21 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 			err = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Delete(context.Background(), cmName, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func() bool {
-				meta, _ := utils.GetDashboardMetadata(context.Background(), testOptions, updateTitle)
+			Eventually(func(g Gomega) bool {
+				meta, err := utils.GetDashboardMetadata(context.Background(), testOptions, updateTitle)
+				g.Expect(err).ToNot(HaveOccurred())
 				return meta != nil
 			}, cleanupTimeout, cleanupInterval).Should(BeFalse())
 
 			// The folder should be reaped eventually (moving/deletion triggers immediate cleanup in the new code)
-			Eventually(func() bool {
-				exists, _ := utils.FolderExists(context.Background(), testOptions, folderA)
+			Eventually(func(g Gomega) bool {
+				exists, err := utils.FolderExists(context.Background(), testOptions, folderA)
+				g.Expect(err).ToNot(HaveOccurred())
 				return exists
 			}, syncTimeout, syncInterval).Should(BeFalse())
-			Eventually(func() bool {
-				exists, _ := utils.FolderExists(context.Background(), testOptions, folderB)
+			Eventually(func(g Gomega) bool {
+				exists, err := utils.FolderExists(context.Background(), testOptions, folderB)
+				g.Expect(err).ToNot(HaveOccurred())
 				return exists
 			}, syncTimeout, syncInterval).Should(BeFalse())
 		},
@@ -259,9 +264,11 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 			err = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Delete(context.Background(), cmName, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func() bool {
-				found1, _ := utils.ContainDashboard(testOptions, "Multi Dash 1")
-				found2, _ := utils.ContainDashboard(testOptions, "Multi Dash 2")
+			Eventually(func(g Gomega) bool {
+				found1, err1 := utils.ContainDashboard(testOptions, "Multi Dash 1")
+				g.Expect(err1).ToNot(HaveOccurred())
+				found2, err2 := utils.ContainDashboard(testOptions, "Multi Dash 2")
+				g.Expect(err2).ToNot(HaveOccurred())
 				return !found1 && !found2
 			}, cleanupTimeout, cleanupInterval).Should(BeTrue())
 		},
@@ -307,8 +314,9 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Wait for deletion in Grafana
-			Eventually(func() bool {
-				found, _ := utils.ContainDashboard(testOptions, dashTitle)
+			Eventually(func(g Gomega) bool {
+				found, err := utils.ContainDashboard(testOptions, dashTitle)
+				g.Expect(err).ToNot(HaveOccurred())
 				return found
 			}, cleanupTimeout, cleanupInterval).Should(BeFalse())
 

--- a/tests/pkg/tests/observability_dashboard_test.go
+++ b/tests/pkg/tests/observability_dashboard_test.go
@@ -7,7 +7,7 @@ package tests
 import (
 	"context"
 	"fmt"
-	"strings"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -25,11 +25,11 @@ const (
 	homeDashboardUIDKey     = "home-dashboard-uid"
 	setHomeDashboardKey     = "set-home-dashboard"
 
-	dashboardName                 = "sample-dashboard"
-	dashboardTitle                = "Sample Dashboard for E2E"
-	updateDashboardTitle          = "Update Sample Dashboard for E2E"
-	clusterOverviewTitle          = "ACM - Clusters Overview"
-	clusterOverviewOptimizedTitle = "ACM - Clusters Overview (Optimized)"
+	dashboardName               = "sample-dashboard"
+	dashboardTitle              = "Sample Dashboard for E2E"
+	updateDashboardTitle        = "Update Sample Dashboard for E2E"
+	clusterOverviewUID          = "2b679d600f3b9e7676a7c5ac3643d448"
+	clusterOverviewOptimizedUID = "b4733fbea8104bae951b04961f47bd20"
 
 	syncTimeout      = 1 * time.Minute
 	syncInterval     = 5 * time.Second
@@ -41,6 +41,10 @@ const (
 
 var _ = Describe("Observability: Dashboard Lifecycle", func() {
 	BeforeEach(func() {
+		if os.Getenv("IS_KIND_ENV") == "true" {
+			Skip("Skip dashboard lifecycle tests in KinD environment")
+		}
+
 		hubClient = utils.NewKubeClient(
 			testOptions.HubCluster.ClusterServerURL,
 			testOptions.KubeConfig,
@@ -382,30 +386,9 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 			}, syncTimeout, syncInterval).Should(BeTrue())
 
 			By("Verifying Grafana home dashboard preference")
-			isForbidden := false
 			Eventually(func() (string, error) {
-				id, err := utils.GetGrafanaHomeDashboard(context.Background(), testOptions)
-				if err != nil {
-					if strings.Contains(err.Error(), "403") {
-						isForbidden = true
-						return "403", nil
-					}
-					return "", err
-				}
-				if id == 0 {
-					return "none", nil
-				}
-				homeUID, err := utils.GetDashboardUIDByID(context.Background(), testOptions, id)
-				return homeUID, err
-			}, syncTimeout, syncInterval).Should(SatisfyAny(
-				Equal(dashUID),
-				Equal("403"), // Handle 403 Access Denied
-			))
-
-			if isForbidden {
-				GinkgoWriter.Printf("WARNING: Access denied (403) while checking home dashboard preference. This is expected if the token lacks organization preference read permissions.\n")
-				Skip("Skipping home dashboard verification due to 403 Access Denied on preferences API")
-			}
+				return utils.GetGrafanaHomeDashboard(context.Background(), testOptions)
+			}, syncTimeout, syncInterval).Should(Equal(dashUID))
 		},
 	)
 
@@ -413,11 +396,11 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 	It("[P2][Sev2][observability][Stable] Should have default overview dashboards (dashboard/g0)", func() {
 		// Check Original dash exists
 		Eventually(func() (bool, error) {
-			return utils.ContainDashboard(testOptions, clusterOverviewTitle)
+			return utils.ContainDashboardByUID(context.Background(), testOptions, clusterOverviewUID)
 		}, syncTimeout, syncInterval).Should(BeTrue())
 		// Check optimized dash
 		Eventually(func() (bool, error) {
-			return utils.ContainDashboard(testOptions, clusterOverviewOptimizedTitle)
+			return utils.ContainDashboardByUID(context.Background(), testOptions, clusterOverviewOptimizedUID)
 		}, syncTimeout, syncInterval).Should(BeTrue())
 	})
 

--- a/tests/pkg/tests/observability_dashboard_test.go
+++ b/tests/pkg/tests/observability_dashboard_test.go
@@ -5,21 +5,41 @@
 package tests
 
 import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/kustomize"
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/utils"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
+	// Locally redeclared constants to avoid build dependency on dashboard loader package
+	customDashboardLabelKey = "grafana-custom-dashboard"
+	customFolderKey         = "observability.open-cluster-management.io/dashboard-folder"
+	homeDashboardUIDKey     = "home-dashboard-uid"
+	setHomeDashboardKey     = "set-home-dashboard"
+
 	dashboardName                 = "sample-dashboard"
 	dashboardTitle                = "Sample Dashboard for E2E"
 	updateDashboardTitle          = "Update Sample Dashboard for E2E"
 	clusterOverviewTitle          = "ACM - Clusters Overview"
 	clusterOverviewOptimizedTitle = "ACM - Clusters Overview (Optimized)"
+
+	syncTimeout      = 5 * time.Minute
+	syncInterval     = 5 * time.Second
+	cleanupTimeout   = 2 * time.Minute
+	cleanupInterval  = 5 * time.Second
+	metadataTimeout  = 1 * time.Minute
+	metadataInterval = 5 * time.Second
 )
 
-var _ = Describe("", func() {
+var _ = Describe("Observability: Dashboard Lifecycle", func() {
 	BeforeEach(func() {
 		hubClient = utils.NewKubeClient(
 			testOptions.HubCluster.ClusterServerURL,
@@ -36,56 +56,337 @@ var _ = Describe("", func() {
 		"RHACM4K-1669: Observability: Verify new customized Grafana dashboard - Should have custom dashboard which defined in configmap [P2][Sev2][Observability][Stable]@ocpInterop @non-ui-post-restore @non-ui-post-release @non-ui-pre-upgrade @non-ui-post-upgrade @post-upgrade @post-restore @e2e @post-release @pre-upgrade (dashboard/g0)",
 		func() {
 			By("Creating custom dashboard configmap")
-			yamlB, _ := kustomize.Render(
+			yamlB, err := kustomize.Render(
 				kustomize.Options{KustomizationPath: "../../../examples/dashboards/sample_custom_dashboard"},
 			)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(
 				utils.ApplyRetryOnConflict(
 					testOptions.HubCluster.ClusterServerURL,
 					testOptions.KubeConfig,
 					testOptions.HubCluster.KubeContext,
 					yamlB)).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				By("Cleaning up custom dashboard")
+				_ = utils.DeleteConfigMap(testOptions, true, dashboardName, MCO_NAMESPACE)
+			})
+
 			Eventually(func() bool {
-				_, result := utils.ContainDashboard(testOptions, dashboardTitle)
+				result, _ := utils.ContainDashboard(testOptions, dashboardTitle)
 				return result
-			}, EventuallyTimeoutMinute*7, EventuallyIntervalSecond*5).Should(BeTrue())
+			}, syncTimeout, syncInterval).Should(BeTrue())
 		},
 	)
 
 	It(
 		"RHACM4K-1669: Observability: Verify new customized Grafana dashboard - Should have update custom dashboard after configmap updated [P2][Sev2][Observability][Stable]@ocpInterop @non-ui-post-restore @non-ui-post-release @non-ui-pre-upgrade @non-ui-post-upgrade @post-upgrade @post-restore @e2e @post-release @pre-upgrade (dashboard/g0)",
 		func() {
-			By("Updating custom dashboard configmap")
-			yamlB, _ := kustomize.Render(
-				kustomize.Options{KustomizationPath: "../../../examples/dashboards/update_sample_custom_dashboard"},
+			By("Creating custom dashboard configmap")
+			yamlB, err := kustomize.Render(
+				kustomize.Options{KustomizationPath: "../../../examples/dashboards/sample_custom_dashboard"},
 			)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(
 				utils.ApplyRetryOnConflict(
 					testOptions.HubCluster.ClusterServerURL,
 					testOptions.KubeConfig,
 					testOptions.HubCluster.KubeContext,
 					yamlB)).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				By("Cleaning up custom dashboard")
+				_ = utils.DeleteConfigMap(testOptions, true, dashboardName, MCO_NAMESPACE)
+			})
+
+			By("Updating custom dashboard configmap")
+			yamlB, err = kustomize.Render(
+				kustomize.Options{KustomizationPath: "../../../examples/dashboards/update_sample_custom_dashboard"},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(
+				utils.ApplyRetryOnConflict(
+					testOptions.HubCluster.ClusterServerURL,
+					testOptions.KubeConfig,
+					testOptions.HubCluster.KubeContext,
+					yamlB)).NotTo(HaveOccurred())
+
 			Eventually(func() bool {
-				_, result := utils.ContainDashboard(testOptions, dashboardTitle)
+				result, _ := utils.ContainDashboard(testOptions, dashboardTitle)
 				return result
-			}, EventuallyTimeoutMinute*7, EventuallyIntervalSecond*5).Should(BeFalse())
+			}, cleanupTimeout, cleanupInterval).Should(BeFalse())
+
 			Eventually(func() bool {
-				_, result := utils.ContainDashboard(testOptions, updateDashboardTitle)
+				result, _ := utils.ContainDashboard(testOptions, updateDashboardTitle)
 				return result
-			}, EventuallyTimeoutMinute*7, EventuallyIntervalSecond*5).Should(BeTrue())
+			}, syncTimeout, syncInterval).Should(BeTrue())
 		},
 	)
 
 	It(
 		"RHACM4K-1669: Observability: Verify new customized Grafana dashboard - Should have no custom dashboard in grafana after related configmap removed [P2][Sev2][Observability][Stable]@ocpInterop @non-ui-post-restore @non-ui-post-release @non-ui-pre-upgrade @non-ui-post-upgrade @post-upgrade @post-restore @e2e @post-release @pre-upgrade (dashboard/g0)",
 		func() {
+			By("Creating custom dashboard configmap")
+			yamlB, err := kustomize.Render(
+				kustomize.Options{KustomizationPath: "../../../examples/dashboards/sample_custom_dashboard"},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(
+				utils.ApplyRetryOnConflict(
+					testOptions.HubCluster.ClusterServerURL,
+					testOptions.KubeConfig,
+					testOptions.HubCluster.KubeContext,
+					yamlB)).NotTo(HaveOccurred())
+
 			By("Deleting custom dashboard configmap")
 			err = utils.DeleteConfigMap(testOptions, true, dashboardName, MCO_NAMESPACE)
 			Expect(err).ToNot(HaveOccurred())
+
 			Eventually(func() bool {
-				_, result := utils.ContainDashboard(testOptions, updateDashboardTitle)
+				result, _ := utils.ContainDashboard(testOptions, dashboardTitle)
 				return result
-			}, EventuallyTimeoutMinute*3, EventuallyIntervalSecond*5).Should(BeFalse())
+			}, syncTimeout, syncInterval).Should(BeFalse())
+		},
+	)
+
+	It(
+		"Observability: Verify dashboard move and folder reaping - Should move dashboard and delete empty folder [P2][Sev2][Observability][Stable]@e2e (dashboard/g1)",
+		func() {
+			cmName := "move-test-dashboard-unique"
+			folderA := "Folder-A"
+			folderB := "Folder-B"
+			dashTitle := "Move Test Dashboard"
+			dashUID := "move-test-uid"
+
+			By("Creating dashboard in Folder-A")
+			cm := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cmName,
+					Namespace: MCO_NAMESPACE,
+					Labels:    map[string]string{customDashboardLabelKey: "true"},
+					Annotations: map[string]string{
+						customFolderKey: folderA,
+					},
+				},
+				Data: map[string]string{
+					"test.json": fmt.Sprintf("{\"title\": \"%s\", \"uid\": \"%s\"}", dashTitle, dashUID),
+				},
+			}
+			_, err := hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Create(context.Background(), cm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() {
+				By("Cleaning up move-test-dashboard")
+				_ = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Delete(context.Background(), cmName, metav1.DeleteOptions{})
+			})
+
+			Eventually(func() string {
+				meta, _ := utils.GetDashboardMetadata(context.Background(), testOptions, dashTitle)
+				if meta != nil {
+					return meta.FolderTitle
+				}
+				return ""
+			}, metadataTimeout, metadataInterval).Should(Equal(folderA))
+
+			By("Moving dashboard to Folder-B")
+			cm, err = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Get(context.Background(), cmName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			cm.Annotations[customFolderKey] = folderB
+			// Also change the title slightly to break any search caches
+			updateTitle := "Move Test Dashboard Updated"
+			cm.Data["test.json"] = fmt.Sprintf("{\"title\": \"%s\", \"uid\": \"%s\"}", updateTitle, dashUID)
+			_, err = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Update(context.Background(), cm, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() string {
+				meta, _ := utils.GetDashboardMetadata(context.Background(), testOptions, updateTitle)
+				if meta != nil {
+					return meta.FolderTitle
+				}
+				return ""
+			}, syncTimeout, syncInterval).Should(Equal(folderB))
+
+			By("Deleting dashboard and verifying folder reaping")
+			err = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Delete(context.Background(), cmName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() bool {
+				meta, _ := utils.GetDashboardMetadata(context.Background(), testOptions, updateTitle)
+				return meta != nil
+			}, cleanupTimeout, cleanupInterval).Should(BeFalse())
+
+			// The folder should be reaped eventually (moving/deletion triggers immediate cleanup in the new code)
+			Eventually(func() bool {
+				exists, _ := utils.FolderExists(context.Background(), testOptions, folderA)
+				return exists
+			}, syncTimeout, syncInterval).Should(BeFalse())
+			Eventually(func() bool {
+				exists, _ := utils.FolderExists(context.Background(), testOptions, folderB)
+				return exists
+			}, syncTimeout, syncInterval).Should(BeFalse())
+		},
+	)
+
+	It(
+		"Observability: Verify multi-dashboard ConfigMap - Should sync multiple dashboards from one CM [P2][Sev2][Observability][Stable]@e2e (dashboard/g2)",
+		func() {
+			cmName := "multi-test-cm-unique"
+			By("Creating multi-dashboard configmap")
+			cm := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cmName,
+					Namespace: MCO_NAMESPACE,
+					Labels:    map[string]string{customDashboardLabelKey: "true"},
+				},
+				Data: map[string]string{
+					"dash1.json": "{\"title\": \"Multi Dash 1\", \"uid\": \"multi-1\"}",
+					"dash2.json": "{\"title\": \"Multi Dash 2\", \"uid\": \"multi-2\"}",
+				},
+			}
+			_, err := hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Create(context.Background(), cm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() {
+				By("Cleaning up multi-dashboard CM")
+				_ = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Delete(context.Background(), cmName, metav1.DeleteOptions{})
+			})
+
+			Eventually(func() bool {
+				found1, _ := utils.ContainDashboard(testOptions, "Multi Dash 1")
+				found2, _ := utils.ContainDashboard(testOptions, "Multi Dash 2")
+				return found1 && found2
+			}, syncTimeout, syncInterval).Should(BeTrue())
+
+			By("Deleting the whole ConfigMap for immediate cleanup")
+			err = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Delete(context.Background(), cmName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() bool {
+				found1, _ := utils.ContainDashboard(testOptions, "Multi Dash 1")
+				found2, _ := utils.ContainDashboard(testOptions, "Multi Dash 2")
+				return !found1 && !found2
+			}, cleanupTimeout, cleanupInterval).Should(BeTrue())
+		},
+	)
+
+	It(
+		"Observability: Verify dashboard UID stability - Should preserve UID across CM recreation [P2][Sev2][Observability][Stable]@e2e (dashboard/g3)",
+		func() {
+			cmName := "stability-test-cm-unique"
+			dashTitle := "Stability Test Dashboard"
+			By("Creating dashboard without UID")
+			cm := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cmName,
+					Namespace: MCO_NAMESPACE,
+					Labels:    map[string]string{customDashboardLabelKey: "true"},
+				},
+				Data: map[string]string{
+					"test.json": fmt.Sprintf("{\"title\": \"%s\"}", dashTitle),
+				},
+			}
+			_, err := hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Create(context.Background(), cm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() {
+				By("Cleaning up stability test CM")
+				_ = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Delete(context.Background(), cmName, metav1.DeleteOptions{})
+			})
+
+			var initialUID string
+			Eventually(func() bool {
+				meta, _ := utils.GetDashboardMetadata(context.Background(), testOptions, dashTitle)
+				if meta != nil {
+					initialUID = meta.UID
+					return true
+				}
+				return false
+			}, syncTimeout, syncInterval).Should(BeTrue())
+
+			Expect(initialUID).NotTo(BeEmpty())
+
+			By("Deleting and recreating ConfigMap")
+			err = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Delete(context.Background(), cmName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Wait for deletion in Grafana
+			Eventually(func() bool {
+				found, _ := utils.ContainDashboard(testOptions, dashTitle)
+				return found
+			}, cleanupTimeout, cleanupInterval).Should(BeFalse())
+
+			// Recreate exactly same
+			_, err = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Create(context.Background(), cm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() string {
+				meta, _ := utils.GetDashboardMetadata(context.Background(), testOptions, dashTitle)
+				if meta != nil {
+					return meta.UID
+				}
+				return ""
+			}, syncTimeout, syncInterval).Should(Equal(initialUID))
+		},
+	)
+
+	It(
+		"Observability: Verify home dashboard setting - Should set custom dashboard as home [P2][Sev2][Observability][Stable]@e2e (dashboard/g4)",
+		func() {
+			cmName := "home-test-dashboard-unique"
+			dashTitle := "Home Test Dashboard"
+			dashUID := "home-test-uid"
+			By("Creating dashboard with home dashboard labels")
+			cm := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cmName,
+					Namespace: MCO_NAMESPACE,
+					Labels: map[string]string{
+						customDashboardLabelKey: "true",
+						homeDashboardUIDKey:     dashUID,
+					},
+					Annotations: map[string]string{
+						setHomeDashboardKey: "true",
+					},
+				},
+				Data: map[string]string{
+					"test.json": fmt.Sprintf("{\"title\": \"%s\", \"uid\": \"%s\"}", dashTitle, dashUID),
+				},
+			}
+			_, err := hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Create(context.Background(), cm, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() {
+				By("Cleaning up home-test-dashboard")
+				_ = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Delete(context.Background(), cmName, metav1.DeleteOptions{})
+			})
+
+			var dashID int64
+			Eventually(func() bool {
+				meta, _ := utils.GetDashboardMetadata(context.Background(), testOptions, dashTitle)
+				if meta != nil {
+					dashID = meta.ID
+					return true
+				}
+				return false
+			}, syncTimeout, syncInterval).Should(BeTrue())
+
+			By("Verifying Grafana home dashboard preference")
+			isForbidden := false
+			Eventually(func() int64 {
+				id, err := utils.GetGrafanaHomeDashboard(context.Background(), testOptions)
+				if err != nil {
+					if strings.Contains(err.Error(), "403") {
+						isForbidden = true
+						return -1
+					}
+					return 0
+				}
+				return id
+			}, syncTimeout, syncInterval).Should(SatisfyAny(
+				Equal(dashID),
+				Equal(int64(-1)), // marker for 403
+			))
+
+			if isForbidden {
+				GinkgoWriter.Printf("WARNING: Access denied (403) while checking home dashboard preference. This is expected if the token lacks organization preference read permissions.\n")
+				Skip("Skipping home dashboard verification due to 403 Access Denied on preferences API")
+			}
 		},
 	)
 
@@ -93,14 +394,14 @@ var _ = Describe("", func() {
 	It("[P2][Sev2][observability][Stable] Should have default overview dashboards (dashboard/g0)", func() {
 		// Check Original dash exists
 		Eventually(func() bool {
-			_, result := utils.ContainDashboard(testOptions, clusterOverviewTitle)
+			result, _ := utils.ContainDashboard(testOptions, clusterOverviewTitle)
 			return result
-		}, EventuallyTimeoutMinute*3, EventuallyIntervalSecond*5).Should(BeTrue())
+		}, syncTimeout, syncInterval).Should(BeTrue())
 		// Check optimized dash
 		Eventually(func() bool {
-			_, result := utils.ContainDashboard(testOptions, clusterOverviewOptimizedTitle)
+			result, _ := utils.ContainDashboard(testOptions, clusterOverviewOptimizedTitle)
 			return result
-		}, EventuallyTimeoutMinute*3, EventuallyIntervalSecond*5).Should(BeTrue())
+		}, syncTimeout, syncInterval).Should(BeTrue())
 	})
 
 	JustAfterEach(func() {
@@ -110,6 +411,14 @@ var _ = Describe("", func() {
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
 			utils.LogFailingTestStandardDebugInfo(testOptions)
+			// Force logs for Grafana pods
+			hubClient := utils.NewKubeClient(
+				testOptions.HubCluster.ClusterServerURL,
+				testOptions.KubeConfig,
+				testOptions.HubCluster.KubeContext)
+			utils.CheckPodsInNamespace(hubClient, MCO_NAMESPACE, []string{"observability-grafana"}, map[string]string{
+				"app": "multicluster-observability-grafana",
+			})
 		}
 		testFailed = testFailed || CurrentSpecReport().Failed()
 	})

--- a/tests/pkg/tests/observability_dashboard_test.go
+++ b/tests/pkg/tests/observability_dashboard_test.go
@@ -356,31 +356,30 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 				_ = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Delete(context.Background(), cmName, metav1.DeleteOptions{})
 			})
 
-			var dashID int64
 			Eventually(func() bool {
 				meta, _ := utils.GetDashboardMetadata(context.Background(), testOptions, dashTitle)
-				if meta != nil {
-					dashID = meta.ID
-					return true
-				}
-				return false
+				return meta != nil && meta.UID == dashUID
 			}, syncTimeout, syncInterval).Should(BeTrue())
 
 			By("Verifying Grafana home dashboard preference")
 			isForbidden := false
-			Eventually(func() int64 {
+			Eventually(func() string {
 				id, err := utils.GetGrafanaHomeDashboard(context.Background(), testOptions)
 				if err != nil {
 					if strings.Contains(err.Error(), "403") {
 						isForbidden = true
-						return -1
+						return "403"
 					}
-					return 0
+					return ""
 				}
-				return id
+				if id == 0 {
+					return "none"
+				}
+				homeUID, _ := utils.GetDashboardUIDByID(context.Background(), testOptions, id)
+				return homeUID
 			}, syncTimeout, syncInterval).Should(SatisfyAny(
-				Equal(dashID),
-				Equal(int64(-1)), // marker for 403
+				Equal(dashUID),
+				Equal("403"), // Handle 403 Access Denied
 			))
 
 			if isForbidden {

--- a/tests/pkg/tests/observability_dashboard_test.go
+++ b/tests/pkg/tests/observability_dashboard_test.go
@@ -31,9 +31,9 @@ const (
 	clusterOverviewTitle          = "ACM - Clusters Overview"
 	clusterOverviewOptimizedTitle = "ACM - Clusters Overview (Optimized)"
 
-	syncTimeout      = 5 * time.Minute
+	syncTimeout      = 1 * time.Minute
 	syncInterval     = 5 * time.Second
-	cleanupTimeout   = 2 * time.Minute
+	cleanupTimeout   = 1 * time.Minute
 	cleanupInterval  = 5 * time.Second
 	metadataTimeout  = 1 * time.Minute
 	metadataInterval = 5 * time.Second
@@ -72,9 +72,8 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 				_ = utils.DeleteConfigMap(testOptions, true, dashboardName, MCO_NAMESPACE)
 			})
 
-			Eventually(func() bool {
-				result, _ := utils.ContainDashboard(testOptions, dashboardTitle)
-				return result
+			Eventually(func() (bool, error) {
+				return utils.ContainDashboard(testOptions, dashboardTitle)
 			}, syncTimeout, syncInterval).Should(BeTrue())
 		},
 	)
@@ -111,15 +110,12 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 					testOptions.HubCluster.KubeContext,
 					yamlB)).NotTo(HaveOccurred())
 
-			Eventually(func(g Gomega) bool {
-				result, err := utils.ContainDashboard(testOptions, dashboardTitle)
-				g.Expect(err).ToNot(HaveOccurred())
-				return result
+			Eventually(func() (bool, error) {
+				return utils.ContainDashboard(testOptions, dashboardTitle)
 			}, cleanupTimeout, cleanupInterval).Should(BeFalse())
 
-			Eventually(func() bool {
-				result, _ := utils.ContainDashboard(testOptions, updateDashboardTitle)
-				return result
+			Eventually(func() (bool, error) {
+				return utils.ContainDashboard(testOptions, updateDashboardTitle)
 			}, syncTimeout, syncInterval).Should(BeTrue())
 		},
 	)
@@ -143,10 +139,8 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 			err = utils.DeleteConfigMap(testOptions, true, dashboardName, MCO_NAMESPACE)
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(func(g Gomega) bool {
-				result, err := utils.ContainDashboard(testOptions, dashboardTitle)
-				g.Expect(err).ToNot(HaveOccurred())
-				return result
+			Eventually(func() (bool, error) {
+				return utils.ContainDashboard(testOptions, dashboardTitle)
 			}, syncTimeout, syncInterval).Should(BeFalse())
 		},
 	)
@@ -181,12 +175,15 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 				_ = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Delete(context.Background(), cmName, metav1.DeleteOptions{})
 			})
 
-			Eventually(func() string {
-				meta, _ := utils.GetDashboardMetadata(context.Background(), testOptions, dashTitle)
-				if meta != nil {
-					return meta.FolderTitle
+			Eventually(func() (string, error) {
+				meta, err := utils.GetDashboardMetadata(context.Background(), testOptions, dashTitle)
+				if err != nil {
+					return "", err
 				}
-				return ""
+				if meta != nil {
+					return meta.FolderTitle, nil
+				}
+				return "", nil
 			}, metadataTimeout, metadataInterval).Should(Equal(folderA))
 
 			By("Moving dashboard to Folder-B")
@@ -199,34 +196,32 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 			_, err = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Update(context.Background(), cm, metav1.UpdateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func() string {
-				meta, _ := utils.GetDashboardMetadata(context.Background(), testOptions, updateTitle)
-				if meta != nil {
-					return meta.FolderTitle
+			Eventually(func() (string, error) {
+				meta, err := utils.GetDashboardMetadata(context.Background(), testOptions, updateTitle)
+				if err != nil {
+					return "", err
 				}
-				return ""
+				if meta != nil {
+					return meta.FolderTitle, nil
+				}
+				return "", nil
 			}, syncTimeout, syncInterval).Should(Equal(folderB))
 
 			By("Deleting dashboard and verifying folder reaping")
 			err = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Delete(context.Background(), cmName, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func(g Gomega) bool {
+			Eventually(func() (bool, error) {
 				meta, err := utils.GetDashboardMetadata(context.Background(), testOptions, updateTitle)
-				g.Expect(err).ToNot(HaveOccurred())
-				return meta != nil
+				return meta != nil, err
 			}, cleanupTimeout, cleanupInterval).Should(BeFalse())
 
 			// The folder should be reaped eventually (moving/deletion triggers immediate cleanup in the new code)
-			Eventually(func(g Gomega) bool {
-				exists, err := utils.FolderExists(context.Background(), testOptions, folderA)
-				g.Expect(err).ToNot(HaveOccurred())
-				return exists
+			Eventually(func() (bool, error) {
+				return utils.FolderExists(context.Background(), testOptions, folderA)
 			}, syncTimeout, syncInterval).Should(BeFalse())
-			Eventually(func(g Gomega) bool {
-				exists, err := utils.FolderExists(context.Background(), testOptions, folderB)
-				g.Expect(err).ToNot(HaveOccurred())
-				return exists
+			Eventually(func() (bool, error) {
+				return utils.FolderExists(context.Background(), testOptions, folderB)
 			}, syncTimeout, syncInterval).Should(BeFalse())
 		},
 	)
@@ -254,22 +249,32 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 				_ = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Delete(context.Background(), cmName, metav1.DeleteOptions{})
 			})
 
-			Eventually(func() bool {
-				found1, _ := utils.ContainDashboard(testOptions, "Multi Dash 1")
-				found2, _ := utils.ContainDashboard(testOptions, "Multi Dash 2")
-				return found1 && found2
+			Eventually(func() (bool, error) {
+				found1, err := utils.ContainDashboard(testOptions, "Multi Dash 1")
+				if err != nil {
+					return false, err
+				}
+				found2, err := utils.ContainDashboard(testOptions, "Multi Dash 2")
+				if err != nil {
+					return false, err
+				}
+				return found1 && found2, nil
 			}, syncTimeout, syncInterval).Should(BeTrue())
 
 			By("Deleting the whole ConfigMap for immediate cleanup")
 			err = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Delete(context.Background(), cmName, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func(g Gomega) bool {
-				found1, err1 := utils.ContainDashboard(testOptions, "Multi Dash 1")
-				g.Expect(err1).ToNot(HaveOccurred())
-				found2, err2 := utils.ContainDashboard(testOptions, "Multi Dash 2")
-				g.Expect(err2).ToNot(HaveOccurred())
-				return !found1 && !found2
+			Eventually(func() (bool, error) {
+				found1, err := utils.ContainDashboard(testOptions, "Multi Dash 1")
+				if err != nil {
+					return false, err
+				}
+				found2, err := utils.ContainDashboard(testOptions, "Multi Dash 2")
+				if err != nil {
+					return false, err
+				}
+				return !found1 && !found2, nil
 			}, cleanupTimeout, cleanupInterval).Should(BeTrue())
 		},
 	)
@@ -298,13 +303,16 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 			})
 
 			var initialUID string
-			Eventually(func() bool {
-				meta, _ := utils.GetDashboardMetadata(context.Background(), testOptions, dashTitle)
+			Eventually(func() (bool, error) {
+				meta, err := utils.GetDashboardMetadata(context.Background(), testOptions, dashTitle)
+				if err != nil {
+					return false, err
+				}
 				if meta != nil {
 					initialUID = meta.UID
-					return true
+					return true, nil
 				}
-				return false
+				return false, nil
 			}, syncTimeout, syncInterval).Should(BeTrue())
 
 			Expect(initialUID).NotTo(BeEmpty())
@@ -314,22 +322,23 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Wait for deletion in Grafana
-			Eventually(func(g Gomega) bool {
-				found, err := utils.ContainDashboard(testOptions, dashTitle)
-				g.Expect(err).ToNot(HaveOccurred())
-				return found
+			Eventually(func() (bool, error) {
+				return utils.ContainDashboard(testOptions, dashTitle)
 			}, cleanupTimeout, cleanupInterval).Should(BeFalse())
 
 			// Recreate exactly same
 			_, err = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Create(context.Background(), cm, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func() string {
-				meta, _ := utils.GetDashboardMetadata(context.Background(), testOptions, dashTitle)
-				if meta != nil {
-					return meta.UID
+			Eventually(func() (string, error) {
+				meta, err := utils.GetDashboardMetadata(context.Background(), testOptions, dashTitle)
+				if err != nil {
+					return "", err
 				}
-				return ""
+				if meta != nil {
+					return meta.UID, nil
+				}
+				return "", nil
 			}, syncTimeout, syncInterval).Should(Equal(initialUID))
 		},
 	)
@@ -364,27 +373,30 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 				_ = hubClient.CoreV1().ConfigMaps(MCO_NAMESPACE).Delete(context.Background(), cmName, metav1.DeleteOptions{})
 			})
 
-			Eventually(func() bool {
-				meta, _ := utils.GetDashboardMetadata(context.Background(), testOptions, dashTitle)
-				return meta != nil && meta.UID == dashUID
+			Eventually(func() (bool, error) {
+				meta, err := utils.GetDashboardMetadata(context.Background(), testOptions, dashTitle)
+				if err != nil {
+					return false, err
+				}
+				return meta != nil && meta.UID == dashUID, nil
 			}, syncTimeout, syncInterval).Should(BeTrue())
 
 			By("Verifying Grafana home dashboard preference")
 			isForbidden := false
-			Eventually(func() string {
+			Eventually(func() (string, error) {
 				id, err := utils.GetGrafanaHomeDashboard(context.Background(), testOptions)
 				if err != nil {
 					if strings.Contains(err.Error(), "403") {
 						isForbidden = true
-						return "403"
+						return "403", nil
 					}
-					return ""
+					return "", err
 				}
 				if id == 0 {
-					return "none"
+					return "none", nil
 				}
-				homeUID, _ := utils.GetDashboardUIDByID(context.Background(), testOptions, id)
-				return homeUID
+				homeUID, err := utils.GetDashboardUIDByID(context.Background(), testOptions, id)
+				return homeUID, err
 			}, syncTimeout, syncInterval).Should(SatisfyAny(
 				Equal(dashUID),
 				Equal("403"), // Handle 403 Access Denied
@@ -400,14 +412,12 @@ var _ = Describe("Observability: Dashboard Lifecycle", func() {
 	// TODO: Need RHACM4K no
 	It("[P2][Sev2][observability][Stable] Should have default overview dashboards (dashboard/g0)", func() {
 		// Check Original dash exists
-		Eventually(func() bool {
-			result, _ := utils.ContainDashboard(testOptions, clusterOverviewTitle)
-			return result
+		Eventually(func() (bool, error) {
+			return utils.ContainDashboard(testOptions, clusterOverviewTitle)
 		}, syncTimeout, syncInterval).Should(BeTrue())
 		// Check optimized dash
-		Eventually(func() bool {
-			result, _ := utils.ContainDashboard(testOptions, clusterOverviewOptimizedTitle)
-			return result
+		Eventually(func() (bool, error) {
+			return utils.ContainDashboard(testOptions, clusterOverviewOptimizedTitle)
 		}, syncTimeout, syncInterval).Should(BeTrue())
 	})
 

--- a/tests/pkg/tests/observability_grafana_test.go
+++ b/tests/pkg/tests/observability_grafana_test.go
@@ -15,10 +15,9 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 )
 
-var _ = Describe("", func() {
+var _ = Describe("Observability: Grafana Connectivity", func() {
 	BeforeEach(func() {
 		hubClient = utils.NewKubeClient(
 			testOptions.HubCluster.ClusterServerURL,
@@ -54,7 +53,7 @@ var _ = Describe("", func() {
 					}
 				}
 				return nil
-			}, EventuallyTimeoutMinute*6, EventuallyIntervalSecond*5).Should(Succeed())
+			}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 		},
 	)
 
@@ -65,7 +64,7 @@ var _ = Describe("", func() {
 				clientDynamic := utils.GetKubeClientDynamic(testOptions, true)
 				objs, err := clientDynamic.Resource(utils.NewOCMManagedClustersGVR()).List(context.TODO(), metav1.ListOptions{})
 				if err != nil {
-					klog.V(1).Infof("Get the managedcluster failed, The err is: %s\n", err)
+					GinkgoWriter.Printf("Get the managedcluster failed, The err is: %s\n", err)
 				}
 
 				for _, obj := range objs.Items {
@@ -74,10 +73,10 @@ var _ = Describe("", func() {
 					if labels["local-cluster"] == "true" {
 						labels := metadata["labels"].(map[string]any)
 						labels["autolabel"] = "grafanacm"
-						klog.V(1).Infof("The cluster with new label: %s\n", labels)
+						GinkgoWriter.Printf("The cluster with new label: %s\n", labels)
 						_, updateErr := clientDynamic.Resource(utils.NewOCMManagedClustersGVR()).Update(context.TODO(), &obj, metav1.UpdateOptions{})
 						if updateErr != nil {
-							klog.V(1).Infof("Update label failed, updateErr is : %s\n", updateErr)
+							GinkgoWriter.Printf("Update label failed, updateErr is : %s\n", updateErr)
 						}
 					}
 
@@ -94,18 +93,18 @@ var _ = Describe("", func() {
 					MCO_NAMESPACE,
 				)
 				if errcm != nil {
-					klog.V(1).Infof("The errcm is: %s\n", errcm)
+					GinkgoWriter.Printf("The errcm is: %s\n", errcm)
 				}
 
 				data, err := json.Marshal(cm)
 				if err != nil {
-					klog.V(1).Infof("The err is: %s\n", err)
+					GinkgoWriter.Printf("The err is: %s\n", err)
 				}
 				if !strings.Contains(string(data), "autolabel") {
-					klog.V(1).Infof("new managedcluster label autolabel is NOT added into configmap  observability-managed-cluster-label-allowlist")
+					GinkgoWriter.Printf("new managedcluster label autolabel is NOT added into configmap  observability-managed-cluster-label-allowlist\n")
 					return false
 				} else {
-					klog.V(1).Infof("new managedcluster label autolabel is added into configmap  observability-managed-cluster-label-allowlist")
+					GinkgoWriter.Printf("new managedcluster label autolabel is added into configmap  observability-managed-cluster-label-allowlist\n")
 					return true
 				}
 			}, EventuallyTimeoutMinute*1, EventuallyIntervalSecond*10).Should(BeTrue())
@@ -119,6 +118,10 @@ var _ = Describe("", func() {
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
 			utils.LogFailingTestStandardDebugInfo(testOptions)
+			// Force logs for Grafana pods
+			utils.CheckPodsInNamespace(hubClient, MCO_NAMESPACE, []string{"observability-grafana"}, map[string]string{
+				"app": "multicluster-observability-grafana",
+			})
 		}
 		testFailed = testFailed || CurrentSpecReport().Failed()
 	})

--- a/tests/pkg/utils/kube_debug.go
+++ b/tests/pkg/utils/kube_debug.go
@@ -99,6 +99,8 @@ func CheckPodsInNamespace(client kubernetes.Interface, ns string, forcePodNamesL
 	printPodsStatuses(pods.Items)
 
 	notRunningPodsCount := 0
+	forcedPodsLogged := make(map[string]bool)
+
 	for _, pod := range pods.Items {
 		if pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != corev1.PodSucceeded {
 			notRunningPodsCount++
@@ -107,7 +109,16 @@ func CheckPodsInNamespace(client kubernetes.Interface, ns string, forcePodNamesL
 		force := false
 		for _, forcePodName := range forcePodNamesLog {
 			if strings.Contains(pod.Name, forcePodName) {
-				force = true
+				// If the pod is running/succeeded, only force logs for one replica to avoid spam
+				if pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodSucceeded {
+					if !forcedPodsLogged[forcePodName] {
+						force = true
+						forcedPodsLogged[forcePodName] = true
+					}
+				} else {
+					// Always log failing pods
+					force = true
+				}
 				break
 			}
 		}

--- a/tests/pkg/utils/kube_debug.go
+++ b/tests/pkg/utils/kube_debug.go
@@ -169,6 +169,7 @@ func LogPodLogs(client kubernetes.Interface, ns string, pod corev1.Pod) {
 
 		// Aggregate info, debug and error logs from the past 6 minutes
 		filteredLines := []string{}
+		windowLines := []string{}
 		lines := strings.Split(string(logs), "\n")
 		cutoffTime := time.Now().Add(-6 * time.Minute)
 		unparseableCount := 0
@@ -198,21 +199,39 @@ func LogPodLogs(client kubernetes.Interface, ns string, pod corev1.Pod) {
 				unparseableCount++
 			}
 
+			windowLines = append(windowLines, line)
 			lowerLine := strings.ToLower(line)
-			if strings.Contains(lowerLine, "error") || strings.Contains(lowerLine, "info") {
+			// Match "info", "error" OR standard klog headers: I (Info), E (Error), W (Warning)
+			// Standard klog header format is e.g. I0409 12:34:56.123456
+			isKlog := false
+			if len(line) > 0 {
+				header := line[0]
+				isKlog = header == 'I' || header == 'E' || header == 'W'
+			}
+
+			if strings.Contains(lowerLine, "error") || strings.Contains(lowerLine, "info") || isKlog {
 				filteredLines = append(filteredLines, line)
 			}
 		}
 
-		// Reverse the lines to restore order
-		for i, j := 0, len(filteredLines)-1; i < j; i, j = i+1, j-1 {
-			filteredLines[i], filteredLines[j] = filteredLines[j], filteredLines[i]
+		// If all lines were filtered out, fallback to the last 40 lines from the window
+		displayLines := filteredLines
+		msg := "aggregated info/debug/error from the last 6 minutes"
+		if len(displayLines) == 0 && len(windowLines) > 0 {
+			count := min(40, len(windowLines))
+			displayLines = windowLines[:count]
+			msg = fmt.Sprintf("last %d lines from the last 6 minutes (filter returned no results)", count)
 		}
 
-		logs = []byte(strings.Join(filteredLines, "\n"))
+		// Reverse the lines to restore chronological order
+		for i, j := 0, len(displayLines)-1; i < j; i, j = i+1, j-1 {
+			displayLines[i], displayLines[j] = displayLines[j], displayLines[i]
+		}
 
-		delimitedLogs := fmt.Sprintf(">>>>>>>>>> container logs >>>>>>>>>>\n%s<<<<<<<<<< container logs <<<<<<<<<<", string(logs))
-		klog.V(1).Infof("Pod %q container %q logs (aggregated info/debug/error from the last 6 minutes): \n%s", pod.Name, container.Name, delimitedLogs)
+		logs = []byte(strings.Join(displayLines, "\n"))
+
+		delimitedLogs := fmt.Sprintf(">>>>>>>>>> container logs >>>>>>>>>>\n%s\n<<<<<<<<<< container logs <<<<<<<<<<", string(logs))
+		klog.V(1).Infof("Pod %q container %q logs (%s): \n%s", pod.Name, container.Name, msg, delimitedLogs)
 	}
 }
 

--- a/tests/pkg/utils/mco_dashboard.go
+++ b/tests/pkg/utils/mco_dashboard.go
@@ -143,6 +143,35 @@ func GetGrafanaHomeDashboard(ctx context.Context, opt TestOptions) (int64, error
 	return res.HomeDashboardID, nil
 }
 
+func GetDashboardUIDByID(ctx context.Context, opt TestOptions, id int64) (string, error) {
+	if id == 0 {
+		return "", nil
+	}
+	// Grafana search API doesn't have a direct "by id" filter, so we list all and find it.
+	// This is only used for verification in tests.
+	resp, err := doGrafanaGet(ctx, opt, "/api/search?type=dash-db")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	results, err := grafanaDecodeJSON[[]struct {
+		ID  int64  `json:"id"`
+		UID string `json:"uid"`
+	}](resp, "failed to search dashboards for UID resolution")
+	if err != nil {
+		return "", err
+	}
+
+	for _, res := range results {
+		if res.ID == id {
+			return res.UID, nil
+		}
+	}
+
+	return "", nil
+}
+
 func FolderExists(ctx context.Context, opt TestOptions, title string) (bool, error) {
 	resp, err := doGrafanaGet(ctx, opt, "/api/search?type=dash-folder")
 	if err != nil {

--- a/tests/pkg/utils/mco_dashboard.go
+++ b/tests/pkg/utils/mco_dashboard.go
@@ -9,13 +9,28 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"k8s.io/klog/v2"
 )
 
 const (
 	trueStr = "true"
+	// grafanaAdminBypassHeader bypasses the OAuth proxy via the internal sidecar port
+	grafanaAdminBypassHeader = "WHAT_YOU_ARE_DOING_IS_VOIDING_SUPPORT_0000000000000000000000000000000000000000000000000000000000000000"
+	// kindGrafanaAdminBypassHeader is the admin user configured in tests/run-in-kind/grafana/grafana-config-test.yaml
+	kindGrafanaAdminBypassHeader = "admin"
+)
+
+var (
+	cachedGrafanaPodName string
+	grafanaPodNameMutex  sync.Mutex
 )
 
 type DashboardMeta struct {
@@ -46,6 +61,14 @@ func getGrafanaHttpClient(opt TestOptions) (*http.Client, string, bool, error) {
 	return client, token, isKind, nil
 }
 
+func getAdminBypassHeader(isKind bool) string {
+	if isKind {
+		return kindGrafanaAdminBypassHeader
+	}
+	return grafanaAdminBypassHeader
+}
+
+// doGrafanaGet performs a standard GET request to Grafana as the configured test user.
 func doGrafanaGet(ctx context.Context, opt TestOptions, path string) (*http.Response, error) {
 	client, token, isKind, err := getGrafanaHttpClient(opt)
 	if err != nil {
@@ -61,11 +84,94 @@ func doGrafanaGet(ctx context.Context, opt TestOptions, path string) (*http.Resp
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
-	if !isKind {
+
+	if isKind {
+		req.Header.Set("X-Forwarded-User", getAdminBypassHeader(isKind))
+	} else {
 		req.Host = opt.HubCluster.GrafanaHost
 	}
 
 	return client.Do(req)
+}
+
+func getGrafanaPodName(ctx context.Context) (string, error) {
+	grafanaPodNameMutex.Lock()
+	defer grafanaPodNameMutex.Unlock()
+	if cachedGrafanaPodName != "" {
+		return cachedGrafanaPodName, nil
+	}
+	podNameCmd := exec.CommandContext(ctx, "oc", "get", "pods", "-n", MCO_NAMESPACE, "-l", "app=multicluster-observability-grafana", "-o", "jsonpath={.items[0].metadata.name}")
+	podNameBytes, err := podNameCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get grafana pod name: %w", err)
+	}
+	cachedGrafanaPodName = strings.TrimSpace(string(podNameBytes))
+	return cachedGrafanaPodName, nil
+}
+
+// execGrafanaAdminGet performs a GET request to Grafana with admin privileges, bypassing the OAuth proxy on OpenShift.
+func execGrafanaAdminGet(ctx context.Context, opt TestOptions, path string) ([]byte, error) {
+	isKind := os.Getenv("IS_KIND_ENV") == trueStr
+	if isKind {
+		// In KinD, we just hit the service directly since there's no complex OAuth proxy blocking preferences
+		client, _, _, err := getGrafanaHttpClient(opt)
+		if err != nil {
+			return nil, err
+		}
+
+		grafanaConsoleURL := GetGrafanaURL(opt)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, grafanaConsoleURL+path, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("X-Forwarded-User", getAdminBypassHeader(isKind))
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("failed to access grafana api, status: %d", resp.StatusCode)
+		}
+		return io.ReadAll(resp.Body)
+	}
+
+	// For OpenShift, bypass the OAuth proxy using oc exec
+	podName, err := getGrafanaPodName(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use the admin bypass header directly on localhost:3001
+	// #nosec G204 -- This is a test utility
+	execCmd := exec.CommandContext(
+		ctx,
+		"oc",
+		"exec",
+		"-n",
+		MCO_NAMESPACE,
+		podName,
+		"-c",
+		"grafana",
+		"--",
+		"curl",
+		"-f",
+		"-s",
+		"-H",
+		"X-Forwarded-User: "+getAdminBypassHeader(isKind),
+		"http://localhost:3001"+path,
+	)
+	out, err := execCmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute curl (is the path valid?): %w, output: %s", err, string(out))
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("grafana api returned empty response for path: %s", path)
+	}
+	return out, nil
 }
 
 func grafanaDecodeJSON[T any](resp *http.Response, errMsg string) (T, error) {
@@ -84,17 +190,45 @@ func grafanaDecodeJSON[T any](resp *http.Response, errMsg string) (T, error) {
 func ContainDashboard(opt TestOptions, title string) (bool, error) {
 	meta, err := GetDashboardMetadata(context.Background(), opt, title)
 	if err != nil {
+		klog.Errorf("ContainDashboard error for title '%s': %v", title, err)
 		return false, err
 	}
 	return meta != nil, nil
+}
+
+func ContainDashboardByUID(ctx context.Context, opt TestOptions, uid string) (bool, error) {
+	resp, err := doGrafanaGet(ctx, opt, "/api/search?type=dash-db")
+	if err != nil {
+		klog.Errorf("ContainDashboardByUID GET error for uid '%s': %v", uid, err)
+		return false, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	results, err := grafanaDecodeJSON[[]struct {
+		UID string `json:"uid"`
+	}](resp, "failed to search dashboards for UID resolution")
+	if err != nil {
+		klog.Errorf("ContainDashboardByUID decode error for uid '%s': %v", uid, err)
+		return false, err
+	}
+
+	for _, res := range results {
+		if res.UID == uid {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func GetDashboardMetadata(ctx context.Context, opt TestOptions, title string) (*DashboardMeta, error) {
 	params := url.Values{}
 	params.Add("query", title)
 	path := "/api/search?" + params.Encode()
+
 	resp, err := doGrafanaGet(ctx, opt, path)
 	if err != nil {
+		klog.Errorf("GetDashboardMetadata GET error for title '%s': %v", title, err)
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -109,6 +243,7 @@ func GetDashboardMetadata(ctx context.Context, opt TestOptions, title string) (*
 
 	results, err := grafanaDecodeJSON[[]searchResult](resp, "failed to access grafana search api")
 	if err != nil {
+		klog.Errorf("GetDashboardMetadata decode error for title '%s': %v", title, err)
 		return nil, err
 	}
 
@@ -126,55 +261,29 @@ func GetDashboardMetadata(ctx context.Context, opt TestOptions, title string) (*
 	return nil, nil
 }
 
-func GetGrafanaHomeDashboard(ctx context.Context, opt TestOptions) (int64, error) {
-	resp, err := doGrafanaGet(ctx, opt, "/api/org/preferences")
+func GetGrafanaHomeDashboard(ctx context.Context, opt TestOptions) (string, error) {
+	// Only this endpoint requires the admin bypass
+	data, err := execGrafanaAdminGet(ctx, opt, "/api/org/preferences")
 	if err != nil {
-		return 0, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	res, err := grafanaDecodeJSON[struct {
-		HomeDashboardID int64 `json:"homeDashboardId"`
-	}](resp, "failed to access grafana preferences")
-	if err != nil {
-		return 0, err
-	}
-
-	return res.HomeDashboardID, nil
-}
-
-func GetDashboardUIDByID(ctx context.Context, opt TestOptions, id int64) (string, error) {
-	if id == 0 {
-		return "", nil
-	}
-	// Grafana search API doesn't have a direct "by id" filter, so we list all and find it.
-	// This is only used for verification in tests.
-	resp, err := doGrafanaGet(ctx, opt, "/api/search?type=dash-db")
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	results, err := grafanaDecodeJSON[[]struct {
-		ID  int64  `json:"id"`
-		UID string `json:"uid"`
-	}](resp, "failed to search dashboards for UID resolution")
-	if err != nil {
+		klog.Errorf("GetGrafanaHomeDashboard exec error: %v", err)
 		return "", err
 	}
 
-	for _, res := range results {
-		if res.ID == id {
-			return res.UID, nil
-		}
+	var res struct {
+		HomeDashboardUID string `json:"homeDashboardUID"`
+	}
+	if err := json.Unmarshal(data, &res); err != nil {
+		klog.Errorf("GetGrafanaHomeDashboard unmarshal error: %v", err)
+		return "", fmt.Errorf("failed to access grafana preferences: %w", err)
 	}
 
-	return "", nil
+	return res.HomeDashboardUID, nil
 }
 
 func FolderExists(ctx context.Context, opt TestOptions, title string) (bool, error) {
 	resp, err := doGrafanaGet(ctx, opt, "/api/search?type=dash-folder")
 	if err != nil {
+		klog.Errorf("FolderExists GET error for title '%s': %v", title, err)
 		return false, err
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -183,6 +292,7 @@ func FolderExists(ctx context.Context, opt TestOptions, title string) (bool, err
 		Title string `json:"title"`
 	}](resp, "failed to search folders")
 	if err != nil {
+		klog.Errorf("FolderExists decode error for title '%s': %v", title, err)
 		return false, err
 	}
 

--- a/tests/pkg/utils/mco_dashboard.go
+++ b/tests/pkg/utils/mco_dashboard.go
@@ -5,73 +5,163 @@
 package utils
 
 import (
+	"context"
 	"crypto/tls"
-	"errors"
+	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
-
-	"k8s.io/klog/v2"
 )
 
 const (
 	trueStr = "true"
 )
 
-func ContainDashboard(opt TestOptions, title string) (error, bool) {
-	grafanaConsoleURL := GetGrafanaURL(opt)
-	path := "/api/search?"
-	queryParams := url.PathEscape(fmt.Sprintf("query=%s", title))
-	req, err := http.NewRequest(
-		http.MethodGet,
-		grafanaConsoleURL+path+queryParams,
-		nil)
-	if err != nil {
-		return err, false
-	}
+type DashboardMeta struct {
+	ID          int64
+	UID         string
+	Tags        []string
+	FolderTitle string
+}
 
+func getGrafanaHttpClient(opt TestOptions) (*http.Client, string, bool, error) {
 	client := &http.Client{}
-	if os.Getenv("IS_KIND_ENV") != trueStr {
+	token := ""
+	isKind := os.Getenv("IS_KIND_ENV") == trueStr
+
+	if !isKind {
 		tr := &http.Transport{
 			// #nosec G402 -- Used in test.
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 
 		client = &http.Client{Transport: tr}
-		token, err := FetchBearerToken(opt)
+		var err error
+		token, err = FetchBearerToken(opt)
 		if err != nil {
-			return err, false
+			return nil, "", false, err
 		}
-		if token != "" {
-			req.Header.Set("Authorization", "Bearer "+token)
-		}
+	}
+	return client, token, isKind, nil
+}
+
+func doGrafanaGet(ctx context.Context, opt TestOptions, path string) (*http.Response, error) {
+	client, token, isKind, err := getGrafanaHttpClient(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	grafanaConsoleURL := GetGrafanaURL(opt)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, grafanaConsoleURL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if !isKind {
 		req.Host = opt.HubCluster.GrafanaHost
 	}
 
-	resp, err := client.Do(req)
+	return client.Do(req)
+}
+
+func grafanaDecodeJSON[T any](resp *http.Response, errMsg string) (T, error) {
+	var result T
+	if resp.StatusCode != http.StatusOK {
+		return result, fmt.Errorf("%s, status: %d", errMsg, resp.StatusCode)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return result, fmt.Errorf("failed to decode grafana response: %w", err)
+	}
+
+	return result, nil
+}
+
+func ContainDashboard(opt TestOptions, title string) (bool, error) {
+	meta, err := GetDashboardMetadata(context.Background(), opt, title)
 	if err != nil {
-		return err, false
+		return false, err
+	}
+	return meta != nil, nil
+}
+
+func GetDashboardMetadata(ctx context.Context, opt TestOptions, title string) (*DashboardMeta, error) {
+	params := url.Values{}
+	params.Add("query", title)
+	path := "/api/search?" + params.Encode()
+	resp, err := doGrafanaGet(ctx, opt, path)
+	if err != nil {
+		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		klog.Errorf("resp: %+v\n", resp)
-		klog.Errorf("err: %+v\n", err)
-		return errors.New("failed to access grafana api"), false
+	type searchResult struct {
+		ID          int64    `json:"id"`
+		UID         string   `json:"uid"`
+		Title       string   `json:"title"`
+		Tags        []string `json:"tags"`
+		FolderTitle string   `json:"folderTitle"`
 	}
 
-	result, err := io.ReadAll(resp.Body)
-	klog.V(1).Infof("result: %s\n", result)
+	results, err := grafanaDecodeJSON[[]searchResult](resp, "failed to access grafana search api")
 	if err != nil {
-		return err, false
+		return nil, err
 	}
 
-	if !strings.Contains(string(result), fmt.Sprintf(`"title":"%s"`, title)) {
-		return errors.New("failed to find the dashboard"), false
-	} else {
-		return nil, true
+	for _, res := range results {
+		if res.Title == title {
+			return &DashboardMeta{
+				ID:          res.ID,
+				UID:         res.UID,
+				Tags:        res.Tags,
+				FolderTitle: res.FolderTitle,
+			}, nil
+		}
 	}
+
+	return nil, nil
+}
+
+func GetGrafanaHomeDashboard(ctx context.Context, opt TestOptions) (int64, error) {
+	resp, err := doGrafanaGet(ctx, opt, "/api/org/preferences")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	res, err := grafanaDecodeJSON[struct {
+		HomeDashboardID int64 `json:"homeDashboardId"`
+	}](resp, "failed to access grafana preferences")
+	if err != nil {
+		return 0, err
+	}
+
+	return res.HomeDashboardID, nil
+}
+
+func FolderExists(ctx context.Context, opt TestOptions, title string) (bool, error) {
+	resp, err := doGrafanaGet(ctx, opt, "/api/search?type=dash-folder")
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	results, err := grafanaDecodeJSON[[]struct {
+		Title string `json:"title"`
+	}](resp, "failed to search folders")
+	if err != nil {
+		return false, err
+	}
+
+	for _, res := range results {
+		if res.Title == title {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worker-based, rate-limited dashboard reconciliation with context-aware startup/shutdown
  * Improved Grafana client interactions for create/update/delete and folder management

* **Bug Fixes**
  * Better error mapping, retry handling, and more reliable UID resolution for dashboards
  * Safer handling of oversized/failed HTTP requests and request cancellation

* **Improvements**
  * Periodic and initial orphan cleanup, empty-folder cleanup, and tag-based source tracking
  * More robust folder title resolution and tag injection for managed dashboards

* **Tests**
  * Expanded unit and new integration tests covering reconciliation, retries, and Grafana API behavior

* **Chores**
  * Added loaders integration-test target; improved dev test script cleanup and timeouts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->