### PR TITLE
[ACM-30530] Fix orphaned rightsizing resources blocking namespace deletion on MCO

### DIFF
--- a/operators/multiclusterobservability/controllers/analytics/analytics_controller.go
+++ b/operators/multiclusterobservability/controllers/analytics/analytics_controller.go
@@ -14,6 +14,7 @@ import (
 	rightsizingctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/analytics/rightsizing"
 	mcoctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/multiclusterobservability"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,6 +44,12 @@ type AnalyticsReconciler struct {
 func (r *AnalyticsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
 	reqLogger.Info("Reconciling RightSizing")
+
+	// Skip reconciliation if MCO is being deleted
+	if operatorconfig.IsMCOTerminating {
+		reqLogger.Info("MCO is terminating, skip reconcile for rightsizing controller")
+		return ctrl.Result{}, nil
+	}
 
 	// Fetch the MultiClusterObservability instance
 	mcoList := &mcov1beta2.MultiClusterObservabilityList{}

--- a/operators/multiclusterobservability/controllers/analytics/analytics_controller.go
+++ b/operators/multiclusterobservability/controllers/analytics/analytics_controller.go
@@ -44,6 +44,7 @@ type AnalyticsReconciler struct {
 // +kubebuilder:rbac:groups=observability.open-cluster-management.io,resources=multiclusterobservabilities/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=observability.open-cluster-management.io,resources=multiclusterobservabilities/finalizers,verbs=update
 
+// Reconcile handles reconciliation of right-sizing resources based on the MCO lifecycle.
 func (r *AnalyticsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
 	reqLogger.Info("Reconciling RightSizing")

--- a/operators/multiclusterobservability/controllers/analytics/analytics_controller.go
+++ b/operators/multiclusterobservability/controllers/analytics/analytics_controller.go
@@ -8,13 +8,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/go-logr/logr"
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	rightsizingctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/analytics/rightsizing"
 	mcoctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/multiclusterobservability"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
-	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
+	commonutil "github.com/stolostron/multicluster-observability-operator/operators/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,6 +30,8 @@ import (
 var log = logf.Log.WithName("controller_rightsizing")
 
 var mcoGVK = mcov1beta2.GroupVersion.WithKind("MultiClusterObservability")
+
+const analyticsFinalizer = "observability.open-cluster-management.io/analytics-cleanup"
 
 // AnalyticsReconciler reconciles a MultiClusterObservability object
 type AnalyticsReconciler struct {
@@ -45,16 +48,9 @@ func (r *AnalyticsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	reqLogger := log.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
 	reqLogger.Info("Reconciling RightSizing")
 
-	// Skip reconciliation if MCO is being deleted
-	if operatorconfig.IsMCOTerminating.Load() {
-		reqLogger.Info("MCO is terminating, skip reconcile for rightsizing controller")
-		return ctrl.Result{}, nil
-	}
-
 	// Fetch the MultiClusterObservability instance
 	mcoList := &mcov1beta2.MultiClusterObservabilityList{}
-	err := r.Client.List(ctx, mcoList)
-	if err != nil {
+	if err := r.Client.List(ctx, mcoList); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to list MultiClusterObservability custom resources: %w", err)
 	}
 	if len(mcoList.Items) == 0 {
@@ -64,6 +60,35 @@ func (r *AnalyticsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	instance := mcoList.Items[0].DeepCopy()
 
+	// Handle deletion: clean up RS resources and remove our finalizer
+	if instance.GetDeletionTimestamp() != nil {
+		if !slices.Contains(instance.GetFinalizers(), analyticsFinalizer) {
+			return ctrl.Result{}, nil // not our responsibility (e.g., upgrade from older version)
+		}
+		reqLogger.Info("rs - MCO is terminating, cleaning up right-sizing resources")
+		if err := rightsizingctrl.CleanupRightSizingResources(ctx, r.Client, instance); err != nil {
+			return ctrl.Result{}, fmt.Errorf("rs - failed to cleanup right-sizing resources: %w", err)
+		}
+		instanceCopy := instance.DeepCopy()
+		instance.SetFinalizers(commonutil.Remove(instance.GetFinalizers(), analyticsFinalizer))
+		if err := r.Client.Patch(ctx, instance, client.MergeFrom(instanceCopy)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("rs - failed to remove analytics finalizer: %w", err)
+		}
+		reqLogger.Info("rs - Analytics finalizer removed after RS cleanup")
+		return ctrl.Result{}, nil
+	}
+
+	// Normal path: ensure our finalizer is present
+	if !slices.Contains(instance.GetFinalizers(), analyticsFinalizer) {
+		instanceCopy := instance.DeepCopy()
+		instance.SetFinalizers(append(instance.GetFinalizers(), analyticsFinalizer))
+		if err := r.Client.Patch(ctx, instance, client.MergeFrom(instanceCopy)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("rs - failed to add analytics finalizer: %w", err)
+		}
+		reqLogger.Info("rs - Analytics finalizer added to MCO CR")
+		return ctrl.Result{}, nil // watch-triggered reconcile picks up updated finalizers
+	}
+
 	// Do not reconcile objects if this instance of mch is labeled "paused"
 	if config.IsPaused(instance.GetAnnotations()) {
 		reqLogger.Info("MCO reconciliation is paused. Nothing more to do.")
@@ -71,15 +96,14 @@ func (r *AnalyticsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// Ensure defaults are set/persisted for analytics right-sizing
-	instance, err = r.ensureRightSizingDefaults(ctx, instance, reqLogger)
+	instance, err := r.ensureRightSizingDefaults(ctx, instance, reqLogger)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
 	// create rightsizing component
-	err = rightsizingctrl.CreateRightSizingComponent(ctx, r.Client, instance)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to create rightsizing component: %w", err)
+	if err := rightsizingctrl.CreateRightSizingComponent(ctx, r.Client, instance); err != nil {
+		return ctrl.Result{}, fmt.Errorf("rs - failed to create rightsizing component: %w", err)
 	}
 
 	return ctrl.Result{}, nil

--- a/operators/multiclusterobservability/controllers/analytics/analytics_controller.go
+++ b/operators/multiclusterobservability/controllers/analytics/analytics_controller.go
@@ -46,7 +46,7 @@ func (r *AnalyticsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	reqLogger.Info("Reconciling RightSizing")
 
 	// Skip reconciliation if MCO is being deleted
-	if operatorconfig.IsMCOTerminating {
+	if operatorconfig.IsMCOTerminating.Load() {
 		reqLogger.Info("MCO is terminating, skip reconcile for rightsizing controller")
 		return ctrl.Result{}, nil
 	}

--- a/operators/multiclusterobservability/controllers/analytics/analytics_controller_test.go
+++ b/operators/multiclusterobservability/controllers/analytics/analytics_controller_test.go
@@ -34,7 +34,10 @@ func setupTestScheme(t *testing.T) *runtime.Scheme {
 
 func newTestMCO(binding string, enabled bool, paused bool) *mcov1beta2.MultiClusterObservability {
 	mco := &mcov1beta2.MultiClusterObservability{
-		ObjectMeta: metav1.ObjectMeta{Name: "observability"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "observability",
+			Finalizers: []string{analyticsFinalizer},
+		},
 		Spec: mcov1beta2.MultiClusterObservabilitySpec{
 			Capabilities: &mcov1beta2.CapabilitiesSpec{
 				Platform: &mcov1beta2.PlatformCapabilitiesSpec{
@@ -182,4 +185,113 @@ func TestAnalyticsReconciler_PausedAnnotation(t *testing.T) {
 	r := &AnalyticsReconciler{Client: c, Scheme: scheme}
 	_, err := r.Reconcile(context.TODO(), ctrl.Request{})
 	require.NoError(t, err)
+}
+
+func TestAnalyticsReconciler_AddsFinalizer(t *testing.T) {
+	scheme := setupTestScheme(t)
+
+	// MCO without analytics finalizer
+	mco := &mcov1beta2.MultiClusterObservability{
+		ObjectMeta: metav1.ObjectMeta{Name: "observability"},
+		Spec: mcov1beta2.MultiClusterObservabilitySpec{
+			Capabilities: &mcov1beta2.CapabilitiesSpec{
+				Platform: &mcov1beta2.PlatformCapabilitiesSpec{
+					Analytics: mcov1beta2.PlatformAnalyticsSpec{
+						NamespaceRightSizingRecommendation: mcov1beta2.PlatformRightSizingRecommendationSpec{
+							Enabled: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mco).
+		Build()
+
+	r := &AnalyticsReconciler{Client: c, Scheme: scheme}
+	_, err := r.Reconcile(context.TODO(), ctrl.Request{})
+	require.NoError(t, err)
+
+	// Verify finalizer was added
+	updated := &mcov1beta2.MultiClusterObservability{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: "observability"}, updated)
+	require.NoError(t, err)
+	require.Contains(t, updated.GetFinalizers(), analyticsFinalizer)
+}
+
+func TestAnalyticsReconciler_DeletionCleansUp(t *testing.T) {
+	scheme := setupTestScheme(t)
+
+	// Include a second finalizer (simulating MCO's resFinalizer) so the object
+	// survives after removing only the analytics finalizer.
+	mco := &mcov1beta2.MultiClusterObservability{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "observability",
+			Finalizers: []string{"observability.open-cluster-management.io/res-cleanup", analyticsFinalizer},
+		},
+		Spec: mcov1beta2.MultiClusterObservabilitySpec{
+			Capabilities: &mcov1beta2.CapabilitiesSpec{
+				Platform: &mcov1beta2.PlatformCapabilitiesSpec{
+					Analytics: mcov1beta2.PlatformAnalyticsSpec{
+						NamespaceRightSizingRecommendation: mcov1beta2.PlatformRightSizingRecommendationSpec{
+							Enabled: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mco).
+		Build()
+
+	// Delete the object to set DeletionTimestamp (finalizers prevent actual removal)
+	err := c.Delete(context.TODO(), mco)
+	require.NoError(t, err)
+
+	r := &AnalyticsReconciler{Client: c, Scheme: scheme}
+	_, err = r.Reconcile(context.TODO(), ctrl.Request{})
+	require.NoError(t, err)
+
+	// Verify analytics finalizer was removed but MCO's finalizer remains
+	updated := &mcov1beta2.MultiClusterObservability{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: "observability"}, updated)
+	require.NoError(t, err)
+	require.NotContains(t, updated.GetFinalizers(), analyticsFinalizer)
+	require.Contains(t, updated.GetFinalizers(), "observability.open-cluster-management.io/res-cleanup")
+}
+
+func TestAnalyticsReconciler_DeletionSkipsWithoutFinalizer(t *testing.T) {
+	scheme := setupTestScheme(t)
+
+	mco := &mcov1beta2.MultiClusterObservability{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "observability",
+			Finalizers: []string{"other-finalizer"}, // no analytics finalizer
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mco).
+		Build()
+
+	// Delete the object to set DeletionTimestamp (finalizer prevents actual removal)
+	err := c.Delete(context.TODO(), mco)
+	require.NoError(t, err)
+
+	r := &AnalyticsReconciler{Client: c, Scheme: scheme}
+	_, err = r.Reconcile(context.TODO(), ctrl.Request{})
+	require.NoError(t, err)
+
+	// Verify the other finalizer is still present (we didn't touch it)
+	updated := &mcov1beta2.MultiClusterObservability{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: "observability"}, updated)
+	require.NoError(t, err)
+	require.Contains(t, updated.GetFinalizers(), "other-finalizer")
 }

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rightsizing_controller.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rightsizing_controller.go
@@ -43,20 +43,31 @@ func CreateRightSizingComponent(
 }
 
 // CleanupRightSizingResources cleans up all right-sizing resources (Policies, Placements, PlacementBindings, ConfigMaps).
-// It reads the namespace from the MCO spec to avoid relying on in-memory state which may be stale after operator restart.
+// It uses a hybrid approach:
+//  1. Label-based cleanup: discovers RS resources across all namespaces using the managed-by label.
+//     This handles cases where NamespaceBinding was changed before deletion.
+//  2. Name-based fallback: cleans up resources by well-known names in the spec namespace.
+//     This handles upgrade scenarios where existing resources don't have labels yet.
 func CleanupRightSizingResources(ctx context.Context, c client.Client, mco *mcov1beta2.MultiClusterObservability) error {
 	log.Info("rs - cleaning up all right-sizing resources")
 
+	var errs []error
+
+	// Label-based cleanup: catches resources in any namespace
+	if err := rsutility.CleanupRSResourcesByLabel(ctx, c); err != nil {
+		errs = append(errs, err)
+	}
+
+	// Name-based fallback: catches old unlabeled resources (upgrade path)
 	nsNamespace := getNamespaceBinding(mco, rsutility.ComponentTypeNamespace)
 	virtNamespace := getNamespaceBinding(mco, rsutility.ComponentTypeVirtualization)
-
-	var errs []error
 	if err := rsnamespace.CleanupRSNamespaceResources(ctx, c, nsNamespace, false); err != nil {
 		errs = append(errs, err)
 	}
 	if err := rsvirtualization.CleanupRSVirtualizationResources(ctx, c, virtNamespace, false); err != nil {
 		errs = append(errs, err)
 	}
+
 	return errors.Join(errs...)
 }
 

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rightsizing_controller.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rightsizing_controller.go
@@ -20,6 +20,7 @@ import (
 
 var log = logf.Log.WithName("analytics")
 
+// CreateRightSizingComponent reconciles namespace and virtualization right-sizing resources based on the MCO spec.
 func CreateRightSizingComponent(
 	ctx context.Context,
 	c client.Client,
@@ -63,7 +64,11 @@ func CleanupRightSizingResources(ctx context.Context, c client.Client, mco *mcov
 // Falls back to the default namespace if not configured.
 func getNamespaceBinding(mco *mcov1beta2.MultiClusterObservability, componentType rsutility.ComponentType) string {
 	_, binding, err := rsutility.GetComponentConfig(mco, componentType)
-	if err != nil || binding == "" {
+	if err != nil {
+		log.V(1).Info("rs - falling back to default namespace", "component", componentType, "error", err)
+		return rsutility.DefaultNamespace
+	}
+	if binding == "" {
 		return rsutility.DefaultNamespace
 	}
 	return binding

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rightsizing_controller.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rightsizing_controller.go
@@ -6,10 +6,12 @@ package rightsizing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	rsnamespace "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-namespace"
+	rsutility "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility"
 	rsvirtualization "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-virtualization"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -37,6 +39,34 @@ func CreateRightSizingComponent(
 
 	log.Info("rs - create component task completed")
 	return nil
+}
+
+// CleanupRightSizingResources cleans up all right-sizing resources (Policies, Placements, PlacementBindings, ConfigMaps).
+// It reads the namespace from the MCO spec to avoid relying on in-memory state which may be stale after operator restart.
+func CleanupRightSizingResources(ctx context.Context, c client.Client, mco *mcov1beta2.MultiClusterObservability) error {
+	log.Info("rs - cleaning up all right-sizing resources")
+
+	nsNamespace := getNamespaceBinding(mco, rsutility.ComponentTypeNamespace)
+	virtNamespace := getNamespaceBinding(mco, rsutility.ComponentTypeVirtualization)
+
+	var errs []error
+	if err := rsnamespace.CleanupRSNamespaceResources(ctx, c, nsNamespace, false); err != nil {
+		errs = append(errs, err)
+	}
+	if err := rsvirtualization.CleanupRSVirtualizationResources(ctx, c, virtNamespace, false); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+// getNamespaceBinding extracts the namespace binding from MCO spec for a given component type.
+// Falls back to the default namespace if not configured.
+func getNamespaceBinding(mco *mcov1beta2.MultiClusterObservability, componentType rsutility.ComponentType) string {
+	_, binding, err := rsutility.GetComponentConfig(mco, componentType)
+	if err != nil || binding == "" {
+		return rsutility.DefaultNamespace
+	}
+	return binding
 }
 
 // GetNamespaceRSConfigMapPredicateFunc returns predicate for namespace right-sizing ConfigMap

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rightsizing_controller_test.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rightsizing_controller_test.go
@@ -11,12 +11,15 @@ import (
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	rsnamespace "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-namespace"
 	rsutility "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility"
+	rsvirtualization "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-virtualization"
+	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -78,6 +81,110 @@ func TestCreateRightSizingComponent_FeatureEnabled(t *testing.T) {
 
 	err := CreateRightSizingComponent(context.TODO(), client, mco)
 	require.NoError(t, err)
+}
+
+func TestCleanupRightSizingResources_DefaultNamespace(t *testing.T) {
+	scheme := setupTestScheme(t)
+
+	ns := rsutility.DefaultNamespace
+	mco := newTestMCO("", true) // No custom binding, uses default namespace
+
+	// Pre-create rightsizing resources that should be cleaned up
+	existingResources := []runtime.Object{
+		&policyv1.Policy{
+			ObjectMeta: metav1.ObjectMeta{Name: rsnamespace.PrometheusRulePolicyName, Namespace: ns},
+		},
+		&clusterv1beta1.Placement{
+			ObjectMeta: metav1.ObjectMeta{Name: rsnamespace.PlacementName, Namespace: ns},
+		},
+		&policyv1.PlacementBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: rsnamespace.PlacementBindingName, Namespace: ns},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: rsnamespace.ConfigMapName, Namespace: config.GetDefaultNamespace()},
+		},
+		&policyv1.Policy{
+			ObjectMeta: metav1.ObjectMeta{Name: rsvirtualization.PrometheusRulePolicyName, Namespace: ns},
+		},
+		&clusterv1beta1.Placement{
+			ObjectMeta: metav1.ObjectMeta{Name: rsvirtualization.PlacementName, Namespace: ns},
+		},
+		&policyv1.PlacementBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: rsvirtualization.PlacementBindingName, Namespace: ns},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: rsvirtualization.ConfigMapName, Namespace: config.GetDefaultNamespace()},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(existingResources...).
+		Build()
+
+	// Ensure resources exist before cleanup
+	policy := &policyv1.Policy{}
+	require.NoError(t, client.Get(context.TODO(), keyFor(rsnamespace.PrometheusRulePolicyName, ns), policy))
+
+	// Run cleanup
+	err := CleanupRightSizingResources(context.TODO(), client, mco)
+	require.NoError(t, err)
+
+	// Verify all namespace RS resources are deleted
+	require.Error(t, client.Get(context.TODO(), keyFor(rsnamespace.PrometheusRulePolicyName, ns), &policyv1.Policy{}))
+	require.Error(t, client.Get(context.TODO(), keyFor(rsnamespace.PlacementName, ns), &clusterv1beta1.Placement{}))
+	require.Error(t, client.Get(context.TODO(), keyFor(rsnamespace.PlacementBindingName, ns), &policyv1.PlacementBinding{}))
+	require.Error(t, client.Get(context.TODO(), keyFor(rsnamespace.ConfigMapName, config.GetDefaultNamespace()), &corev1.ConfigMap{}))
+
+	// Verify all virtualization RS resources are deleted
+	require.Error(t, client.Get(context.TODO(), keyFor(rsvirtualization.PrometheusRulePolicyName, ns), &policyv1.Policy{}))
+	require.Error(t, client.Get(context.TODO(), keyFor(rsvirtualization.PlacementName, ns), &clusterv1beta1.Placement{}))
+	require.Error(t, client.Get(context.TODO(), keyFor(rsvirtualization.PlacementBindingName, ns), &policyv1.PlacementBinding{}))
+	require.Error(t, client.Get(context.TODO(), keyFor(rsvirtualization.ConfigMapName, config.GetDefaultNamespace()), &corev1.ConfigMap{}))
+}
+
+func TestCleanupRightSizingResources_CustomNamespace(t *testing.T) {
+	scheme := setupTestScheme(t)
+
+	customNS := "custom-ns"
+	mco := newTestMCO(customNS, true) // Custom binding
+
+	// Resources are in the custom namespace (as they would be when created with custom binding)
+	existingResources := []runtime.Object{
+		&policyv1.Policy{
+			ObjectMeta: metav1.ObjectMeta{Name: rsnamespace.PrometheusRulePolicyName, Namespace: customNS},
+		},
+		&clusterv1beta1.Placement{
+			ObjectMeta: metav1.ObjectMeta{Name: rsnamespace.PlacementName, Namespace: customNS},
+		},
+		&policyv1.PlacementBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: rsnamespace.PlacementBindingName, Namespace: customNS},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: rsnamespace.ConfigMapName, Namespace: config.GetDefaultNamespace()},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(existingResources...).
+		Build()
+
+	// Ensure resources exist before cleanup
+	require.NoError(t, client.Get(context.TODO(), keyFor(rsnamespace.PrometheusRulePolicyName, customNS), &policyv1.Policy{}))
+
+	// Run cleanup — should use namespace from MCO spec, not ComponentState
+	err := CleanupRightSizingResources(context.TODO(), client, mco)
+	require.NoError(t, err)
+
+	// Verify resources in custom namespace are deleted
+	require.Error(t, client.Get(context.TODO(), keyFor(rsnamespace.PrometheusRulePolicyName, customNS), &policyv1.Policy{}))
+	require.Error(t, client.Get(context.TODO(), keyFor(rsnamespace.PlacementName, customNS), &clusterv1beta1.Placement{}))
+	require.Error(t, client.Get(context.TODO(), keyFor(rsnamespace.PlacementBindingName, customNS), &policyv1.PlacementBinding{}))
+}
+
+func keyFor(name, namespace string) client.ObjectKey {
+	return client.ObjectKey{Name: name, Namespace: namespace}
 }
 
 func TestCreateRightSizingComponent_FeatureDisabled(t *testing.T) {

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rightsizing_controller_test.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rightsizing_controller_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
@@ -130,17 +131,17 @@ func TestCleanupRightSizingResources_DefaultNamespace(t *testing.T) {
 	err := CleanupRightSizingResources(context.TODO(), client, mco)
 	require.NoError(t, err)
 
-	// Verify all namespace RS resources are deleted
-	require.Error(t, client.Get(context.TODO(), keyFor(rsnamespace.PrometheusRulePolicyName, ns), &policyv1.Policy{}))
-	require.Error(t, client.Get(context.TODO(), keyFor(rsnamespace.PlacementName, ns), &clusterv1beta1.Placement{}))
-	require.Error(t, client.Get(context.TODO(), keyFor(rsnamespace.PlacementBindingName, ns), &policyv1.PlacementBinding{}))
-	require.Error(t, client.Get(context.TODO(), keyFor(rsnamespace.ConfigMapName, config.GetDefaultNamespace()), &corev1.ConfigMap{}))
+	// Verify all namespace RS resources are deleted (NotFound, not just any error)
+	require.True(t, apierrors.IsNotFound(client.Get(context.TODO(), keyFor(rsnamespace.PrometheusRulePolicyName, ns), &policyv1.Policy{})))
+	require.True(t, apierrors.IsNotFound(client.Get(context.TODO(), keyFor(rsnamespace.PlacementName, ns), &clusterv1beta1.Placement{})))
+	require.True(t, apierrors.IsNotFound(client.Get(context.TODO(), keyFor(rsnamespace.PlacementBindingName, ns), &policyv1.PlacementBinding{})))
+	require.True(t, apierrors.IsNotFound(client.Get(context.TODO(), keyFor(rsnamespace.ConfigMapName, config.GetDefaultNamespace()), &corev1.ConfigMap{})))
 
-	// Verify all virtualization RS resources are deleted
-	require.Error(t, client.Get(context.TODO(), keyFor(rsvirtualization.PrometheusRulePolicyName, ns), &policyv1.Policy{}))
-	require.Error(t, client.Get(context.TODO(), keyFor(rsvirtualization.PlacementName, ns), &clusterv1beta1.Placement{}))
-	require.Error(t, client.Get(context.TODO(), keyFor(rsvirtualization.PlacementBindingName, ns), &policyv1.PlacementBinding{}))
-	require.Error(t, client.Get(context.TODO(), keyFor(rsvirtualization.ConfigMapName, config.GetDefaultNamespace()), &corev1.ConfigMap{}))
+	// Verify all virtualization RS resources are deleted (NotFound, not just any error)
+	require.True(t, apierrors.IsNotFound(client.Get(context.TODO(), keyFor(rsvirtualization.PrometheusRulePolicyName, ns), &policyv1.Policy{})))
+	require.True(t, apierrors.IsNotFound(client.Get(context.TODO(), keyFor(rsvirtualization.PlacementName, ns), &clusterv1beta1.Placement{})))
+	require.True(t, apierrors.IsNotFound(client.Get(context.TODO(), keyFor(rsvirtualization.PlacementBindingName, ns), &policyv1.PlacementBinding{})))
+	require.True(t, apierrors.IsNotFound(client.Get(context.TODO(), keyFor(rsvirtualization.ConfigMapName, config.GetDefaultNamespace()), &corev1.ConfigMap{})))
 }
 
 func TestCleanupRightSizingResources_CustomNamespace(t *testing.T) {
@@ -177,10 +178,10 @@ func TestCleanupRightSizingResources_CustomNamespace(t *testing.T) {
 	err := CleanupRightSizingResources(context.TODO(), client, mco)
 	require.NoError(t, err)
 
-	// Verify resources in custom namespace are deleted
-	require.Error(t, client.Get(context.TODO(), keyFor(rsnamespace.PrometheusRulePolicyName, customNS), &policyv1.Policy{}))
-	require.Error(t, client.Get(context.TODO(), keyFor(rsnamespace.PlacementName, customNS), &clusterv1beta1.Placement{}))
-	require.Error(t, client.Get(context.TODO(), keyFor(rsnamespace.PlacementBindingName, customNS), &policyv1.PlacementBinding{}))
+	// Verify resources in custom namespace are deleted (NotFound, not just any error)
+	require.True(t, apierrors.IsNotFound(client.Get(context.TODO(), keyFor(rsnamespace.PrometheusRulePolicyName, customNS), &policyv1.Policy{})))
+	require.True(t, apierrors.IsNotFound(client.Get(context.TODO(), keyFor(rsnamespace.PlacementName, customNS), &clusterv1beta1.Placement{})))
+	require.True(t, apierrors.IsNotFound(client.Get(context.TODO(), keyFor(rsnamespace.PlacementBindingName, customNS), &policyv1.PlacementBinding{})))
 }
 
 func keyFor(name, namespace string) client.ObjectKey {

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-namespace/helper.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-namespace/helper.go
@@ -64,7 +64,7 @@ func GetRightSizingNamespaceConfig(mco *mcov1beta2.MultiClusterObservability) (b
 }
 
 // CleanupRSNamespaceResources cleans up the resources created for namespace right-sizing
-func CleanupRSNamespaceResources(ctx context.Context, c client.Client, namespace string, bindingUpdated bool) {
+func CleanupRSNamespaceResources(ctx context.Context, c client.Client, namespace string, bindingUpdated bool) error {
 	log.V(1).Info("rs - cleaning up namespace resources if exist")
-	rsutility.CleanupComponentResources(ctx, c, componentConfig, namespace, bindingUpdated)
+	return rsutility.CleanupComponentResources(ctx, c, componentConfig, namespace, bindingUpdated)
 }

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-namespace/helper_test.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-namespace/helper_test.go
@@ -245,8 +245,8 @@ func TestCleanupRSNamespaceResources_UsesCorrectComponentConfig(t *testing.T) {
 
 	// Test that the function executes without error (basic smoke test)
 	// The actual cleanup logic is tested comprehensively in rs-utility/component_test.go
-	CleanupRSNamespaceResources(ctx, client, rsutility.DefaultNamespace, false)
-	CleanupRSNamespaceResources(ctx, client, rsutility.DefaultNamespace, true)
+	require.NoError(t, CleanupRSNamespaceResources(ctx, client, rsutility.DefaultNamespace, false))
+	require.NoError(t, CleanupRSNamespaceResources(ctx, client, rsutility.DefaultNamespace, true))
 
 	// Test passes if no panic or error occurs, confirming the wrapper works correctly
 }

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component.go
@@ -6,12 +6,13 @@ package rsutility
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
@@ -77,7 +78,7 @@ func HandleComponentRightSizing(
 	// Get right-sizing configuration
 	isEnabled, newBinding, err := GetComponentConfig(mco, componentConfig.ComponentType)
 	if err != nil {
-		return fmt.Errorf("failed to get %s right-sizing config: %w", componentConfig.ComponentType, err)
+		return fmt.Errorf("rs - failed to get %s right-sizing config: %w", componentConfig.ComponentType, err)
 	}
 
 	// Set to default namespace if not given
@@ -89,7 +90,9 @@ func HandleComponentRightSizing(
 	// If disabled then cleanup related resources
 	if !isEnabled {
 		log.V(1).Info("rs - feature not enabled", "component", componentConfig.ComponentType)
-		CleanupComponentResources(ctx, c, componentConfig, state.Namespace, false)
+		if err := CleanupComponentResources(ctx, c, componentConfig, state.Namespace, false); err != nil {
+			return fmt.Errorf("rs - failed to cleanup %s resources: %w", componentConfig.ComponentType, err)
+		}
 		state.Namespace = newBinding
 		state.Enabled = false
 		return nil
@@ -112,7 +115,9 @@ func HandleComponentRightSizing(
 
 	if namespaceBindingUpdated {
 		// Clean up resources except config map to update NamespaceBinding
-		CleanupComponentResources(ctx, c, componentConfig, existingNamespace, true)
+		if err := CleanupComponentResources(ctx, c, componentConfig, existingNamespace, true); err != nil {
+			return fmt.Errorf("rs - failed to cleanup %s resources after namespace binding update: %w", componentConfig.ComponentType, err)
+		}
 
 		// Get configmap
 		cm := &corev1.ConfigMap{}
@@ -143,7 +148,7 @@ func CleanupComponentResources(
 	componentConfig ComponentConfig,
 	namespace string,
 	bindingUpdated bool,
-) {
+) error {
 	log.V(1).Info("rs - cleaning up resources if exist", "component", componentConfig.ComponentType)
 
 	var resourcesToDelete []client.Object
@@ -163,12 +168,18 @@ func CleanupComponentResources(
 		)
 	}
 
-	// Delete related resources
+	// Delete related resources, collecting errors so all deletes are attempted
+	var errs []error
 	for _, resource := range resourcesToDelete {
 		err := c.Delete(ctx, resource)
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			log.Error(err, "rs - failed to delete resource", "name", resource.GetName(), "component", componentConfig.ComponentType)
+			errs = append(errs, err)
 		}
 	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
 	log.Info("rs - cleanup success", "component", componentConfig.ComponentType)
+	return nil
 }

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
@@ -172,7 +173,7 @@ func CleanupComponentResources(
 	var errs []error
 	for _, resource := range resourcesToDelete {
 		err := c.Delete(ctx, resource)
-		if err != nil && !apierrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
 			log.Error(err, "rs - failed to delete resource", "name", resource.GetName(), "namespace", resource.GetNamespace(), "component", componentConfig.ComponentType)
 			errs = append(errs, err)
 		}

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component.go
@@ -26,7 +26,16 @@ type ComponentType string
 const (
 	ComponentTypeNamespace      ComponentType = "namespace"
 	ComponentTypeVirtualization ComponentType = "virtualization"
+
+	// RSManagedByLabel is applied to all RS resources for label-based discovery during cleanup.
+	RSManagedByLabel = "observability.open-cluster-management.io/managed-by"
+	RSManagedByValue = "analytics-rightsizing"
 )
+
+// RSLabels returns the standard labels applied to all right-sizing resources.
+func RSLabels() map[string]string {
+	return map[string]string{RSManagedByLabel: RSManagedByValue}
+}
 
 // ComponentConfig holds configuration for a right-sizing component
 type ComponentConfig struct {
@@ -183,4 +192,71 @@ func CleanupComponentResources(
 	}
 	log.Info("rs - cleanup success", "component", componentConfig.ComponentType)
 	return nil
+}
+
+// CleanupRSResourcesByLabel deletes all right-sizing resources across namespaces using the managed-by label.
+// This catches resources that may have been created in a different namespace due to NamespaceBinding changes.
+func CleanupRSResourcesByLabel(ctx context.Context, c client.Client) error {
+	log.Info("rs - label-based cleanup of all right-sizing resources")
+	labelSelector := client.MatchingLabels{RSManagedByLabel: RSManagedByValue}
+
+	var errs []error
+
+	// Clean up Policies
+	policyList := &policyv1.PolicyList{}
+	if err := c.List(ctx, policyList, labelSelector); err != nil {
+		if !meta.IsNoMatchError(err) {
+			errs = append(errs, fmt.Errorf("rs - failed to list policies: %w", err))
+		}
+	} else {
+		for i := range policyList.Items {
+			if err := c.Delete(ctx, &policyList.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	// Clean up PlacementBindings
+	pbList := &policyv1.PlacementBindingList{}
+	if err := c.List(ctx, pbList, labelSelector); err != nil {
+		if !meta.IsNoMatchError(err) {
+			errs = append(errs, fmt.Errorf("rs - failed to list placementbindings: %w", err))
+		}
+	} else {
+		for i := range pbList.Items {
+			if err := c.Delete(ctx, &pbList.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	// Clean up Placements
+	placementList := &clusterv1beta1.PlacementList{}
+	if err := c.List(ctx, placementList, labelSelector); err != nil {
+		if !meta.IsNoMatchError(err) {
+			errs = append(errs, fmt.Errorf("rs - failed to list placements: %w", err))
+		}
+	} else {
+		for i := range placementList.Items {
+			if err := c.Delete(ctx, &placementList.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	// Clean up ConfigMaps
+	cmList := &corev1.ConfigMapList{}
+	if err := c.List(ctx, cmList, labelSelector); err != nil {
+		if !meta.IsNoMatchError(err) {
+			errs = append(errs, fmt.Errorf("rs - failed to list configmaps: %w", err))
+		}
+	} else {
+		for i := range cmList.Items {
+			if err := c.Delete(ctx, &cmList.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	return errors.Join(errs...)
 }

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component.go
@@ -173,7 +173,7 @@ func CleanupComponentResources(
 	for _, resource := range resourcesToDelete {
 		err := c.Delete(ctx, resource)
 		if err != nil && !apierrors.IsNotFound(err) {
-			log.Error(err, "rs - failed to delete resource", "name", resource.GetName(), "component", componentConfig.ComponentType)
+			log.Error(err, "rs - failed to delete resource", "name", resource.GetName(), "namespace", resource.GetNamespace(), "component", componentConfig.ComponentType)
 			errs = append(errs, err)
 		}
 	}

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component_test.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component_test.go
@@ -240,10 +240,11 @@ func TestCleanupComponentResources_WithConfigMap(t *testing.T) {
 	defer cancel()
 
 	// Test cleanup with bindingUpdated=false (should delete all resources including configmap)
-	CleanupComponentResources(ctx, client, componentConfig, "test-ns", false)
+	err := CleanupComponentResources(ctx, client, componentConfig, "test-ns", false)
+	assert.NoError(t, err)
 
 	// Verify all resources were deleted
-	err := client.Get(ctx, types.NamespacedName{Name: "test-config", Namespace: "open-cluster-management-observability"}, &corev1.ConfigMap{})
+	err = client.Get(ctx, types.NamespacedName{Name: "test-config", Namespace: "open-cluster-management-observability"}, &corev1.ConfigMap{})
 	assert.True(t, errors.IsNotFound(err))
 
 	err = client.Get(ctx, types.NamespacedName{Name: "test-placement", Namespace: "test-ns"}, &clusterv1beta1.Placement{})
@@ -292,10 +293,11 @@ func TestCleanupComponentResources_WithoutConfigMap(t *testing.T) {
 	defer cancel()
 
 	// Test cleanup with bindingUpdated=true (should not delete configmap)
-	CleanupComponentResources(ctx, client, componentConfig, "test-ns", true)
+	err := CleanupComponentResources(ctx, client, componentConfig, "test-ns", true)
+	assert.NoError(t, err)
 
 	// Verify configmap was not deleted
-	err := client.Get(ctx, types.NamespacedName{Name: "test-config", Namespace: "open-cluster-management-observability"}, &corev1.ConfigMap{})
+	err = client.Get(ctx, types.NamespacedName{Name: "test-config", Namespace: "open-cluster-management-observability"}, &corev1.ConfigMap{})
 	assert.NoError(t, err) // ConfigMap should still exist
 
 	// Verify other resources were deleted

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/configmap.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/configmap.go
@@ -27,6 +27,7 @@ func EnsureRSConfigMapExists(ctx context.Context, c client.Client, configMapName
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      configMapName,
 			Namespace: config.GetDefaultNamespace(),
+			Labels:    RSLabels(),
 		},
 	}
 

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/placement.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/placement.go
@@ -7,6 +7,7 @@ package rsutility
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +41,7 @@ func CreateUpdateRSPlacement(ctx context.Context, c client.Client, placementName
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      placementName,
 			Namespace: namespace,
+			Labels:    RSLabels(),
 		},
 	}
 	key := types.NamespacedName{
@@ -68,6 +70,10 @@ func CreateUpdateRSPlacement(ctx context.Context, c client.Client, placementName
 	}
 
 	// Update existing placement
+	if placement.Labels == nil {
+		placement.Labels = map[string]string{}
+	}
+	maps.Copy(placement.Labels, RSLabels())
 	placement.Spec = placementConfig.Spec
 	if err := c.Update(ctx, placement); err != nil {
 		return fmt.Errorf("rs - failed to update placement: %w", err)

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/placementbinding.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/placementbinding.go
@@ -21,6 +21,7 @@ func CreateRSPlacementBinding(ctx context.Context, c client.Client, placementBin
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      placementBindingName,
 			Namespace: namespace,
+			Labels:    RSLabels(),
 		},
 	}
 

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/policy.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/policy.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -25,6 +26,7 @@ func CreateOrUpdateRSPrometheusRulePolicy(ctx context.Context, c client.Client, 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      policyName,
 			Namespace: namespace,
+			Labels:    RSLabels(),
 		},
 	}
 
@@ -106,6 +108,10 @@ func CreateOrUpdateRSPrometheusRulePolicy(ctx context.Context, c client.Client, 
 		}
 		log.Info("rs - created prometheusrulepolicy successfully", logCtx...)
 	} else {
+		if policy.Labels == nil {
+			policy.Labels = map[string]string{}
+		}
+		maps.Copy(policy.Labels, RSLabels())
 		if err := c.Update(ctx, policy); err != nil {
 			return fmt.Errorf("rs - failed to update prometheusrulepolicy: %w", err)
 		}

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-virtualization/helper.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-virtualization/helper.go
@@ -64,7 +64,7 @@ func GetRightSizingVirtualizationConfig(mco *mcov1beta2.MultiClusterObservabilit
 }
 
 // CleanupRSVirtualizationResources cleans up the resources created for virtualization right-sizing
-func CleanupRSVirtualizationResources(ctx context.Context, c client.Client, namespace string, bindingUpdated bool) {
+func CleanupRSVirtualizationResources(ctx context.Context, c client.Client, namespace string, bindingUpdated bool) error {
 	log.V(1).Info("rs - cleaning up virtualization resources if exist")
-	rsutility.CleanupComponentResources(ctx, c, componentConfig, namespace, bindingUpdated)
+	return rsutility.CleanupComponentResources(ctx, c, componentConfig, namespace, bindingUpdated)
 }

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-virtualization/helper_test.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-virtualization/helper_test.go
@@ -223,8 +223,8 @@ func TestCleanupRSVirtualizationResources_UsesCorrectComponentConfig(t *testing.
 
 	// Test that the function executes without error (basic smoke test)
 	// The actual cleanup logic is tested comprehensively in rs-utility/component_test.go
-	CleanupRSVirtualizationResources(ctx, client, rsutility.DefaultNamespace, false)
-	CleanupRSVirtualizationResources(ctx, client, rsutility.DefaultNamespace, true)
+	require.NoError(t, CleanupRSVirtualizationResources(ctx, client, rsutility.DefaultNamespace, false))
+	require.NoError(t, CleanupRSVirtualizationResources(ctx, client, rsutility.DefaultNamespace, true))
 
 	// Test passes if no panic or error occurs, confirming the wrapper works correctly
 }

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/grafana.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/grafana.go
@@ -317,10 +317,10 @@ func GenerateGrafanaOauthClient(
 	return nil, nil
 }
 
-func DeleteGrafanaOauthClient(c client.Client) error {
+func DeleteGrafanaOauthClient(ctx context.Context, c client.Client) error {
 	found := &oauthv1.OAuthClient{}
 	err := c.Get(
-		context.TODO(),
+		ctx,
 		types.NamespacedName{Name: config.GrafanaOauthClientName},
 		found,
 	)
@@ -331,6 +331,6 @@ func DeleteGrafanaOauthClient(c client.Client) error {
 			return nil
 		}
 	}
-	err = c.Delete(context.TODO(), found, &client.DeleteOptions{})
+	err = c.Delete(ctx, found, &client.DeleteOptions{})
 	return err
 }

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -23,7 +23,6 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
-	rightsizingctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/analytics/rightsizing"
 	placementctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/placementrule"
 	certctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/certificates"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
@@ -467,6 +466,14 @@ func (r *MultiClusterObservabilityReconciler) initFinalization(ctx context.Conte
 
 		return true, nil
 	}
+
+	// Do not add finalizer to an object being deleted.
+	// After MCO removes resFinalizer, the CR may survive if the analytics
+	// finalizer is still present. Without this guard, we'd re-add resFinalizer.
+	if mco.GetDeletionTimestamp() != nil {
+		return true, nil
+	}
+
 	if !slices.Contains(mco.GetFinalizers(), resFinalizer) {
 		// Use Patch instead of Update to avoid serializing zero-value structs
 		mcoCopy := mco.DeepCopy()
@@ -962,11 +969,6 @@ func cleanUpClusterScopedResources(
 		if err != nil {
 			return err
 		}
-	}
-
-	// Clean up right-sizing resources
-	if err := rightsizingctrl.CleanupRightSizingResources(ctx, r.Client, mco); err != nil {
-		return err
 	}
 
 	ingressCtlCrdExists := r.CRDMap[config.IngressControllerCRD]

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -23,6 +23,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
+	rightsizingctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/analytics/rightsizing"
 	placementctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/placementrule"
 	certctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/certificates"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
@@ -955,6 +956,11 @@ func cleanUpClusterScopedResources(
 		if err != nil {
 			return err
 		}
+	}
+
+	// Clean up right-sizing resources
+	if err := rightsizingctrl.CleanupRightSizingResources(context.TODO(), r.Client, mco); err != nil {
+		return err
 	}
 
 	ingressCtlCrdExists := r.CRDMap[config.IngressControllerCRD]

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -174,13 +174,15 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	}
 
 	// Init finalizers
-	operatorconfig.IsMCOTerminating, err = r.initFinalization(ctx, instance)
+	terminating, err := r.initFinalization(ctx, instance)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to initialize finalization: %w", err)
-	} else if operatorconfig.IsMCOTerminating {
+	}
+	if terminating {
 		reqLogger.Info("MCO instance is in Terminating status, skip the reconcile")
 		return ctrl.Result{}, nil
 	}
+	operatorconfig.IsMCOTerminating.Store(false)
 
 	// check if the MCH CRD exists
 	mchCrdExists := r.CRDMap[config.MCHCrdName]
@@ -437,10 +439,13 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 
 func (r *MultiClusterObservabilityReconciler) initFinalization(ctx context.Context, mco *mcov1beta2.MultiClusterObservability) (bool, error) {
 	if mco.GetDeletionTimestamp() != nil && slices.Contains(mco.GetFinalizers(), resFinalizer) {
+		// Signal termination before cleanup so other controllers (analytics, placementrule)
+		// stop reconciling and don't recreate resources being deleted.
+		operatorconfig.IsMCOTerminating.Store(true)
+
 		log.Info("To delete resources across namespaces")
 		// clean up the cluster resources, eg. clusterrole, clusterrolebinding, etc
-		operatorconfig.IsMCOTerminating = true
-		if err := cleanUpClusterScopedResources(r, mco); err != nil {
+		if err := cleanUpClusterScopedResources(ctx, r, mco); err != nil {
 			log.Error(err, "Failed to remove cluster scoped resources")
 			return false, err
 		}
@@ -926,6 +931,7 @@ func GenerateProxyRoute(
 // cleanUpClusterScopedResources delete the cluster scoped resources created by the MCO operator
 // The cluster scoped resources need to be deleted manually because they don't have ownerrefenence set as the MCO CR
 func cleanUpClusterScopedResources(
+	ctx context.Context,
 	r *MultiClusterObservabilityReconciler,
 	mco *mcov1beta2.MultiClusterObservability,
 ) error {
@@ -935,37 +941,37 @@ func cleanUpClusterScopedResources(
 	}
 
 	clusterRoleList := &rbacv1.ClusterRoleList{}
-	err := r.Client.List(context.TODO(), clusterRoleList, listOpts...)
+	err := r.Client.List(ctx, clusterRoleList, listOpts...)
 	if err != nil {
 		return err
 	}
 	for idx := range clusterRoleList.Items {
-		err := r.Client.Delete(context.TODO(), &clusterRoleList.Items[idx], &client.DeleteOptions{})
+		err := r.Client.Delete(ctx, &clusterRoleList.Items[idx], &client.DeleteOptions{})
 		if err != nil {
 			return err
 		}
 	}
 
 	clusterRoleBindingList := &rbacv1.ClusterRoleBindingList{}
-	err = r.Client.List(context.TODO(), clusterRoleBindingList, listOpts...)
+	err = r.Client.List(ctx, clusterRoleBindingList, listOpts...)
 	if err != nil {
 		return err
 	}
 	for idx := range clusterRoleBindingList.Items {
-		err := r.Client.Delete(context.TODO(), &clusterRoleBindingList.Items[idx], &client.DeleteOptions{})
+		err := r.Client.Delete(ctx, &clusterRoleBindingList.Items[idx], &client.DeleteOptions{})
 		if err != nil {
 			return err
 		}
 	}
 
 	// Clean up right-sizing resources
-	if err := rightsizingctrl.CleanupRightSizingResources(context.TODO(), r.Client, mco); err != nil {
+	if err := rightsizingctrl.CleanupRightSizingResources(ctx, r.Client, mco); err != nil {
 		return err
 	}
 
 	ingressCtlCrdExists := r.CRDMap[config.IngressControllerCRD]
 	if ingressCtlCrdExists {
-		return DeleteGrafanaOauthClient(r.Client)
+		return DeleteGrafanaOauthClient(ctx, r.Client)
 	}
 
 	return nil

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -575,7 +575,7 @@ func createManifestWorks(
 }
 
 func ensureResourcesForHubMetricsCollection(ctx context.Context, c client.Client, owner client.Object, manifests []workv1.Manifest) error {
-	if operatorconfig.IsMCOTerminating {
+	if operatorconfig.IsMCOTerminating.Load() {
 		log.Info("MCO Operator is terminating, skip creating resources for hub metrics collection")
 		return nil
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/placementrule/predicate_func.go
@@ -106,7 +106,7 @@ func getHubEndpointOperatorPredicates() predicate.Funcs {
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			if operatorconfig.IsMCOTerminating {
+			if operatorconfig.IsMCOTerminating.Load() {
 				log.Info("MCO is terminating, skip reconcile for hub endpoint operator")
 				return false
 			}
@@ -159,7 +159,7 @@ func getPred(name string, namespace string,
 	}
 	if isDelete {
 		deleteFunc = func(e event.DeleteEvent) bool {
-			if operatorconfig.IsMCOTerminating {
+			if operatorconfig.IsMCOTerminating.Load() {
 				log.Info("MCO is terminating, skip reconcile for placementrule controller", "name", name, "namespace", namespace)
 				return false
 			}

--- a/operators/pkg/config/config.go
+++ b/operators/pkg/config/config.go
@@ -4,6 +4,8 @@
 
 package config
 
+import "sync/atomic"
+
 const (
 	ClusterNameKey                  = "cluster-name"
 	HubInfoSecretName               = "hub-info-secret"
@@ -58,7 +60,7 @@ const (
 	WorkloadPartitioningNSExpectedValue  = "management"
 )
 
-var IsMCOTerminating = false
+var IsMCOTerminating atomic.Bool
 
 const (
 	DefaultClusterType = ""

--- a/tests/pkg/tests/observability-e2e-test_suite_test.go
+++ b/tests/pkg/tests/observability-e2e-test_suite_test.go
@@ -53,8 +53,8 @@ const (
 	MCO_NAMESPACE            = "open-cluster-management-observability"
 	MCO_ADDON_NAMESPACE      = "open-cluster-management-addon-observability"
 	MCO_GLOBAL_SET_NAMESPACE = "open-cluster-management-global-set"
-	MCO_LABEL           = "name=multicluster-observability-operator"
-	MCO_LABEL_OWNER     = "owner=multicluster-observability-operator"
+	MCO_LABEL                = "name=multicluster-observability-operator"
+	MCO_LABEL_OWNER          = "owner=multicluster-observability-operator"
 
 	ALERTMANAGER_LABEL      = "app=multicluster-observability-alertmanager"
 	GRAFANA_LABEL           = "app=multicluster-observability-grafana"

--- a/tests/pkg/tests/observability-e2e-test_suite_test.go
+++ b/tests/pkg/tests/observability-e2e-test_suite_test.go
@@ -49,9 +49,10 @@ const (
 	charset             = "abcdefghijklmnopqrstuvwxyz" +
 		"0123456789"
 
-	MCO_CR_NAME         = "observability"
-	MCO_NAMESPACE       = "open-cluster-management-observability"
-	MCO_ADDON_NAMESPACE = "open-cluster-management-addon-observability"
+	MCO_CR_NAME              = "observability"
+	MCO_NAMESPACE            = "open-cluster-management-observability"
+	MCO_ADDON_NAMESPACE      = "open-cluster-management-addon-observability"
+	MCO_GLOBAL_SET_NAMESPACE = "open-cluster-management-global-set"
 	MCO_LABEL           = "name=multicluster-observability-operator"
 	MCO_LABEL_OWNER     = "owner=multicluster-observability-operator"
 

--- a/tests/pkg/tests/observability_uninstall_test.go
+++ b/tests/pkg/tests/observability_uninstall_test.go
@@ -37,6 +37,14 @@ func uninstallMCO() {
 	err := utils.UninstallMCO(testOptions)
 	Expect(err).ToNot(HaveOccurred())
 
+	// Verify right-sizing resources are cleaned up during MCO deletion.
+	// Acts as a safety net: if right-sizing tests are skipped or their teardown fails,
+	// these resources must still be cleaned up by the MCO finalizer.
+	By("Verifying right-sizing resources are cleaned up after MCO deletion")
+	Eventually(func() error {
+		return utils.VerifyRSResourcesCleanedUp(dynClient)
+	}, EventuallyTimeoutMinute*2, EventuallyIntervalSecond*5).Should(Succeed())
+
 	By("Waiting for delete all MCO components")
 	Eventually(func() error {
 		podList, _ := hubClient.CoreV1().Pods(MCO_NAMESPACE).List(context.TODO(), metav1.ListOptions{})

--- a/tests/pkg/tests/observability_uninstall_test.go
+++ b/tests/pkg/tests/observability_uninstall_test.go
@@ -42,7 +42,7 @@ func uninstallMCO() {
 	// these resources must still be cleaned up by the MCO finalizer.
 	By("Verifying right-sizing resources are cleaned up after MCO deletion")
 	Eventually(func() error {
-		return utils.VerifyRSResourcesCleanedUp(dynClient)
+		return utils.VerifyRSResourcesCleanedUp(context.TODO(), dynClient)
 	}, EventuallyTimeoutMinute*2, EventuallyIntervalSecond*5).Should(Succeed())
 
 	By("Waiting for delete all MCO components")

--- a/tests/pkg/utils/mco_deploy.go
+++ b/tests/pkg/utils/mco_deploy.go
@@ -34,12 +34,14 @@ const (
 	MCO_NAMESPACE                 = "open-cluster-management-observability"
 	MCO_ADDON_NAMESPACE           = "open-cluster-management-addon-observability"
 	MCO_AGENT_ADDON_NAMESPACE     = "open-cluster-management-agent-addon"
+	MCO_GLOBAL_SET_NAMESPACE      = "open-cluster-management-global-set"
 	MCO_PULL_SECRET_NAME          = "multiclusterhub-operator-pull-secret"
 	OBJ_SECRET_NAME               = "thanos-object-storage" // #nosec G101 -- Not a hardcoded credential.
 	MCO_GROUP                     = "observability.open-cluster-management.io"
 	OCM_WORK_GROUP                = "work.open-cluster-management.io"
 	OCM_CLUSTER_GROUP             = "cluster.open-cluster-management.io"
 	OCM_ADDON_GROUP               = "addon.open-cluster-management.io"
+	OCM_POLICY_GROUP              = "policy.open-cluster-management.io"
 )
 
 func NewMCOGVRV1BETA2() schema.GroupVersionResource {
@@ -128,6 +130,66 @@ func NewScrapeConfigGVR() schema.GroupVersionResource {
 		Version:  "v1alpha1",
 		Resource: "scrapeconfigs",
 	}
+}
+
+func NewPolicyGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    OCM_POLICY_GROUP,
+		Version:  "v1",
+		Resource: "policies",
+	}
+}
+
+func NewPlacementGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    OCM_CLUSTER_GROUP,
+		Version:  "v1beta1",
+		Resource: "placements",
+	}
+}
+
+func NewPlacementBindingGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    OCM_POLICY_GROUP,
+		Version:  "v1",
+		Resource: "placementbindings",
+	}
+}
+
+// VerifyRSResourcesCleanedUp checks that all right-sizing resources have been deleted.
+// Returns an error listing any resources that still exist, or nil if all are gone.
+func VerifyRSResourcesCleanedUp(dynClient dynamic.Interface) error {
+	configMapGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+	rsResources := []struct {
+		gvr       schema.GroupVersionResource
+		name      string
+		namespace string
+	}{
+		{NewPolicyGVR(), "rs-prom-rules-policy", MCO_GLOBAL_SET_NAMESPACE},
+		{NewPolicyGVR(), "rs-virt-prom-rules-policy", MCO_GLOBAL_SET_NAMESPACE},
+		{NewPlacementGVR(), "rs-placement", MCO_GLOBAL_SET_NAMESPACE},
+		{NewPlacementGVR(), "rs-virt-placement", MCO_GLOBAL_SET_NAMESPACE},
+		{NewPlacementBindingGVR(), "rs-policyset-binding", MCO_GLOBAL_SET_NAMESPACE},
+		{NewPlacementBindingGVR(), "rs-virt-policyset-binding", MCO_GLOBAL_SET_NAMESPACE},
+		{configMapGVR, "rs-namespace-config", MCO_NAMESPACE},
+		{configMapGVR, "rs-virt-config", MCO_NAMESPACE},
+	}
+
+	var remaining []string
+	for _, r := range rsResources {
+		_, err := dynClient.Resource(r.gvr).Namespace(r.namespace).Get(context.TODO(), r.name, metav1.GetOptions{})
+		if err == nil {
+			remaining = append(remaining, fmt.Sprintf("%s/%s", r.namespace, r.name))
+		} else if !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("error checking resource %s/%s: %w", r.namespace, r.name, err)
+		}
+	}
+
+	if len(remaining) > 0 {
+		return fmt.Errorf("right-sizing resources still exist: %v", remaining)
+	}
+	return nil
 }
 
 func GetAllMCOPods(opt TestOptions) ([]corev1.Pod, error) {

--- a/tests/pkg/utils/mco_deploy.go
+++ b/tests/pkg/utils/mco_deploy.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -132,6 +133,7 @@ func NewScrapeConfigGVR() schema.GroupVersionResource {
 	}
 }
 
+// NewPolicyGVR returns the GVR for OCM Policy resources.
 func NewPolicyGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group:    OCM_POLICY_GROUP,
@@ -140,6 +142,7 @@ func NewPolicyGVR() schema.GroupVersionResource {
 	}
 }
 
+// NewPlacementGVR returns the GVR for OCM Placement resources.
 func NewPlacementGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group:    OCM_CLUSTER_GROUP,
@@ -148,6 +151,7 @@ func NewPlacementGVR() schema.GroupVersionResource {
 	}
 }
 
+// NewPlacementBindingGVR returns the GVR for OCM PlacementBinding resources.
 func NewPlacementBindingGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group:    OCM_POLICY_GROUP,
@@ -157,10 +161,36 @@ func NewPlacementBindingGVR() schema.GroupVersionResource {
 }
 
 // VerifyRSResourcesCleanedUp checks that all right-sizing resources have been deleted.
-// Returns an error listing any resources that still exist, or nil if all are gone.
+// Uses both label-based discovery (catches resources in any namespace) and name-based
+// checks (catches old unlabeled resources) to ensure nothing is left behind.
 func VerifyRSResourcesCleanedUp(ctx context.Context, dynClient dynamic.Interface) error {
 	configMapGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
 
+	var remaining []string
+
+	// Label-based check: find RS resources in any namespace by managed-by label
+	rsLabel := "observability.open-cluster-management.io/managed-by=analytics-rightsizing"
+	labeledGVRs := []schema.GroupVersionResource{
+		NewPolicyGVR(),
+		NewPlacementGVR(),
+		NewPlacementBindingGVR(),
+		configMapGVR,
+	}
+	for _, gvr := range labeledGVRs {
+		list, err := dynClient.Resource(gvr).Namespace("").List(ctx, metav1.ListOptions{LabelSelector: rsLabel})
+		if err == nil {
+			for _, item := range list.Items {
+				remaining = append(remaining, fmt.Sprintf("%s/%s (labeled)", item.GetNamespace(), item.GetName()))
+			}
+			continue
+		}
+		// Ignore NotFound (CRD may not exist), but fail on transient API/RBAC errors
+		if !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("error listing %s for right-sizing cleanup verification: %w", gvr.Resource, err)
+		}
+	}
+
+	// Name-based fallback: check well-known names in default namespaces (upgrade path)
 	rsResources := []struct {
 		gvr       schema.GroupVersionResource
 		name      string
@@ -176,11 +206,14 @@ func VerifyRSResourcesCleanedUp(ctx context.Context, dynClient dynamic.Interface
 		{configMapGVR, "rs-virt-config", MCO_NAMESPACE},
 	}
 
-	var remaining []string
 	for _, r := range rsResources {
 		_, err := dynClient.Resource(r.gvr).Namespace(r.namespace).Get(ctx, r.name, metav1.GetOptions{})
 		if err == nil {
-			remaining = append(remaining, fmt.Sprintf("%s/%s", r.namespace, r.name))
+			entry := fmt.Sprintf("%s/%s", r.namespace, r.name)
+			// Avoid duplicates from label-based check
+			if !slices.Contains(remaining, entry+" (labeled)") {
+				remaining = append(remaining, entry)
+			}
 		} else if !k8serrors.IsNotFound(err) {
 			return fmt.Errorf("error checking resource %s/%s: %w", r.namespace, r.name, err)
 		}

--- a/tests/pkg/utils/mco_deploy.go
+++ b/tests/pkg/utils/mco_deploy.go
@@ -158,7 +158,7 @@ func NewPlacementBindingGVR() schema.GroupVersionResource {
 
 // VerifyRSResourcesCleanedUp checks that all right-sizing resources have been deleted.
 // Returns an error listing any resources that still exist, or nil if all are gone.
-func VerifyRSResourcesCleanedUp(dynClient dynamic.Interface) error {
+func VerifyRSResourcesCleanedUp(ctx context.Context, dynClient dynamic.Interface) error {
 	configMapGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
 
 	rsResources := []struct {
@@ -178,7 +178,7 @@ func VerifyRSResourcesCleanedUp(dynClient dynamic.Interface) error {
 
 	var remaining []string
 	for _, r := range rsResources {
-		_, err := dynClient.Resource(r.gvr).Namespace(r.namespace).Get(context.TODO(), r.name, metav1.GetOptions{})
+		_, err := dynClient.Resource(r.gvr).Namespace(r.namespace).Get(ctx, r.name, metav1.GetOptions{})
 		if err == nil {
 			remaining = append(remaining, fmt.Sprintf("%s/%s", r.namespace, r.name))
 		} else if !k8serrors.IsNotFound(err) {


### PR DESCRIPTION
## Problem
When MCO (MultiClusterObservability) is deleted with right-sizing enabled, related rightsizing resources are left orphaned. These orphaned resources block namespace deletion, causing ACM uninstall to hang with namespaces stuck in Terminating state.

## Root Cause
The MCO finalizer (cleanUpClusterScopedResources) doesn't clean up right-sizing resources during MCO deletion. Meanwhile, the analytics reconciler keeps recreating them because it doesn't check if MCO is being terminated.

## Fixes
### Core: Move RS cleanup ownership to analytics controller
Per reviewer feedback, the analytics controller now fully owns the right-sizing resource lifecycle using its own finalizer (`analytics-cleanup`), rather than relying on the MCO controller for cleanup.

- **Analytics controller finalizer** — Added `observability.open-cluster-management.io/analytics-cleanup` finalizer. On MCO deletion, the analytics controller cleans up all RS resources (policies, placements, configmaps) and removes its finalizer.
- **DeletionTimestamp guard in MCO controller** — After the MCO controller removes its `res-cleanup` finalizer, the CR may survive if the analytics finalizer is still present. Added a guard in `initFinalization` to prevent re-adding `res-cleanup` to a deleting object.

### Deletion flow
User deletes MCO CR → API server sets deletionTimestamp

MCO Controller:                                             
→ cleanUpClusterScopedResources() (ClusterRoles, ClusterRoleBindings)         
→ Remove res-cleanup finalizer                  

Analytics Controller:
→ CleanupRightSizingResources() (Policies, Placements, ConfigMaps)
→ Remove analytics-cleanup finalizer

Both finalizers removed → MCO CR deleted by API server                                           
                                                                                                                                                          
#### Hardening (pre-existing issues fixed while in the area)  based on coderabbitai suggestion                                                                                                                           
 - Data race on `IsMCOTerminating`: Changed from plain `bool` to `atomic.Bool` — the flag is written by the MCO controller and read by informer/predicate goroutines concurrently  
 - `context.TODO()` in finalizer: Propagated `ctx` through `cleanUpClusterScopedResources` and `DeleteGrafanaOauthClient` (5 call sites)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved finalizer and termination handling so uninstall finalization runs reliably and preserves unrelated finalizers.

* **New Features**
  * Right-sizing resources are consistently labeled and discoverable for cross-namespace cleanup; cleanup APIs now return aggregated errors and respect provided request contexts.
  * Grafana OAuth client deletion uses caller contexts.

* **Tests**
  * Added unit and e2e tests verifying finalizer behavior and right-sizing cleanup/verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->