### PR TITLE
Add FIPS build flags to Dockerfile

### DIFF
--- a/collectors/metrics/Containerfile.operator
+++ b/collectors/metrics/Containerfile.operator
@@ -8,7 +8,7 @@ COPY go.sum go.mod ./
 COPY ./collectors/metrics ./collectors/metrics
 COPY ./operators/pkg ./operators/pkg
 COPY ./operators/multiclusterobservability/api ./operators/multiclusterobservability/api
-RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -v -o metrics-collector ./collectors/metrics/cmd/metrics-collector/main.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOFLAGS="" go build -a -installsuffix cgo -v -o metrics-collector ./collectors/metrics/cmd/metrics-collector/main.go
 
 # IMPORTANT: When changing base image RHEL version (ubi9 → ubi10):
 # 1. Update FROM statement below

--- a/loaders/dashboards/Containerfile.operator
+++ b/loaders/dashboards/Containerfile.operator
@@ -7,7 +7,7 @@ WORKDIR /workspace
 COPY go.sum go.mod ./loaders/dashboards ./
 COPY ./loaders/dashboards ./loaders/dashboards
 
-RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -v -o main loaders/dashboards/cmd/main.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOFLAGS="" go build -a -installsuffix cgo -v -o main loaders/dashboards/cmd/main.go
 
 # IMPORTANT: When changing base image RHEL version (ubi9 → ubi10):
 # 1. Update FROM statement below

--- a/operators/endpointmetrics/Containerfile.operator
+++ b/operators/endpointmetrics/Containerfile.operator
@@ -9,8 +9,8 @@ COPY ./operators/multiclusterobservability/api ./operators/multiclusterobservabi
 COPY ./operators/multiclusterobservability/pkg/config ./operators/multiclusterobservability/pkg/config
 COPY ./operators/pkg ./operators/pkg
 
-RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -o build/_output/bin/endpoint-monitoring-operator operators/endpointmetrics/main.go
-RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -o build/_output/bin/cmo-config-revert operators/endpointmetrics/cmd/cmo-config-revert/main.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOFLAGS="" go build -a -installsuffix cgo -o build/_output/bin/endpoint-monitoring-operator operators/endpointmetrics/main.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOFLAGS="" go build -a -installsuffix cgo -o build/_output/bin/cmo-config-revert operators/endpointmetrics/cmd/cmo-config-revert/main.go
 
 # IMPORTANT: When changing base image RHEL version (ubi9 → ubi10):
 # 1. Update FROM statement below

--- a/operators/multiclusterobservability/Containerfile.operator
+++ b/operators/multiclusterobservability/Containerfile.operator
@@ -8,7 +8,7 @@ COPY go.sum go.mod ./
 COPY ./operators/multiclusterobservability ./operators/multiclusterobservability
 COPY ./operators/pkg ./operators/pkg
 
-RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -o bin/manager operators/multiclusterobservability/main.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOFLAGS="" go build -a -installsuffix cgo -o bin/manager operators/multiclusterobservability/main.go
 
 # IMPORTANT: When changing base image RHEL version (ubi9 → ubi10):
 # 1. Update FROM statement below

--- a/proxy/Containerfile.operator
+++ b/proxy/Containerfile.operator
@@ -6,7 +6,7 @@ WORKDIR /workspace
 COPY go.sum go.mod ./
 COPY ./proxy ./proxy
 
-RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -v -o main proxy/cmd/main.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOFLAGS="" go build -a -installsuffix cgo -v -o main proxy/cmd/main.go
 
 # IMPORTANT: When changing base image RHEL version (ubi9 → ubi10):
 # 1. Update FROM statement below


### PR DESCRIPTION
Add CGO_ENABLED=1 and GOEXPERIMENT=strictfipsruntime to go build, make, and promu build lines for FIPS compliance.

JIRA: HYPBLD-847