### PR TITLE
[ACM-30704] Fix hub cluster name resolution in e2e tests

### DIFF
--- a/tests/pkg/tests/observability-e2e-test_suite_test.go
+++ b/tests/pkg/tests/observability-e2e-test_suite_test.go
@@ -272,9 +272,12 @@ func initVars() {
 	if testOptions.HubCluster.Password != "" {
 		kubeadminCredential = testOptions.HubCluster.Password
 	}
-	if testOptions.HubCluster.Name == "" {
-		testOptions.HubCluster.Name = "local-cluster"
+	hubName, err := utils.GetHubClusterName(testOptions)
+	if err != nil {
+		klog.Warningf("Failed to resolve hub managed cluster name, using default: %v", err)
+		hubName = "local-cluster"
 	}
+	testOptions.HubCluster.Name = hubName
 
 	if testOptions.ManagedClusters != nil && len(testOptions.ManagedClusters) > 0 {
 		for i, mc := range testOptions.ManagedClusters {

--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -196,6 +196,21 @@ func GetManagedClusters(opt TestOptions) ([]*clusterv1.ManagedCluster, error) {
 	return ret, nil
 }
 
+// GetHubClusterName queries the ManagedCluster API and returns the name of the hub cluster
+// (identified by the "local-cluster=true" label). Falls back to "local-cluster" if not found.
+func GetHubClusterName(opt TestOptions) (string, error) {
+	clusters, err := ListManagedClusters(opt)
+	if err != nil {
+		return "", fmt.Errorf("failed to list managed clusters: %w", err)
+	}
+	for _, c := range clusters {
+		if c.IsLocalCluster {
+			return c.Name, nil
+		}
+	}
+	return "local-cluster", nil
+}
+
 func GetAvailableManagedClusters(opt TestOptions) ([]*clusterv1.ManagedCluster, error) {
 	clusters, err := GetManagedClusters(opt)
 	if err != nil {


### PR DESCRIPTION
Related: [ACM-30704](https://redhat.atlassian.net/browse/ACM-30704) 
## Summary                                                                                                        
                                                            
  - Resolve hub cluster name from the ManagedCluster API instead of `options.yaml`                                  
  - The `options.yaml` `hub.name` field contains the infrastructure hostname (e.g., `ci-vb-arm-tr37`), which doesn't match the ACM managed cluster name used in metric labels                                          
  - Add `GetHubClusterName()` utility that finds the hub by the `local-cluster=true` label  and returns its actual `metadata.name`                                                                          
  - Fixes MCOA e2e test failures in QE regression where metric queries like `up{cluster="ci-vb-arm-tr37"}` return no results                                                                
                                                                                                                   

[ACM-30704]: https://redhat.atlassian.net/browse/ACM-30704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Enhanced hub cluster name detection in test infrastructure with improved error handling and automatic fallback mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->