### PR TITLE
[RFE-9238] Restrict right-sizing policies to OpenShift clusters only

### DIFF
--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/placement.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/placement.go
@@ -16,11 +16,27 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetDefaultRSPlacement creates a default placement configuration for right-sizing
+// GetDefaultRSPlacement creates a default placement configuration for right-sizing.
+// Only OpenShift clusters are targeted because the policies enforce PrometheusRules
+// in openshift-monitoring, which does not exist on non-OpenShift distributions (e.g. AKS).
 func GetDefaultRSPlacement() clusterv1beta1.Placement {
 	return clusterv1beta1.Placement{
 		Spec: clusterv1beta1.PlacementSpec{
-			Predicates: []clusterv1beta1.ClusterPredicate{},
+			Predicates: []clusterv1beta1.ClusterPredicate{
+				{
+					RequiredClusterSelector: clusterv1beta1.ClusterSelector{
+						LabelSelector: metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "vendor",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"OpenShift"},
+								},
+							},
+						},
+					},
+				},
+			},
 			Tolerations: []clusterv1beta1.Toleration{
 				{
 					Key:      "cluster.open-cluster-management.io/unreachable",

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/placement_test.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/placement_test.go
@@ -19,8 +19,16 @@ import (
 func TestGetDefaultRSPlacement(t *testing.T) {
 	placement := GetDefaultRSPlacement()
 
-	assert.Empty(t, placement.Spec.Predicates)
+	assert.Len(t, placement.Spec.Predicates, 1)
 	assert.Len(t, placement.Spec.Tolerations, 2)
+
+	// Verify the vendor=OpenShift cluster selector
+	predicate := placement.Spec.Predicates[0]
+	matchExprs := predicate.RequiredClusterSelector.LabelSelector.MatchExpressions
+	assert.Len(t, matchExprs, 1)
+	assert.Equal(t, "vendor", matchExprs[0].Key)
+	assert.Equal(t, metav1.LabelSelectorOpIn, matchExprs[0].Operator)
+	assert.Equal(t, []string{"OpenShift"}, matchExprs[0].Values)
 
 	// Check tolerations
 	tolerations := placement.Spec.Tolerations


### PR DESCRIPTION
Restrict right-sizing policy Placement defaults to OpenShift clusters only (vendor=OpenShift) so that the rs-prom-rules-policy and rs-virt-prom-rules-policy policies are not deployed to non-OpenShift clusters (e.g. AKS) that lack the openshift-monitoring namespace and Prometheus CRDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Rightsizing analytics default placement now targets OpenShift clusters exclusively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->