### PR TITLE
feat: add node memory metrics to allowlist and scrape config

### DIFF
--- a/cicd-scripts/metrics/Makefile
+++ b/cicd-scripts/metrics/Makefile
@@ -71,7 +71,8 @@ check-virtualization-metrics:
 	@$(CURDIR)/scripts/extract-dashboards-metrics.sh -d $(VIRTUALIZATION_DASH_DIR) --preprocess "sed 's/\$${status:raw}/1/g; s/\$$operator_health/==1/g; s/\$$days_in_status_gt/0/g; s/\$$days_in_status_lt/0/g'" | tr '\n' ',' > $(TMPDIR)/dash-metrics
 	@go run cmd/dashcheck/main.go --scrape-configs=$(VIRTUALIZATION_DASH_DIR)/scrape-config.yaml \
 		--dashboard-metrics=$$(cat $(TMPDIR)/dash-metrics) \
-		--additional-scrape-configs=$(PLATFORM_DASH_DIR)/scrape-config.yaml,$(ALERTS_DASH_DIR)/scrape-config.yaml
+		--additional-scrape-configs=$(PLATFORM_DASH_DIR)/scrape-config.yaml,$(ALERTS_DASH_DIR)/scrape-config.yaml \
+		--ignored-scrapeconfig-metrics=container_memory_rss,node_memory_SwapFree_bytes,node_memory_SwapTotal_bytes,node_pressure_memory_waiting_seconds_total,kube_pod_resource_request,kube_pod_labels,kubevirt_vmi_launcher_memory_overhead_bytes
 	@rm -d $(TMPDIR)/dash-metrics
 
 check-analytics-metrics: 

--- a/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
+++ b/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
@@ -152,6 +152,7 @@ data:
       - kubevirt_vmi_filesystem_capacity_bytes
       - kubevirt_vmi_filesystem_used_bytes
       - kubevirt_vmi_info
+      - kubevirt_vmi_launcher_memory_overhead_bytes
       - kubevirt_vmi_memory_available_bytes
       - kubevirt_vmi_memory_cached_bytes
       - kubevirt_vmi_memory_swap_in_traffic_bytes
@@ -206,12 +207,14 @@ data:
       - node_filesystem_size_bytes
       - node_memory_MemAvailable_bytes
       - node_memory_MemTotal_bytes
-      - node_memory_MemTotal_bytes
+      - node_memory_SwapFree_bytes
+      - node_memory_SwapTotal_bytes
       - node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
       - node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m
       - node_netstat_Tcp_OutSegs
       - node_netstat_Tcp_RetransSegs
       - node_netstat_TcpExt_TCPSynRetrans
+      - node_pressure_memory_waiting_seconds_total
       - policy:policy_governance_info:propagated_count
       - policy:policy_governance_info:propagated_noncompliant_count
       - policyreport_info
@@ -228,8 +231,11 @@ data:
       - __name__="process_resident_memory_bytes",job=~"apiserver|etcd"
       - __name__="container_memory_cache",container!=""
       - __name__="container_memory_rss",container!=""
+      - __name__="container_memory_rss",id="/system.slice"
       - __name__="container_memory_swap",container!=""
       - __name__="container_memory_working_set_bytes",container!=""
+      - __name__="kube_pod_labels",label_vm_kubevirt_io_name!=""
+      - __name__="kube_pod_resource_request",resource="memory"
     renames:
       mixin_pod_workload: namespace_workload_pod:kube_pod_owner:relabel
       namespace:kube_pod_container_resource_requests_cpu_cores:sum: namespace_cpu:kube_pod_container_resource_requests:sum

--- a/operators/multiclusterobservability/manifests/base/grafana/virtualization/scrape-config.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/virtualization/scrape-config.yaml
@@ -20,6 +20,8 @@ spec:
     - '{__name__="descheduler:nodepressure:cpu:avg1m"}'
     - '{__name__="kube_node_labels"}'
     - '{__name__="kube_node_role"}'
+    - '{__name__="kube_pod_labels",label_vm_kubevirt_io_name!=""}'
+    - '{__name__="kube_pod_resource_request",resource="memory"}'
     - '{__name__="kubevirt_hco_system_health_status"}'
     - '{__name__="kubevirt_hyperconverged_operator_health_status"}'
     - '{__name__="kubevirt_vm_cpu_usage_seconds_total"}'
@@ -36,6 +38,7 @@ spec:
     - '{__name__="kubevirt_vmi_filesystem_capacity_bytes"}'
     - '{__name__="kubevirt_vmi_filesystem_used_bytes"}'
     - '{__name__="kubevirt_vmi_info"}'
+    - '{__name__="kubevirt_vmi_launcher_memory_overhead_bytes"}'
     - '{__name__="kubevirt_vmi_memory_available_bytes"}'
     - '{__name__="kubevirt_vmi_memory_swap_in_traffic_bytes"}'
     - '{__name__="kubevirt_vmi_memory_swap_out_traffic_bytes"}'
@@ -59,7 +62,16 @@ spec:
     - '{__name__="kubevirt_vmsnapshot_succeeded_timestamp_seconds"}'
     - '{__name__="node_cpu_seconds_total"}'
     - '{__name__="node_memory_MemTotal_bytes"}'
+    - '{__name__="node_memory_SwapFree_bytes"}'
+    - '{__name__="node_memory_SwapTotal_bytes"}'
+    - '{__name__="node_pressure_memory_waiting_seconds_total"}'
     - '{__name__="machine_cpu_cores"}'
+    - '{__name__="container_memory_rss",id="/system.slice"}'
   metricRelabelings:
+  - sourceLabels: [__name__, id]
+    regex: container_memory_rss;(/system\.slice)
+    targetLabel: cgroup_id
+    replacement: "$1"
+    action: replace
   - action: labeldrop
     regex: managed_cluster|id


### PR DESCRIPTION
## Summary

- Add metrics required by the Nodes Memory Overview
  dashboard to the default allowlist:
  `kube_pod_labels`, `kube_pod_resource_request`,
  `node_memory_Swap*`,
  `node_pressure_memory_waiting_seconds_total`,
  `kubevirt_vmi_launcher_memory_overhead_bytes`,
  `container_memory_rss{id="/system.slice"}`
- Remove `id` from `labeldrop` in the virtualization
  scrape config to preserve the `id` label needed by
  system reserved memory queries
- Fix duplicate `node_memory_MemTotal_bytes` entry in
  the default allowlist

## Test plan

- [ ] Verify the listed metrics are scraped from spoke
  clusters after applying the allowlist change
- [ ] Confirm the Nodes Memory Overview dashboard panels
  populate correctly (system reserved, swap, launcher
  overhead)
- [ ] Check no regression in existing virtualization
  dashboard panels that relied on scrape config labels


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded virtualization metrics coverage to include VMI memory overhead, node swap/free and total memory, memory-pressure waiting time, and additional pod label and memory resource-request metrics.
  * Improved container RSS selection by restricting it to `system.slice` and deriving a `cgroup_id` label for better metric correlation.

* **Chores**
  * Updated CI metric validation to reflect the expanded scrape/allowlist set used for virtualization metrics checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->