### PR TITLE
[ACM-27932] Remove offset 6h from ACMThanosCompactHasNotRun alert

### DIFF
--- a/operators/multiclusterobservability/manifests/base/alertmanager/prometheusrule.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/prometheusrule.yaml
@@ -71,7 +71,7 @@ spec:
           #TODO: add link to ACM documentation link to description
           message: ACM Thanos Compact {{$labels.job}} in {{$labels.namespace}} has not uploaded anything for 24 hours.
           summary: ACM Thanos Compact has not uploaded anything for last 24 hours.
-        expr: (time() - max by (namespace, job) (max_over_time(acm_thanos_objstore_bucket_last_successful_upload_time{job="observability-thanos-compact"}[24h] offset 6h))) / 60 / 60 > 24
+        expr: (time() - max by (namespace, job) (max_over_time(acm_thanos_objstore_bucket_last_successful_upload_time{job="observability-thanos-compact"}[24h]))) / 60 / 60 > 24
         labels:
           namespace: open-cluster-management-observability
           severity: warning


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                    
- Remove `offset 6h` from the `ACMThanosCompactHasNotRun` PromQL expression to align with the upstream Thanos alert definition and eliminate false positives after compactor recovery                                                             
                                                                                                                                                                                                                                                  
## Problem                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                  
The `ACMThanosCompactHasNotRun` alert expression uses `offset 6h`, which shifts the `max_over_time` lookback window 6 hours into the past (evaluating 6h–30h ago instead of 0h–24h ago). This creates a blind spot: after a compactor recovers from a crash loop or corrupted blocks, new successful uploads are invisible to the alert for up to 6 hours,                                                                                                                                                        causing false positive alerts even though the compactor is healthy.  

## Upstream references                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                    
Source of truth (jsonnet mixin):                                                                                                                                                                                                                  
https://github.com/thanos-io/thanos/blob/main/mixin/alerts/compact.libsonnet
                                                                                                                                                                                                                                                    
Generated alerts:                                                                                                                                                                                                                                 
https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml#L52                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                  
                                                                                                                                                             

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Thanos compact upload alert logic to more accurately compute the time since the last successful upload by removing an internal retrospective offset. Alerts now compare the last upload timestamp directly to current time, reducing false positives and improving timeliness and reliability of compact upload monitoring across clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->