### PR TITLE
[ACM-26131] <MCO>: <Fix Issue Where Some ObservabilityAddOnSpec Resources are not being forwarded to the spoke's metric controller>

### DIFF
--- a/operators/multiclusterobservability/pkg/config/resources.go
+++ b/operators/multiclusterobservability/pkg/config/resources.go
@@ -260,7 +260,6 @@ func GetOBAResources(oba *mcoshared.ObservabilityAddonSpec, tshirtSize observabi
 	memoryRequests := MetricsCollectorMemoryRequest[tshirtSize]
 	memoryLimits := MetricsCollectorMemoryLimits
 	resourceReq := &corev1.ResourceRequirements{}
-
 	if oba.Resources != nil {
 		if len(oba.Resources.Requests) != 0 {
 			if oba.Resources.Requests.Cpu().String() != "0" {
@@ -296,6 +295,10 @@ func GetOBAResources(oba *mcoshared.ObservabilityAddonSpec, tshirtSize observabi
 	}
 	resourceReq.Limits = limits
 	resourceReq.Requests = requests
+	print(resourceReq)
+	print("RESOURCE REQ for spoke check")
+	print(resourceReq.Requests)
+	print(resourceReq.Limits)
 
 	return resourceReq
 }

--- a/operators/multiclusterobservability/pkg/config/resources.go
+++ b/operators/multiclusterobservability/pkg/config/resources.go
@@ -260,7 +260,18 @@ func GetOBAResources(oba *mcoshared.ObservabilityAddonSpec, tshirtSize observabi
 	memoryRequests := MetricsCollectorMemoryRequest[tshirtSize]
 	memoryLimits := MetricsCollectorMemoryLimits
 	resourceReq := &corev1.ResourceRequirements{}
+	requests := corev1.ResourceList{}
+	limits := corev1.ResourceList{}
 	if oba.Resources != nil {
+		resourceReq = oba.Resources.DeepCopy()
+		requests = resourceReq.Requests
+		limits = resourceReq.Limits
+		if requests == nil {
+			requests = corev1.ResourceList{}
+		}
+		if limits == nil {
+			limits = corev1.ResourceList{}
+		}
 		if len(oba.Resources.Requests) != 0 {
 			if oba.Resources.Requests.Cpu().String() != "0" {
 				cpuRequests = oba.Resources.Requests.Cpu().String()
@@ -278,9 +289,6 @@ func GetOBAResources(oba *mcoshared.ObservabilityAddonSpec, tshirtSize observabi
 			}
 		}
 	}
-
-	requests := corev1.ResourceList{}
-	limits := corev1.ResourceList{}
 	if cpuRequests != "" {
 		requests[corev1.ResourceCPU] = resource.MustParse(cpuRequests)
 	}
@@ -295,10 +303,6 @@ func GetOBAResources(oba *mcoshared.ObservabilityAddonSpec, tshirtSize observabi
 	}
 	resourceReq.Limits = limits
 	resourceReq.Requests = requests
-	print(resourceReq)
-	print("RESOURCE REQ for spoke check")
-	print(resourceReq.Requests)
-	print(resourceReq.Limits)
 
 	return resourceReq
 }

--- a/operators/multiclusterobservability/pkg/config/resources_test.go
+++ b/operators/multiclusterobservability/pkg/config/resources_test.go
@@ -363,7 +363,25 @@ func TestGetOBAResources(t *testing.T) {
 			},
 		},
 		{
-			name:          "Pass Through Recourse Requests For Fields Other Than CPU And Memory",
+			name:          "pass through requests for fields other than CPU and memory",
+			componentName: ObservatoriumAPI,
+			raw: &mcoshared.ObservabilityAddonSpec{
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceEphemeralStorage: resource.MustParse("1Ki"),
+					},
+				},
+			},
+			result: func(resources corev1.ResourceRequirements) bool {
+				return resources.Requests.Cpu().String() == MetricsCollectorCPURequest[Default] &&
+					resources.Requests.Memory().String() == MetricsCollectorMemoryRequest[Default] &&
+					resources.Limits.Cpu().String() == "0" &&
+					resources.Limits.Memory().String() == "0" &&
+					resources.Requests.StorageEphemeral().String() == "1Ki"
+			},
+		},
+		{
+			name:          "pass through limits for fields other than CPU and memory",
 			componentName: ObservatoriumAPI,
 			raw: &mcoshared.ObservabilityAddonSpec{
 				Resources: &corev1.ResourceRequirements{
@@ -380,6 +398,7 @@ func TestGetOBAResources(t *testing.T) {
 					resources.Limits.StorageEphemeral().String() == "1Ki"
 			},
 		},
+
 		{
 			name:          "no resources defined",
 			componentName: ObservatoriumAPI,

--- a/operators/multiclusterobservability/pkg/config/resources_test.go
+++ b/operators/multiclusterobservability/pkg/config/resources_test.go
@@ -363,6 +363,24 @@ func TestGetOBAResources(t *testing.T) {
 			},
 		},
 		{
+			name:          "Pass Through Recourse Requests For Fields Other Than CPU And Memory",
+			componentName: ObservatoriumAPI,
+			raw: &mcoshared.ObservabilityAddonSpec{
+				Resources: &corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceEphemeralStorage: resource.MustParse("1Ki"),
+					},
+				},
+			},
+			result: func(resources corev1.ResourceRequirements) bool {
+				return resources.Requests.Cpu().String() == MetricsCollectorCPURequest[Default] &&
+					resources.Requests.Memory().String() == MetricsCollectorMemoryRequest[Default] &&
+					resources.Limits.Cpu().String() == "0" &&
+					resources.Limits.Memory().String() == "0" &&
+					resources.Limits.StorageEphemeral().String() == "1Ki"
+			},
+		},
+		{
 			name:          "no resources defined",
 			componentName: ObservatoriumAPI,
 			raw: &mcoshared.ObservabilityAddonSpec{


### PR DESCRIPTION
Summary:

Passes

Fixes [ACM-26131](https://redhat.atlassian.net/browse/ACM-26131)

Problem:

Ephemeral storage specifications in MCO Spec were not being passed on to the metrics-collector-deployment on Spokes cluster. 

Root Cause:

On spoke clusters, the generation of the resources for the ObservabilityAddOn were only passing through cpu and memory, wiping out other settings, including ephemeral storage.   

Fix:

Edit the generation of these resources, so that all resource settings from the MCO ObservabilityAddOnSpec are created in the ObservabilityAddOn, not just cpu and memory. 

Files Changed:

Modified: 
```
operators/multiclusterobservability/controllers/placementrule/obsaddon.go
operators/multiclusterobservability/controllers/placementrule/obsaddon_test.go
```

Test Plan:
Run `go test ./operators/multiclusterobservability/pkg/config/... -run TestGetOBAResources -v`
Tested by spinning up a hub and spoke cluster with this image, and running the below command to confirm that ephemeral storage was successfully passed to the metrics-controller deployment on the spoke cluster. 

`kubectl get deploy metrics-collector-deployment -n open-cluster-management-observability \
  -o jsonpath='{.spec.template.spec.containers[0].resources}' | jq .
{
  "requests": {
    "ephemeral-storage": "2040Ki"
  }
}
`
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved resource allocation configuration handling to properly preserve and maintain additional resource types (such as ephemeral-storage) when processing resource limits and requests. The system now ensures complete resource configurations are fully respected during processing while properly applying defaults for standard CPU and memory settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ACM-26131]: https://redhat.atlassian.net/browse/ACM-26131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ