### PR TITLE
Refactor e2e hub cluster name resolution to use ManagedCluster API

### DIFF
--- a/tests/pkg/tests/observability-e2e-test_suite_test.go
+++ b/tests/pkg/tests/observability-e2e-test_suite_test.go
@@ -272,12 +272,9 @@ func initVars() {
 	if testOptions.HubCluster.Password != "" {
 		kubeadminCredential = testOptions.HubCluster.Password
 	}
-	hubName, err := utils.GetHubClusterName(testOptions)
-	if err != nil {
-		klog.Warningf("Failed to resolve hub managed cluster name, using default: %v", err)
-		hubName = "local-cluster"
+	if testOptions.HubCluster.Name == "" {
+		testOptions.HubCluster.Name = "local-cluster"
 	}
-	testOptions.HubCluster.Name = hubName
 
 	if testOptions.ManagedClusters != nil && len(testOptions.ManagedClusters) > 0 {
 		for i, mc := range testOptions.ManagedClusters {

--- a/tests/pkg/tests/observability_mcoa_test.go
+++ b/tests/pkg/tests/observability_mcoa_test.go
@@ -33,15 +33,24 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 	// var ocpClustersWithHub []utils.Cluster
 
 	BeforeAll(func() {
-		By("Getting available managed clusters")
+		By("Getting all available managed clusters from the API")
 		var err error
-		managedClusters, err = utils.GetAvailableManagedClustersAsClusters(testOptions)
+		managedClustersWithHub, err = utils.GetAvailableClustersFromAPI(testOptions, true)
 		Expect(err).ToNot(HaveOccurred())
-		clusterNames := []string{}
+
+		hubClusterName, err := utils.GetHubClusterName(testOptions)
+		Expect(err).ToNot(HaveOccurred())
+
+		managedClusters = make([]utils.Cluster, 0, len(managedClustersWithHub))
+		for _, c := range managedClustersWithHub {
+			if c.Name != hubClusterName {
+				managedClusters = append(managedClusters, c)
+			}
+		}
+		clusterNames := make([]string, 0, len(managedClusters))
 		for _, cluster := range managedClusters {
 			clusterNames = append(clusterNames, cluster.Name)
 		}
-		managedClustersWithHub = append(managedClusters, testOptions.HubCluster)
 		By(fmt.Sprintf("Running tests against the following managed clusters (excluding the hub): %v", clusterNames))
 
 		By("Getting available OCP managed clusters")

--- a/tests/pkg/tests/observability_mcoa_test.go
+++ b/tests/pkg/tests/observability_mcoa_test.go
@@ -47,15 +47,24 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 	// var ocpClustersWithHub []utils.Cluster
 
 	BeforeAll(func() {
-		By("Getting available managed clusters")
+		By("Getting all available managed clusters from the API")
 		var err error
-		managedClusters, err = utils.GetAvailableManagedClustersAsClusters(testOptions)
+		managedClustersWithHub, err = utils.GetAvailableClustersFromAPI(testOptions, true)
 		Expect(err).ToNot(HaveOccurred())
-		clusterNames := []string{}
+
+		hubClusterName, err := utils.GetHubClusterName(testOptions)
+		Expect(err).ToNot(HaveOccurred())
+
+		managedClusters = make([]utils.Cluster, 0, len(managedClustersWithHub))
+		for _, c := range managedClustersWithHub {
+			if c.Name != hubClusterName {
+				managedClusters = append(managedClusters, c)
+			}
+		}
+		clusterNames := make([]string, 0, len(managedClusters))
 		for _, cluster := range managedClusters {
 			clusterNames = append(clusterNames, cluster.Name)
 		}
-		managedClustersWithHub = append(managedClusters, testOptions.HubCluster)
 		By(fmt.Sprintf("Running tests against the following managed clusters (excluding the hub): %v", clusterNames))
 
 		By("Getting available OCP managed clusters")

--- a/tests/pkg/utils/mco_addon.go
+++ b/tests/pkg/utils/mco_addon.go
@@ -50,7 +50,7 @@ func CheckManagedClusterAddonStatus(opt TestOptions, name string) {
 func GetAvailableClustersFromAPI(opt TestOptions, includeHub bool) ([]Cluster, error) {
 	availableManagedClusters, err := GetAvailableManagedClusters(opt)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get available managed clusters from API: %w", err)
 	}
 
 	clusterList := make([]Cluster, 0, len(availableManagedClusters))

--- a/tests/pkg/utils/mco_addon.go
+++ b/tests/pkg/utils/mco_addon.go
@@ -44,30 +44,28 @@ func CheckManagedClusterAddonStatus(opt TestOptions, name string) {
 	}, 300, 5).Should(gomega.Not(gomega.HaveOccurred()))
 }
 
-// GetAvailableManagedClustersAsClusters returns a list of available managed clusters.
-// The hub cluster is not included in the list.
-func GetAvailableManagedClustersAsClusters(opt TestOptions) ([]Cluster, error) {
+// GetAvailableClustersFromAPI returns available managed clusters discovered from the ManagedCluster API.
+// When includeHub is false, the hub cluster (local-cluster=true) is excluded.
+// Connection info from opt.ManagedClusters is enriched when available.
+func GetAvailableClustersFromAPI(opt TestOptions, includeHub bool) ([]Cluster, error) {
 	availableManagedClusters, err := GetAvailableManagedClusters(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	var clusterList []Cluster
-	for _, managedCluster := range availableManagedClusters {
-		if IsHubCluster(managedCluster) {
+	clusterList := make([]Cluster, 0, len(availableManagedClusters))
+	for _, mc := range availableManagedClusters {
+		if !includeHub && IsHubCluster(mc) {
 			continue
 		}
-
-		var cluster Cluster
+		cluster := Cluster{Name: mc.Name}
 		for _, c := range opt.ManagedClusters {
-			if c.Name == managedCluster.Name {
+			if c.Name == mc.Name {
 				cluster = c
 				break
 			}
 		}
-		if cluster.Name != "" {
-			clusterList = append(clusterList, cluster)
-		}
+		clusterList = append(clusterList, cluster)
 	}
 	return clusterList, nil
 }

--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -197,7 +197,7 @@ func GetManagedClusters(opt TestOptions) ([]*clusterv1.ManagedCluster, error) {
 }
 
 // GetHubClusterName queries the ManagedCluster API and returns the name of the hub cluster
-// (identified by the "local-cluster=true" label). Falls back to "local-cluster" if not found.
+// (identified by the "local-cluster=true" label).
 func GetHubClusterName(opt TestOptions) (string, error) {
 	clusters, err := ListManagedClusters(opt)
 	if err != nil {
@@ -208,7 +208,7 @@ func GetHubClusterName(opt TestOptions) (string, error) {
 			return c.Name, nil
 		}
 	}
-	return "local-cluster", nil
+	return "", fmt.Errorf("no managed cluster with label local-cluster=true found among %d clusters", len(clusters))
 }
 
 func GetAvailableManagedClusters(opt TestOptions) ([]*clusterv1.ManagedCluster, error) {

--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -199,12 +199,12 @@ func GetManagedClusters(opt TestOptions) ([]*clusterv1.ManagedCluster, error) {
 // GetHubClusterName queries the ManagedCluster API and returns the name of the hub cluster
 // (identified by the "local-cluster=true" label).
 func GetHubClusterName(opt TestOptions) (string, error) {
-	clusters, err := ListManagedClusters(opt)
+	clusters, err := GetManagedClusters(opt)
 	if err != nil {
-		return "", fmt.Errorf("failed to list managed clusters: %w", err)
+		return "", fmt.Errorf("failed to get managed clusters: %w", err)
 	}
 	for _, c := range clusters {
-		if c.IsLocalCluster {
+		if IsHubCluster(c) {
 			return c.Name, nil
 		}
 	}


### PR DESCRIPTION
 Summary:
  - Stop overwriting testOptions.HubCluster.Name globally in initVars() — reverts to only setting default when empty 
  - MCOA test now discovers all clusters directly from ManagedCluster CRs via GetAvailableClustersFromAPI(), independent of options.yaml
  - Consolidated GetAvailableManagedClustersAsClusters and GetAllAvailableClustersAsClusterList into single GetAvailableClustersFromAPI(opt, includeHub) — API-driven discovery with optional connection info enrichment from options.yaml
  - GetHubClusterName now returns error when no hub found instead of silent "local-cluster" fallback

Fixes hub name mismatch in QE environments where options.yaml hub name (infrastructure hostname) differs from ManagedCluster name. Also fixes empty spoke list when options.yaml has no managedClusters entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved cluster discovery for end-to-end tests, including clearer separation of hub and managed clusters.
  * Enhanced cluster information handling and error reporting when cluster data cannot be retrieved.
  * Simplified hub cluster setup by defaulting to “local-cluster” when no name is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->