### PR TITLE
[ACM-32728] Improve multiclusterobservability CRD field descriptions

### DIFF
--- a/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
+++ b/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
@@ -32,12 +32,14 @@ func (u URL) URL() (*url.URL, error) {
 
 // ObservabilityAddonSpec is the spec of observability addon.
 type ObservabilityAddonSpec struct {
-	// EnableMetrics indicates the observability addon push metrics to hub server.
+	// When false, the managed cluster addon stops pushing metrics to the hub,
+	// reducing storage usage but disabling per-cluster dashboards.
 	// +optional
 	// +kubebuilder:default:=true
 	EnableMetrics bool `json:"enableMetrics"`
 
-	// Interval for the observability addon push metrics to hub server.
+	// Interval in seconds at which the observability addon on each managed cluster
+	// pushes metrics to the hub. Default: 300.
 	// +optional
 	// +kubebuilder:default:=300
 	// +kubebuilder:validation:Minimum=15
@@ -71,13 +73,16 @@ type PreConfiguredStorage struct {
 	// Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 	// +required
 	Name string `json:"name"`
-	// TLS secret contains the custom certificate for the object store
+	// Name of a Secret containing a custom CA certificate for the object store endpoint.
+	// Required when the object store uses a self-signed certificate or a private CA not trusted by the system root store.
 	// +optional
 	TLSSecretName string `json:"tlsSecretName,omitempty"`
-	// TLS secret mount path for the custom certificate for the object store
+	// Filesystem path where the custom TLS certificate is mounted inside Thanos pods.
+	// Only relevant when tlsSecretName is set.
 	// +optional
 	TLSSecretMountPath string `json:"tlsSecretMountPath,omitempty"`
-	// serviceAccountProjection indicates whether mount service account token to thanos pods. Default is false.
+	// When true, mounts a projected service account token into Thanos pods.
+	// Enable this for cloud-provider IAM integration instead of static credentials. Default is false.
 	// +optional
 	ServiceAccountProjection bool `json:"serviceAccountProjection,omitempty"`
 }

--- a/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
+++ b/operators/multiclusterobservability/api/shared/multiclusterobservability_shared.go
@@ -32,14 +32,13 @@ func (u URL) URL() (*url.URL, error) {
 
 // ObservabilityAddonSpec is the spec of observability addon.
 type ObservabilityAddonSpec struct {
-	// When false, the managed cluster addon stops pushing metrics to the hub,
-	// reducing storage usage but disabling per-cluster dashboards.
+	// When false, the managed cluster addon stops pushing metrics to the hub.
 	// +optional
 	// +kubebuilder:default:=true
 	EnableMetrics bool `json:"enableMetrics"`
 
 	// Interval in seconds at which the observability addon on each managed cluster
-	// pushes metrics to the hub. Default: 300.
+	// pushes metrics to the hub.
 	// +optional
 	// +kubebuilder:default:=300
 	// +kubebuilder:validation:Minimum=15
@@ -82,7 +81,7 @@ type PreConfiguredStorage struct {
 	// +optional
 	TLSSecretMountPath string `json:"tlsSecretMountPath,omitempty"`
 	// When true, mounts a projected service account token into Thanos pods.
-	// Enable this for cloud-provider IAM integration instead of static credentials. Default is false.
+	// Enable this for cloud-provider IAM integration instead of static credentials.
 	// +optional
 	ServiceAccountProjection bool `json:"serviceAccountProjection,omitempty"`
 }

--- a/operators/multiclusterobservability/api/v1beta1/multiclusterobservability_types.go
+++ b/operators/multiclusterobservability/api/v1beta1/multiclusterobservability_types.go
@@ -23,7 +23,7 @@ const (
 	HAHigh AvailabilityType = "High"
 )
 
-// MultiClusterObservabilitySpec defines the desired state of MultiClusterObservability.
+// Configuration for the hub-side Observability stack.
 type MultiClusterObservabilitySpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -43,17 +43,20 @@ type MultiClusterObservabilitySpec struct {
 	// +kubebuilder:default:=false
 	EnableDownSampling bool `json:"enableDownSampling"`
 
-	// Pull policy of the MultiClusterObservability images
+	// Pull policy of the MultiClusterObservability images.
+	// One of: Always, Never, IfNotPresent. Defaults to IfNotPresent.
 	// +optional
 	// +kubebuilder:default:=IfNotPresent
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
-	// Pull secret of the MultiClusterObservability images
+	// Name of an existing Secret of type kubernetes.io/dockerconfigjson in the same namespace
+	// used for pulling MultiClusterObservability images.
 	// +optional
 	// +kubebuilder:default:=multiclusterhub-operator-pull-secret
 	ImagePullSecret string `json:"imagePullSecret,omitempty"`
 
-	// Spec of NodeSelector
+	// Node labels used to schedule all Observability workloads.
+	// Pods are only placed on nodes matching all specified labels.
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
@@ -62,21 +65,25 @@ type MultiClusterObservabilitySpec struct {
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
 	// How long to retain raw samples in a bucket.
+	// Format: duration string, e.g. '5d'. Raw data has the highest storage cost per day retained.
 	// +optional
 	// +kubebuilder:default:="5d"
 	RetentionResolutionRaw string `json:"retentionResolutionRaw,omitempty"`
 
-	// How long to retain samples of resolution 1 (5 minutes) in bucket.
+	// How long to retain 5-minute downsampled (resolution 1) samples in object storage.
+	// Format: duration string, e.g. '14d'.
 	// +optional
 	// +kubebuilder:default:="14d"
 	RetentionResolution5m string `json:"retentionResolution5m,omitempty"`
 
-	// How long to retain samples of resolution 2 (1 hour) in bucket.
+	// How long to retain 1-hour downsampled (resolution 2) samples in object storage.
+	// Format: duration string, e.g. '365d'.
 	// +optional
 	// +kubebuilder:default:="30d"
 	RetentionResolution1h string `json:"retentionResolution1h,omitempty"`
 
-	// Specifies the storage to be used by Observability
+	// Storage configuration for Observability StatefulSets and object storage.
+	// Supports any S3-compatible object store (AWS S3, MinIO, Ceph). Required.
 	// +required
 	StorageConfig *StorageConfigObject `json:"storageConfigObject,omitempty"`
 
@@ -88,29 +95,32 @@ type MultiClusterObservabilitySpec struct {
 
 // StorageConfigObject is the spec of object storage.
 type StorageConfigObject struct {
-	// Object store config secret for metrics
+	// Reference to a Secret containing the Thanos object storage configuration.
+	// The secret must use the Thanos storage config format (YAML).
+	// See spec.storageConfigObject.metricObjectStorage.key.
 	// +required
 	MetricObjectStorage *observabilityshared.PreConfiguredStorage `json:"metricObjectStorage,omitempty"`
+
 	// The amount of storage applied to the Observability stateful sets, i.e.
 	// Thanos store, Rule, compact and receiver.
 	// +optional
 	// +kubebuilder:default:="10Gi"
 	StatefulSetSize string `json:"statefulSetSize,omitempty"`
 
-	// 	Specify the storageClass Stateful Sets. This storage class will also
-	// be used for Object Storage if MetricObjectStorage was configured for
-	// the system to create the storage.
+	// StorageClass used by Observability StatefulSets (Thanos store, ruler, compactor, receiver)
+	// and, when no object storage is configured, the object storage PVC.
 	// +optional
 	// +kubebuilder:default:=gp2
 	StatefulSetStorageClass string `json:"statefulSetStorageClass,omitempty"`
 }
 
-// MultiClusterObservabilityStatus defines the observed state of MultiClusterObservability.
+// Observed state of the MultiClusterObservability installation, including component health and addon status.
 type MultiClusterObservabilityStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Represents the status of each deployment
+	// Conditions describing the current state of the MultiClusterObservability installation.
+	// Condition types include: Ready, Installing, Failed, MetricsDisabled, MultiClusterObservabilityAddonDegraded.
 	// +optional
 	Conditions []observabilityshared.Condition `json:"conditions,omitempty"`
 }

--- a/operators/multiclusterobservability/api/v1beta1/multiclusterobservability_types.go
+++ b/operators/multiclusterobservability/api/v1beta1/multiclusterobservability_types.go
@@ -82,8 +82,7 @@ type MultiClusterObservabilitySpec struct {
 	// +kubebuilder:default:="30d"
 	RetentionResolution1h string `json:"retentionResolution1h,omitempty"`
 
-	// Storage configuration for Observability StatefulSets and object storage.
-	// Supports any S3-compatible object store (AWS S3, MinIO, Ceph). Required.
+	// S3 storage configuration for Observability StatefulSets and object storage.
 	// +required
 	StorageConfig *StorageConfigObject `json:"storageConfigObject,omitempty"`
 

--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -49,7 +49,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-03-25T15:45:30Z"
+    createdAt: "2026-04-24T08:28:43Z"
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-observability-operator.v0.1.0

--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -49,7 +49,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-04-24T08:28:43Z"
+    createdAt: "2026-04-24T15:01:38Z"
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-observability-operator.v0.1.0

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -101,15 +101,14 @@ spec:
                 properties:
                   enableMetrics:
                     default: true
-                    description: |-
-                      When false, the managed cluster addon stops pushing metrics to the hub,
-                      reducing storage usage but disabling per-cluster dashboards.
+                    description: When false, the managed cluster addon stops pushing
+                      metrics to the hub.
                     type: boolean
                   interval:
                     default: 300
                     description: |-
                       Interval in seconds at which the observability addon on each managed cluster
-                      pushes metrics to the hub. Default: 300.
+                      pushes metrics to the hub.
                     format: int32
                     maximum: 3600
                     minimum: 15
@@ -209,9 +208,8 @@ spec:
                   Format: duration string, e.g. '5d'. Raw data has the highest storage cost per day retained.
                 type: string
               storageConfigObject:
-                description: |-
-                  Storage configuration for Observability StatefulSets and object storage.
-                  Supports any S3-compatible object store (AWS S3, MinIO, Ceph). Required.
+                description: S3 storage configuration for Observability StatefulSets
+                  and object storage.
                 properties:
                   metricObjectStorage:
                     description: |-
@@ -230,7 +228,7 @@ spec:
                       serviceAccountProjection:
                         description: |-
                           When true, mounts a projected service account token into Thanos pods.
-                          Enable this for cloud-provider IAM integration instead of static credentials. Default is false.
+                          Enable this for cloud-provider IAM integration instead of static credentials.
                         type: boolean
                       tlsSecretMountPath:
                         description: |-
@@ -10933,15 +10931,14 @@ spec:
                 properties:
                   enableMetrics:
                     default: true
-                    description: |-
-                      When false, the managed cluster addon stops pushing metrics to the hub,
-                      reducing storage usage but disabling per-cluster dashboards.
+                    description: When false, the managed cluster addon stops pushing
+                      metrics to the hub.
                     type: boolean
                   interval:
                     default: 300
                     description: |-
                       Interval in seconds at which the observability addon on each managed cluster
-                      pushes metrics to the hub. Default: 300.
+                      pushes metrics to the hub.
                     format: int32
                     maximum: 3600
                     minimum: 15
@@ -11049,7 +11046,7 @@ spec:
                       serviceAccountProjection:
                         description: |-
                           When true, mounts a projected service account token into Thanos pods.
-                          Enable this for cloud-provider IAM integration instead of static credentials. Default is false.
+                          Enable this for cloud-provider IAM integration instead of static credentials.
                         type: boolean
                       tlsSecretMountPath:
                         description: |-
@@ -11102,7 +11099,7 @@ spec:
                         serviceAccountProjection:
                           description: |-
                             When true, mounts a projected service account token into Thanos pods.
-                            Enable this for cloud-provider IAM integration instead of static credentials. Default is false.
+                            Enable this for cloud-provider IAM integration instead of static credentials.
                           type: boolean
                         tlsSecretMountPath:
                           description: |-

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -58,8 +58,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: MultiClusterObservabilitySpec defines the desired state of
-              MultiClusterObservability.
+            description: Configuration for the hub-side Observability stack.
             properties:
               availabilityConfig:
                 default: High
@@ -78,16 +77,22 @@ spec:
                 type: boolean
               imagePullPolicy:
                 default: IfNotPresent
-                description: Pull policy of the MultiClusterObservability images
+                description: |-
+                  Pull policy of the MultiClusterObservability images.
+                  One of: Always, Never, IfNotPresent. Defaults to IfNotPresent.
                 type: string
               imagePullSecret:
                 default: multiclusterhub-operator-pull-secret
-                description: Pull secret of the MultiClusterObservability images
+                description: |-
+                  Name of an existing Secret of type kubernetes.io/dockerconfigjson in the same namespace
+                  used for pulling MultiClusterObservability images.
                 type: string
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: Spec of NodeSelector
+                description: |-
+                  Node labels used to schedule all Observability workloads.
+                  Pods are only placed on nodes matching all specified labels.
                 type: object
               observabilityAddonSpec:
                 description: |-
@@ -96,13 +101,15 @@ spec:
                 properties:
                   enableMetrics:
                     default: true
-                    description: EnableMetrics indicates the observability addon push
-                      metrics to hub server.
+                    description: |-
+                      When false, the managed cluster addon stops pushing metrics to the hub,
+                      reducing storage usage but disabling per-cluster dashboards.
                     type: boolean
                   interval:
                     default: 300
-                    description: Interval for the observability addon push metrics
-                      to hub server.
+                    description: |-
+                      Interval in seconds at which the observability addon on each managed cluster
+                      pushes metrics to the hub. Default: 300.
                     format: int32
                     maximum: 3600
                     minimum: 15
@@ -185,23 +192,32 @@ spec:
                 type: object
               retentionResolution1h:
                 default: 30d
-                description: How long to retain samples of resolution 2 (1 hour) in
-                  bucket.
+                description: |-
+                  How long to retain 1-hour downsampled (resolution 2) samples in object storage.
+                  Format: duration string, e.g. '365d'.
                 type: string
               retentionResolution5m:
                 default: 14d
-                description: How long to retain samples of resolution 1 (5 minutes)
-                  in bucket.
+                description: |-
+                  How long to retain 5-minute downsampled (resolution 1) samples in object storage.
+                  Format: duration string, e.g. '14d'.
                 type: string
               retentionResolutionRaw:
                 default: 5d
-                description: How long to retain raw samples in a bucket.
+                description: |-
+                  How long to retain raw samples in a bucket.
+                  Format: duration string, e.g. '5d'. Raw data has the highest storage cost per day retained.
                 type: string
               storageConfigObject:
-                description: Specifies the storage to be used by Observability
+                description: |-
+                  Storage configuration for Observability StatefulSets and object storage.
+                  Supports any S3-compatible object store (AWS S3, MinIO, Ceph). Required.
                 properties:
                   metricObjectStorage:
-                    description: Object store config secret for metrics
+                    description: |-
+                      Reference to a Secret containing the Thanos object storage configuration.
+                      The secret must use the Thanos storage config format (YAML).
+                      See spec.storageConfigObject.metricObjectStorage.key.
                     properties:
                       key:
                         description: |-
@@ -212,16 +228,19 @@ spec:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
                       serviceAccountProjection:
-                        description: serviceAccountProjection indicates whether mount
-                          service account token to thanos pods. Default is false.
+                        description: |-
+                          When true, mounts a projected service account token into Thanos pods.
+                          Enable this for cloud-provider IAM integration instead of static credentials. Default is false.
                         type: boolean
                       tlsSecretMountPath:
-                        description: TLS secret mount path for the custom certificate
-                          for the object store
+                        description: |-
+                          Filesystem path where the custom TLS certificate is mounted inside Thanos pods.
+                          Only relevant when tlsSecretName is set.
                         type: string
                       tlsSecretName:
-                        description: TLS secret contains the custom certificate for
-                          the object store
+                        description: |-
+                          Name of a Secret containing a custom CA certificate for the object store endpoint.
+                          Required when the object store uses a self-signed certificate or a private CA not trusted by the system root store.
                         type: string
                     required:
                     - key
@@ -235,9 +254,9 @@ spec:
                     type: string
                   statefulSetStorageClass:
                     default: gp2
-                    description: "\tSpecify the storageClass Stateful Sets. This storage
-                      class will also\nbe used for Object Storage if MetricObjectStorage
-                      was configured for\nthe system to create the storage."
+                    description: |-
+                      StorageClass used by Observability StatefulSets (Thanos store, ruler, compactor, receiver)
+                      and, when no object storage is configured, the object storage PVC.
                     type: string
                 required:
                 - metricObjectStorage
@@ -286,11 +305,13 @@ spec:
             - storageConfigObject
             type: object
           status:
-            description: MultiClusterObservabilityStatus defines the observed state
-              of MultiClusterObservability.
+            description: Observed state of the MultiClusterObservability installation,
+              including component health and addon status.
             properties:
               conditions:
-                description: Represents the status of each deployment
+                description: |-
+                  Conditions describing the current state of the MultiClusterObservability installation.
+                  Condition types include: Ready, Installing, Failed, MetricsDisabled, MultiClusterObservabilityAddonDegraded.
                 items:
                   description: |-
                     Condition is from metav1.Condition.
@@ -10912,13 +10933,15 @@ spec:
                 properties:
                   enableMetrics:
                     default: true
-                    description: EnableMetrics indicates the observability addon push
-                      metrics to hub server.
+                    description: |-
+                      When false, the managed cluster addon stops pushing metrics to the hub,
+                      reducing storage usage but disabling per-cluster dashboards.
                     type: boolean
                   interval:
                     default: 300
-                    description: Interval for the observability addon push metrics
-                      to hub server.
+                    description: |-
+                      Interval in seconds at which the observability addon on each managed cluster
+                      pushes metrics to the hub. Default: 300.
                     format: int32
                     maximum: 3600
                     minimum: 15
@@ -11024,16 +11047,19 @@ spec:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
                       serviceAccountProjection:
-                        description: serviceAccountProjection indicates whether mount
-                          service account token to thanos pods. Default is false.
+                        description: |-
+                          When true, mounts a projected service account token into Thanos pods.
+                          Enable this for cloud-provider IAM integration instead of static credentials. Default is false.
                         type: boolean
                       tlsSecretMountPath:
-                        description: TLS secret mount path for the custom certificate
-                          for the object store
+                        description: |-
+                          Filesystem path where the custom TLS certificate is mounted inside Thanos pods.
+                          Only relevant when tlsSecretName is set.
                         type: string
                       tlsSecretName:
-                        description: TLS secret contains the custom certificate for
-                          the object store
+                        description: |-
+                          Name of a Secret containing a custom CA certificate for the object store endpoint.
+                          Required when the object store uses a self-signed certificate or a private CA not trusted by the system root store.
                         type: string
                     required:
                     - key
@@ -11074,17 +11100,19 @@ spec:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                         serviceAccountProjection:
-                          description: serviceAccountProjection indicates whether
-                            mount service account token to thanos pods. Default is
-                            false.
+                          description: |-
+                            When true, mounts a projected service account token into Thanos pods.
+                            Enable this for cloud-provider IAM integration instead of static credentials. Default is false.
                           type: boolean
                         tlsSecretMountPath:
-                          description: TLS secret mount path for the custom certificate
-                            for the object store
+                          description: |-
+                            Filesystem path where the custom TLS certificate is mounted inside Thanos pods.
+                            Only relevant when tlsSecretName is set.
                           type: string
                         tlsSecretName:
-                          description: TLS secret contains the custom certificate
-                            for the object store
+                          description: |-
+                            Name of a Secret containing a custom CA certificate for the object store endpoint.
+                            Required when the object store uses a self-signed certificate or a private CA not trusted by the system root store.
                           type: string
                       required:
                       - key

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_observabilityaddons.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_observabilityaddons.yaml
@@ -43,15 +43,14 @@ spec:
             properties:
               enableMetrics:
                 default: true
-                description: |-
-                  When false, the managed cluster addon stops pushing metrics to the hub,
-                  reducing storage usage but disabling per-cluster dashboards.
+                description: When false, the managed cluster addon stops pushing metrics
+                  to the hub.
                 type: boolean
               interval:
                 default: 300
                 description: |-
                   Interval in seconds at which the observability addon on each managed cluster
-                  pushes metrics to the hub. Default: 300.
+                  pushes metrics to the hub.
                 format: int32
                 maximum: 3600
                 minimum: 15

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_observabilityaddons.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_observabilityaddons.yaml
@@ -43,13 +43,15 @@ spec:
             properties:
               enableMetrics:
                 default: true
-                description: EnableMetrics indicates the observability addon push
-                  metrics to hub server.
+                description: |-
+                  When false, the managed cluster addon stops pushing metrics to the hub,
+                  reducing storage usage but disabling per-cluster dashboards.
                 type: boolean
               interval:
                 default: 300
-                description: Interval for the observability addon push metrics to
-                  hub server.
+                description: |-
+                  Interval in seconds at which the observability addon on each managed cluster
+                  pushes metrics to the hub. Default: 300.
                 format: int32
                 maximum: 3600
                 minimum: 15

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -84,15 +84,14 @@ spec:
                 properties:
                   enableMetrics:
                     default: true
-                    description: |-
-                      When false, the managed cluster addon stops pushing metrics to the hub,
-                      reducing storage usage but disabling per-cluster dashboards.
+                    description: When false, the managed cluster addon stops pushing
+                      metrics to the hub.
                     type: boolean
                   interval:
                     default: 300
                     description: |-
                       Interval in seconds at which the observability addon on each managed cluster
-                      pushes metrics to the hub. Default: 300.
+                      pushes metrics to the hub.
                     format: int32
                     maximum: 3600
                     minimum: 15
@@ -192,9 +191,8 @@ spec:
                   Format: duration string, e.g. '5d'. Raw data has the highest storage cost per day retained.
                 type: string
               storageConfigObject:
-                description: |-
-                  Storage configuration for Observability StatefulSets and object storage.
-                  Supports any S3-compatible object store (AWS S3, MinIO, Ceph). Required.
+                description: S3 storage configuration for Observability StatefulSets
+                  and object storage.
                 properties:
                   metricObjectStorage:
                     description: |-
@@ -213,7 +211,7 @@ spec:
                       serviceAccountProjection:
                         description: |-
                           When true, mounts a projected service account token into Thanos pods.
-                          Enable this for cloud-provider IAM integration instead of static credentials. Default is false.
+                          Enable this for cloud-provider IAM integration instead of static credentials.
                         type: boolean
                       tlsSecretMountPath:
                         description: |-
@@ -10918,15 +10916,14 @@ spec:
                 properties:
                   enableMetrics:
                     default: true
-                    description: |-
-                      When false, the managed cluster addon stops pushing metrics to the hub,
-                      reducing storage usage but disabling per-cluster dashboards.
+                    description: When false, the managed cluster addon stops pushing
+                      metrics to the hub.
                     type: boolean
                   interval:
                     default: 300
                     description: |-
                       Interval in seconds at which the observability addon on each managed cluster
-                      pushes metrics to the hub. Default: 300.
+                      pushes metrics to the hub.
                     format: int32
                     maximum: 3600
                     minimum: 15
@@ -11034,7 +11031,7 @@ spec:
                       serviceAccountProjection:
                         description: |-
                           When true, mounts a projected service account token into Thanos pods.
-                          Enable this for cloud-provider IAM integration instead of static credentials. Default is false.
+                          Enable this for cloud-provider IAM integration instead of static credentials.
                         type: boolean
                       tlsSecretMountPath:
                         description: |-
@@ -11087,7 +11084,7 @@ spec:
                         serviceAccountProjection:
                           description: |-
                             When true, mounts a projected service account token into Thanos pods.
-                            Enable this for cloud-provider IAM integration instead of static credentials. Default is false.
+                            Enable this for cloud-provider IAM integration instead of static credentials.
                           type: boolean
                         tlsSecretMountPath:
                           description: |-

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -41,8 +41,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: MultiClusterObservabilitySpec defines the desired state of
-              MultiClusterObservability.
+            description: Configuration for the hub-side Observability stack.
             properties:
               availabilityConfig:
                 default: High
@@ -61,16 +60,22 @@ spec:
                 type: boolean
               imagePullPolicy:
                 default: IfNotPresent
-                description: Pull policy of the MultiClusterObservability images
+                description: |-
+                  Pull policy of the MultiClusterObservability images.
+                  One of: Always, Never, IfNotPresent. Defaults to IfNotPresent.
                 type: string
               imagePullSecret:
                 default: multiclusterhub-operator-pull-secret
-                description: Pull secret of the MultiClusterObservability images
+                description: |-
+                  Name of an existing Secret of type kubernetes.io/dockerconfigjson in the same namespace
+                  used for pulling MultiClusterObservability images.
                 type: string
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: Spec of NodeSelector
+                description: |-
+                  Node labels used to schedule all Observability workloads.
+                  Pods are only placed on nodes matching all specified labels.
                 type: object
               observabilityAddonSpec:
                 description: |-
@@ -79,13 +84,15 @@ spec:
                 properties:
                   enableMetrics:
                     default: true
-                    description: EnableMetrics indicates the observability addon push
-                      metrics to hub server.
+                    description: |-
+                      When false, the managed cluster addon stops pushing metrics to the hub,
+                      reducing storage usage but disabling per-cluster dashboards.
                     type: boolean
                   interval:
                     default: 300
-                    description: Interval for the observability addon push metrics
-                      to hub server.
+                    description: |-
+                      Interval in seconds at which the observability addon on each managed cluster
+                      pushes metrics to the hub. Default: 300.
                     format: int32
                     maximum: 3600
                     minimum: 15
@@ -168,23 +175,32 @@ spec:
                 type: object
               retentionResolution1h:
                 default: 30d
-                description: How long to retain samples of resolution 2 (1 hour) in
-                  bucket.
+                description: |-
+                  How long to retain 1-hour downsampled (resolution 2) samples in object storage.
+                  Format: duration string, e.g. '365d'.
                 type: string
               retentionResolution5m:
                 default: 14d
-                description: How long to retain samples of resolution 1 (5 minutes)
-                  in bucket.
+                description: |-
+                  How long to retain 5-minute downsampled (resolution 1) samples in object storage.
+                  Format: duration string, e.g. '14d'.
                 type: string
               retentionResolutionRaw:
                 default: 5d
-                description: How long to retain raw samples in a bucket.
+                description: |-
+                  How long to retain raw samples in a bucket.
+                  Format: duration string, e.g. '5d'. Raw data has the highest storage cost per day retained.
                 type: string
               storageConfigObject:
-                description: Specifies the storage to be used by Observability
+                description: |-
+                  Storage configuration for Observability StatefulSets and object storage.
+                  Supports any S3-compatible object store (AWS S3, MinIO, Ceph). Required.
                 properties:
                   metricObjectStorage:
-                    description: Object store config secret for metrics
+                    description: |-
+                      Reference to a Secret containing the Thanos object storage configuration.
+                      The secret must use the Thanos storage config format (YAML).
+                      See spec.storageConfigObject.metricObjectStorage.key.
                     properties:
                       key:
                         description: |-
@@ -195,16 +211,19 @@ spec:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
                       serviceAccountProjection:
-                        description: serviceAccountProjection indicates whether mount
-                          service account token to thanos pods. Default is false.
+                        description: |-
+                          When true, mounts a projected service account token into Thanos pods.
+                          Enable this for cloud-provider IAM integration instead of static credentials. Default is false.
                         type: boolean
                       tlsSecretMountPath:
-                        description: TLS secret mount path for the custom certificate
-                          for the object store
+                        description: |-
+                          Filesystem path where the custom TLS certificate is mounted inside Thanos pods.
+                          Only relevant when tlsSecretName is set.
                         type: string
                       tlsSecretName:
-                        description: TLS secret contains the custom certificate for
-                          the object store
+                        description: |-
+                          Name of a Secret containing a custom CA certificate for the object store endpoint.
+                          Required when the object store uses a self-signed certificate or a private CA not trusted by the system root store.
                         type: string
                     required:
                     - key
@@ -218,9 +237,9 @@ spec:
                     type: string
                   statefulSetStorageClass:
                     default: gp2
-                    description: "\tSpecify the storageClass Stateful Sets. This storage
-                      class will also\nbe used for Object Storage if MetricObjectStorage
-                      was configured for\nthe system to create the storage."
+                    description: |-
+                      StorageClass used by Observability StatefulSets (Thanos store, ruler, compactor, receiver)
+                      and, when no object storage is configured, the object storage PVC.
                     type: string
                 required:
                 - metricObjectStorage
@@ -269,11 +288,13 @@ spec:
             - storageConfigObject
             type: object
           status:
-            description: MultiClusterObservabilityStatus defines the observed state
-              of MultiClusterObservability.
+            description: Observed state of the MultiClusterObservability installation,
+              including component health and addon status.
             properties:
               conditions:
-                description: Represents the status of each deployment
+                description: |-
+                  Conditions describing the current state of the MultiClusterObservability installation.
+                  Condition types include: Ready, Installing, Failed, MetricsDisabled, MultiClusterObservabilityAddonDegraded.
                 items:
                   description: |-
                     Condition is from metav1.Condition.
@@ -10897,13 +10918,15 @@ spec:
                 properties:
                   enableMetrics:
                     default: true
-                    description: EnableMetrics indicates the observability addon push
-                      metrics to hub server.
+                    description: |-
+                      When false, the managed cluster addon stops pushing metrics to the hub,
+                      reducing storage usage but disabling per-cluster dashboards.
                     type: boolean
                   interval:
                     default: 300
-                    description: Interval for the observability addon push metrics
-                      to hub server.
+                    description: |-
+                      Interval in seconds at which the observability addon on each managed cluster
+                      pushes metrics to the hub. Default: 300.
                     format: int32
                     maximum: 3600
                     minimum: 15
@@ -11009,16 +11032,19 @@ spec:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
                       serviceAccountProjection:
-                        description: serviceAccountProjection indicates whether mount
-                          service account token to thanos pods. Default is false.
+                        description: |-
+                          When true, mounts a projected service account token into Thanos pods.
+                          Enable this for cloud-provider IAM integration instead of static credentials. Default is false.
                         type: boolean
                       tlsSecretMountPath:
-                        description: TLS secret mount path for the custom certificate
-                          for the object store
+                        description: |-
+                          Filesystem path where the custom TLS certificate is mounted inside Thanos pods.
+                          Only relevant when tlsSecretName is set.
                         type: string
                       tlsSecretName:
-                        description: TLS secret contains the custom certificate for
-                          the object store
+                        description: |-
+                          Name of a Secret containing a custom CA certificate for the object store endpoint.
+                          Required when the object store uses a self-signed certificate or a private CA not trusted by the system root store.
                         type: string
                     required:
                     - key
@@ -11059,17 +11085,19 @@ spec:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                         serviceAccountProjection:
-                          description: serviceAccountProjection indicates whether
-                            mount service account token to thanos pods. Default is
-                            false.
+                          description: |-
+                            When true, mounts a projected service account token into Thanos pods.
+                            Enable this for cloud-provider IAM integration instead of static credentials. Default is false.
                           type: boolean
                         tlsSecretMountPath:
-                          description: TLS secret mount path for the custom certificate
-                            for the object store
+                          description: |-
+                            Filesystem path where the custom TLS certificate is mounted inside Thanos pods.
+                            Only relevant when tlsSecretName is set.
                           type: string
                         tlsSecretName:
-                          description: TLS secret contains the custom certificate
-                            for the object store
+                          description: |-
+                            Name of a Secret containing a custom CA certificate for the object store endpoint.
+                            Required when the object store uses a self-signed certificate or a private CA not trusted by the system root store.
                           type: string
                       required:
                       - key

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_observabilityaddons.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_observabilityaddons.yaml
@@ -43,15 +43,14 @@ spec:
             properties:
               enableMetrics:
                 default: true
-                description: |-
-                  When false, the managed cluster addon stops pushing metrics to the hub,
-                  reducing storage usage but disabling per-cluster dashboards.
+                description: When false, the managed cluster addon stops pushing metrics
+                  to the hub.
                 type: boolean
               interval:
                 default: 300
                 description: |-
                   Interval in seconds at which the observability addon on each managed cluster
-                  pushes metrics to the hub. Default: 300.
+                  pushes metrics to the hub.
                 format: int32
                 maximum: 3600
                 minimum: 15

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_observabilityaddons.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_observabilityaddons.yaml
@@ -43,13 +43,15 @@ spec:
             properties:
               enableMetrics:
                 default: true
-                description: EnableMetrics indicates the observability addon push
-                  metrics to hub server.
+                description: |-
+                  When false, the managed cluster addon stops pushing metrics to the hub,
+                  reducing storage usage but disabling per-cluster dashboards.
                 type: boolean
               interval:
                 default: 300
-                description: Interval for the observability addon push metrics to
-                  hub server.
+                description: |-
+                  Interval in seconds at which the observability addon on each managed cluster
+                  pushes metrics to the hub. Default: 300.
                 format: int32
                 maximum: 3600
                 minimum: 15


### PR DESCRIPTION
Improve MCO CRD description quality as indicated by ACM-32728.
The grading rubric requires the fix of the following fields: 
  - spec
  - spec.nodeSelector
  - spec.observabilityAddonSpec.interval
  - spec.storageConfigObject
  - spec.storageConfigObject.metricObjectStorage
  - spec.storageConfigObject.statefulSetStorageClass
  - status
  - status.conditions
  - spec.imagePullPolicy
  - spec.imagePullSecret
  - spec.retentionResolution1h
  - spec.retentionResolution5m
  - spec.observabilityAddonSpec.enableMetrics
  - spec.storageConfigObject.metricObjectStorage.tlsSecretName
  - spec.storageConfigObject.metricObjectStorage.tlsSecretMountPath
  - spec.storageConfigObject.metricObjectStorage.serviceAccountProjection

/cherry-pick release-2.17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified API and CRD docs: metric enablement effects (runtime behavior, dashboard availability), per-cluster push interval units/default (seconds, default 300), imagePullPolicy allowed values and imagePullSecret expectations, nodeSelector matching semantics, retention duration formats and object-storage/downsample semantics, S3-compatible/Thanos metric storage secret requirements, TLS CA secret and mount-path guidance, projected service-account token (IAM) notes, and status condition types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->