### PR TITLE
fix(deployer): eliminate infinite reconciliation loops caused by semantic equality failures

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
@@ -27,7 +27,7 @@ func GetMCOPredicateFunc() predicate.Funcs {
 			checkStorageChanged(e.ObjectOld.(*mcov1beta2.MultiClusterObservability).Spec.StorageConfig,
 				e.ObjectNew.(*mcov1beta2.MultiClusterObservability).Spec.StorageConfig)
 			config.SetMonitoringCRName(e.ObjectNew.GetName())
-			return e.ObjectOld.GetResourceVersion() != e.ObjectNew.GetResourceVersion()
+			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return !e.DeleteStateUnknown

--- a/operators/pkg/deploying/deployer.go
+++ b/operators/pkg/deploying/deployer.go
@@ -119,7 +119,7 @@ func (d *Deployer) Deploy(ctx context.Context, obj *unstructured.Unstructured) e
 }
 
 func (d *Deployer) updateDeployment(ctx context.Context, desiredObj, runtimeObj *unstructured.Unstructured) error {
-	desiredDeploy, _, err := unstructuredPairToTyped[appsv1.Deployment](desiredObj, runtimeObj)
+	desiredDeploy, runtimeDeploy, err := unstructuredPairToTyped[appsv1.Deployment](desiredObj, runtimeObj)
 	if err != nil {
 		return err
 	}
@@ -133,6 +133,7 @@ func (d *Deployer) updateDeployment(ctx context.Context, desiredObj, runtimeObj 
 		!isMapSubset(runtimeObj.GetLabels(), desiredObj.GetLabels()) ||
 		!isMapSubset(runtimeObj.GetAnnotations(), desiredObj.GetAnnotations()) {
 		logUpdateInfo(runtimeObj)
+		desiredDeploy.ResourceVersion = runtimeDeploy.ResourceVersion
 		return d.client.Update(ctx, desiredDeploy)
 	}
 
@@ -150,8 +151,7 @@ func (d *Deployer) updateStatefulSet(ctx context.Context, desiredObj, runtimeObj
 		!isMapSubset(runtimeObj.GetLabels(), desiredObj.GetLabels()) ||
 		!isMapSubset(runtimeObj.GetAnnotations(), desiredObj.GetAnnotations()) {
 		logUpdateInfo(runtimeObj)
-		runtimeSTS.Spec.Replicas = desiredSTS.Spec.Replicas
-		runtimeSTS.Spec.Template = desiredSTS.Spec.Template
+		runtimeSTS.Spec = desiredSTS.Spec
 		return d.client.Update(ctx, runtimeSTS)
 	}
 
@@ -170,6 +170,7 @@ func (d *Deployer) updateService(ctx context.Context, desiredObj, runtimeObj *un
 		!isMapSubset(runtimeObj.GetAnnotations(), desiredObj.GetAnnotations()) {
 		desiredService.ResourceVersion = runtimeService.ResourceVersion
 		desiredService.Spec.ClusterIP = runtimeService.Spec.ClusterIP
+		desiredService.Spec.ClusterIPs = runtimeService.Spec.ClusterIPs
 		logUpdateInfo(runtimeObj)
 		return d.client.Update(ctx, desiredService)
 	}
@@ -212,8 +213,11 @@ func (d *Deployer) updateSecret(ctx context.Context, desiredObj, runtimeObj *uns
 		}
 	}
 
+	// Changes to Secret.Type are not handled here (they typically require delete/recreate),
+	// so only Data is compared.
 	if !equality.Semantic.DeepDerivative(desiredSecret.Data, runtimeSecret.Data) {
 		logUpdateInfo(desiredObj)
+		desiredSecret.ResourceVersion = runtimeSecret.ResourceVersion
 		return d.client.Update(ctx, desiredSecret)
 	}
 	return nil

--- a/operators/pkg/deploying/deployer.go
+++ b/operators/pkg/deploying/deployer.go
@@ -11,7 +11,6 @@ import (
 	"maps"
 	"strings"
 
-	"github.com/google/go-cmp/cmp"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
@@ -133,7 +132,6 @@ func (d *Deployer) updateDeployment(ctx context.Context, desiredObj, runtimeObj 
 	if !equality.Semantic.DeepDerivative(desiredObj.Object["spec"], runtimeObj.Object["spec"]) ||
 		!isMapSubset(runtimeObj.GetLabels(), desiredObj.GetLabels()) ||
 		!isMapSubset(runtimeObj.GetAnnotations(), desiredObj.GetAnnotations()) {
-		log.Info("Deployment update required", "name", desiredDeploy.Name, "diff", cmp.Diff(runtimeObj.Object["spec"], desiredObj.Object["spec"]))
 		logUpdateInfo(runtimeObj)
 		return d.client.Update(ctx, desiredDeploy)
 	}
@@ -204,8 +202,7 @@ func (d *Deployer) updateSecret(ctx context.Context, desiredObj, runtimeObj *uns
 	// Handle StringData by converting it to Data for comparison.
 	// This prevents an infinite loop where the operator constantly tries to update secrets
 	// defined with StringData because the Kube API converts it to Data on the server side,
-	// causing DeepDerivative(nil, runtime.Data) to return true (if ignoring nil) but
-	// historically forcing an update here.
+	// causing DeepDerivative(nil, runtime.Data) to return true (if ignoring nil).
 	if len(desiredSecret.StringData) > 0 {
 		if desiredSecret.Data == nil {
 			desiredSecret.Data = make(map[string][]byte)

--- a/operators/pkg/deploying/deployer.go
+++ b/operators/pkg/deploying/deployer.go
@@ -187,8 +187,17 @@ func (d *Deployer) updateSecret(ctx context.Context, desiredObj, runtimeObj *uns
 		return err
 	}
 
-	if desiredSecret.Data == nil ||
-		!equality.Semantic.DeepDerivative(desiredSecret.Data, runtimeSecret.Data) {
+	// Handle StringData by converting it to Data for comparison
+	if len(desiredSecret.StringData) > 0 {
+		if desiredSecret.Data == nil {
+			desiredSecret.Data = make(map[string][]byte)
+		}
+		for k, v := range desiredSecret.StringData {
+			desiredSecret.Data[k] = []byte(v)
+		}
+	}
+
+	if !equality.Semantic.DeepDerivative(desiredSecret.Data, runtimeSecret.Data) {
 		logUpdateInfo(desiredObj)
 		return d.client.Update(ctx, desiredSecret)
 	}

--- a/operators/pkg/deploying/deployer.go
+++ b/operators/pkg/deploying/deployer.go
@@ -133,6 +133,11 @@ func (d *Deployer) updateDeployment(ctx context.Context, desiredObj, runtimeObj 
 		!isMapSubset(runtimeObj.GetLabels(), desiredObj.GetLabels()) ||
 		!isMapSubset(runtimeObj.GetAnnotations(), desiredObj.GetAnnotations()) {
 		logUpdateInfo(runtimeObj)
+		// Merge desired labels/annotations into runtime to preserve user-added entries.
+		desiredDeploy.Labels, desiredDeploy.Annotations = mergeMetadata(
+			runtimeDeploy.Labels, runtimeDeploy.Annotations,
+			desiredDeploy.Labels, desiredDeploy.Annotations,
+		)
 		desiredDeploy.ResourceVersion = runtimeDeploy.ResourceVersion
 		return d.client.Update(ctx, desiredDeploy)
 	}
@@ -146,12 +151,30 @@ func (d *Deployer) updateStatefulSet(ctx context.Context, desiredObj, runtimeObj
 		return err
 	}
 
-	// Use unstructured Spec comparison to avoid Go zero-value conflicts with cluster defaults.
-	if !equality.Semantic.DeepDerivative(desiredObj.Object["spec"], runtimeObj.Object["spec"]) ||
+	// volumeClaimTemplates is immutable in StatefulSets; storage-size changes are handled
+	// separately by HandleStorageSizeChange (PVC resize + STS delete/recreate). Exclude it
+	// from the comparison to avoid triggering an Update that Kubernetes will reject or silently ignore.
+	desiredSpec := maps.Clone(desiredObj.Object["spec"].(map[string]any))
+	runtimeSpec := maps.Clone(runtimeObj.Object["spec"].(map[string]any))
+	delete(desiredSpec, "volumeClaimTemplates")
+	delete(runtimeSpec, "volumeClaimTemplates")
+
+	if !equality.Semantic.DeepDerivative(desiredSpec, runtimeSpec) ||
 		!isMapSubset(runtimeObj.GetLabels(), desiredObj.GetLabels()) ||
 		!isMapSubset(runtimeObj.GetAnnotations(), desiredObj.GetAnnotations()) {
 		logUpdateInfo(runtimeObj)
-		runtimeSTS.Spec = desiredSTS.Spec
+		// Merge desired labels/annotations into runtime to preserve user-added entries.
+		runtimeSTS.Labels, runtimeSTS.Annotations = mergeMetadata(
+			runtimeSTS.Labels, runtimeSTS.Annotations,
+			desiredSTS.Labels, desiredSTS.Annotations,
+		)
+		// Only update the mutable Spec fields; volumeClaimTemplates is immutable.
+		runtimeSTS.Spec.Replicas = desiredSTS.Spec.Replicas
+		runtimeSTS.Spec.Template = desiredSTS.Spec.Template
+		runtimeSTS.Spec.UpdateStrategy = desiredSTS.Spec.UpdateStrategy
+		runtimeSTS.Spec.MinReadySeconds = desiredSTS.Spec.MinReadySeconds
+		runtimeSTS.Spec.PersistentVolumeClaimRetentionPolicy = desiredSTS.Spec.PersistentVolumeClaimRetentionPolicy
+		runtimeSTS.Spec.Ordinals = desiredSTS.Spec.Ordinals
 		return d.client.Update(ctx, runtimeSTS)
 	}
 
@@ -638,4 +661,22 @@ func isControllerOwner(ownerRefs []metav1.OwnerReference, obj client.Object) boo
 	}
 
 	return false
+}
+
+// mergeMetadata returns merged label and annotation maps where desired values override
+// runtime values on conflict, but runtime-only entries (user additions) are preserved.
+func mergeMetadata(runtimeLabels, runtimeAnnotations, desiredLabels, desiredAnnotations map[string]string) (map[string]string, map[string]string) {
+	merged := maps.Clone(runtimeLabels)
+	if merged == nil {
+		merged = make(map[string]string)
+	}
+	maps.Copy(merged, desiredLabels)
+
+	mergedAnnotations := maps.Clone(runtimeAnnotations)
+	if mergedAnnotations == nil {
+		mergedAnnotations = make(map[string]string)
+	}
+	maps.Copy(mergedAnnotations, desiredAnnotations)
+
+	return merged, mergedAnnotations
 }

--- a/operators/pkg/deploying/deployer.go
+++ b/operators/pkg/deploying/deployer.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"strings"
 
+	"github.com/google/go-cmp/cmp"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
@@ -119,12 +120,20 @@ func (d *Deployer) Deploy(ctx context.Context, obj *unstructured.Unstructured) e
 }
 
 func (d *Deployer) updateDeployment(ctx context.Context, desiredObj, runtimeObj *unstructured.Unstructured) error {
-	desiredDeploy, runtimeDepoly, err := unstructuredPairToTyped[appsv1.Deployment](desiredObj, runtimeObj)
+	desiredDeploy, _, err := unstructuredPairToTyped[appsv1.Deployment](desiredObj, runtimeObj)
 	if err != nil {
 		return err
 	}
 
-	if !equality.Semantic.DeepDerivative(desiredDeploy.Spec, runtimeDepoly.Spec) {
+	// Compare using unstructured maps for the Spec field.
+	// Typed Go structs zero-initialize missing fields (e.g., timeoutSeconds: 0),
+	// which causes DeepDerivative to fail against cluster-side defaults (e.g., timeoutSeconds: 1).
+	// Unstructured maps preserve the "missing key" state, allowing DeepDerivative to correctly
+	// ignore defaulted fields that aren't explicitly set in our manifest.
+	if !equality.Semantic.DeepDerivative(desiredObj.Object["spec"], runtimeObj.Object["spec"]) ||
+		!isMapSubset(runtimeObj.GetLabels(), desiredObj.GetLabels()) ||
+		!isMapSubset(runtimeObj.GetAnnotations(), desiredObj.GetAnnotations()) {
+		log.Info("Deployment update required", "name", desiredDeploy.Name, "diff", cmp.Diff(runtimeObj.Object["spec"], desiredObj.Object["spec"]))
 		logUpdateInfo(runtimeObj)
 		return d.client.Update(ctx, desiredDeploy)
 	}
@@ -133,17 +142,19 @@ func (d *Deployer) updateDeployment(ctx context.Context, desiredObj, runtimeObj 
 }
 
 func (d *Deployer) updateStatefulSet(ctx context.Context, desiredObj, runtimeObj *unstructured.Unstructured) error {
-	desiredDepoly, runtimeDepoly, err := unstructuredPairToTyped[appsv1.StatefulSet](desiredObj, runtimeObj)
+	desiredSTS, runtimeSTS, err := unstructuredPairToTyped[appsv1.StatefulSet](desiredObj, runtimeObj)
 	if err != nil {
 		return err
 	}
 
-	if !equality.Semantic.DeepDerivative(desiredDepoly.Spec.Template, runtimeDepoly.Spec.Template) ||
-		!equality.Semantic.DeepDerivative(desiredDepoly.Spec.Replicas, runtimeDepoly.Spec.Replicas) {
+	// Use unstructured Spec comparison to avoid Go zero-value conflicts with cluster defaults.
+	if !equality.Semantic.DeepDerivative(desiredObj.Object["spec"], runtimeObj.Object["spec"]) ||
+		!isMapSubset(runtimeObj.GetLabels(), desiredObj.GetLabels()) ||
+		!isMapSubset(runtimeObj.GetAnnotations(), desiredObj.GetAnnotations()) {
 		logUpdateInfo(runtimeObj)
-		runtimeDepoly.Spec.Replicas = desiredDepoly.Spec.Replicas
-		runtimeDepoly.Spec.Template = desiredDepoly.Spec.Template
-		return d.client.Update(ctx, runtimeDepoly)
+		runtimeSTS.Spec.Replicas = desiredSTS.Spec.Replicas
+		runtimeSTS.Spec.Template = desiredSTS.Spec.Template
+		return d.client.Update(ctx, runtimeSTS)
 	}
 
 	return nil
@@ -155,7 +166,10 @@ func (d *Deployer) updateService(ctx context.Context, desiredObj, runtimeObj *un
 		return err
 	}
 
-	if !equality.Semantic.DeepDerivative(desiredService.Spec, runtimeService.Spec) {
+	// Use unstructured Spec comparison to avoid Go zero-value conflicts with cluster defaults.
+	if !equality.Semantic.DeepDerivative(desiredObj.Object["spec"], runtimeObj.Object["spec"]) ||
+		!isMapSubset(runtimeObj.GetLabels(), desiredObj.GetLabels()) ||
+		!isMapSubset(runtimeObj.GetAnnotations(), desiredObj.GetAnnotations()) {
 		desiredService.ResourceVersion = runtimeService.ResourceVersion
 		desiredService.Spec.ClusterIP = runtimeService.Spec.ClusterIP
 		logUpdateInfo(runtimeObj)
@@ -187,7 +201,11 @@ func (d *Deployer) updateSecret(ctx context.Context, desiredObj, runtimeObj *uns
 		return err
 	}
 
-	// Handle StringData by converting it to Data for comparison
+	// Handle StringData by converting it to Data for comparison.
+	// This prevents an infinite loop where the operator constantly tries to update secrets
+	// defined with StringData because the Kube API converts it to Data on the server side,
+	// causing DeepDerivative(nil, runtime.Data) to return true (if ignoring nil) but
+	// historically forcing an update here.
 	if len(desiredSecret.StringData) > 0 {
 		if desiredSecret.Data == nil {
 			desiredSecret.Data = make(map[string][]byte)

--- a/operators/pkg/deploying/deployer_test.go
+++ b/operators/pkg/deploying/deployer_test.go
@@ -85,7 +85,7 @@ func TestDeploy(t *testing.T) {
 			},
 		},
 		{
-			name: "create and no update the deployment",
+			name: "create and update the deployment with labels",
 			createObj: &appsv1.Deployment{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "apps/v1",
@@ -125,7 +125,7 @@ func TestDeploy(t *testing.T) {
 				client.Get(context.Background(), namespacedName, obj)
 
 				if len(obj.ObjectMeta.GetLabels()) == 0 {
-					t.Fatalf("should not update the deployment")
+					t.Fatalf("deployment was not updated; expected labels to be present")
 				}
 			},
 		},
@@ -297,6 +297,92 @@ func TestDeploy(t *testing.T) {
 				if len(obj.Data) == 0 {
 					t.Fatalf("fail to update the secret")
 				}
+			},
+		},
+		{
+			name: "secret defined with StringData that matches runtime Data does not trigger update loop",
+			createObj: &corev1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret-stringdata-no-update",
+					Namespace: "ns2",
+				},
+				Data: map[string][]byte{
+					"key": []byte("value"),
+				},
+			},
+			updateObj: &corev1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-secret-stringdata-no-update",
+					Namespace:       "ns2",
+					ResourceVersion: "1",
+				},
+				StringData: map[string]string{
+					"key": "value",
+				},
+			},
+			validateResults: func(client client.Client) {
+				namespacedName := types.NamespacedName{
+					Name:      "test-secret-stringdata-no-update",
+					Namespace: "ns2",
+				}
+				obj := &corev1.Secret{}
+				client.Get(context.Background(), namespacedName, obj)
+
+				if obj.ResourceVersion != "1" {
+					t.Fatalf("secret should not have been updated; expected ResourceVersion 1, got %s", obj.ResourceVersion)
+				}
+			},
+		},
+		{
+			name: "secret defined with StringData that differs triggers update",
+			createObj: &corev1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret-stringdata-update",
+					Namespace: "ns2",
+				},
+				Data: map[string][]byte{
+					"key": []byte("old-value"),
+				},
+			},
+			updateObj: &corev1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-secret-stringdata-update",
+					Namespace:       "ns2",
+					ResourceVersion: "1",
+				},
+				StringData: map[string]string{
+					"key": "new-value",
+				},
+			},
+			validateResults: func(client client.Client) {
+				namespacedName := types.NamespacedName{
+					Name:      "test-secret-stringdata-update",
+					Namespace: "ns2",
+				}
+				obj := &corev1.Secret{}
+				client.Get(context.Background(), namespacedName, obj)
+
+				if string(obj.Data["key"]) != "new-value" {
+					t.Fatalf("secret was not updated; expected value 'new-value', got %s", string(obj.Data["key"]))
+				}
+				// In fake client, ResourceVersion might not increment automatically on Update if not configured,
+				// but it should at least match the updated data.
 			},
 		},
 		{

--- a/operators/pkg/deploying/deployer_test.go
+++ b/operators/pkg/deploying/deployer_test.go
@@ -124,7 +124,7 @@ func TestDeploy(t *testing.T) {
 				obj := &appsv1.Deployment{}
 				client.Get(context.Background(), namespacedName, obj)
 
-				if len(obj.ObjectMeta.GetLabels()) != 0 {
+				if len(obj.ObjectMeta.GetLabels()) == 0 {
 					t.Fatalf("should not update the deployment")
 				}
 			},

--- a/operators/pkg/deploying/deployer_test.go
+++ b/operators/pkg/deploying/deployer_test.go
@@ -18,6 +18,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -168,6 +169,159 @@ func TestDeploy(t *testing.T) {
 
 				if *obj.Spec.Replicas != 2 {
 					t.Fatalf("fail to update the statefulset")
+				}
+			},
+		},
+		{
+			// volumeClaimTemplates are immutable; storage-size changes are handled by
+			// HandleStorageSizeChange (PVC resize + STS delete/recreate). The deployer must
+			// NOT attempt to update volumeClaimTemplates itself to avoid API rejections.
+			name: "statefulset volumeClaimTemplates change does not trigger update",
+			createObj: &appsv1.StatefulSet{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sts-pvc",
+					Namespace: "ns1",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: &replicas1,
+					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+						{ObjectMeta: metav1.ObjectMeta{Name: "data"}, Spec: corev1.PersistentVolumeClaimSpec{
+							Resources: corev1.VolumeResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceStorage: func() resource.Quantity {
+										q, _ := resource.ParseQuantity("10Gi")
+										return q
+									}(),
+								},
+							},
+						}},
+					},
+				},
+			},
+			updateObj: &appsv1.StatefulSet{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-sts-pvc",
+					Namespace:       "ns1",
+					ResourceVersion: "1",
+				},
+				// Only replicas changed; VolumeClaimTemplates storage size changed to 3Gi
+				// (simulating what MCO desires after alertmanagerStorageSize update).
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: &replicas1,
+					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+						{ObjectMeta: metav1.ObjectMeta{Name: "data"}, Spec: corev1.PersistentVolumeClaimSpec{
+							Resources: corev1.VolumeResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceStorage: func() resource.Quantity {
+										q, _ := resource.ParseQuantity("3Gi")
+										return q
+									}(),
+								},
+							},
+						}},
+					},
+				},
+			},
+			validateResults: func(client client.Client) {
+				namespacedName := types.NamespacedName{Name: "test-sts-pvc", Namespace: "ns1"}
+				obj := &appsv1.StatefulSet{}
+				client.Get(context.Background(), namespacedName, obj)
+				// The deployer must NOT have updated the VolumeClaimTemplates;
+				// the original 10Gi value must remain (storage resize is done externally).
+				got := obj.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage]
+				expected, _ := resource.ParseQuantity("10Gi")
+				if !got.Equal(expected) {
+					t.Fatalf("deployer must not update volumeClaimTemplates; got %s, want 10Gi", got.String())
+				}
+			},
+		},
+		{
+			name: "statefulset update merges desired labels into runtime (preserves user labels)",
+			createObj: &appsv1.StatefulSet{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sts-labels",
+					Namespace: "ns1",
+					Labels:    map[string]string{"user-label": "user-value"},
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: &replicas1},
+			},
+			updateObj: &appsv1.StatefulSet{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-sts-labels",
+					Namespace:       "ns1",
+					ResourceVersion: "1",
+					// Desired state has an MCO-managed label but NOT the user label.
+					Labels: map[string]string{"mco-label": "mco-value"},
+				},
+				Spec: appsv1.StatefulSetSpec{Replicas: &replicas2},
+			},
+			validateResults: func(client client.Client) {
+				namespacedName := types.NamespacedName{Name: "test-sts-labels", Namespace: "ns1"}
+				obj := &appsv1.StatefulSet{}
+				client.Get(context.Background(), namespacedName, obj)
+				labels := obj.GetLabels()
+				if labels["mco-label"] != "mco-value" {
+					t.Fatalf("desired mco-label not applied; labels: %v", labels)
+				}
+				if labels["user-label"] != "user-value" {
+					t.Fatalf("user-label was removed; labels: %v", labels)
+				}
+			},
+		},
+		{
+			name: "deployment update merges desired labels into runtime (preserves user labels)",
+			createObj: &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deploy-labels",
+					Namespace: "ns1",
+					Labels:    map[string]string{"user-label": "user-value"},
+				},
+				Spec: appsv1.DeploymentSpec{Replicas: &replicas1},
+			},
+			updateObj: &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-deploy-labels",
+					Namespace:       "ns1",
+					ResourceVersion: "1",
+					// Desired state has an MCO-managed label but NOT the user label.
+					Labels: map[string]string{"mco-label": "mco-value"},
+				},
+				Spec: appsv1.DeploymentSpec{Replicas: &replicas2},
+			},
+			validateResults: func(client client.Client) {
+				namespacedName := types.NamespacedName{Name: "test-deploy-labels", Namespace: "ns1"}
+				obj := &appsv1.Deployment{}
+				client.Get(context.Background(), namespacedName, obj)
+				labels := obj.GetLabels()
+				if labels["mco-label"] != "mco-value" {
+					t.Fatalf("desired mco-label not applied; labels: %v", labels)
+				}
+				if labels["user-label"] != "user-value" {
+					t.Fatalf("user-label was removed; labels: %v", labels)
 				}
 			},
 		},


### PR DESCRIPTION
### What this PR does / why we need it:

This PR resolves a set of infinite reconciliation loops in the `Deployer` component that were silently consuming operator CPU and generating excessive API server traffic. The loops were caused by subtle failures in `equality.Semantic.DeepDerivative` across two distinct resource types:

**1. Workload Specs (Deployments, StatefulSets, Services)**
When parsed from Kustomize templates, missing fields in typed Go structs (e.g., `TimeoutSeconds: 0`) are zero-initialized. When compared against the runtime state, the cluster injects defaults (e.g., `timeoutSeconds: 1`). Because custom equality functions often bypass `DeepDerivative`'s zero-value-ignore logic, the operator continually detected a false drift. 
**Fix:** We now evaluate semantic equality against the `unstructured` maps for the `Spec` fields. This preserves the "missing key" state, allowing `DeepDerivative` to correctly ignore cluster-side defaults that are not explicitly managed by our manifests.

**2. Secrets with `StringData`**
Historically, secrets generated with `stringData` (like `grafana-config`) caused an infinite loop because their Go struct `Data` property evaluates to `nil`. A legacy hack attempted to bypass this by unconditionally forcing an update if `desiredSecret.Data == nil`. The Kube API accepted the update, converted the `stringData` to `data`, detected no actual byte changes, and dropped the update without bumping the `ResourceVersion`, leaving the operator in a perpetual "silent" retry loop.
**Fix:** We removed the hack and now explicitly convert `StringData` to `Data` in memory prior to the `DeepDerivative` check, accurately aligning our desired state representation with the API server's runtime representation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable update detection by using generation-based checks.
  * Secret handling improved to avoid unnecessary update loops when server converts stringData.

* **Refactor**
  * Unified, map-based comparison and metadata-merge approach for Deployments, StatefulSets, and Services to preserve user-managed fields while applying desired changes.

* **Tests**
  * Expanded and adjusted tests covering label-merge behavior, volumeClaimTemplates, and secret update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->