### PR TITLE
fix(allowlist): update custom allowlist example to match default label change

### DIFF
--- a/examples/metrics/allowlist/custom-metrics-allowlist.yaml
+++ b/examples/metrics/allowlist/custom-metrics-allowlist.yaml
@@ -10,4 +10,4 @@ data:
       - -cluster_version_payload # this default metric is not being collected from your managed clusters
       - -instance:node_num_cpu:sum # this default metric is not being collected from your managed clusters
     matches:
-      - -__name__="go_goroutines",job="apiserver" # this default metric is not being collected from your managed clusters
+      - -__name__="go_goroutines",service="kubernetes" # this default metric is not being collected from your managed clusters


### PR DESCRIPTION
PR #2244 changed go_goroutines from job="apiserver" to service="kubernetes" in the default allowlist, but missed updating the custom allowlist example, causing the e2e metric deletion test (RHACM4K-3063) to fail.

Ref: https://jenkins-csb-rhacm-tests.dno.corp.redhat.com/job/CI-Jobs/job/observability_tests/89/console

Backport to release-2.17 after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the metrics allowlist configuration to adjust the label selector for Kubernetes metrics monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->