### PR TITLE
ACM-27035: fixing accelerator_card_info metric to node_accelerator_ca…

### DIFF
--- a/cicd-scripts/metrics/Makefile
+++ b/cicd-scripts/metrics/Makefile
@@ -17,7 +17,7 @@ check-platform-metrics:
 	@echo "--> Checking platform metrics:"
 	@$(CURDIR)/scripts/extract-dashboards-metrics.sh -d $(PLATFORM_DASH_DIR) | tr '\n' ',' > $(TMPDIR)/dash-metrics
 	@go run cmd/dashcheck/main.go --scrape-configs=$(PLATFORM_DASH_DIR)/scrape-config.yaml \
-		--ignored-scrapeconfig-metrics=accelerator_card_info \
+		--ignored-scrapeconfig-metrics=node_accelerator_card_info \
 		--dashboard-metrics=$$(cat $(TMPDIR)/dash-metrics)
 	@cat $(PLATFORM_DASH_DIR)/prometheus-rule.yaml | yq '.spec' | promtool check rules
 	@go run cmd/rulescheck/main.go --scrape-configs=$(PLATFORM_DASH_DIR)/scrape-config.yaml \

--- a/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
+++ b/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
@@ -6,7 +6,6 @@ data:
   metrics_list.yaml: |
     names:
       - :node_memory_MemAvailable_bytes:sum
-      - accelerator_card_info
       - acm_managed_cluster_labels
       - acm_rs:namespace:cpu_request_hard
       - acm_rs:namespace:cpu_request
@@ -199,6 +198,7 @@ data:
       - namespace_workload_pod:kube_pod_owner:relabel
       - namespace:container_memory_usage_bytes:sum
       - namespace:kube_pod_container_resource_requests_cpu_cores:sum
+      - node_accelerator_card_info
       - node_cpu_seconds_total
       - node_cpu_seconds_total
       - node_filesystem_avail_bytes

--- a/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/scrape-config.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/scrape-config.yaml
@@ -14,7 +14,6 @@ spec:
   params:
     match[]:
     - '{__name__=":node_memory_MemAvailable_bytes:sum"}'
-    - '{__name__="accelerator_card_info"}'
     - '{__name__="acm_label_names"}' # metrics generated on the hub by MCE, needed for Grafana
     - '{__name__="acm_managed_cluster_labels"}' # metrics generated on the hub by MCE, needed for Grafana
     - '{__name__="active_streams_lease:grpc_server_handled_total:sum"}'
@@ -78,6 +77,7 @@ spec:
     - '{__name__="namespace_pod:container_network_transmit_packets_dropped_total:sum"}'
     - '{__name__="namespace_workload_pod:kube_pod_owner:relabel:avg"}'
     - '{__name__="namespace_workload_pod:kube_pod_owner:relabel"}'
+    - '{__name__="node_accelerator_card_info"}'
     - '{__name__="node_cpu_seconds_total:mode_idle:avg_rate5m"}'
     - '{__name__="node_filesystem_avail_bytes"}'
     - '{__name__="node_filesystem_size_bytes"}'


### PR DESCRIPTION
…rd_info

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated accelerator-card metric naming to the node-scoped variant across monitoring allowlists, scrape/federation configuration, and validation tooling.
  * Ensures the node-scoped accelerator metric is now permitted, discovered, and validated consistently by the monitoring pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->