### PR TITLE
fix(alert): do not use expression in ViolatedPolicyReport alert's labels

### DIFF
--- a/operators/multiclusterobservability/manifests/base/alertmanager/alert_rules.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/alert_rules.yaml
@@ -40,7 +40,7 @@ data:
           expr: sum without (managed_cluster_id) (label_replace((sum without (clusterID) (label_replace((sum(policyreport_info * on (managed_cluster_id) group_left (cluster) label_replace(acm_managed_cluster_labels, "cluster", "$1", "name", "(.*)")) by (cluster, category, clusterID, managed_cluster_id, policy, severity) > 0),"hub_cluster_id", "$1", "clusterID", "(.*)"))),"clusterID", "$1", "managed_cluster_id", "(.*)"))
           for: 1m
           labels:
-            severity: "{{ $labels.severity }}"
+            severity: critical
       - name: slo-sli-trends
         rules:
         - expr: sli:apiserver_request_duration_seconds:trend:1m >= bool 0.9900

--- a/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/prometheus-rule.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/prometheus-rule.yaml
@@ -220,7 +220,7 @@ spec:
         expr: sum without (managed_cluster_id) (label_replace((sum without (clusterID) (label_replace((sum(policyreport_info * on (managed_cluster_id) group_left (cluster) label_replace(acm_managed_cluster_labels, "cluster", "$1", "name", "(.*)")) by (cluster, category, clusterID, managed_cluster_id, policy, severity) > 0),"hub_cluster_id", "$1", "clusterID", "(.*)"))),"clusterID", "$1", "managed_cluster_id", "(.*)"))
         for: 1m
         labels:
-          severity: "{{ $labels.severity }}"
+          severity: critical
   - name: acm-metrics-collector-federation-alerts
     rules:
       - alert: MetricsCollectorNotIngestingSamples


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected alert rule configurations by removing severity label declarations from policy violation report alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->