### PR TITLE
[release-2.17] [ACM-30763] Handle storage class changes in MCO CR

### DIFF
--- a/operators/multiclusterobservability/api/v1beta1/multiclusterobservability_types.go
+++ b/operators/multiclusterobservability/api/v1beta1/multiclusterobservability_types.go
@@ -109,7 +109,6 @@ type StorageConfigObject struct {
 	// StorageClass used by Observability StatefulSets (Thanos store, ruler, compactor, receiver)
 	// and, when no object storage is configured, the object storage PVC.
 	// +optional
-	// +kubebuilder:default:=gp2
 	StatefulSetStorageClass string `json:"statefulSetStorageClass,omitempty"`
 }
 

--- a/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
+++ b/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
@@ -575,7 +575,6 @@ type StorageConfig struct {
 	// be used for Object Storage if MetricObjectStorage was configured for
 	// the system to create the storage.
 	// +optional
-	// +kubebuilder:default:=gp2
 	StorageClass string `json:"storageClass,omitempty"`
 	// The amount of storage applied to alertmanager stateful sets,
 	// +optional

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -251,7 +251,6 @@ spec:
                       Thanos store, Rule, compact and receiver.
                     type: string
                   statefulSetStorageClass:
-                    default: gp2
                     description: |-
                       StorageClass used by Observability StatefulSets (Thanos store, ruler, compactor, receiver)
                       and, when no object storage is configured, the object storage PVC.
@@ -11073,7 +11072,6 @@ spec:
                       sets,
                     type: string
                   storageClass:
-                    default: gp2
                     description: |-
                       Specify the storageClass Stateful Sets. This storage class will also
                       be used for Object Storage if MetricObjectStorage was configured for

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -234,7 +234,6 @@ spec:
                       Thanos store, Rule, compact and receiver.
                     type: string
                   statefulSetStorageClass:
-                    default: gp2
                     description: |-
                       StorageClass used by Observability StatefulSets (Thanos store, ruler, compactor, receiver)
                       and, when no object storage is configured, the object storage PVC.
@@ -11058,7 +11057,6 @@ spec:
                       sets,
                     type: string
                   storageClass:
-                    default: gp2
                     description: |-
                       Specify the storageClass Stateful Sets. This storage class will also
                       be used for Object Storage if MetricObjectStorage was configured for

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -71,26 +71,22 @@ const (
 )
 
 var (
-	log                              = logf.Log.WithName("controller_multiclustermonitoring")
-	isAlertmanagerStorageSizeChanged = false
-	isCompactStorageSizeChanged      = false
-	isRuleStorageSizeChanged         = false
-	isReceiveStorageSizeChanged      = false
-	isStoreStorageSizeChanged        = false
-	isLegacyResourceRemoved          = false
-	lastLogTime                      = time.Now()
+	log                     = logf.Log.WithName("controller_multiclustermonitoring")
+	isLegacyResourceRemoved = false
+	lastLogTime             = time.Now()
 )
 
 // MultiClusterObservabilityReconciler reconciles a MultiClusterObservability object
 type MultiClusterObservabilityReconciler struct {
-	Manager     manager.Manager
-	Client      client.Client
-	Log         logr.Logger
-	Scheme      *runtime.Scheme
-	CRDMap      map[string]bool
-	APIReader   client.Reader
-	RESTMapper  meta.RESTMapper
-	ImageClient imagev1client.ImageV1Interface
+	Manager           manager.Manager
+	Client            client.Client
+	Log               logr.Logger
+	Scheme            *runtime.Scheme
+	CRDMap            map[string]bool
+	APIReader         client.Reader
+	RESTMapper        meta.RESTMapper
+	ImageClient       imagev1client.ImageV1Interface
+	LastStorageConfig *mcov1beta2.StorageConfig
 }
 
 // +kubebuilder:rbac:groups=observability.open-cluster-management.io,resources=multiclusterobservabilities,verbs=get;list;watch;create;update;patch;delete
@@ -218,13 +214,13 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 		}
 	}
 
-	storageClassSelected, err := getStorageClass(instance, r.Client)
+	storageClassSelected, err := getStorageClass(ctx, instance, r.Client)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get storage class: %w", err)
 	}
 
 	// handle storagesize changes
-	result, err := r.HandleStorageSizeChange(instance)
+	result, err := r.HandleStorageSizeChange(ctx, instance)
 	if result != nil {
 		// If err is non-nil, wrap it. fmt.Errorf with %w handles nil err gracefully (returns nil).
 		return *result, fmt.Errorf("error during storage size change handling: %w", err)
@@ -408,7 +404,7 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	}
 
 	// create an Observatorium CR
-	result, err = GenerateObservatoriumCR(r.Client, r.Scheme, instance)
+	result, err = GenerateObservatoriumCR(ctx, r.Client, r.Scheme, instance)
 	if result != nil {
 		return *result, fmt.Errorf("failed to generate the observatorium CR: %w", err)
 	}
@@ -494,12 +490,11 @@ func (r *MultiClusterObservabilityReconciler) initFinalization(ctx context.Conte
 	return false, nil
 }
 
-// getStorageClass resolves the storage class to use for MCO persistent volumes.
-func getStorageClass(mco *mcov1beta2.MultiClusterObservability, cl client.Client) (string, error) {
+func getStorageClass(ctx context.Context, mco *mcov1beta2.MultiClusterObservability, cl client.Client) (string, error) {
 	storageClassSelected := mco.Spec.StorageConfig.StorageClass
 	// for the test, the reader is just nil
 	storageClassList := &storev1.StorageClassList{}
-	err := cl.List(context.TODO(), storageClassList, &client.ListOptions{})
+	err := cl.List(ctx, storageClassList, &client.ListOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -629,96 +624,120 @@ func (r *MultiClusterObservabilityReconciler) SetupWithManager(mgr ctrl.Manager)
 	return ctrBuilder.Complete(r)
 }
 
-// checkStorageChanged detects storage configuration changes between old and new MCO specs.
-func checkStorageChanged(mcoOldConfig, mcoNewConfig *mcov1beta2.StorageConfig) {
-	if mcoOldConfig.AlertmanagerStorageSize != mcoNewConfig.AlertmanagerStorageSize {
-		isAlertmanagerStorageSizeChanged = true
-	}
-	if mcoOldConfig.CompactStorageSize != mcoNewConfig.CompactStorageSize {
-		isCompactStorageSizeChanged = true
-	}
-	if mcoOldConfig.RuleStorageSize != mcoNewConfig.RuleStorageSize {
-		isRuleStorageSizeChanged = true
-	}
-	if mcoOldConfig.ReceiveStorageSize != mcoNewConfig.ReceiveStorageSize {
-		isReceiveStorageSizeChanged = true
-	}
-	if mcoOldConfig.StoreStorageSize != mcoNewConfig.StoreStorageSize {
-		isStoreStorageSizeChanged = true
-	}
-}
-
-// HandleStorageSizeChange is used to deal with the storagesize change in CR
-// 1. Directly changed the StatefulSet pvc's size on the pvc itself for
-// 2. Removed StatefulSet and
-// wait for operator to re-create the StatefulSet with the correct size on the claim
+// HandleStorageSizeChange compares the current storage config against the last known config
+// and handles any changes:
+// 1. For storage size changes: updates PVC sizes directly and deletes StatefulSets for re-creation
+// 2. For storage class changes: deletes StatefulSets and PVCs for re-creation with the new class
 func (r *MultiClusterObservabilityReconciler) HandleStorageSizeChange(
+	ctx context.Context,
 	mco *mcov1beta2.MultiClusterObservability,
 ) (*reconcile.Result, error) {
-	if isAlertmanagerStorageSizeChanged {
-		isAlertmanagerStorageSizeChanged = false
-		err := updateStorageSizeChange(r.Client,
+	currentConfig := mco.Spec.StorageConfig
+	lastConfig := r.LastStorageConfig
+
+	// On first reconcile there is no previous config to compare against
+	if lastConfig == nil {
+		r.LastStorageConfig = currentConfig.DeepCopy()
+		return nil, nil
+	}
+
+	if lastConfig.AlertmanagerStorageSize != currentConfig.AlertmanagerStorageSize {
+		err := updateStorageSizeChange(ctx, r.Client,
 			map[string]string{
 				"observability.open-cluster-management.io/name": mco.GetName(),
 				"alertmanager": "observability",
-			}, mco.Spec.StorageConfig.AlertmanagerStorageSize)
+			}, currentConfig.AlertmanagerStorageSize)
 		if err != nil {
 			return &reconcile.Result{}, err
 		}
 	}
 
-	if isReceiveStorageSizeChanged {
-		isReceiveStorageSizeChanged = false
-		err := updateStorageSizeChange(r.Client,
+	if lastConfig.ReceiveStorageSize != currentConfig.ReceiveStorageSize {
+		err := updateStorageSizeChange(ctx, r.Client,
 			map[string]string{
 				"app.kubernetes.io/instance": mco.GetName(),
 				"app.kubernetes.io/name":     "thanos-receive",
-			}, mco.Spec.StorageConfig.ReceiveStorageSize)
+			}, currentConfig.ReceiveStorageSize)
 		if err != nil {
 			return &reconcile.Result{}, err
 		}
 	}
 
-	if isCompactStorageSizeChanged {
-		isCompactStorageSizeChanged = false
-		err := updateStorageSizeChange(r.Client,
+	if lastConfig.CompactStorageSize != currentConfig.CompactStorageSize {
+		err := updateStorageSizeChange(ctx, r.Client,
 			map[string]string{
 				"app.kubernetes.io/instance": mco.GetName(),
 				"app.kubernetes.io/name":     "thanos-compact",
-			}, mco.Spec.StorageConfig.CompactStorageSize)
+			}, currentConfig.CompactStorageSize)
 		if err != nil {
 			return &reconcile.Result{}, err
 		}
 	}
 
-	if isRuleStorageSizeChanged {
-		isRuleStorageSizeChanged = false
-		err := updateStorageSizeChange(r.Client,
+	if lastConfig.RuleStorageSize != currentConfig.RuleStorageSize {
+		err := updateStorageSizeChange(ctx, r.Client,
 			map[string]string{
 				"app.kubernetes.io/instance": mco.GetName(),
 				"app.kubernetes.io/name":     "thanos-rule",
-			}, mco.Spec.StorageConfig.RuleStorageSize)
+			}, currentConfig.RuleStorageSize)
 		if err != nil {
 			return &reconcile.Result{}, err
 		}
 	}
 
-	if isStoreStorageSizeChanged {
-		isStoreStorageSizeChanged = false
-		err := updateStorageSizeChange(r.Client,
+	if lastConfig.StoreStorageSize != currentConfig.StoreStorageSize {
+		err := updateStorageSizeChange(ctx, r.Client,
 			map[string]string{
 				"app.kubernetes.io/instance": mco.GetName(),
 				"app.kubernetes.io/name":     "thanos-store",
-			}, mco.Spec.StorageConfig.StoreStorageSize)
+			}, currentConfig.StoreStorageSize)
 		if err != nil {
 			return &reconcile.Result{}, err
 		}
 	}
+
+	if lastConfig.StorageClass != currentConfig.StorageClass {
+		for _, component := range []map[string]string{
+			{"observability.open-cluster-management.io/name": mco.GetName(), "alertmanager": "observability"},
+			{"app.kubernetes.io/instance": mco.GetName(), "app.kubernetes.io/name": "thanos-receive"},
+			{"app.kubernetes.io/instance": mco.GetName(), "app.kubernetes.io/name": "thanos-compact"},
+			{"app.kubernetes.io/instance": mco.GetName(), "app.kubernetes.io/name": "thanos-rule"},
+			{"app.kubernetes.io/instance": mco.GetName(), "app.kubernetes.io/name": "thanos-store"},
+		} {
+			if err := deleteStatefulSetsAndPVCs(ctx, r.Client, component); err != nil {
+				return &reconcile.Result{}, err
+			}
+		}
+	}
+	r.LastStorageConfig = currentConfig.DeepCopy()
 	return nil, nil
 }
 
-// updateStorageSizeChange updates PVC sizes for matching persistent volume claims.
-func updateStorageSizeChange(c client.Client, matchLabels map[string]string, storageSize string) error {
+func deleteStatefulSetsAndPVCs(ctx context.Context, c client.Client, matchLabels map[string]string) error {
+	stsList, err := commonutil.GetStatefulSetList(c, config.GetDefaultNamespace(), matchLabels)
+	if err != nil {
+		return err
+	}
+	for index, sts := range stsList {
+		if err := c.Delete(ctx, &stsList[index]); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		log.Info("Deleted StatefulSet due to storage class change", "sts", sts.Name)
+	}
+	pvcList, err := commonutil.GetPVCList(c, config.GetDefaultNamespace(), matchLabels)
+	if err != nil {
+		return err
+	}
+	for index, pvc := range pvcList {
+		if err := c.Delete(ctx, &pvcList[index]); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		log.Info("Deleted PVC due to storage class change", "pvc", pvc.Name)
+	}
+	return nil
+}
+
+func updateStorageSizeChange(ctx context.Context, c client.Client, matchLabels map[string]string, storageSize string) error {
 	pvcList, err := commonutil.GetPVCList(c, config.GetDefaultNamespace(), matchLabels)
 	if err != nil {
 		return err
@@ -730,21 +749,28 @@ func updateStorageSizeChange(c client.Client, matchLabels map[string]string, sto
 	}
 
 	// update pvc directly
+	newSize := resource.MustParse(storageSize)
 	for index, pvc := range pvcList {
-		if !pvc.Spec.Resources.Requests.Storage().Equal(resource.MustParse(storageSize)) {
-			pvcList[index].Spec.Resources.Requests = corev1.ResourceList{
-				corev1.ResourceStorage: resource.MustParse(storageSize),
-			}
-			err := c.Update(context.TODO(), &pvcList[index])
-			if err != nil {
-				return err
-			}
-			log.Info("Update storage size for PVC", "pvc", pvc.Name)
+		if pvc.Spec.Resources.Requests.Storage().Equal(newSize) {
+			continue
 		}
+		if currentCap := pvc.Status.Capacity.Storage(); currentCap != nil && newSize.Cmp(*currentCap) < 0 {
+			log.Info("Skipping PVC storage shrink: Kubernetes does not support reducing PVC size",
+				"pvc", pvc.Name, "currentCapacity", currentCap.String(), "requestedSize", storageSize)
+			continue
+		}
+		pvcList[index].Spec.Resources.Requests = corev1.ResourceList{
+			corev1.ResourceStorage: newSize,
+		}
+		err := c.Update(ctx, &pvcList[index])
+		if err != nil {
+			return err
+		}
+		log.Info("Update storage size for PVC", "pvc", pvc.Name)
 	}
 	// update sts
 	for index, sts := range stsList {
-		err := c.Delete(context.TODO(), &stsList[index], &client.DeleteOptions{})
+		err := c.Delete(ctx, &stsList[index], &client.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -5,6 +5,7 @@
 package multiclusterobservability
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -35,6 +36,7 @@ import (
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	storev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -361,6 +363,7 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	addonv1alpha1.AddToScheme(s)
 	migrationv1alpha1.SchemeBuilder.AddToScheme(s)
 	operatorv1.AddToScheme(s)
+	storev1.AddToScheme(s)
 
 	svc := createObservatoriumAPIService(name, namespace)
 	serverCACerts := newTestCert(config.ServerCACerts, namespace)
@@ -384,11 +387,12 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 		},
 	}
 	alertManagerRoute := newAlertManagerRoute()
+	gp2StorageClass := newStorageClass("gp2", true)
 
 	objs := []runtime.Object{
 		mco, svc, serverCACerts, clientCACerts, proxyRouteBYOCACerts, grafanaCert, serverCert,
 		testAmRouteBYOCaSecret, testAmRouteBYOCertSecret, proxyRouteBYOCert, clustermgmtAddon, extensionApiserverAuthenticationCM,
-		alertManagerRoute,
+		alertManagerRoute, gp2StorageClass,
 	}
 	// Create a fake client to mock API calls.
 	cl := fake.NewClientBuilder().
@@ -401,7 +405,7 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 		).
 		Build()
 
-		// Create fake imagestream client
+	// Create fake imagestream client
 	imageClient := &fakeimagev1client.FakeImageV1{Fake: &(fakeimageclient.NewSimpleClientset().Fake)}
 	_, err := imageClient.ImageStreams(config.OauthProxyImageStreamNamespace).Create(t.Context(),
 		&imagev1.ImageStream{
@@ -847,6 +851,7 @@ func TestImageReplaceForMCO(t *testing.T) {
 	addonv1alpha1.AddToScheme(s)
 	migrationv1alpha1.SchemeBuilder.AddToScheme(s)
 	operatorv1.AddToScheme(s)
+	storev1.AddToScheme(s)
 
 	observatoriumAPIsvc := createObservatoriumAPIService(name, namespace)
 	serverCACerts := newTestCert(config.ServerCACerts, namespace)
@@ -871,11 +876,12 @@ func TestImageReplaceForMCO(t *testing.T) {
 	}
 
 	alertManagerRoute := newAlertManagerRoute()
+	gp2StorageClass := newStorageClass("gp2", true)
 
 	objs := []runtime.Object{
 		mco, observatoriumAPIsvc, serverCACerts, clientCACerts, grafanaCert, serverCert,
 		testMCHInstance, imageManifestsCM, testAmRouteBYOCaSecret, testAmRouteBYOCertSecret, clustermgmtAddon, extensionApiserverAuthenticationCM,
-		alertManagerRoute,
+		alertManagerRoute, gp2StorageClass,
 	}
 	// Create a fake client to mock API calls.
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
@@ -1130,9 +1136,14 @@ func TestHandleStorageSizeChange(t *testing.T) {
 		createPersistentVolumeClaim(mco.Name, config.GetDefaultNamespace(), "test"),
 	}
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
-	r := &MultiClusterObservabilityReconciler{Client: c, Scheme: s}
-	isAlertmanagerStorageSizeChanged = true
-	r.HandleStorageSizeChange(mco)
+	r := &MultiClusterObservabilityReconciler{
+		Client: c,
+		Scheme: s,
+		LastStorageConfig: &mcov1beta2.StorageConfig{
+			AlertmanagerStorageSize: "1Gi",
+		},
+	}
+	r.HandleStorageSizeChange(context.TODO(), mco)
 
 	pvc := &corev1.PersistentVolumeClaim{}
 	err := c.Get(t.Context(), types.NamespacedName{
@@ -1147,6 +1158,170 @@ func TestHandleStorageSizeChange(t *testing.T) {
 	} else {
 		t.Errorf("update pvc failed: %v", err)
 	}
+}
+
+func TestGetStorageClass(t *testing.T) {
+	s := scheme.Scheme
+	mcov1beta2.SchemeBuilder.AddToScheme(s)
+	storev1.SchemeBuilder.AddToScheme(s)
+
+	tests := []struct {
+		name           string
+		mcoSC          string
+		storageClasses []runtime.Object
+		expectedSC     string
+	}{
+		{
+			name:  "configured SC exists on cluster",
+			mcoSC: "fast-storage",
+			storageClasses: []runtime.Object{
+				&storev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{Name: "fast-storage"},
+				},
+				&storev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "standard",
+						Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"},
+					},
+				},
+			},
+			expectedSC: "fast-storage",
+		},
+		{
+			name:  "configured SC does not exist, falls back to cluster default",
+			mcoSC: "gp2",
+			storageClasses: []runtime.Object{
+				&storev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "standard",
+						Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"},
+					},
+				},
+			},
+			expectedSC: "standard",
+		},
+		{
+			name:           "empty SC and no cluster default",
+			mcoSC:          "",
+			storageClasses: []runtime.Object{},
+			expectedSC:     "",
+		},
+		{
+			name:  "empty SC resolves to cluster default",
+			mcoSC: "",
+			storageClasses: []runtime.Object{
+				&storev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "gp3",
+						Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"},
+					},
+				},
+			},
+			expectedSC: "gp3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mco := &mcov1beta2.MultiClusterObservability{
+				Spec: mcov1beta2.MultiClusterObservabilitySpec{
+					StorageConfig: &mcov1beta2.StorageConfig{
+						StorageClass: tt.mcoSC,
+					},
+				},
+			}
+			objs := append([]runtime.Object{mco}, tt.storageClasses...)
+			c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
+			got, err := getStorageClass(context.TODO(), mco, c)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedSC, got)
+		})
+	}
+}
+
+func TestHandleStorageClassChange(t *testing.T) {
+	s := scheme.Scheme
+	mcov1beta2.SchemeBuilder.AddToScheme(s)
+
+	mco := &mcov1beta2.MultiClusterObservability{
+		TypeMeta:   metav1.TypeMeta{Kind: "MultiClusterObservability"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		Spec: mcov1beta2.MultiClusterObservabilitySpec{
+			StorageConfig: &mcov1beta2.StorageConfig{
+				MetricObjectStorage: &mcoshared.PreConfiguredStorage{
+					Key:  "test",
+					Name: "test",
+				},
+				StorageClass:            "gp3",
+				AlertmanagerStorageSize: "1Gi",
+			},
+		},
+	}
+
+	receiveSts := &appsv1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "StatefulSet"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "thanos-receive-default",
+			Namespace: config.GetDefaultNamespace(),
+			Labels: map[string]string{
+				"app.kubernetes.io/instance": mco.GetName(),
+				"app.kubernetes.io/name":     "thanos-receive",
+			},
+		},
+	}
+
+	storageName := "gp2"
+	receivePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "data-thanos-receive-default-0",
+			Namespace: config.GetDefaultNamespace(),
+			Labels: map[string]string{
+				"app.kubernetes.io/instance": mco.GetName(),
+				"app.kubernetes.io/name":     "thanos-receive",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: &storageName,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	objs := []runtime.Object{mco, receiveSts, receivePVC}
+	c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
+	r := &MultiClusterObservabilityReconciler{
+		Client: c,
+		Scheme: s,
+		LastStorageConfig: &mcov1beta2.StorageConfig{
+			StorageClass:            "gp2",
+			AlertmanagerStorageSize: "1Gi",
+		},
+	}
+
+	// HandleStorageSizeChange detects storage class changed from gp2 -> gp3
+	result, err := r.HandleStorageSizeChange(context.TODO(), mco)
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+
+	// Verify the StatefulSet was deleted
+	sts := &appsv1.StatefulSet{}
+	err = c.Get(context.TODO(), types.NamespacedName{
+		Name:      "thanos-receive-default",
+		Namespace: config.GetDefaultNamespace(),
+	}, sts)
+	assert.True(t, errors.IsNotFound(err), "StatefulSet should have been deleted")
+
+	// Verify the PVC was deleted
+	pvc := &corev1.PersistentVolumeClaim{}
+	err = c.Get(context.TODO(), types.NamespacedName{
+		Name:      "data-thanos-receive-default-0",
+		Namespace: config.GetDefaultNamespace(),
+	}, pvc)
+	assert.True(t, errors.IsNotFound(err), "PVC should have been deleted")
 }
 
 func createStatefulSet(name, namespace, statefulSetName string) *appsv1.StatefulSet {
@@ -1203,6 +1378,21 @@ func newMultiClusterObservability() *mcov1beta2.MultiClusterObservability {
 			},
 		},
 	}
+}
+
+func newStorageClass(name string, isDefault bool) *storev1.StorageClass {
+	sc := &storev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Provisioner: "kubernetes.io/no-provisioner",
+	}
+	if isDefault {
+		sc.Annotations = map[string]string{
+			"storageclass.kubernetes.io/is-default-class": "true",
+		}
+	}
+	return sc
 }
 
 func createNamespaceInstance(name string) *corev1.Namespace {

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -85,6 +85,7 @@ func hashObservatoriumCRConfig(cl client.Client) (string, error) {
 
 // GenerateObservatoriumCR returns Observatorium cr defined in MultiClusterObservability
 func GenerateObservatoriumCR(
+	ctx context.Context,
 	cl client.Client, scheme *runtime.Scheme,
 	mco *mcov1beta2.MultiClusterObservability,
 ) (*ctrl.Result, error) {
@@ -98,17 +99,16 @@ func GenerateObservatoriumCR(
 		obsCRConfigHashLabelName: hash,
 	}
 
-	storageClassSelected, err := getStorageClass(mco, cl)
-	if err != nil {
-		return &ctrl.Result{}, fmt.Errorf("failed to get the storage class: %w", err)
-	}
-
 	// fetch TLS secret mount path from the object store secret
 	tlsSecretMountPath, err := getTLSSecretMountPath(cl, mco.Spec.StorageConfig.MetricObjectStorage)
 	if err != nil {
 		return &ctrl.Result{}, fmt.Errorf("failed to get the tls secret mount path: %w", err)
 	}
 
+	storageClassSelected, err := getStorageClass(ctx, mco, cl)
+	if err != nil {
+		return &ctrl.Result{}, fmt.Errorf("failed to get the storage class: %w", err)
+	}
 	log.Info("storageClassSelected", "storageClassSelected", storageClassSelected)
 
 	obsSpec, err := newDefaultObservatoriumSpec(cl, mco, storageClassSelected, tlsSecretMountPath)

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
@@ -272,7 +272,7 @@ func TestUpdateObservatoriumCR(t *testing.T) {
 	noConfigCl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mco).Build()
 	mcoconfig.SetOperandNames(noConfigCl)
 
-	_, err := GenerateObservatoriumCR(noConfigCl, s, mco)
+	_, err := GenerateObservatoriumCR(context.TODO(), noConfigCl, s, mco)
 	if err != nil {
 		t.Errorf("Failed to create observatorium due to %v", err)
 	}
@@ -296,7 +296,7 @@ func TestUpdateObservatoriumCR(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(append(objs, createdObservatoriumCR)...).Build()
 	mcoconfig.SetOperandNames(cl)
 
-	_, err = GenerateObservatoriumCR(cl, s, mco)
+	_, err = GenerateObservatoriumCR(context.TODO(), cl, s, mco)
 	if err != nil {
 		t.Errorf("Failed to update observatorium due to %v", err)
 	}
@@ -363,7 +363,7 @@ func TestTShirtSizeUpdateObservatoriumCR(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mco).Build()
 	mcoconfig.SetOperandNames(cl)
 
-	_, err := GenerateObservatoriumCR(cl, s, mco)
+	_, err := GenerateObservatoriumCR(context.TODO(), cl, s, mco)
 	if err != nil {
 		t.Errorf("Failed to create observatorium due to %v", err)
 	}
@@ -382,7 +382,7 @@ func TestTShirtSizeUpdateObservatoriumCR(t *testing.T) {
 	}
 
 	mco.Spec.InstanceSize = mcoconfig.TwoXLarge
-	_, err = GenerateObservatoriumCR(cl, s, mco)
+	_, err = GenerateObservatoriumCR(context.TODO(), cl, s, mco)
 	if err != nil {
 		t.Errorf("Failed to update observatorium due to %v", err)
 	}
@@ -474,7 +474,7 @@ func TestNoUpdateObservatoriumCR(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 	mcoconfig.SetOperandNames(cl)
 
-	_, err := GenerateObservatoriumCR(cl, s, mco)
+	_, err := GenerateObservatoriumCR(context.TODO(), cl, s, mco)
 	if err != nil {
 		t.Errorf("Failed to create observatorium due to %v", err)
 	}
@@ -507,7 +507,7 @@ func TestNoUpdateObservatoriumCR(t *testing.T) {
 		t.Errorf("%v should be equal to %v", string(oldSpecBytes), string(newSpecBytes))
 	}
 
-	_, err = GenerateObservatoriumCR(cl, s, mco)
+	_, err = GenerateObservatoriumCR(context.TODO(), cl, s, mco)
 	if err != nil {
 		t.Errorf("Failed to update observatorium due to %v", err)
 	}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"reflect"
 
-	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,8 +23,6 @@ func GetMCOPredicateFunc() predicate.Funcs {
 			return true
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			checkStorageChanged(e.ObjectOld.(*mcov1beta2.MultiClusterObservability).Spec.StorageConfig,
-				e.ObjectNew.(*mcov1beta2.MultiClusterObservability).Spec.StorageConfig)
 			config.SetMonitoringCRName(e.ObjectNew.GetName())
 			return e.ObjectOld.GetResourceVersion() != e.ObjectNew.GetResourceVersion()
 		},

--- a/tests/pkg/tests/observability_config_test.go
+++ b/tests/pkg/tests/observability_config_test.go
@@ -76,7 +76,7 @@ var _ = Describe("", func() {
 
 				klog.V(3).Infof("maxItemSize is effect in sts observability-thanos-store-memcached")
 				return true
-			}, EventuallyTimeoutMinute*1, EventuallyIntervalSecond*10).Should(BeTrue())
+			}, EventuallyTimeoutMinute*2, EventuallyIntervalSecond*10).Should(BeTrue())
 
 			By("Check the value is effect in the sts observability-thanos-query-frontend-memcached")
 			Eventually(func() bool {
@@ -97,7 +97,7 @@ var _ = Describe("", func() {
 
 				klog.V(3).Infof("maxItemSize is effect in sts observability-thanos-query-frontend-memcached")
 				return true
-			}, EventuallyTimeoutMinute*1, EventuallyIntervalSecond*10).Should(BeTrue())
+			}, EventuallyTimeoutMinute*2, EventuallyIntervalSecond*10).Should(BeTrue())
 		},
 	)
 
@@ -123,16 +123,19 @@ var _ = Describe("", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			spec := mcoSC.Object["spec"].(map[string]any)
-			scInCR := spec["storageConfig"].(map[string]any)["storageClass"].(string)
+			storageConfig, _ := spec["storageConfig"].(map[string]any)
+			scInCR, _ := storageConfig["storageClass"].(string)
 
-			scList, _ := hubClient.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
+			scList, err := hubClient.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
 			scMatch := false
 			defaultSC := ""
 			for _, sc := range scList.Items {
 				if sc.Annotations["storageclass.kubernetes.io/is-default-class"] == trueStr {
 					defaultSC = sc.Name
 				}
-				if sc.Name == scInCR {
+				if scInCR != "" && sc.Name == scInCR {
 					scMatch = true
 				}
 			}
@@ -243,18 +246,35 @@ var _ = Describe("", func() {
 			}
 			klog.V(1).Infof("The component is: %s\n", key)
 			replicas := advancedSpec[key].(map[string]any)["replicas"]
+			expectedReplicas := int(replicas.(int64))
 			if component.Type == "Deployment" {
-				deploys, err := utils.GetDeploymentWithLabel(testOptions, true, component.Label, MCO_NAMESPACE)
-				Expect(err).NotTo(HaveOccurred())
-				for _, deployInfo := range (*deploys).Items {
-					Expect(int(replicas.(int64))).To(Equal(int(*deployInfo.Spec.Replicas)))
-				}
+				Eventually(func() bool {
+					deploys, err := utils.GetDeploymentWithLabel(testOptions, true, component.Label, MCO_NAMESPACE)
+					if err != nil {
+						return false
+					}
+					for _, deployInfo := range (*deploys).Items {
+						if int(*deployInfo.Spec.Replicas) != expectedReplicas {
+							klog.V(1).Infof("Deployment %s has %d replicas, expected %d", deployInfo.Name, *deployInfo.Spec.Replicas, expectedReplicas)
+							return false
+						}
+					}
+					return true
+				}, EventuallyTimeoutMinute*2, EventuallyIntervalSecond*10).Should(BeTrue())
 			} else {
-				sts, err := utils.GetStatefulSetWithLabel(testOptions, true, component.Label, MCO_NAMESPACE)
-				Expect(err).NotTo(HaveOccurred())
-				for _, stsInfo := range (*sts).Items {
-					Expect(int(replicas.(int64))).To(Equal(int(*stsInfo.Spec.Replicas)))
-				}
+				Eventually(func() bool {
+					sts, err := utils.GetStatefulSetWithLabel(testOptions, true, component.Label, MCO_NAMESPACE)
+					if err != nil {
+						return false
+					}
+					for _, stsInfo := range (*sts).Items {
+						if int(*stsInfo.Spec.Replicas) != expectedReplicas {
+							klog.V(1).Infof("StatefulSet %s has %d replicas, expected %d", stsInfo.Name, *stsInfo.Spec.Replicas, expectedReplicas)
+							return false
+						}
+					}
+					return true
+				}, EventuallyTimeoutMinute*2, EventuallyIntervalSecond*10).Should(BeTrue())
 			}
 		}
 	})
@@ -384,7 +404,7 @@ var _ = Describe("", func() {
 					}
 				}
 				return false
-			}).Should(BeTrue())
+			}, EventuallyTimeoutMinute*2, EventuallyIntervalSecond*10).Should(BeTrue())
 
 			mcoRes, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).
 				Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})


### PR DESCRIPTION
## Summary
- Stop persisting the default storage class into the MCO CR when not explicitly set by the user. The operator resolves it in-memory for rendering instead.
- Replace global storage-change booleans with instance-level config comparison via `LastStorageConfig`.
- Handle storage class changes by deleting StatefulSets and PVCs so they are re-created with the new class.
- Skip PVC shrink operations in storage size reconciliation.
- Update e2e test to handle missing `storageClass` field in MCO CR using safe type assertions.

## Test plan
- [ ] Unit tests pass (`go test ./operators/multiclusterobservability/...`)
- [ ] E2e storage class and PVC test passes with and without explicit `storageClass` in MCO CR
- [ ] Verify PVCs are recreated when storage class is changed in MCO CR