### PR TITLE
[ACM-33381] fix(endpointmetrics): support HCP ServiceMonitors on Managed Clusters

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -174,7 +174,7 @@ func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 	rendering.Images = imagesCM.Data
 
-	if r.IsHubMetricsCollector && isHypershift {
+	if isHypershift {
 		updatedHCs, err := hypershift.ReconcileHostedClustersServiceMonitors(ctx, r.Client)
 		if err != nil {
 			r.Logger.Error(err, "Failed to create ServiceMonitors for hypershift")

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_test.go
@@ -6,6 +6,7 @@ package observabilityendpoint
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"slices"
 	"testing"
@@ -136,6 +137,29 @@ func newImagesCM(ns string) *corev1.ConfigMap {
 	}
 }
 
+func newHC(name, ns string) *hyperv1.HostedCluster {
+	return &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: hyperv1.HostedClusterSpec{},
+	}
+}
+
+func newSM(name, ns string) *promv1.ServiceMonitor {
+	return &promv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: promv1.ServiceMonitorSpec{
+			Endpoints: []promv1.Endpoint{{Port: "metrics"}},
+			Selector:  metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+		},
+	}
+}
+
 func init() {
 	os.Setenv("UNIT_TEST", "true")
 }
@@ -152,6 +176,7 @@ alertmanager-router-ca: |
 
 	testNamespace := "test-ns"
 	testHubNamespace := "test-hub-ns"
+	testHcNamespace := "test-hc-clusters"
 	hubObjs := []runtime.Object{}
 	hubInfo := newHubInfoSecret(hubInfoData, testNamespace)
 	amAccessSrt := newAMAccessorSecret(testNamespace, "test-token")
@@ -294,6 +319,51 @@ alertmanager-router-ca: |
 	}
 	if !slices.Contains(foundOba.Finalizers, obsAddonFinalizer) {
 		t.Fatal("Finalizer not set in observabilityAddon")
+	}
+
+	// test reconcile service monitors if hosted clusters exist
+	hcName := "testHc"
+	hc := newHC(hcName, testHcNamespace)
+	err = c.Create(ctx, hc)
+	if err != nil {
+		t.Fatalf("failed to create hosted cluster to install: (%v)", err)
+	}
+	smNamespce := fmt.Sprintf("%s-%s", hc.Namespace, hc.Name)
+	origEtcdSM := newSM("etcd", smNamespce)
+	err = c.Create(ctx, origEtcdSM)
+	if err != nil {
+		t.Fatalf("failed to create etcd service monitor to install: (%v)", err)
+	}
+	origKubeApiSM := newSM("kube-apiserver", smNamespce)
+	err = c.Create(ctx, origKubeApiSM)
+	if err != nil {
+		t.Fatalf("failed to create kube-apiserver service monitor to install: (%v)", err)
+	}
+	req = ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "install",
+			Namespace: testNamespace,
+		},
+	}
+	_, err = r.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+	acmEtcdSM := &promv1.ServiceMonitor{}
+	err = c.Get(ctx, types.NamespacedName{
+		Name:      "acm-etcd",
+		Namespace: smNamespce,
+	}, acmEtcdSM)
+	if err != nil {
+		t.Fatalf("ACM etcd ServiceMonitor not created: (%v)", err)
+	}
+	acmApiSM := &promv1.ServiceMonitor{}
+	err = c.Get(ctx, types.NamespacedName{
+		Name:      "acm-kube-apiserver",
+		Namespace: smNamespce,
+	}, acmApiSM)
+	if err != nil {
+		t.Fatalf("ACM kube-apiserver ServiceMonitor not created: (%v)", err)
 	}
 
 	// test reconcile metrics collector deployment updated if cert secret updated


### PR DESCRIPTION
Reconcile ServiceMonitors for Hosted Control Planes (HCP) on any hypershift cluster (before it was limited on Hub clusters only).

This has been tested on a Managed Cluster running Hypershift and a Hosted Cluster (HC) control plane on the `clusters-hc-emu` namespace.

## Before the fix
### ServiceMonitor exsistence
`oc get servicemonitor -n clusters-hc-emu acm-etcd acm-kube-apiserver` returned empty

### Metrics generation
Given the HC ID: 
```
oc get hostedcluster -n clusters hc-emu -o jsonpath='{.spec.clusterID}'
f937ceb1-3ed9-4f82-9993-2af781e22079
```
PromQL query 
`{cluster="hc-emu", cluster_id="f937ceb1-3ed9-4f82-9993-2af781e22079"}` 
response was empty

## After the fix:
### ServiceMonitor exsistance
`oc get servicemonitor -n clusters-hc-emu acm-etcd acm-kube-apiserver` returns:
```
NAME                 AGE
acm-etcd             18h
acm-kube-apiserver   18h
```

### Metrics generation
Giving the HC ID: 
```
oc get hostedcluster -n clusters hc-emu -o jsonpath='{.spec.clusterID}'
f937ceb1-3ed9-4f82-9993-2af781e22079
```
PromQL query 
`{cluster="hc-emu", cluster_id="f937ceb1-3ed9-4f82-9993-2af781e22079"}` 
response contains etcd and apiserver metrics like:

`etcd_server_has_leader{cluster="hc-emu", clusterID="f937ceb1-3ed9-4f82-9993-2af781e22079", clusterType="SNO", cluster_id="f937ceb1-3ed9-4f82-9993-2af781e22079", container="etcd-metrics", endpoint="metrics", instance="10.128.0.222:2381", job="etcd", managementcluster="griciopp-acm216-ocp421-spoke-hcp", managementclusterID="c2f6bf7f-fc73-4b11-9036-0116e5bbee74", namespace="clusters-hc-emu", pod="etcd-0", receive="true", service="etcd-client", tenant_id="4fbb6fbd-3df7-4f63-a448-11a0ff844a3e"}`

`apiserver_current_inflight_requests{cluster="hc-emu", clusterID="f937ceb1-3ed9-4f82-9993-2af781e22079", clusterType="SNO", container="openshift-apiserver", endpoint="https", instance="10.128.0.228:8443", job="openshift-apiserver", managementcluster="griciopp-acm216-ocp421-spoke-hcp", managementclusterID="c2f6bf7f-fc73-4b11-9036-0116e5bbee74", namespace="clusters-hc-emu", pod="openshift-apiserver-5fd5c466c9-b7z8b", receive="true", request_kind="readOnly", service="openshift-apiserver", tenant_id="4fbb6fbd-3df7-4f63-a448-11a0ff844a3e"}`

Here is the complete metrics list introduced by the introduced ServiceMonitors:
<img width="1667" height="836" alt="image" src="https://github.com/user-attachments/assets/14b8be33-2e76-4716-8893-71780c570ad1" />

Dashboards are working:
<img width="1364" height="881" alt="image" src="https://github.com/user-attachments/assets/36b21c6f-fbb3-4ec2-a0c0-79df33ed6f9c" />
<img width="1149" height="870" alt="image" src="https://github.com/user-attachments/assets/50b77065-2a55-40e1-966b-df4db2ee460a" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service monitor reconciliation for hosted clusters in hypershift environments to now support additional cluster configurations that were previously unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->