### PR TITLE
Bugfix/acm 33641 remove vestigial proxy ingress

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -35,6 +35,7 @@ import (
 	observatoriumv1alpha1 "github.com/stolostron/observatorium-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -432,6 +433,10 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 		// Delete ServiceMonitor from openshft-monitoring namespace
 		if err := r.deleteServiceMonitorInOpenshiftMonitoringNamespace(ctx); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to delete ServiceMonitor in openshift-monitoring namespace: %w", err)
+		}
+		// The rbac-query-proxy Ingress is no longer rendered; clean up any leftover from prior versions.
+		if err := r.deleteVestigialProxyIngress(ctx); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to delete vestigial rbac-query-proxy-ingress: %w", err)
 		}
 		isLegacyResourceRemoved = true
 	}
@@ -1066,6 +1071,27 @@ func (r *MultiClusterObservabilityReconciler) deleteSpecificPrometheusRule(ctx c
 		log.Info("Deleted PrometheusRule from openshift-monitoring namespace")
 	} else if !apierrors.IsNotFound(err) {
 		log.Error(err, "Failed to fetch PrometheusRule")
+		return err
+	}
+
+	return nil
+}
+
+// deleteVestigialProxyIngress removes the rbac-query-proxy-ingress Ingress that is no longer
+// rendered. The proxy is served via Route; the Ingress targeted the deprecated management-ingress
+// controller and causes admission failures on clusters with the AWS Load Balancer Controller.
+func (r *MultiClusterObservabilityReconciler) deleteVestigialProxyIngress(ctx context.Context) error {
+	ingress := &networkingv1.Ingress{}
+	err := r.Client.Get(ctx, client.ObjectKey{
+		Name:      "rbac-query-proxy-ingress",
+		Namespace: config.GetDefaultNamespace(),
+	}, ingress)
+	if err == nil {
+		if err := r.Client.Delete(ctx, ingress); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		log.Info("Deleted vestigial rbac-query-proxy-ingress Ingress")
+	} else if !apierrors.IsNotFound(err) {
 		return err
 	}
 

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -36,6 +36,7 @@ import (
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	storev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -1553,5 +1554,57 @@ func newAlertManagerRoute() *routev1.Route {
 		Spec: routev1.RouteSpec{
 			Host: "alert.manager",
 		},
+	}
+}
+
+func TestDeleteVestigialProxyIngress(t *testing.T) {
+	s := scheme.Scheme
+
+	tests := []struct {
+		name           string
+		existingObjs   []runtime.Object
+		expectDeletion bool
+	}{
+		{
+			name: "deletes existing ingress",
+			existingObjs: []runtime.Object{
+				&networkingv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rbac-query-proxy-ingress",
+						Namespace: config.GetDefaultNamespace(),
+					},
+				},
+			},
+			expectDeletion: true,
+		},
+		{
+			name:           "no-op when ingress does not exist",
+			existingObjs:   []runtime.Object{},
+			expectDeletion: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(tt.existingObjs...).Build()
+			r := &MultiClusterObservabilityReconciler{Client: c, Scheme: s}
+
+			err := r.deleteVestigialProxyIngress(t.Context())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			ingress := &networkingv1.Ingress{}
+			err = c.Get(t.Context(), types.NamespacedName{
+				Name:      "rbac-query-proxy-ingress",
+				Namespace: config.GetDefaultNamespace(),
+			}, ingress)
+
+			if tt.expectDeletion {
+				assert.True(t, errors.IsNotFound(err), "ingress should have been deleted")
+			} else {
+				assert.True(t, errors.IsNotFound(err), "ingress should not exist")
+			}
+		})
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically removes a leftover legacy Ingress used by the proxy during reconciliation, ensuring outdated proxy routing is cleaned up and harmless “resource not found” conditions are suppressed.
* **Tests**
  * Added unit tests verifying the cleanup removes the legacy Ingress when present and completes without errors when the Ingress is already absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->