### PR TITLE
fix(rightsizing): eliminate ConfigMap predicate reconciliation storm

### DIFF
--- a/operators/multiclusterobservability/controllers/analytics/analytics_controller.go
+++ b/operators/multiclusterobservability/controllers/analytics/analytics_controller.go
@@ -140,7 +140,7 @@ func (r *AnalyticsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, fmt.Errorf("rs - failed to add analytics finalizer: %w", err)
 		}
 		reqLogger.Info("rs - Analytics finalizer added to MCO CR")
-		return ctrl.Result{}, nil // watch-triggered reconcile picks up updated finalizers
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// Do not reconcile objects if this instance of mch is labeled "paused"
@@ -274,12 +274,9 @@ func (r *AnalyticsReconciler) ensureRightSizingDefaults(ctx context.Context, ins
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AnalyticsReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	c := mgr.GetClient()
-	ctx := context.Background()
-
 	mcoPred := mcoctrl.GetMCOPredicateFunc()
-	cmNamespaceRSPred := rightsizingctrl.GetNamespaceRSConfigMapPredicateFunc(ctx, c)
-	cmVirtualizationRSPred := rightsizingctrl.GetVirtualizationRSConfigMapPredicateFunc(ctx, c)
+	cmNamespaceRSPred := rightsizingctrl.GetNamespaceRSConfigMapPredicateFunc()
+	cmVirtualizationRSPred := rightsizingctrl.GetVirtualizationRSConfigMapPredicateFunc()
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("rightsizing").
 		For(&mcov1beta2.MultiClusterObservability{}, builder.WithPredicates(mcoPred)).

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rightsizing_controller.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rightsizing_controller.go
@@ -86,13 +86,13 @@ func getNamespaceBinding(mco *mcov1beta2.MultiClusterObservability, componentTyp
 }
 
 // GetNamespaceRSConfigMapPredicateFunc returns predicate for namespace right-sizing ConfigMap
-func GetNamespaceRSConfigMapPredicateFunc(ctx context.Context, c client.Client) predicate.Funcs {
-	return rsnamespace.GetNamespaceRSConfigMapPredicateFunc(ctx, c)
+func GetNamespaceRSConfigMapPredicateFunc() predicate.Funcs {
+	return rsnamespace.GetNamespaceRSConfigMapPredicateFunc()
 }
 
 // GetVirtualizationRSConfigMapPredicateFunc returns predicate for virtualization right-sizing ConfigMap
-func GetVirtualizationRSConfigMapPredicateFunc(ctx context.Context, c client.Client) predicate.Funcs {
-	return rsvirtualization.GetVirtualizationRSConfigMapPredicateFunc(ctx, c)
+func GetVirtualizationRSConfigMapPredicateFunc() predicate.Funcs {
+	return rsvirtualization.GetVirtualizationRSConfigMapPredicateFunc()
 }
 
 // CleanupPolicyResourcesForDelegation cleans up Policy-based right-sizing resources when delegating to MCOA.

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-namespace/configmap.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-namespace/configmap.go
@@ -35,9 +35,9 @@ func GetRightSizingConfigData(cm *corev1.ConfigMap) (rsutility.RSNamespaceConfig
 	return rsutility.GetRSConfigData(cm)
 }
 
-// Gets the namesapce rightsizing predicate function
-func GetNamespaceRSConfigMapPredicateFunc(ctx context.Context, c client.Client) predicate.Funcs {
-	return rsutility.GetRSConfigMapPredicateFunc(ctx, c, ConfigMapName, ApplyRSNamespaceConfigMapChanges)
+// GetNamespaceRSConfigMapPredicateFunc returns the namespace right-sizing ConfigMap predicate.
+func GetNamespaceRSConfigMapPredicateFunc() predicate.Funcs {
+	return rsutility.GetRSConfigMapPredicateFunc(ConfigMapName)
 }
 
 // ApplyRSNamespaceConfigMapChanges updates PrometheusRule, Policy, Placement based on configmap changes

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component.go
@@ -110,9 +110,6 @@ func HandleComponentRightSizing(
 		return nil
 	}
 
-	// Detect fresh enable (first time, or re-enable after delegation cleanup reset)
-	freshEnable := !state.Enabled
-
 	// Set the flag if namespaceBindingUpdated
 	namespaceBindingUpdated := state.Namespace != newBinding && state.Enabled
 
@@ -128,30 +125,28 @@ func HandleComponentRightSizing(
 		return err
 	}
 
-	if namespaceBindingUpdated || freshEnable {
-		if namespaceBindingUpdated {
-			// Clean up resources except config map to update NamespaceBinding
-			if err := CleanupComponentResources(ctx, c, componentConfig, existingNamespace, true); err != nil {
-				return fmt.Errorf("rs - failed to cleanup %s resources after namespace binding update: %w", componentConfig.ComponentType, err)
-			}
+	if namespaceBindingUpdated {
+		// Clean up resources except config map to update NamespaceBinding
+		if err := CleanupComponentResources(ctx, c, componentConfig, existingNamespace, true); err != nil {
+			return fmt.Errorf("rs - failed to cleanup %s resources after namespace binding update: %w", componentConfig.ComponentType, err)
 		}
+	}
 
-		// Get configmap
-		cm := &corev1.ConfigMap{}
-		if err := c.Get(ctx, client.ObjectKey{Name: componentConfig.ConfigMapName, Namespace: config.GetDefaultNamespace()}, cm); err != nil {
-			return fmt.Errorf("rs - failed to get existing configmap: %w", err)
-		}
+	// Get configmap
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(ctx, client.ObjectKey{Name: componentConfig.ConfigMapName, Namespace: config.GetDefaultNamespace()}, cm); err != nil {
+		return fmt.Errorf("rs - failed to get existing configmap: %w", err)
+	}
 
-		// Get configmap data into specified structure
-		configData, err := GetRSConfigData(cm)
-		if err != nil {
-			return fmt.Errorf("rs - failed to extract config data: %w", err)
-		}
+	// Get configmap data into specified structure
+	configData, err := GetRSConfigData(cm)
+	if err != nil {
+		return fmt.Errorf("rs - failed to extract config data: %w", err)
+	}
 
-		// Apply the Policy, Placement, PlacementBinding
-		if err := componentConfig.ApplyChangesFunc(ctx, c, configData); err != nil {
-			return fmt.Errorf("rs - failed to apply configmap changes: %w", err)
-		}
+	// Apply the Policy, Placement, PlacementBinding
+	if err := componentConfig.ApplyChangesFunc(ctx, c, configData); err != nil {
+		return fmt.Errorf("rs - failed to apply configmap changes: %w", err)
 	}
 
 	log.Info("rs - create component task completed", "component", componentConfig.ComponentType)

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component_test.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component_test.go
@@ -249,8 +249,8 @@ func TestHandleComponentRightSizing_FreshEnableAfterDelegation(t *testing.T) {
 	assert.True(t, state.Enabled)
 	assert.Equal(t, "custom-ns", state.Namespace)
 
-	// Verify ApplyChangesFunc was called (freshEnable path)
-	assert.True(t, applyChangesCalled, "ApplyChangesFunc should be called on fresh enable after delegation reset")
+	// Verify ApplyChangesFunc was called
+	assert.True(t, applyChangesCalled, "ApplyChangesFunc should be called after delegation reset")
 }
 
 func TestCleanupComponentResources_WithConfigMap(t *testing.T) {

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component_test.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component_test.go
@@ -253,6 +253,94 @@ func TestHandleComponentRightSizing_FreshEnableAfterDelegation(t *testing.T) {
 	assert.True(t, applyChangesCalled, "ApplyChangesFunc should be called after delegation reset")
 }
 
+func TestHandleComponentRightSizing_NamespaceBindingChange(t *testing.T) {
+	scheme := setupComponentTestScheme(t)
+	mco := newTestMCOForComponent(ComponentTypeNamespace, "new-ns", true)
+
+	applyChangesCalled := false
+	trackingApplyFunc := func(ctx context.Context, c client.Client, configData RSNamespaceConfigMapData) error {
+		applyChangesCalled = true
+		return nil
+	}
+
+	componentConfig := ComponentConfig{
+		ComponentType:            ComponentTypeNamespace,
+		ConfigMapName:            "test-config",
+		PlacementName:            "test-placement",
+		PlacementBindingName:     "test-binding",
+		PrometheusRulePolicyName: "test-policy",
+		DefaultNamespace:         "default-ns",
+		GetDefaultConfigFunc:     mockGetDefaultConfigFunc,
+		ApplyChangesFunc:         trackingApplyFunc,
+	}
+
+	// Simulate already-enabled state with a different namespace
+	state := &ComponentState{
+		Namespace: "old-ns",
+		Enabled:   true,
+	}
+
+	// Pre-create resources in the old namespace that should be cleaned up
+	oldPlacement := &clusterv1beta1.Placement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-placement",
+			Namespace: "old-ns",
+		},
+	}
+	oldBinding := &policyv1.PlacementBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-binding",
+			Namespace: "old-ns",
+		},
+	}
+	oldPolicy := &policyv1.Policy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-policy",
+			Namespace: "old-ns",
+		},
+	}
+
+	existingCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: "open-cluster-management-observability",
+		},
+		Data: mockGetDefaultConfigFunc(),
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mco, existingCM, oldPlacement, oldBinding, oldPolicy).
+		Build()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := HandleComponentRightSizing(ctx, client, mco, componentConfig, state)
+	require.NoError(t, err)
+
+	// Verify state updated to new namespace
+	assert.True(t, state.Enabled)
+	assert.Equal(t, "new-ns", state.Namespace)
+
+	// Verify ApplyChangesFunc was called
+	assert.True(t, applyChangesCalled, "ApplyChangesFunc should be called after namespace binding change")
+
+	// Verify old namespace resources were cleaned up
+	err = client.Get(ctx, types.NamespacedName{Name: "test-placement", Namespace: "old-ns"}, &clusterv1beta1.Placement{})
+	assert.True(t, errors.IsNotFound(err), "old placement should be deleted")
+
+	err = client.Get(ctx, types.NamespacedName{Name: "test-binding", Namespace: "old-ns"}, &policyv1.PlacementBinding{})
+	assert.True(t, errors.IsNotFound(err), "old placement binding should be deleted")
+
+	err = client.Get(ctx, types.NamespacedName{Name: "test-policy", Namespace: "old-ns"}, &policyv1.Policy{})
+	assert.True(t, errors.IsNotFound(err), "old policy should be deleted")
+
+	// Verify ConfigMap was NOT deleted (bindingUpdated=true preserves it)
+	err = client.Get(ctx, types.NamespacedName{Name: "test-config", Namespace: "open-cluster-management-observability"}, &corev1.ConfigMap{})
+	assert.NoError(t, err, "ConfigMap should be preserved during namespace binding change")
+}
+
 func TestCleanupComponentResources_WithConfigMap(t *testing.T) {
 	scheme := setupComponentTestScheme(t)
 

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/configmap.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/configmap.go
@@ -9,9 +9,7 @@ import (
 	"fmt"
 	"reflect"
 
-	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
-	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/util"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -81,61 +79,26 @@ func GetRSConfigData(cm *corev1.ConfigMap) (RSNamespaceConfigMapData, error) {
 	return configData, nil
 }
 
-// GetRSConfigMapPredicateFunc returns a predicate function for watching ConfigMap events
-func GetRSConfigMapPredicateFunc(ctx context.Context, c client.Client, configMapName string, applyChangesFunc func(context.Context, client.Client, RSNamespaceConfigMapData) error) predicate.Funcs {
-	log.Info("rs - watch for ConfigMap events set up started")
-
-	processConfigMap := func(cm *corev1.ConfigMap) bool {
-		// Skip policy creation when RS is delegated to MCOA.
-		// Without this check, the predicate side-effect creates MCO policies
-		// even when the analytics controller detects delegation and returns early.
-		mcoList := &mcov1beta2.MultiClusterObservabilityList{}
-		if err := c.List(ctx, mcoList); err == nil && len(mcoList.Items) > 0 {
-			if util.IsRightSizingDelegated(&mcoList.Items[0]) {
-				log.Info("rs - skipping ConfigMap policy side-effect, delegated to MCOA")
-				return true
-			}
-		}
-
-		configData, err := GetRSConfigData(cm)
-		if err != nil {
-			log.Error(err, "rs - failed to extract config data")
-			return false
-		}
-
-		// Apply changes based on the config map
-		if err := applyChangesFunc(ctx, c, configData); err != nil {
-			log.Error(err, "rs - failed to apply configmap changes")
-			return false
-		}
-		return true
-	}
-
+// GetRSConfigMapPredicateFunc returns a predicate that filters ConfigMap watch
+// events to only the named RS ConfigMap with actual data changes.
+func GetRSConfigMapPredicateFunc(configMapName string) predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			if e.Object.GetName() == configMapName && e.Object.GetNamespace() == config.GetDefaultNamespace() {
-				if cm, ok := e.Object.(*corev1.ConfigMap); ok {
-					return processConfigMap(cm)
-				}
-			}
-			return true
+			return e.Object.GetName() == configMapName && e.Object.GetNamespace() == config.GetDefaultNamespace()
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			if e.ObjectNew.GetName() != configMapName || e.ObjectNew.GetNamespace() != config.GetDefaultNamespace() {
-				return true
+				return false
 			}
 
-			// Check if the ConfigMap `Data` has changed before proceeding
 			oldCM, oldOK := e.ObjectOld.(*corev1.ConfigMap)
 			newCM, newOK := e.ObjectNew.(*corev1.ConfigMap)
-
 			if oldOK && newOK && reflect.DeepEqual(oldCM.Data, newCM.Data) {
-				log.V(1).Info("rs - no changes detected in configmap data, skipping update")
-				return true
+				return false
 			}
-
-			log.V(1).Info("rs - configmap data has changed, processing update")
-			return processConfigMap(newCM)
+			return true
 		},
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
 }

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-virtualization/configmap.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-virtualization/configmap.go
@@ -34,8 +34,8 @@ func GetRightSizingVirtualizationConfigData(cm *corev1.ConfigMap) (rsutility.RSN
 	return rsutility.GetRSConfigData(cm)
 }
 
-func GetVirtualizationRSConfigMapPredicateFunc(ctx context.Context, c client.Client) predicate.Funcs {
-	return rsutility.GetRSConfigMapPredicateFunc(ctx, c, ConfigMapName, ApplyRSVirtualizationConfigMapChanges)
+func GetVirtualizationRSConfigMapPredicateFunc() predicate.Funcs {
+	return rsutility.GetRSConfigMapPredicateFunc(ConfigMapName)
 }
 
 func ApplyRSVirtualizationConfigMapChanges(ctx context.Context, c client.Client, configData rsutility.RSNamespaceConfigMapData) error {


### PR DESCRIPTION
The analytics controller's ConfigMap predicates returned true for non-matching ConfigMaps and executed side-effects (Policy/Placement creation) inside the informer goroutine, causing many spurious reconciles per operator restart.

Fix 1: Predicate now returns false for non-matching ConfigMaps, adds explicit DeleteFunc/GenericFunc returning false, and skips reconcile when ConfigMap data hasn't changed.

Fix 2: Removed processConfigMap side-effect closure from predicate. Apply logic now runs unconditionally in the reconcile loop via HandleComponentRightSizing, which is safe since all apply functions are idempotent (Get-then-Create/Update).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified ConfigMap event predicates to be pure filters (no side-effectful processing) and reduced coupling to controller context.
  * Updated right-sizing logic to always load/apply config when enabled and to perform cleanup only when namespace bindings change.
  * Adjusted analytics reconcile flow to requeue immediately after adding finalizers for faster follow-up processing.

* **Tests**
  * Updated unit assertions to reflect the revised right-sizing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->