### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/collectors/metrics/Dockerfile.art
+++ b/collectors/metrics/Dockerfile.art
@@ -1,0 +1,62 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+WORKDIR /workspace
+COPY go.sum go.mod ./
+COPY ./collectors/metrics ./collectors/metrics
+COPY ./operators/pkg ./operators/pkg
+COPY ./operators/multiclusterobservability/api ./operators/multiclusterobservability/api
+RUN CGO_ENABLED=1 GOFLAGS="" GOEXPERIMENT=strictfipsruntime go build -a -installsuffix cgo -v -o metrics-collector ./collectors/metrics/cmd/metrics-collector/main.go
+
+# IMPORTANT: When changing base image RHEL version (ubi9 → ubi10):
+# 1. Update FROM statement below
+# 2. Update 'name' label to match new destination repo (rhel9 → rhel10)
+# 3. Update 'cpe' label with correct RHEL version (::el9 → ::el10)
+# 4. Verify destination repository exists in registry.redhat.io
+# 5. Run 'make verify-containerfile-labels' to check consistency
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+ARG vcs_ref
+ARG VCS_URL
+ARG IMAGE_DESCRIPTION
+ARG IMAGE_DISPLAY_NAME
+ARG IMAGE_NAME_ARCH
+ARG IMAGE_MAINTAINER
+ARG IMAGE_VENDOR
+ARG IMAGE_VERSION
+ARG IMAGE_RELEASE
+ARG IMAGE_SUMMARY
+ARG IMAGE_OPENSHIFT_TAGS
+
+LABEL org.label-schema.vendor="Red Hat" \
+    com.redhat.component="metrics-collector" \
+    org.label-schema.name="$IMAGE_NAME_ARCH" \
+    org.label-schema.description="$IMAGE_DESCRIPTION" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url=$VCS_URL \
+    org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+    org.label-schema.schema-version="1.0" \
+    name="rhacm2/metrics-collector-rhel9" \
+    cpe="cpe:/a:redhat:acm:2.16::el9" \
+    maintainer="$IMAGE_MAINTAINER" \
+    version="$IMAGE_VERSION" \
+    release="$IMAGE_RELEASE" \
+    description="$IMAGE_DESCRIPTION" \
+    summary="$IMAGE_SUMMARY" \
+    io.k8s.display-name="$IMAGE_DISPLAY_NAME" \
+    io.k8s.description="$IMAGE_DESCRIPTION" \
+    io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
+
+USER 1001:1001
+
+COPY --from=builder /workspace/metrics-collector /usr/bin/
+
+# standalone required parameters
+ENV FROM_CA_FILE="/from/service-ca.crt"
+ENV INTERVAL="60s"
+ENV MATCH_FILE="/metrics/match-file"
+ENV LIMIT_BYTES=1073741824
+
+CMD ["/bin/bash", "-c", "/usr/bin/metrics-collector --from ${FROM} --from-ca-file ${FROM_CA_FILE} --from-token ${FROM_TOKEN} --to-upload ${TO_UPLOAD} --id ${TENANT_ID} --label cluster=${CLUSTER_NAME} --label clusterID=${CLUSTER_ID} --match-file ${MATCH_FILE} --interval ${INTERVAL} --limit-bytes=${LIMIT_BYTES}"]

--- a/loaders/dashboards/Dockerfile.art
+++ b/loaders/dashboards/Dockerfile.art
@@ -1,0 +1,59 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+WORKDIR /workspace
+COPY go.sum go.mod ./loaders/dashboards ./
+COPY ./loaders/dashboards ./loaders/dashboards
+
+RUN CGO_ENABLED=1 GOFLAGS="" GOEXPERIMENT=strictfipsruntime go build -a -installsuffix cgo -v -o main loaders/dashboards/cmd/main.go
+
+# IMPORTANT: When changing base image RHEL version (ubi9 → ubi10):
+# 1. Update FROM statement below
+# 2. Update 'name' label to match new destination repo (rhel9 → rhel10)
+# 3. Update 'cpe' label with correct RHEL version (::el9 → ::el10)
+# 4. Verify destination repository exists in registry.redhat.io
+# 5. Run 'make verify-containerfile-labels' to check consistency
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+ARG VCS_REF
+ARG VCS_URL
+ARG IMAGE_DESCRIPTION
+ARG IMAGE_DISPLAY_NAME
+ARG IMAGE_NAME_ARCH
+ARG IMAGE_MAINTAINER
+ARG IMAGE_VENDOR
+ARG IMAGE_VERSION
+ARG IMAGE_RELEASE
+ARG IMAGE_SUMMARY
+ARG IMAGE_OPENSHIFT_TAGS
+
+LABEL org.label-schema.vendor="Red Hat" \
+    com.redhat.component="grafana-dashboard" \
+    org.label-schema.name="$IMAGE_NAME_ARCH" \
+    org.label-schema.description="$IMAGE_DESCRIPTION" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url=$VCS_URL \
+    org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+    org.label-schema.schema-version="1.0" \
+    name="rhacm2/grafana-dashboard-loader-rhel9" \
+    cpe="cpe:/a:redhat:acm:2.16::el9" \
+    maintainer="$IMAGE_MAINTAINER" \
+    version="$IMAGE_VERSION" \
+    release="$IMAGE_RELEASE" \
+    description="$IMAGE_DESCRIPTION" \
+    summary="$IMAGE_SUMMARY" \
+    io.k8s.display-name="$IMAGE_DISPLAY_NAME" \
+    io.k8s.description="$IMAGE_DESCRIPTION" \
+    io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
+
+WORKDIR /
+
+USER 1001:1001
+
+COPY --from=builder /workspace/main grafana-dashboard-loader
+
+EXPOSE 3002
+
+ENTRYPOINT ["/grafana-dashboard-loader"]

--- a/operators/endpointmetrics/Dockerfile.art
+++ b/operators/endpointmetrics/Dockerfile.art
@@ -1,0 +1,66 @@
+# Copyright (c) 2021 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project.
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+WORKDIR /workspace
+COPY go.sum go.mod ./
+COPY ./operators/endpointmetrics ./operators/endpointmetrics
+COPY ./operators/multiclusterobservability/api ./operators/multiclusterobservability/api
+COPY ./operators/multiclusterobservability/pkg/config ./operators/multiclusterobservability/pkg/config
+COPY ./operators/pkg ./operators/pkg
+
+RUN CGO_ENABLED=1 GOFLAGS="" GOEXPERIMENT=strictfipsruntime go build -a -installsuffix cgo -o build/_output/bin/endpoint-monitoring-operator operators/endpointmetrics/main.go
+RUN CGO_ENABLED=1 GOFLAGS="" GOEXPERIMENT=strictfipsruntime go build -a -installsuffix cgo -o build/_output/bin/cmo-config-revert operators/endpointmetrics/cmd/cmo-config-revert/main.go
+
+# IMPORTANT: When changing base image RHEL version (ubi9 → ubi10):
+# 1. Update FROM statement below
+# 2. Update 'name' label to match new destination repo (rhel9 → rhel10)
+# 3. Update 'cpe' label with correct RHEL version (::el9 → ::el10)
+# 4. Verify destination repository exists in registry.redhat.io
+# 5. Run 'make verify-containerfile-labels' to check consistency
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+ARG VCS_REF
+ARG VCS_URL
+ARG IMAGE_DESCRIPTION
+ARG IMAGE_DISPLAY_NAME
+ARG IMAGE_NAME_ARCH
+ARG IMAGE_MAINTAINER
+ARG IMAGE_VENDOR
+ARG IMAGE_VERSION
+ARG IMAGE_RELEASE
+ARG IMAGE_SUMMARY
+ARG IMAGE_OPENSHIFT_TAGS
+
+LABEL org.label-schema.vendor="Red Hat" \
+    com.redhat.component="endpoint-monitoring-operator" \
+    org.label-schema.name="$IMAGE_NAME_ARCH" \
+    org.label-schema.description="$IMAGE_DESCRIPTION" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url=$VCS_URL \
+    org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+    org.label-schema.schema-version="1.0" \
+    name="rhacm2/endpoint-monitoring-rhel9-operator" \
+    cpe="cpe:/a:redhat:acm:2.16::el9" \
+    maintainer="$IMAGE_MAINTAINER" \
+    version="$IMAGE_VERSION" \
+    release="$IMAGE_RELEASE" \
+    description="$IMAGE_DESCRIPTION" \
+    summary="$IMAGE_SUMMARY" \
+    io.k8s.display-name="$IMAGE_DISPLAY_NAME" \
+    io.k8s.description="$IMAGE_DESCRIPTION" \
+    io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
+
+ENV OPERATOR=/usr/local/bin/endpoint-monitoring-operator \
+    USER_UID=1001 \
+    USER_NAME=endpoint-monitoring-operator
+
+COPY ./operators/endpointmetrics/manifests /usr/local/manifests
+
+# install operator binary
+COPY --from=builder /workspace/build/_output/bin/endpoint-monitoring-operator ${OPERATOR}
+# install cmo-config-revert binary
+COPY --from=builder /workspace/build/_output/bin/cmo-config-revert cmo-config-revert
+
+USER ${USER_UID}
+ENTRYPOINT ["/usr/local/bin/endpoint-monitoring-operator"]

--- a/operators/multiclusterobservability/Dockerfile.art
+++ b/operators/multiclusterobservability/Dockerfile.art
@@ -1,0 +1,67 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+WORKDIR /workspace
+COPY go.sum go.mod ./
+COPY ./operators/multiclusterobservability ./operators/multiclusterobservability
+COPY ./operators/pkg ./operators/pkg
+
+RUN CGO_ENABLED=1 GOFLAGS="" GOEXPERIMENT=strictfipsruntime go build -a -installsuffix cgo -o bin/manager operators/multiclusterobservability/main.go
+
+# IMPORTANT: When changing base image RHEL version (ubi9 → ubi10):
+# 1. Update FROM statement below
+# 2. Update 'name' label to match new destination repo (rhel9 → rhel10)
+# 3. Update 'cpe' label with correct RHEL version (::el9 → ::el10)
+# 4. Verify destination repository exists in registry.redhat.io
+# 5. Run 'make verify-containerfile-labels' to check consistency
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+ARG VCS_REF
+ARG VCS_URL
+ARG IMAGE_DESCRIPTION
+ARG IMAGE_DISPLAY_NAME
+ARG IMAGE_NAME_ARCH
+ARG IMAGE_MAINTAINER
+ARG IMAGE_VENDOR
+ARG IMAGE_VERSION
+ARG IMAGE_RELEASE
+ARG IMAGE_SUMMARY
+ARG IMAGE_OPENSHIFT_TAGS
+
+LABEL org.label-schema.vendor="Red Hat" \
+    com.redhat.component="mco" \
+    org.label-schema.name="$IMAGE_NAME_ARCH" \
+    org.label-schema.description="$IMAGE_DESCRIPTION" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url=$VCS_URL \
+    org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+    org.label-schema.schema-version="1.0" \
+    name="rhacm2/multicluster-observability-rhel9-operator" \
+    cpe="cpe:/a:redhat:acm:2.16::el9" \
+    maintainer="$IMAGE_MAINTAINER" \
+    version="$IMAGE_VERSION" \
+    release="$IMAGE_RELEASE" \
+    description="$IMAGE_DESCRIPTION" \
+    summary="$IMAGE_SUMMARY" \
+    io.k8s.display-name="$IMAGE_DISPLAY_NAME" \
+    io.k8s.description="$IMAGE_DESCRIPTION" \
+    io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
+
+ENV OPERATOR=/usr/local/bin/mco-operator \
+    USER_UID=1001 \
+    USER_NAME=mco
+
+
+# install templates
+COPY ./operators/multiclusterobservability/manifests /usr/local/manifests
+
+# install the prestop script
+COPY ./operators/multiclusterobservability/prestop.sh /usr/local/bin/prestop.sh
+
+# install operator binary
+COPY --from=builder /workspace/bin/manager ${OPERATOR}
+USER ${USER_UID}
+
+ENTRYPOINT ["/usr/local/bin/mco-operator"]

--- a/proxy/Dockerfile.art
+++ b/proxy/Dockerfile.art
@@ -1,0 +1,58 @@
+# Copyright Contributors to the Open Cluster Management project
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+WORKDIR /workspace
+COPY go.sum go.mod ./
+COPY ./proxy ./proxy
+
+RUN CGO_ENABLED=1 GOFLAGS="" GOEXPERIMENT=strictfipsruntime go build -a -installsuffix cgo -v -o main proxy/cmd/main.go
+
+# IMPORTANT: When changing base image RHEL version (ubi9 → ubi10):
+# 1. Update FROM statement below
+# 2. Update 'name' label to match new destination repo (rhel9 → rhel10)
+# 3. Update 'cpe' label with correct RHEL version (::el9 → ::el10)
+# 4. Verify destination repository exists in registry.redhat.io
+# 5. Run 'make verify-containerfile-labels' to check consistency
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+ARG VCS_REF
+ARG VCS_URL
+ARG IMAGE_DESCRIPTION
+ARG IMAGE_DISPLAY_NAME
+ARG IMAGE_NAME_ARCH
+ARG IMAGE_MAINTAINER
+ARG IMAGE_VENDOR
+ARG IMAGE_VERSION
+ARG IMAGE_RELEASE
+ARG IMAGE_SUMMARY
+ARG IMAGE_OPENSHIFT_TAGS
+
+LABEL org.label-schema.vendor="RedHat" \
+    com.redhat.component="rbac-query-proxy" \
+    org.label-schema.name="$IMAGE_NAME_ARCH" \
+    org.label-schema.description="$IMAGE_DESCRIPTION" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url=$VCS_URL \
+    org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+    org.label-schema.schema-version="1.0" \
+    name="rhacm2/rbac-query-proxy-rhel9" \
+    cpe="cpe:/a:redhat:acm:2.16::el9" \
+    maintainer="$IMAGE_MAINTAINER" \
+    version="$IMAGE_VERSION" \
+    release="$IMAGE_RELEASE" \
+    description="$IMAGE_DESCRIPTION" \
+    summary="$IMAGE_SUMMARY" \
+    io.k8s.display-name="$IMAGE_DISPLAY_NAME" \
+    io.k8s.description="$IMAGE_DESCRIPTION" \
+    io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
+
+WORKDIR /
+
+USER 1001:1001
+
+COPY --from=builder /workspace/main rbac-query-proxy
+
+EXPOSE 3002
+
+ENTRYPOINT ["/rbac-query-proxy"]


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)