### PR TITLE
[release-2.13] Adding proxy for Grafana tests

### DIFF
--- a/tests/pkg/tests/observability_alert_test.go
+++ b/tests/pkg/tests/observability_alert_test.go
@@ -397,6 +397,7 @@ var _ = Describe("", func() {
 
 		client := &http.Client{
 			Transport: &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{RootCAs: pool},
 			},
 		}
@@ -543,6 +544,7 @@ var _ = Describe("", func() {
 
 		client := &http.Client{
 			Transport: &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{RootCAs: pool},
 			},
 		}

--- a/tests/pkg/tests/observability_route_test.go
+++ b/tests/pkg/tests/observability_route_test.go
@@ -72,6 +72,7 @@ var _ = Describe("", func() {
 			pool := x509.NewCertPool()
 			pool.AppendCertsFromPEM(caCrt)
 			tr := &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{RootCAs: pool},
 			}
 
@@ -155,6 +156,7 @@ var _ = Describe("", func() {
 			pool := x509.NewCertPool()
 			pool.AppendCertsFromPEM(caCrt)
 			tr := &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{RootCAs: pool},
 			}
 

--- a/tests/pkg/utils/mco_dashboard.go
+++ b/tests/pkg/utils/mco_dashboard.go
@@ -36,6 +36,7 @@ func ContainDashboard(opt TestOptions, title string) (error, bool) {
 	client := &http.Client{}
 	if os.Getenv("IS_KIND_ENV") != trueStr {
 		tr := &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			// #nosec G402 -- Used in test.
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}

--- a/tests/pkg/utils/mco_metric.go
+++ b/tests/pkg/utils/mco_metric.go
@@ -73,6 +73,7 @@ func QueryGrafana(opt TestOptions, query string) (*GrafanaResponse, error) {
 	client := &http.Client{}
 	if os.Getenv("IS_KIND_ENV") != "true" {
 		tr := &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			// #nosec G402 -- Only used in test.
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}


### PR DESCRIPTION
* Adding proxy to query grafana and grafana dashboards  in qe environment in 2.13
* Added proxy to alert and route tests where external requests are used