### PR TITLE
fix(predicate): react to MCO CR annotation changes

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
@@ -24,7 +24,11 @@ func GetMCOPredicateFunc() predicate.Funcs {
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			config.SetMonitoringCRName(e.ObjectNew.GetName())
-			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+			if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+				return true
+			}
+			// Annotation changes (e.g., right-sizing delegation, mco-pause) don't increment generation.
+			return !reflect.DeepEqual(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations())
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return !e.DeleteStateUnknown

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func_test.go
@@ -127,7 +127,23 @@ func TestGetMCOPredicateFunc(t *testing.T) {
 
 	updateEvent := event.UpdateEvent{ObjectOld: mcoObj, ObjectNew: mcoObj}
 	if mcoPred.Update(updateEvent) {
-		t.Error("mco Update function should return false when resource version is unchanged")
+		t.Error("mco Update function should return false when generation and annotations are unchanged")
+	}
+
+	// Annotation change should trigger reconciliation (e.g., right-sizing delegation)
+	mcoObjWithAnnotation := mcoObj.DeepCopy()
+	mcoObjWithAnnotation.Annotations = map[string]string{
+		"observability.open-cluster-management.io/right-sizing-capable": "true",
+	}
+	annotationUpdateEvent := event.UpdateEvent{ObjectOld: mcoObj, ObjectNew: mcoObjWithAnnotation}
+	if !mcoPred.Update(annotationUpdateEvent) {
+		t.Error("mco Update function should return true when annotations change")
+	}
+
+	// Removing annotation should also trigger
+	annotationRemoveEvent := event.UpdateEvent{ObjectOld: mcoObjWithAnnotation, ObjectNew: mcoObj}
+	if !mcoPred.Update(annotationRemoveEvent) {
+		t.Error("mco Update function should return true when annotations are removed")
 	}
 
 	deleteEvent := event.DeleteEvent{Object: mcoObj}


### PR DESCRIPTION
The MCO predicate (GetMCOPredicateFunc) was changed from ResourceVersion to Generation comparison to fix infinite reconciliation loops (PR #2444). However, Kubernetes only increments generation on spec changes — annotation changes are metadata-only and do not affect generation. This broke annotation-driven reconciliation for both the main controller and the analytics controller.

Affected features:
- Right-sizing delegation (right-sizing-capable annotation)
- MCO pause (mco-pause annotation)

Fix: Fall back to annotation comparison when generation is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where annotation changes were not being recognized for system reconciliation, ensuring configuration updates are now properly detected and applied.

* **Tests**
  * Updated test coverage to verify annotation changes correctly trigger system reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->