### PR TITLE
[ACM-29923] Fix ObservabilityAddon status stuck in Progressing after cert rotation

### DIFF
--- a/operators/endpointmetrics/controllers/status/status_controller.go
+++ b/operators/endpointmetrics/controllers/status/status_controller.go
@@ -117,7 +117,7 @@ func (r *StatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return res, nil
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 }
 
 func (s *StatusReconciler) updateSpokeAddon(ctx context.Context) (ctrl.Result, error) {
@@ -182,7 +182,7 @@ func (s *StatusReconciler) updateHubAddon(ctx context.Context) (ctrl.Result, err
 	retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		// Fetch the ObservabilityAddon instance in local cluster
 		obsAddon := &oav1beta1.ObservabilityAddon{}
-		if err != s.Client.Get(ctx, types.NamespacedName{Name: s.ObsAddonName, Namespace: s.Namespace}, obsAddon) {
+		if err := s.Client.Get(ctx, types.NamespacedName{Name: s.ObsAddonName, Namespace: s.Namespace}, obsAddon); err != nil {
 			return err
 		}
 
@@ -198,6 +198,14 @@ func (s *StatusReconciler) updateHubAddon(ctx context.Context) (ctrl.Result, err
 		return s.HubClient.Status().Update(ctx, updatedAddon)
 	})
 	if retryErr != nil {
+		if isAuthOrConnectionErr(retryErr) {
+			var reloadErr error
+			if s.HubClient, reloadErr = s.HubClient.Reload(); reloadErr != nil {
+				return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("failed to reload the hub client: %w", reloadErr))
+			}
+			return ctrl.Result{}, fmt.Errorf("failed to update status in hub cluster, reloaded hub client: %w", retryErr)
+		}
+
 		if util.IsTransientClientErr(retryErr) || errors.IsConflict(retryErr) {
 			s.Logger.Info("Retryable error while updating status, request will be retried.", "error", retryErr)
 			return s.requeueWithOptionalDelay(retryErr)

--- a/operators/endpointmetrics/controllers/status/status_controller_test.go
+++ b/operators/endpointmetrics/controllers/status/status_controller_test.go
@@ -56,13 +56,13 @@ func TestStatusController_HubNominalCase(t *testing.T) {
 		Logger:       logr.Discard(),
 	}
 
-	// no status difference triggers no update
+	// no status difference triggers no update, but periodic resync is scheduled
 	resp, err := statusReconciler.Reconcile(context.Background(), ctrl.Request{})
 	if err != nil {
 		t.Fatalf("Failed to reconcile: %v", err)
 	}
-	if !resp.IsZero() {
-		t.Fatalf("Expected no requeue")
+	if resp.RequeueAfter != 5*time.Minute {
+		t.Fatalf("Expected periodic resync with RequeueAfter=5m, got %v", resp.RequeueAfter)
 	}
 	if custumHubClient.UpdateCallsCount() > 0 {
 		t.Fatalf("Expected no update")
@@ -82,8 +82,8 @@ func TestStatusController_HubNominalCase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to reconcile: %v", err)
 	}
-	if !resp.IsZero() {
-		t.Fatalf("Expected no requeue")
+	if resp.RequeueAfter != 5*time.Minute {
+		t.Fatalf("Expected periodic resync with RequeueAfter=5m, got %v", resp.RequeueAfter)
 	}
 	if custumHubClient.UpdateCallsCount() != 1 {
 		t.Fatalf("Expected update")
@@ -114,7 +114,12 @@ func TestStatusController_UpdateHubAddonFailures(t *testing.T) {
 	hubOba := newObservabilityAddon(addonName, addonHubNamespace)
 	var updateErr error
 	hubClientWithConflict := newClientWithUpdateError(newClient(hubOba), updateErr, nil)
-	reloadableHubClient, err := util.NewReloadableHubClientWithReloadFunc(func() (client.Client, error) { return hubClientWithConflict, nil })
+
+	var reloadCount int
+	reloadableHubClient, err := util.NewReloadableHubClientWithReloadFunc(func() (client.Client, error) {
+		reloadCount++
+		return hubClientWithConflict, nil
+	})
 	if err != nil {
 		t.Fatalf("Failed to create reloadable hub client: %v", err)
 	}
@@ -134,6 +139,7 @@ func TestStatusController_UpdateHubAddonFailures(t *testing.T) {
 		requeueAfterVal int
 		updateCallsMin  int
 		updateCallsMax  int
+		reloadExpected  bool
 	}{
 		"Conflict": {
 			updateErr:      apiErrors.NewConflict(schema.GroupResource{Group: oav1beta1.GroupVersion.Group, Resource: "FakeResource"}, addonName, fmt.Errorf("fake conflict")),
@@ -167,6 +173,13 @@ func TestStatusController_UpdateHubAddonFailures(t *testing.T) {
 			},
 			requeue:        true,
 			updateCallsMax: 1,
+			reloadExpected: true,
+		},
+		"Unauthorized should reload and requeue": {
+			updateErr:      apiErrors.NewUnauthorized("unauthorized"),
+			requeue:        true,
+			updateCallsMax: 1,
+			reloadExpected: true,
 		},
 	}
 
@@ -174,6 +187,7 @@ func TestStatusController_UpdateHubAddonFailures(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			hubClientWithConflict.UpdateError = tc.updateErr
 			hubClientWithConflict.Reset()
+			reloadCount = 0
 			resp, err := statusReconciler.Reconcile(context.Background(), ctrl.Request{})
 			isTerminalErr := errors.Is(err, reconcile.TerminalError(nil))
 			if tc.terminalErr != isTerminalErr {
@@ -193,6 +207,12 @@ func TestStatusController_UpdateHubAddonFailures(t *testing.T) {
 			}
 			if tc.updateCallsMax > 0 && hubClientWithConflict.UpdateCallsCount() > tc.updateCallsMax {
 				t.Fatalf("Expected update retry at most %d times, got %d", tc.updateCallsMax, hubClientWithConflict.UpdateCallsCount())
+			}
+			if tc.reloadExpected && reloadCount == 0 {
+				t.Fatalf("Expected hub client reload but got none")
+			}
+			if !tc.reloadExpected && reloadCount > 0 {
+				t.Fatalf("Unexpected hub client reload: got %d", reloadCount)
 			}
 		})
 	}
@@ -411,7 +431,7 @@ func TestStatusController_UpdateSpokeAddon(t *testing.T) {
 
 			resp, err := statusReconciler.Reconcile(context.Background(), ctrl.Request{})
 			assert.NoError(t, err)
-			assert.True(t, resp.IsZero())
+			assert.Equal(t, 5*time.Minute, resp.RequeueAfter)
 
 			newSpokeOba := &oav1beta1.ObservabilityAddon{}
 			err = spokeClient.Get(context.Background(), types.NamespacedName{Name: addonName, Namespace: addonNamespace}, newSpokeOba)


### PR DESCRIPTION
 ## Summary                                                

  - Fix `err !=` typo in `updateHubAddon` that silently skipped the spoke Get, potentially writing empty status to the hub
  - Handle auth/connection errors on the `HubClient.Status().Update()` path by reloading the hub client and requeuing (previously fell through to TerminalError, permanently stopping reconciliation after cert rotation)                                
  - Add periodic resync (RequeueAfter: 5m) so missed status updates self-correct            
                                                                                            
## Root Cause                                                                             
                                                                                            
During cert rotation on managed clusters, the hub client's credentials become invalid. The Get path already handled this by reloading the client, but the Update path did not — auth errors were treated as terminal, stopping reconciliation permanently. Combined with the `err !=` typo (which compared against outer-scope nil instead of assigning), the spoke status never propagated to the hub.                                                                               


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status reconciliation now schedules periodic resynchronization (every 5 minutes) for continuous monitoring.

* **Bug Fixes**
  * Enhanced handling of authentication and connection failures with automatic recovery and appropriate retry behavior.

* **Tests**
  * Test suite updated to expect periodic resync behavior and to verify recovery/retry logic for auth/connection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->