### PR TITLE
[release-2.17] proxy: get user from JWT

### DIFF
--- a/proxy/pkg/proxy/proxy.go
+++ b/proxy/pkg/proxy/proxy.go
@@ -17,6 +17,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stolostron/multicluster-observability-operator/proxy/pkg/cache"
 	proxyconfig "github.com/stolostron/multicluster-observability-operator/proxy/pkg/config"
 	"github.com/stolostron/multicluster-observability-operator/proxy/pkg/health"
@@ -166,8 +167,8 @@ func (p *Proxy) preCheckRequest(req *http.Request) error {
 		userName, _ = p.userProjectInfo.GetUserName(token)
 	}
 
+	// If username is still missing, try to fetch it from the API.
 	var c client.Client
-	// If username is still missing, fetch it from the API.
 	if userName == "" {
 		var err error
 		c, err = p.getKubeClientWithTokenFunc(token)
@@ -175,13 +176,23 @@ func (p *Proxy) preCheckRequest(req *http.Request) error {
 			return fmt.Errorf("failed to get kube client: %w", err)
 		}
 
-		userName, err = util.GetUserName(req.Context(), c)
+		userName, _ = util.GetUserName(req.Context(), c)
+	}
+	// If username is still missing, final attempt to get a UID from the JWT
+	if userName == "" {
+		parsedToken, _, err := jwt.NewParser().ParseUnverified(token, jwt.MapClaims{})
 		if err != nil {
-			return fmt.Errorf("failed to get user name: %w", err)
+			return fmt.Errorf("unable to parse jwt to get username: %w", err)
 		}
-		if userName == "" {
-			return errors.New("failed to find user name")
+
+		userName, err = parsedToken.Claims.GetSubject()
+		if err != nil {
+			return fmt.Errorf("failed to get subject from jwt: %w", err)
 		}
+	}
+
+	if userName == "" {
+		return errors.New("failed to find user name")
 	}
 	req.Header.Set("X-Forwarded-User", userName)
 


### PR DESCRIPTION
This commit allows the proxy to get a user ID (subject/uuid) from the JWT auth token, if we fail to find the username from any other methods.

When external OIDC, we cannot query the OCP api for the username, since that api type doesn't exist in this case.

The JWT token contain a few different fields that can be used, but we use the `subject` as other fields such as `email` or `preferred_username` are less likely to be guaranteed to exist.