### PR TITLE
[ACM-19093] <Grafana>: <Fix Issue Where managed namespaces were appearing twice in CPU Quota Table>

### DIFF
--- a/operators/multiclusterobservability/manifests/base/grafana/platform/dash-k8s-compute-resources-cluster.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/platform/dash-k8s-compute-resources-cluster.yaml
@@ -966,7 +966,7 @@ data:
               "step": 10
             },
             {
-              "expr": "namespace_workload_pod:kube_pod_owner:relabel:avg{cluster=\"$cluster\"}",
+              "expr": "sum(namespace_workload_pod:kube_pod_owner:relabel:avg{cluster=\"$cluster\"}) by (namespace)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -977,7 +977,7 @@ data:
               "step": 10
             },
             {
-              "expr": "node_namespace_pod_container:container_cpu_usage_seconds_total:sum{cluster=\"$cluster\"}",
+              "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum{cluster=\"$cluster\"}) by (namespace)",
               "format": "table",
               "instant": true,
               "intervalFactor": 2,


### PR DESCRIPTION
Summary:

Edits queries made by built in cpu quota dashboard so that additional labels are removed, allowing Grafana to successfully merge the queries.

Fixes [ACM-19093](https://redhat.atlassian.net/browse/ACM-19093)

Problem:

Our CPU quota dashboard was displaying two rows for each namespace in a managed cluster, when it should be only one. These rows also had differing entries in some of the columns, causing confusion. 

Root Cause:


The queries that were causing the issue were 
`namespace_workload_pod:kube_pod_owner:relabel:avg{cluster=\"$cluster\"}` and `kube_pod_owner{cluster=\"$cluster\"}`. Through checking in the panel explorer in Grafana, I was able to see that these two queries were returning series with additional labels other than namespace, such as `__name__`. Since these two queries returned a label with a key of `__name__` with two different values respectively, this caused Grafana to not be able to merge all queries into one row correctly, causing two separate merges that both had the same entry for namespace. 

Fix:

Edit these two queries, so that they explicitly sum by namespace, this removes the other labels and leaves namespace as the only label, matching the pattern in the other queries. This causes all of these queries to be merged onto one row.

Files Changed: 

Modified: `operators/multiclusterobservability/manifests/base/grafana/platform/dash-k8s-compute-resources-cluster.yaml`

Test Plan:
`Make check-metrics` passes
Tested by disabling the MCO, editing the config map with these queries on a running cluster, and see what appears to be the correct output (only one namespace, no duplicates). 

[ACM-19093]: https://redhat.atlassian.net/browse/ACM-19093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated CPU quota metrics aggregation in Grafana dashboards to explicitly group container CPU usage and workload data by namespace for improved data organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->