### PR TITLE
[ACM-34202] feat(scripts): provision an HCP on AWS

### DIFF
--- a/dev-scripts/provision-hcp/.gitignore
+++ b/dev-scripts/provision-hcp/.gitignore
@@ -1,0 +1,4 @@
+hub.yaml
+spoke.yaml
+env.sh
+.DS_Store

--- a/dev-scripts/provision-hcp/01-check-prereqs.sh
+++ b/dev-scripts/provision-hcp/01-check-prereqs.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Check:
+# - Required environment variables are set
+# - Required tools are installed and in PATH
+# - Required files (pull secret, SSH key) exist and are valid
+# - Clusters access
+# - AWS credentials
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+log_pass() {
+  echo -e "  ${GREEN}PASS${NC} $1"
+  ((PASS++)) || true
+}
+log_fail() {
+  echo -e "  ${RED}FAIL${NC} $1"
+  ((FAIL++)) || true
+}
+log_info() { echo -e "${YELLOW}==>${NC} $1"; }
+
+# --- Source env.sh ---
+if [[ ! -f "${SCRIPT_DIR}/env.sh" ]]; then
+  echo -e "${RED}ERROR:${NC} env.sh not found. Run: cp env.sh.example env.sh"
+  exit 1
+fi
+source "${SCRIPT_DIR}/env.sh"
+
+# --- 1. Required environment variables ---
+log_info "Checking environment variables"
+
+REQUIRED_VARS=(
+  HUB_KUBECONFIG
+  SPOKE_KUBECONFIG
+  MC_NAME
+  HC_NAME
+  HC_NAMESPACE
+  AWS_REGION
+  BASE_DOMAIN
+  PARENT_DOMAIN
+  PULL_SECRET_FILE
+  SSH_KEY_FILE
+)
+
+for var in "${REQUIRED_VARS[@]}"; do
+  if [[ -z ${!var:-} ]]; then
+    log_fail "$var is not set"
+  else
+    log_pass "$var=${!var}"
+  fi
+done
+
+# --- 2. Required tools ---
+log_info "Checking required tools"
+
+REQUIRED_TOOLS=(oc aws hcp jq dig timeout)
+
+for tool in "${REQUIRED_TOOLS[@]}"; do
+  if command -v "$tool" &>/dev/null; then
+    log_pass "$tool found: $(command -v "$tool")"
+  else
+    log_fail "$tool not found in PATH"
+  fi
+done
+
+# --- 3. Files ---
+log_info "Checking files"
+
+if [[ -f ${PULL_SECRET_FILE} ]]; then
+  if jq empty "${PULL_SECRET_FILE}" 2>/dev/null; then
+    log_pass "Pull secret exists and is valid JSON: ${PULL_SECRET_FILE}"
+  else
+    log_fail "Pull secret exists but is not valid JSON: ${PULL_SECRET_FILE}"
+  fi
+else
+  log_fail "Pull secret not found: ${PULL_SECRET_FILE}"
+fi
+
+if [[ -f ${SSH_KEY_FILE} ]]; then
+  log_pass "SSH key exists: ${SSH_KEY_FILE}"
+else
+  log_fail "SSH key not found: ${SSH_KEY_FILE}"
+fi
+
+# --- 4. Hub cluster access ---
+log_info "Checking hub cluster access"
+
+if [[ ! -f ${HUB_KUBECONFIG} ]]; then
+  log_fail "Hub kubeconfig not found: ${HUB_KUBECONFIG}"
+else
+  HUB_USER=$(KUBECONFIG="${HUB_KUBECONFIG}" oc whoami 2>/dev/null) &&
+    log_pass "Hub access: logged in as ${HUB_USER}" ||
+    log_fail "Hub access: cannot authenticate (check HUB_KUBECONFIG)"
+
+  HUB_SERVER=$(KUBECONFIG="${HUB_KUBECONFIG}" oc whoami --show-server 2>/dev/null) &&
+    log_pass "Hub server: ${HUB_SERVER}" || true
+
+  MC_STATUS=$(KUBECONFIG="${HUB_KUBECONFIG}" oc get managedcluster "${MC_NAME}" -o jsonpath='{.status.conditions[?(@.type=="ManagedClusterConditionAvailable")].status}' 2>/dev/null) || true
+  if [[ ${MC_STATUS} == "True" ]]; then
+    log_pass "ManagedCluster ${MC_NAME} is available"
+  else
+    log_fail "ManagedCluster ${MC_NAME} not found or not available"
+  fi
+fi
+
+# --- 5. Spoke cluster access ---
+log_info "Checking spoke cluster access"
+
+if [[ ! -f ${SPOKE_KUBECONFIG} ]]; then
+  log_fail "Spoke kubeconfig not found: ${SPOKE_KUBECONFIG}"
+else
+  SPOKE_USER=$(KUBECONFIG="${SPOKE_KUBECONFIG}" oc whoami 2>/dev/null) &&
+    log_pass "Spoke access: logged in as ${SPOKE_USER}" ||
+    log_fail "Spoke access: cannot authenticate (check SPOKE_KUBECONFIG)"
+
+  SPOKE_SERVER=$(KUBECONFIG="${SPOKE_KUBECONFIG}" oc whoami --show-server 2>/dev/null) &&
+    log_pass "Spoke server: ${SPOKE_SERVER}" || true
+
+  SPOKE_NODES=$(KUBECONFIG="${SPOKE_KUBECONFIG}" oc get nodes --no-headers 2>/dev/null | wc -l) &&
+    log_pass "Spoke has ${SPOKE_NODES} node(s)" ||
+    log_fail "Cannot list spoke nodes"
+fi
+
+# --- 6. AWS credentials ---
+log_info "Checking AWS credentials"
+
+if AWS_IDENTITY=$(aws sts get-caller-identity --output json 2>/dev/null); then
+  AWS_ACCOUNT=$(echo "${AWS_IDENTITY}" | jq -r '.Account')
+  AWS_ARN=$(echo "${AWS_IDENTITY}" | jq -r '.Arn')
+  log_pass "AWS identity: ${AWS_ARN} (account ${AWS_ACCOUNT})"
+else
+  log_fail "AWS credentials not configured or invalid"
+fi
+
+if aws s3api list-buckets --query 'Buckets[0].Name' --output text &>/dev/null; then
+  log_pass "AWS S3 access works"
+else
+  log_fail "AWS S3 access failed (check IAM permissions)"
+fi
+
+if aws route53 list-hosted-zones --query 'HostedZones[0].Name' --output text &>/dev/null; then
+  log_pass "AWS Route53 access works"
+else
+  log_fail "AWS Route53 access failed (check IAM permissions)"
+fi
+
+# --- Summary ---
+echo ""
+echo "=============================="
+echo -e "  ${GREEN}PASSED: ${PASS}${NC}    ${RED}FAILED: ${FAIL}${NC}"
+echo "=============================="
+
+if [[ ${FAIL} -gt 0 ]]; then
+  echo -e "\n${RED}Fix the failures above before proceeding.${NC}"
+  exit 1
+else
+  echo -e "\n${GREEN}All checks passed. Ready to run 02-aws-setup.sh${NC}"
+fi

--- a/dev-scripts/provision-hcp/02-aws-setup.sh
+++ b/dev-scripts/provision-hcp/02-aws-setup.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# Setup AWS resources for Hosted Clusters.
+# Each function is idempontent: if the resource already exists, it is skipped
+# So the script can safely be re-run.
+# Creates:
+# - Route53 hosted zone for the base domain, with delegation from the parent domain
+# - S3 bucket for OIDC storage, with public read access
+# - ConfigMap on the spoke with OIDC bucket info
+# - Secret + AddOnDeploymentConfig on the hub for OIDC credentials
+# - IAM role with permissions for Hypershift
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_DIR="${SCRIPT_DIR}/.state"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log_ok() { echo -e "  ${GREEN}OK${NC}   $1"; }
+log_skip() { echo -e "  ${GREEN}SKIP${NC} $1 (already exists)"; }
+log_run() { echo -e "  ${YELLOW}CREATE${NC} $1"; }
+log_err() { echo -e "  ${RED}ERROR${NC} $1"; }
+log_info() { echo -e "${YELLOW}==>${NC} $1"; }
+
+source "${SCRIPT_DIR}/env.sh"
+mkdir -p "${STATE_DIR}"
+
+OIDC_BUCKET="hcp-oidc-${USER}-${HC_NAME}"
+
+# ============================================================
+# 1. Route53 sub-zone
+# ============================================================
+log_info "Route53 sub-zone: ${BASE_DOMAIN}"
+
+SUBZONE_ID=$(aws route53 list-hosted-zones \
+  --query "HostedZones[?Name=='${BASE_DOMAIN}.'].Id" --output text 2>/dev/null | head -1)
+
+if [[ -n ${SUBZONE_ID} && ${SUBZONE_ID} != "None" ]]; then
+  log_skip "Zone ${BASE_DOMAIN} (${SUBZONE_ID})"
+else
+  log_run "Creating zone ${BASE_DOMAIN}"
+  SUBZONE_ID=$(aws route53 create-hosted-zone \
+    --name "${BASE_DOMAIN}" \
+    --caller-reference "hcp-$(date +%s)" \
+    --query 'HostedZone.Id' --output text)
+  log_ok "Created zone ${SUBZONE_ID}"
+fi
+echo "${SUBZONE_ID}" >"${STATE_DIR}/subzone-id"
+
+# Get NS records
+NS_RECORDS=$(aws route53 get-hosted-zone --id "${SUBZONE_ID}" \
+  --query 'DelegationSet.NameServers' --output json)
+log_ok "NS records: $(echo "${NS_RECORDS}" | jq -r 'join(", ")')"
+
+# NS delegation in parent
+log_info "NS delegation in parent zone: ${PARENT_DOMAIN}"
+
+PARENT_ZONE_ID=$(aws route53 list-hosted-zones \
+  --query "HostedZones[?Name=='${PARENT_DOMAIN}.'].Id" --output text 2>/dev/null | head -1)
+
+if [[ -z ${PARENT_ZONE_ID} || ${PARENT_ZONE_ID} == "None" ]]; then
+  log_err "Parent zone ${PARENT_DOMAIN} not found"
+  exit 1
+fi
+
+log_run "Upserting NS delegation for ${BASE_DOMAIN} in ${PARENT_DOMAIN}"
+NS_RRS=$(echo "${NS_RECORDS}" | jq '[.[] | {"Value": .}]')
+aws route53 change-resource-record-sets --hosted-zone-id "${PARENT_ZONE_ID}" --change-batch '{
+  "Changes": [{
+    "Action": "UPSERT",
+    "ResourceRecordSet": {
+      "Name": "'"${BASE_DOMAIN}"'",
+      "Type": "NS",
+      "TTL": 300,
+      "ResourceRecords": '"${NS_RRS}"'
+    }
+  }]
+}' >/dev/null
+log_ok "NS delegation set"
+
+# Verify
+NS_CHECK=$(dig +short NS "${BASE_DOMAIN}" 2>/dev/null | head -1)
+if [[ -n ${NS_CHECK} ]]; then
+  log_ok "DNS delegation verified: ${NS_CHECK} ..."
+else
+  echo -e "  ${YELLOW}WARN${NC} DNS delegation not yet resolving (may take a few minutes)"
+fi
+
+# ============================================================
+# 2. OIDC S3 bucket
+# ============================================================
+log_info "OIDC S3 bucket: ${OIDC_BUCKET}"
+
+if aws s3api head-bucket --bucket "${OIDC_BUCKET}" >/dev/null 2>&1; then
+  log_skip "Bucket ${OIDC_BUCKET}"
+else
+  log_run "Creating bucket ${OIDC_BUCKET}"
+  aws s3api create-bucket --bucket "${OIDC_BUCKET}" --region "${AWS_REGION}" >/dev/null
+  log_ok "Bucket created"
+fi
+echo "${OIDC_BUCKET}" >"${STATE_DIR}/oidc-bucket"
+
+log_run "Configuring public access (idempotent)"
+aws s3api put-public-access-block --bucket "${OIDC_BUCKET}" \
+  --public-access-block-configuration \
+  "BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false"
+
+aws s3api put-bucket-policy --bucket "${OIDC_BUCKET}" --policy '{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "AllowPublicRead",
+    "Effect": "Allow",
+    "Principal": "*",
+    "Action": "s3:GetObject",
+    "Resource": "arn:aws:s3:::'"${OIDC_BUCKET}"'/*"
+  }]
+}'
+log_ok "Bucket policy set"
+
+# ============================================================
+# 3. OIDC ConfigMap on spoke
+# ============================================================
+log_info "OIDC ConfigMap on spoke (kube-public)"
+
+KUBECONFIG="${SPOKE_KUBECONFIG}" oc apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oidc-storage-provider-s3-config
+  namespace: kube-public
+data:
+  name: ${OIDC_BUCKET}
+  region: ${AWS_REGION}
+EOF
+log_ok "ConfigMap applied"
+
+# ============================================================
+# 4. OIDC secret + AddOnDeploymentConfig on hub
+# ============================================================
+log_info "OIDC credentials on hub (namespace: ${MC_NAME})"
+
+if KUBECONFIG="${HUB_KUBECONFIG}" oc get secret \
+  hypershift-operator-oidc-provider-s3-credentials \
+  -n "${MC_NAME}" >/dev/null 2>&1; then
+  log_skip "OIDC credentials secret in ${MC_NAME}"
+else
+  log_run "Creating OIDC credentials secret"
+  TMPFILE=$(mktemp)
+  cat >"${TMPFILE}" <<CREDS
+[default]
+aws_access_key_id = $(aws configure get aws_access_key_id)
+aws_secret_access_key = $(aws configure get aws_secret_access_key)
+CREDS
+  KUBECONFIG="${HUB_KUBECONFIG}" oc create secret generic \
+    hypershift-operator-oidc-provider-s3-credentials \
+    --from-file=credentials="${TMPFILE}" \
+    --from-literal=bucket="${OIDC_BUCKET}" \
+    --from-literal=region="${AWS_REGION}" \
+    -n "${MC_NAME}"
+  rm -f "${TMPFILE}"
+  log_ok "Secret created"
+fi
+
+log_info "AddOnDeploymentConfig on hub"
+KUBECONFIG="${HUB_KUBECONFIG}" oc apply -f - <<EOF
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: hypershift-operator-oidc-provider-s3
+  namespace: ${MC_NAME}
+spec:
+  customizedVariables:
+  - name: bucketSecretName
+    value: hypershift-operator-oidc-provider-s3-credentials
+  - name: bucketName
+    value: ${OIDC_BUCKET}
+  - name: bucketRegion
+    value: ${AWS_REGION}
+EOF
+log_ok "AddOnDeploymentConfig applied"
+
+# ============================================================
+# 5. IAM role
+# ============================================================
+log_info "IAM role: hcp-hypershift-role"
+
+if aws iam get-role --role-name hcp-hypershift-role &>/dev/null; then
+  log_skip "IAM role hcp-hypershift-role"
+else
+  log_run "Creating IAM role"
+  AWS_USER_ARN=$(aws sts get-caller-identity --query Arn --output text)
+
+  TMPFILE=$(mktemp)
+  cat >"${TMPFILE}" <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "AWS": "${AWS_USER_ARN}" },
+    "Action": "sts:AssumeRole"
+  }]
+}
+EOF
+  ROLE_ARN=$(aws iam create-role \
+    --role-name hcp-hypershift-role \
+    --assume-role-policy-document "file://${TMPFILE}" \
+    --query 'Role.Arn' --output text)
+  rm -f "${TMPFILE}"
+  log_ok "Role created: ${ROLE_ARN}"
+fi
+
+ROLE_ARN=$(aws iam get-role --role-name hcp-hypershift-role --query 'Role.Arn' --output text)
+echo "${ROLE_ARN}" >"${STATE_DIR}/role-arn"
+
+log_info "IAM role policy"
+TMPFILE=$(mktemp)
+cat >"${TMPFILE}" <<'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {"Sid": "EC2Full", "Effect": "Allow", "Action": "ec2:*", "Resource": "*"},
+    {"Sid": "ELB", "Effect": "Allow", "Action": "elasticloadbalancing:*", "Resource": "*"},
+    {"Sid": "Route53", "Effect": "Allow", "Action": "route53:*", "Resource": "*"},
+    {"Sid": "IAM", "Effect": "Allow", "Action": [
+      "iam:CreateRole", "iam:DeleteRole", "iam:GetRole", "iam:TagRole", "iam:UntagRole",
+      "iam:AttachRolePolicy", "iam:DetachRolePolicy", "iam:PutRolePolicy",
+      "iam:DeleteRolePolicy", "iam:GetRolePolicy", "iam:ListRolePolicies",
+      "iam:ListAttachedRolePolicies",
+      "iam:CreateInstanceProfile", "iam:DeleteInstanceProfile", "iam:GetInstanceProfile",
+      "iam:AddRoleToInstanceProfile", "iam:RemoveRoleFromInstanceProfile",
+      "iam:PassRole", "iam:CreateServiceLinkedRole",
+      "iam:CreateOpenIDConnectProvider", "iam:DeleteOpenIDConnectProvider",
+      "iam:GetOpenIDConnectProvider", "iam:TagOpenIDConnectProvider",
+      "iam:ListOpenIDConnectProviders"
+    ], "Resource": "*"},
+    {"Sid": "S3", "Effect": "Allow", "Action": "s3:*", "Resource": "*"},
+    {"Sid": "STS", "Effect": "Allow", "Action": ["sts:AssumeRole", "sts:AssumeRoleWithWebIdentity", "sts:GetCallerIdentity"], "Resource": "*"},
+    {"Sid": "KMS", "Effect": "Allow", "Action": ["kms:DescribeKey", "kms:CreateGrant"], "Resource": "*"}
+  ]
+}
+EOF
+aws iam put-role-policy \
+  --role-name hcp-hypershift-role \
+  --policy-name hypershift-permissions \
+  --policy-document "file://${TMPFILE}"
+rm -f "${TMPFILE}"
+log_ok "Role policy attached"
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "=============================="
+echo -e "${GREEN}AWS setup complete${NC}"
+echo "=============================="
+echo "  Route53 zone:  ${BASE_DOMAIN} (${SUBZONE_ID})"
+echo "  OIDC bucket:   ${OIDC_BUCKET}"
+echo "  IAM role:      ${ROLE_ARN}"
+echo "  State dir:     ${STATE_DIR}/"
+echo ""
+echo -e "${GREEN}Ready to run 03-create-hc.sh${NC}"

--- a/dev-scripts/provision-hcp/03-create-hc.sh
+++ b/dev-scripts/provision-hcp/03-create-hc.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# Prerequisites: run 01-check-prereqs.sh and 02-aws-setup.sh first
+# Executes:
+# - Hypershift installation via ACM AddOn
+# - HCP and AWS resource provisioning
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_DIR="${SCRIPT_DIR}/.state"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log_ok() { echo -e "  ${GREEN}OK${NC}   $1"; }
+log_skip() { echo -e "  ${GREEN}SKIP${NC} $1 (already exists)"; }
+log_run() { echo -e "  ${YELLOW}...${NC}  $1"; }
+log_err() { echo -e "  ${RED}ERROR${NC} $1"; }
+log_info() { echo -e "${YELLOW}==>${NC} $1"; }
+
+source "${SCRIPT_DIR}/env.sh"
+
+HCP_NAMESPACE="clusters-${HC_NAME}"
+ROLE_ARN=$(cat "${STATE_DIR}/role-arn" 2>/dev/null || aws iam get-role --role-name hcp-hypershift-role --query 'Role.Arn' --output text 2>/dev/null || echo "")
+
+if [[ -z ${ROLE_ARN} ]]; then
+  log_err "IAM role not found. Run 02-aws-setup.sh first."
+  exit 1
+fi
+
+# ============================================================
+# 1. Enable hypershift-addon on hub
+# ============================================================
+log_info "hypershift-addon on hub (namespace: ${MC_NAME})"
+
+if KUBECONFIG="${HUB_KUBECONFIG}" oc get managedclusteraddon \
+  hypershift-addon -n "${MC_NAME}" >/dev/null 2>&1; then
+  log_skip "ManagedClusterAddOn hypershift-addon"
+else
+  log_run "Creating ManagedClusterAddOn"
+  KUBECONFIG="${HUB_KUBECONFIG}" oc apply -f - <<EOF
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: hypershift-addon
+  namespace: ${MC_NAME}
+spec:
+  installNamespace: open-cluster-management-agent-addon
+  configs:
+  - group: addon.open-cluster-management.io
+    resource: addondeploymentconfigs
+    name: hypershift-operator-oidc-provider-s3
+    namespace: ${MC_NAME}
+EOF
+  log_ok "ManagedClusterAddOn created"
+fi
+
+log_run "Waiting for addon to become available (timeout 3m)"
+for i in $(seq 1 18); do
+  AVAILABLE=$(KUBECONFIG="${HUB_KUBECONFIG}" oc get managedclusteraddon \
+    hypershift-addon -n "${MC_NAME}" \
+    -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null || echo "")
+  if [[ ${AVAILABLE} == "True" ]]; then
+    log_ok "Addon is available"
+    break
+  fi
+  if [[ $i -eq 18 ]]; then
+    log_err "Addon not available after 3 minutes"
+    KUBECONFIG="${HUB_KUBECONFIG}" oc get managedclusteraddon -n "${MC_NAME}" hypershift-addon
+    exit 1
+  fi
+  sleep 10
+done
+
+# ============================================================
+# 2. Verify operator has been deployed on spoke
+# ============================================================
+log_info "HyperShift operator on spoke"
+
+log_run "Waiting for operator pods to be ready (timeout 3m)"
+for i in $(seq 1 18); do
+  READY_PODS=$(KUBECONFIG="${SPOKE_KUBECONFIG}" oc get deploy -n hypershift operator \
+    -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+  READY_PODS=${READY_PODS:-0}
+  if [[ ${READY_PODS} -ge 2 ]]; then
+    log_ok "${READY_PODS} operator pods ready"
+    break
+  fi
+  if [[ $i -eq 18 ]]; then
+    log_err "Operator pods not ready after 3 minutes"
+    KUBECONFIG="${SPOKE_KUBECONFIG}" oc get pods -n hypershift
+    exit 1
+  fi
+  sleep 10
+done
+
+OIDC_ARGS=$(KUBECONFIG="${SPOKE_KUBECONFIG}" oc get deploy -n hypershift operator \
+  -o jsonpath='{.spec.template.spec.containers[0].args}' 2>/dev/null || echo "")
+if echo "${OIDC_ARGS}" | grep -q "oidc-storage-provider-s3-bucket-name"; then
+  log_ok "Operator has OIDC S3 args configured"
+else
+  log_err "Operator missing OIDC S3 args — check AddOnDeploymentConfig on hub"
+  exit 1
+fi
+
+# ============================================================
+# 3. Enable wildcard routes
+# ============================================================
+log_info "Wildcard routes on spoke"
+
+KUBECONFIG="${SPOKE_KUBECONFIG}" oc patch ingresscontroller -n openshift-ingress-operator default \
+  --type=merge -p '{"spec":{"routeAdmission":{"wildcardPolicy":"WildcardsAllowed"}}}' 2>/dev/null || true
+log_ok "Wildcard routes enabled"
+
+# ============================================================
+# 4. Check if HC already exists
+# ============================================================
+log_info "Checking for existing HostedCluster ${HC_NAME}"
+
+if KUBECONFIG="${SPOKE_KUBECONFIG}" oc get hostedcluster "${HC_NAME}" \
+  -n "${HC_NAMESPACE}" >/dev/null 2>&1; then
+  HC_AVAILABLE=$(KUBECONFIG="${SPOKE_KUBECONFIG}" oc get hostedcluster "${HC_NAME}" \
+    -n "${HC_NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null || echo "")
+  if [[ ${HC_AVAILABLE} == "True" ]]; then
+    log_skip "HostedCluster ${HC_NAME} (already available)"
+    KUBECONFIG="${SPOKE_KUBECONFIG}" oc get hostedcluster -n "${HC_NAMESPACE}" "${HC_NAME}"
+  else
+    echo -e "  ${YELLOW}WAIT${NC} HostedCluster ${HC_NAME} exists but not yet available — skipping to wait step"
+  fi
+else
+  # ============================================================
+  # 5. Determine release version
+  # ============================================================
+  if [[ -z ${RELEASE_VERSION:-} ]]; then
+    log_info "Determining release version"
+    SUPPORTED_OCP=$(KUBECONFIG="${SPOKE_KUBECONFIG}" oc logs -n hypershift -l app=operator \
+      --tail=200 2>/dev/null | grep -o "Latest supported OCP: [0-9.]*" | head -1 | awk '{print $NF}')
+    if [[ -z ${SUPPORTED_OCP} ]]; then
+      log_err "Could not determine supported OCP version from operator logs"
+      exit 1
+    fi
+    OCP_MAJOR_MINOR=$(echo "${SUPPORTED_OCP}" | grep -o '^[0-9]*\.[0-9]*')
+    RELEASE_VERSION=$(curl -s "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-${OCP_MAJOR_MINOR}/release.txt" |
+      grep "Name:" | awk '{print $2}')
+    if [[ -z ${RELEASE_VERSION} ]]; then
+      log_err "Could not determine latest stable patch for ${OCP_MAJOR_MINOR}"
+      exit 1
+    fi
+    log_ok "Release version: ${RELEASE_VERSION} (auto-detected)"
+  else
+    log_ok "Release version: ${RELEASE_VERSION} (from env.sh)"
+  fi
+
+  # ============================================================
+  # 6. Generate STS session token
+  # ============================================================
+  log_info "Generating STS session token"
+  aws sts get-session-token --output json >/tmp/sts-creds.json
+  log_ok "STS token saved to /tmp/sts-creds.json"
+
+  # ============================================================
+  # 7. Render + apply
+  # ============================================================
+  log_info "Rendering HostedCluster manifests"
+
+  if [[ ! -f ${PULL_SECRET_FILE} ]]; then
+    log_err "Pull secret not found: ${PULL_SECRET_FILE}"
+    exit 1
+  fi
+  if [[ ! -f ${SSH_KEY_FILE} ]]; then
+    log_err "SSH key not found: ${SSH_KEY_FILE}"
+    exit 1
+  fi
+
+  log_run "Running hcp create cluster aws --render (creates AWS infra)"
+  RENDER_LOG="/tmp/hcp-render-${HC_NAME}.log"
+
+  if KUBECONFIG="${SPOKE_KUBECONFIG}" hcp create cluster aws \
+    --name="${HC_NAME}" \
+    --namespace="${HC_NAMESPACE}" \
+    --region="${AWS_REGION}" \
+    --release-image="quay.io/openshift-release-dev/ocp-release:${RELEASE_VERSION}-x86_64" \
+    --pull-secret="${PULL_SECRET_FILE}" \
+    --ssh-key="${SSH_KEY_FILE}" \
+    --node-pool-replicas="${NODE_POOL_REPLICAS:-2}" \
+    --instance-type="${INSTANCE_TYPE:-m6i.xlarge}" \
+    --base-domain="${BASE_DOMAIN}" \
+    --control-plane-availability-policy="${AVAILABILITY_POLICY:-SingleReplica}" \
+    --infra-availability-policy="${AVAILABILITY_POLICY:-SingleReplica}" \
+    --sts-creds=/tmp/sts-creds.json \
+    --role-arn="${ROLE_ARN}" \
+    --render --render-sensitive >/tmp/hc-rendered.yaml 2> >(tee "${RENDER_LOG}" >&2); then
+    log_ok "Rendered to /tmp/hc-rendered.yaml"
+  else
+    log_err "Render failed. Check output above for details."
+    FAILED_INFRA_ID=$(grep '"Creating infrastructure"' "${RENDER_LOG}" 2>/dev/null | grep -o '"id":"[^"]*"' | cut -d'"' -f4) || true
+    if [[ -n ${FAILED_INFRA_ID} ]]; then
+      echo "${FAILED_INFRA_ID}" >"${STATE_DIR}/infra-id"
+      log_err "AWS resources were created with infra ID: ${FAILED_INFRA_ID}"
+    fi
+    log_err "Run ./04-destroy-hc.sh to clean up orphaned AWS resources."
+    rm -f "${RENDER_LOG}"
+    exit 1
+  fi
+  rm -f "${RENDER_LOG}"
+
+  if [[ ! -s /tmp/hc-rendered.yaml ]]; then
+    log_err "Rendered file is empty — render produced no output."
+    exit 1
+  fi
+
+  log_info "Applying HostedCluster manifest"
+  KUBECONFIG="${SPOKE_KUBECONFIG}" oc apply -f /tmp/hc-rendered.yaml
+  log_ok "Applied"
+fi
+
+# ============================================================
+# 8. Wait for availability
+# ============================================================
+log_info "Waiting for HostedCluster to become available (timeout 30m)"
+
+for i in $(seq 1 180); do
+  HC_AVAILABLE=$(KUBECONFIG="${SPOKE_KUBECONFIG}" oc get hostedcluster "${HC_NAME}" \
+    -n "${HC_NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null || echo "")
+  HC_MSG=$(KUBECONFIG="${SPOKE_KUBECONFIG}" oc get hostedcluster "${HC_NAME}" \
+    -n "${HC_NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Available")].message}' 2>/dev/null || echo "")
+
+  if [[ ${HC_AVAILABLE} == "True" ]]; then
+    log_ok "HostedCluster is available: ${HC_MSG}"
+    break
+  fi
+
+  if [[ $((i % 6)) -eq 0 ]]; then
+    echo -e "  ${YELLOW}...${NC}  [$((i * 10 / 60))m] ${HC_MSG:-waiting...}"
+  fi
+
+  if [[ $i -eq 180 ]]; then
+    log_err "HostedCluster not available after 30 minutes"
+    KUBECONFIG="${SPOKE_KUBECONFIG}" oc get hostedcluster -n "${HC_NAMESPACE}" "${HC_NAME}"
+    exit 1
+  fi
+  sleep 10
+done
+
+# Wait for nodes
+log_info "Waiting for worker nodes"
+DESIRED=$(KUBECONFIG="${SPOKE_KUBECONFIG}" oc get nodepool -n "${HC_NAMESPACE}" \
+  -o jsonpath='{.items[0].spec.replicas}' 2>/dev/null || echo "${NODE_POOL_REPLICAS:-2}")
+
+for i in $(seq 1 60); do
+  CURRENT=$(KUBECONFIG="${SPOKE_KUBECONFIG}" oc get nodepool -n "${HC_NAMESPACE}" \
+    -o jsonpath='{.items[0].status.replicas}' 2>/dev/null || echo "0")
+  if [[ ${CURRENT} -ge ${DESIRED} ]]; then
+    log_ok "${CURRENT}/${DESIRED} nodes ready"
+    break
+  fi
+  if [[ $i -eq 60 ]]; then
+    echo -e "  ${YELLOW}WARN${NC} Nodes ${CURRENT}/${DESIRED} after 10 minutes — continuing anyway"
+    break
+  fi
+  sleep 10
+done
+
+# Extract kubeconfig
+log_info "Extracting admin kubeconfig"
+HC_KUBECONFIG="/tmp/${HC_NAME}-kubeconfig"
+KUBECONFIG="${SPOKE_KUBECONFIG}" oc extract "secret/${HC_NAME}-admin-kubeconfig" \
+  -n "${HC_NAMESPACE}" --to=- >"${HC_KUBECONFIG}" 2>/dev/null
+echo "${HC_KUBECONFIG}" >"${STATE_DIR}/hc-kubeconfig"
+log_ok "Kubeconfig saved to ${HC_KUBECONFIG}"
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "=============================="
+echo -e "${GREEN}Hosted cluster ${HC_NAME} is ready${NC}"
+echo "=============================="
+echo ""
+echo "  Destroy:"
+echo "    ./04-destroy-hc.sh"

--- a/dev-scripts/provision-hcp/04-destroy-hc.sh
+++ b/dev-scripts/provision-hcp/04-destroy-hc.sh
@@ -1,0 +1,407 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_DIR="${SCRIPT_DIR}/.state"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+ok() { echo -e "  ${GREEN}OK${NC}   $1"; }
+skip() { echo -e "  ${GREEN}SKIP${NC} $1 (not found)"; }
+run() { echo -e "  ${YELLOW}...${NC}  $1"; }
+CLEANUP_FAILED=false
+err() {
+  echo -e "  ${RED}ERROR${NC} $1"
+  CLEANUP_FAILED=true
+}
+info() { echo -e "${YELLOW}==>${NC} $1"; }
+
+source "${SCRIPT_DIR}/env.sh"
+
+HCP_NAMESPACE="clusters-${HC_NAME}"
+OIDC_BUCKET=$(cat "${STATE_DIR}/oidc-bucket" 2>/dev/null || echo "hcp-oidc-${USER}-${HC_NAME}")
+ROLE_ARN=$(cat "${STATE_DIR}/role-arn" 2>/dev/null ||
+  aws iam get-role --role-name hcp-hypershift-role --query 'Role.Arn' --output text 2>/dev/null || echo "")
+
+# ============================================================
+# cleanup_aws_infra <infra-id>
+# Deletes all AWS resources tagged with the given infra ID:
+# ============================================================
+cleanup_aws_infra() {
+  local infra_id="$1"
+  info "Cleaning AWS resources for infra ID: ${infra_id}"
+
+  # EC2 instances
+  local instance_ids
+  instance_ids=$(aws ec2 describe-instances \
+    --filters "Name=tag:kubernetes.io/cluster/${infra_id},Values=owned" "Name=instance-state-name,Values=running,pending,stopping,stopped" \
+    --query 'Reservations[].Instances[].InstanceId' --output text --region "${AWS_REGION}" 2>/dev/null)
+  if [[ -n ${instance_ids} ]]; then
+    run "Terminating EC2 instances"
+    aws ec2 terminate-instances --instance-ids ${instance_ids} --region "${AWS_REGION}" >/dev/null
+    aws ec2 wait instance-terminated --instance-ids ${instance_ids} --region "${AWS_REGION}" 2>/dev/null || true
+    ok "EC2 instances terminated"
+  fi
+
+  # VPC and its dependencies
+  local vpc_id
+  vpc_id=$(aws ec2 describe-vpcs \
+    --filters "Name=tag:kubernetes.io/cluster/${infra_id},Values=owned" \
+    --query 'Vpcs[0].VpcId' --output text --region "${AWS_REGION}" 2>/dev/null)
+
+  if [[ -n ${vpc_id} && ${vpc_id} != "None" ]]; then
+    # Load balancers (NLB/ALB)
+    local lb_arns
+    lb_arns=$(aws elbv2 describe-load-balancers \
+      --query "LoadBalancers[?VpcId=='${vpc_id}'].LoadBalancerArn" --output text --region "${AWS_REGION}" 2>/dev/null)
+    for lb in ${lb_arns}; do
+      run "Deleting load balancer"
+      aws elbv2 delete-load-balancer --load-balancer-arn "${lb}" --region "${AWS_REGION}" 2>/dev/null || true
+    done
+    # Classic ELBs
+    local clb_names
+    clb_names=$(aws elb describe-load-balancers \
+      --query "LoadBalancerDescriptions[?VPCId=='${vpc_id}'].LoadBalancerName" --output text --region "${AWS_REGION}" 2>/dev/null)
+    for clb in ${clb_names}; do
+      run "Deleting classic LB ${clb}"
+      aws elb delete-load-balancer --load-balancer-name "${clb}" --region "${AWS_REGION}" 2>/dev/null || true
+    done
+    if [[ -n ${lb_arns} || -n ${clb_names} ]]; then
+      run "Waiting for LB ENIs to detach (30s)"
+      sleep 30
+    fi
+
+    # Security groups (non-default)
+    local sg_ids
+    sg_ids=$(aws ec2 describe-security-groups \
+      --filters "Name=vpc-id,Values=${vpc_id}" \
+      --query "SecurityGroups[?GroupName!='default'].GroupId" --output text --region "${AWS_REGION}" 2>/dev/null)
+    for sg in ${sg_ids}; do
+      local ingress egress
+      ingress=$(aws ec2 describe-security-groups --group-ids "${sg}" --query 'SecurityGroups[0].IpPermissions' --output json --region "${AWS_REGION}" 2>/dev/null)
+      [[ ${ingress} != "[]" ]] && aws ec2 revoke-security-group-ingress --group-id "${sg}" --ip-permissions "${ingress}" --region "${AWS_REGION}" >/dev/null 2>&1 || true
+      egress=$(aws ec2 describe-security-groups --group-ids "${sg}" --query 'SecurityGroups[0].IpPermissionsEgress' --output json --region "${AWS_REGION}" 2>/dev/null)
+      [[ ${egress} != "[]" ]] && aws ec2 revoke-security-group-egress --group-id "${sg}" --ip-permissions "${egress}" --region "${AWS_REGION}" >/dev/null 2>&1 || true
+      aws ec2 delete-security-group --group-id "${sg}" --region "${AWS_REGION}" >/dev/null 2>&1 || true
+    done
+
+    # NAT gateways
+    local nat_ids
+    nat_ids=$(aws ec2 describe-nat-gateways \
+      --filter "Name=vpc-id,Values=${vpc_id}" "Name=state,Values=available,pending" \
+      --query 'NatGateways[].NatGatewayId' --output text --region "${AWS_REGION}" 2>/dev/null)
+    for nat in ${nat_ids}; do
+      run "Deleting NAT gateway ${nat}"
+      aws ec2 delete-nat-gateway --nat-gateway-id "${nat}" --region "${AWS_REGION}" >/dev/null 2>&1 || true
+    done
+    [[ -n ${nat_ids} ]] && sleep 60
+
+    # VPC endpoints
+    local vpce_ids
+    vpce_ids=$(aws ec2 describe-vpc-endpoints \
+      --filters "Name=vpc-id,Values=${vpc_id}" \
+      --query 'VpcEndpoints[].VpcEndpointId' --output text --region "${AWS_REGION}" 2>/dev/null)
+    [[ -n ${vpce_ids} ]] && aws ec2 delete-vpc-endpoints --vpc-endpoint-ids ${vpce_ids} --region "${AWS_REGION}" >/dev/null 2>&1 || true
+
+    # Subnets
+    for subnet in $(aws ec2 describe-subnets --filters "Name=vpc-id,Values=${vpc_id}" --query 'Subnets[].SubnetId' --output text --region "${AWS_REGION}" 2>/dev/null); do
+      aws ec2 delete-subnet --subnet-id "${subnet}" --region "${AWS_REGION}" 2>/dev/null || true
+    done
+
+    # Internet gateway
+    for igw in $(aws ec2 describe-internet-gateways --filters "Name=attachment.vpc-id,Values=${vpc_id}" --query 'InternetGateways[].InternetGatewayId' --output text --region "${AWS_REGION}" 2>/dev/null); do
+      aws ec2 detach-internet-gateway --internet-gateway-id "${igw}" --vpc-id "${vpc_id}" --region "${AWS_REGION}" 2>/dev/null || true
+      aws ec2 delete-internet-gateway --internet-gateway-id "${igw}" --region "${AWS_REGION}" 2>/dev/null || true
+    done
+
+    # Route tables (non-main)
+    for rt in $(aws ec2 describe-route-tables --filters "Name=vpc-id,Values=${vpc_id}" --query 'RouteTables[?Associations[0].Main!=`true`].RouteTableId' --output text --region "${AWS_REGION}" 2>/dev/null); do
+      for assoc in $(aws ec2 describe-route-tables --route-table-ids "${rt}" --query 'RouteTables[0].Associations[?!Main].RouteTableAssociationId' --output text --region "${AWS_REGION}" 2>/dev/null); do
+        aws ec2 disassociate-route-table --association-id "${assoc}" --region "${AWS_REGION}" 2>/dev/null || true
+      done
+      aws ec2 delete-route-table --route-table-id "${rt}" --region "${AWS_REGION}" 2>/dev/null || true
+    done
+
+    # EIPs
+    for eip in $(aws ec2 describe-addresses --filters "Name=tag:kubernetes.io/cluster/${infra_id},Values=owned" --query 'Addresses[].AllocationId' --output text --region "${AWS_REGION}" 2>/dev/null); do
+      aws ec2 release-address --allocation-id "${eip}" --region "${AWS_REGION}" 2>/dev/null || true
+    done
+
+    # VPC
+    run "Deleting VPC ${vpc_id}"
+    aws ec2 delete-vpc --vpc-id "${vpc_id}" --region "${AWS_REGION}" 2>/dev/null &&
+      ok "VPC deleted" || err "VPC deletion failed — may need manual cleanup"
+
+    # DHCP options
+    for dhcp in $(aws ec2 describe-dhcp-options --filters "Name=tag:kubernetes.io/cluster/${infra_id},Values=owned" --query 'DhcpOptions[].DhcpOptionsId' --output text --region "${AWS_REGION}" 2>/dev/null); do
+      aws ec2 delete-dhcp-options --dhcp-options-id "${dhcp}" --region "${AWS_REGION}" 2>/dev/null || true
+    done
+  fi
+
+  # Route53 private zones
+  for zone_name in "${HC_NAME}.${BASE_DOMAIN}." "${HC_NAME}.hypershift.local."; do
+    local zone_id
+    zone_id=$(aws route53 list-hosted-zones \
+      --query "HostedZones[?Name=='${zone_name}' && Config.PrivateZone==\`true\`].Id" --output text 2>/dev/null | head -1)
+    if [[ -n ${zone_id} && ${zone_id} != "None" && ${zone_id} != "" ]]; then
+      local change_batch record_count
+      change_batch=$(aws route53 list-resource-record-sets --hosted-zone-id "${zone_id}" --output json |
+        jq '{"Changes": [.ResourceRecordSets[] | select(.Type != "NS" and .Type != "SOA") | {"Action": "DELETE", "ResourceRecordSet": .}]}')
+      record_count=$(echo "${change_batch}" | jq '.Changes | length')
+      if [[ ${record_count} -gt 0 ]]; then
+        echo "${change_batch}" >/tmp/zone-batch.json
+        aws route53 change-resource-record-sets --hosted-zone-id "${zone_id}" \
+          --change-batch file:///tmp/zone-batch.json >/dev/null 2>&1 || true
+        rm -f /tmp/zone-batch.json
+      fi
+      aws route53 delete-hosted-zone --id "${zone_id}" >/dev/null 2>&1 || true
+      ok "Deleted private zone ${zone_name}"
+    fi
+  done
+
+  # IAM roles
+  for role_suffix in cloud-network-config-controller openshift-ingress openshift-image-registry \
+    aws-ebs-csi-driver-controller cloud-controller node-pool control-plane-operator; do
+    aws iam delete-role-policy --role-name "${infra_id}-${role_suffix}" --policy-name "${infra_id}-${role_suffix}" 2>/dev/null || true
+    aws iam delete-role --role-name "${infra_id}-${role_suffix}" 2>/dev/null || true
+  done
+  aws iam remove-role-from-instance-profile --instance-profile-name "${infra_id}-worker" --role-name "${infra_id}-worker-role" 2>/dev/null || true
+  aws iam delete-instance-profile --instance-profile-name "${infra_id}-worker" 2>/dev/null || true
+  aws iam delete-role-policy --role-name "${infra_id}-worker-role" --policy-name "${infra_id}-worker-policy" 2>/dev/null || true
+  aws iam delete-role --role-name "${infra_id}-worker-role" 2>/dev/null || true
+
+  # OIDC provider
+  local aws_account_id
+  aws_account_id=$(aws sts get-caller-identity --query Account --output text)
+  aws iam delete-open-id-connect-provider \
+    --open-id-connect-provider-arn "arn:aws:iam::${aws_account_id}:oidc-provider/${OIDC_BUCKET}.s3.${AWS_REGION}.amazonaws.com/${infra_id}" 2>/dev/null || true
+
+  ok "AWS infrastructure cleanup complete for ${infra_id}"
+}
+
+# ============================================================
+# force_cleanup_hcp
+# Removes K8s finalizers and force-deletes the HostedCluster,
+# then calls cleanup_aws_infra to clean orphaned AWS resources.
+# ============================================================
+force_cleanup_hcp() {
+  local infra_id
+  infra_id=$(KUBECONFIG="${SPOKE_KUBECONFIG}" oc get hostedcluster "${HC_NAME}" \
+    -n "${HC_NAMESPACE}" -o jsonpath='{.spec.infraID}' 2>/dev/null || echo "")
+
+  KUBECONFIG="${SPOKE_KUBECONFIG}" oc patch hostedcontrolplane -n "${HCP_NAMESPACE}" "${HC_NAME}" \
+    --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+  KUBECONFIG="${SPOKE_KUBECONFIG}" oc patch cluster.cluster.x-k8s.io -n "${HCP_NAMESPACE}" "${HC_NAME}" \
+    --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+  KUBECONFIG="${SPOKE_KUBECONFIG}" oc delete hostedcluster -n "${HC_NAMESPACE}" "${HC_NAME}" \
+    --force --grace-period=0 2>/dev/null || true
+  KUBECONFIG="${SPOKE_KUBECONFIG}" oc delete namespace "${HCP_NAMESPACE}" \
+    --force --grace-period=0 2>/dev/null || true
+  ok "Kubernetes resources force-deleted"
+
+  if [[ -n ${infra_id} ]]; then
+    cleanup_aws_infra "${infra_id}"
+  else
+    err "Could not determine infra ID — check for orphaned AWS resources manually"
+  fi
+}
+
+# ============================================================
+# Parse flags
+# ============================================================
+CLEANUP_DNS=false
+SKIP_CONFIRM=false
+for arg in "$@"; do
+  case "${arg}" in
+    --cleanup-dns) CLEANUP_DNS=true ;;
+    --yes) SKIP_CONFIRM=true ;;
+  esac
+done
+
+# ============================================================
+# Confirmation
+# ============================================================
+if [[ ${SKIP_CONFIRM} != "true" ]]; then
+  echo ""
+  echo -e "${RED}This will destroy:${NC}"
+  echo "  - HostedCluster ${HC_NAME} (and all its AWS resources: VPC, EC2, ELB, etc.)"
+  echo "  - hypershift-addon on spoke ${MC_NAME}"
+  echo "  - IAM role hcp-hypershift-role"
+  echo "  - OIDC S3 bucket ${OIDC_BUCKET}"
+  if [[ ${CLEANUP_DNS} == "true" ]]; then
+    echo "  - Route53 sub-zone ${BASE_DOMAIN} and NS delegation"
+  fi
+  echo ""
+  read -rp "Continue? [y/N] " confirm
+  if [[ ${confirm} != "y" && ${confirm} != "Y" ]]; then
+    echo "Aborted."
+    exit 0
+  fi
+fi
+
+# ============================================================
+# 1. Destroy hosted cluster
+# ============================================================
+info "Destroying HostedCluster ${HC_NAME}"
+
+if KUBECONFIG="${SPOKE_KUBECONFIG}" oc get hostedcluster "${HC_NAME}" \
+  -n "${HC_NAMESPACE}" >/dev/null 2>&1; then
+  if [[ ! -f /tmp/sts-creds.json ]]; then
+    run "Generating STS session token"
+    aws sts get-session-token --output json >/tmp/sts-creds.json
+  fi
+
+  run "Running hcp destroy cluster aws (timeout 15m)"
+  if KUBECONFIG="${SPOKE_KUBECONFIG}" timeout 900 hcp destroy cluster aws \
+    --name="${HC_NAME}" \
+    --namespace="${HC_NAMESPACE}" \
+    --sts-creds=/tmp/sts-creds.json \
+    --role-arn="${ROLE_ARN}" \
+    --region="${AWS_REGION}" 2>&1; then
+    ok "HostedCluster destroyed"
+  else
+    echo -e "  ${YELLOW}WARN${NC} hcp destroy timed out or failed — attempting force cleanup"
+    force_cleanup_hcp
+  fi
+else
+  # No HC on cluster — check for orphaned infra from a failed render
+  ORPHAN_INFRA_ID=$(cat "${STATE_DIR}/infra-id" 2>/dev/null || echo "")
+  if [[ -n ${ORPHAN_INFRA_ID} ]]; then
+    info "No HostedCluster found, but orphaned infra ID detected: ${ORPHAN_INFRA_ID}"
+    cleanup_aws_infra "${ORPHAN_INFRA_ID}"
+    rm -f "${STATE_DIR}/infra-id"
+  else
+    skip "HostedCluster ${HC_NAME}"
+  fi
+fi
+
+# ============================================================
+# 2. Remove hypershift-addon (on hub)
+# ============================================================
+info "Removing hypershift-addon from hub"
+
+KUBECONFIG="${HUB_KUBECONFIG}" oc delete managedclusteraddon \
+  hypershift-addon -n "${MC_NAME}" --ignore-not-found 2>/dev/null &&
+  ok "ManagedClusterAddOn deleted" || skip "ManagedClusterAddOn"
+
+KUBECONFIG="${HUB_KUBECONFIG}" oc delete addondeploymentconfig \
+  hypershift-operator-oidc-provider-s3 -n "${MC_NAME}" --ignore-not-found 2>/dev/null &&
+  ok "AddOnDeploymentConfig deleted" || skip "AddOnDeploymentConfig"
+
+KUBECONFIG="${HUB_KUBECONFIG}" oc delete secret \
+  hypershift-operator-oidc-provider-s3-credentials -n "${MC_NAME}" --ignore-not-found 2>/dev/null &&
+  ok "OIDC credentials secret deleted" || skip "OIDC credentials secret"
+
+# ============================================================
+# 3. Clean up spoke-side OIDC resources
+# ============================================================
+info "Cleaning spoke-side OIDC ConfigMap"
+
+KUBECONFIG="${SPOKE_KUBECONFIG}" oc delete configmap \
+  oidc-storage-provider-s3-config -n kube-public --ignore-not-found 2>/dev/null &&
+  ok "ConfigMap deleted" || skip "ConfigMap"
+
+# ============================================================
+# 4. Clean up IAM role
+# ============================================================
+info "Cleaning IAM role"
+
+if aws iam get-role --role-name hcp-hypershift-role &>/dev/null; then
+  aws iam delete-role-policy --role-name hcp-hypershift-role \
+    --policy-name hypershift-permissions 2>/dev/null || true
+  aws iam delete-role --role-name hcp-hypershift-role 2>/dev/null
+  ok "IAM role hcp-hypershift-role deleted"
+else
+  skip "IAM role hcp-hypershift-role"
+fi
+
+# ============================================================
+# 5. Clean up S3 bucket
+# ============================================================
+info "Cleaning OIDC S3 bucket: ${OIDC_BUCKET}"
+
+if aws s3api head-bucket --bucket "${OIDC_BUCKET}" >/dev/null 2>&1; then
+  aws s3 rm "s3://${OIDC_BUCKET}" --recursive --quiet 2>/dev/null || true
+  aws s3api delete-bucket --bucket "${OIDC_BUCKET}" 2>/dev/null
+  ok "Bucket ${OIDC_BUCKET} deleted"
+else
+  skip "Bucket ${OIDC_BUCKET}"
+fi
+
+# ============================================================
+# 6. Clean up Route53 (optional)
+# ============================================================
+if [[ ${CLEANUP_DNS} == "true" ]]; then
+  info "Cleaning Route53 sub-zone: ${BASE_DOMAIN}"
+
+  SUBZONE_ID=$(cat "${STATE_DIR}/subzone-id" 2>/dev/null ||
+    aws route53 list-hosted-zones --query "HostedZones[?Name=='${BASE_DOMAIN}.'].Id" --output text 2>/dev/null | head -1)
+
+  if [[ -n ${SUBZONE_ID} && ${SUBZONE_ID} != "None" ]]; then
+    PARENT_ZONE_ID=$(aws route53 list-hosted-zones \
+      --query "HostedZones[?Name=='${PARENT_DOMAIN}.'].Id" --output text 2>/dev/null | head -1)
+
+    if [[ -n ${PARENT_ZONE_ID} && ${PARENT_ZONE_ID} != "None" ]]; then
+      NS_RECORDS=$(aws route53 get-hosted-zone --id "${SUBZONE_ID}" \
+        --query 'DelegationSet.NameServers' --output json 2>/dev/null || echo "[]")
+      NS_RRS=$(echo "${NS_RECORDS}" | jq '[.[] | {"Value": .}]')
+
+      aws route53 change-resource-record-sets --hosted-zone-id "${PARENT_ZONE_ID}" --change-batch '{
+              "Changes": [{
+                "Action": "DELETE",
+                "ResourceRecordSet": {
+                  "Name": "'"${BASE_DOMAIN}"'",
+                  "Type": "NS",
+                  "TTL": 300,
+                  "ResourceRecords": '"${NS_RRS}"'
+                }
+              }]
+            }' >/dev/null 2>&1 && ok "NS delegation removed" || echo -e "  ${YELLOW}WARN${NC} Could not remove NS delegation"
+    fi
+
+    # Delete all records in the sub-zone before deleting it
+    CHANGE_BATCH=$(aws route53 list-resource-record-sets --hosted-zone-id "${SUBZONE_ID}" --output json |
+      jq '{"Changes": [.ResourceRecordSets[] | select(.Type != "NS" and .Type != "SOA") | {"Action": "DELETE", "ResourceRecordSet": .}]}')
+    RECORD_COUNT=$(echo "${CHANGE_BATCH}" | jq '.Changes | length')
+
+    if [[ ${RECORD_COUNT} -gt 0 ]]; then
+      echo "${CHANGE_BATCH}" >/tmp/zone-batch.json
+      aws route53 change-resource-record-sets --hosted-zone-id "${SUBZONE_ID}" \
+        --change-batch file:///tmp/zone-batch.json >/dev/null 2>&1 || true
+      rm -f /tmp/zone-batch.json
+    fi
+
+    aws route53 delete-hosted-zone --id "${SUBZONE_ID}" >/dev/null 2>&1 &&
+      ok "Sub-zone ${BASE_DOMAIN} deleted" || err "Could not delete sub-zone"
+  else
+    skip "Sub-zone ${BASE_DOMAIN}"
+  fi
+else
+  echo -e "\n${YELLOW}NOTE:${NC} Route53 sub-zone ${BASE_DOMAIN} was NOT deleted."
+  echo "      Pass --cleanup-dns to also remove the sub-zone and NS delegation."
+fi
+
+# ============================================================
+# 7. Clean up state
+# ============================================================
+rm -f "/tmp/${HC_NAME}-kubeconfig" /tmp/hc-rendered.yaml /tmp/sts-creds.json
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+if [[ ${CLEANUP_FAILED} == "true" ]]; then
+  echo "=============================="
+  echo -e "${RED}Cleanup completed with errors${NC}"
+  echo "=============================="
+  echo -e "  .state/ preserved for retry. Re-run ./04-destroy-hc.sh"
+  exit 1
+else
+  rm -rf "${STATE_DIR}"
+  echo "=============================="
+  echo -e "${GREEN}Cleanup complete${NC}"
+  echo "=============================="
+fi

--- a/dev-scripts/provision-hcp/README.md
+++ b/dev-scripts/provision-hcp/README.md
@@ -1,0 +1,62 @@
+# HCP on AWS — Automation Scripts
+
+Scripts to deploy a Hosted Control Plane on a spoke cluster via the hub's `hypershift-addon`.
+See the [full guide](./docs/hcp-aws-spoke-via-addon-guide.md) for detailed explanations.
+
+## Architecture
+
+![Architecture](docs/architecture.png)
+
+## Quick Start
+
+Setup the environment values and run the numbered scripts in order
+
+```bash
+cp env.sh.example env.sh
+
+./01-check-prereqs.sh       # Validate requirements
+./02-aws-setup.sh           # Create Route53, OIDC S3, IAM role
+./03-create-hc.sh           # Deploy hypershift-addon + hosted cluster
+```
+
+When done, tear down OCP and AWS resources
+
+```
+./04-destroy-hc.sh          # Tear down everything
+```
+
+
+## Environment Variables
+
+| Variable | Description | Example |
+|---|---|---|
+| `HUB_KUBECONFIG` | Path to hub cluster kubeconfig | `~/.kube/hub-kubeconfig` |
+| `SPOKE_KUBECONFIG` | Path to spoke cluster kubeconfig | `~/.kube/spoke-kubeconfig` |
+| `MC_NAME` | ManagedCluster name on the hub | `my-spoke-cluster` |
+| `HC_NAME` | HostedCluster name | `hc-aws` |
+| `HC_NAMESPACE` | Namespace for HC/NodePool CRs | `clusters` |
+| `AWS_REGION` | AWS region for worker nodes | `us-east-1` |
+| `BASE_DOMAIN` | Route53 public hosted zone | `hcp-capa-me.dev07.red-chesterfield.com` |
+| `PARENT_DOMAIN` | Parent domain for NS delegation | `dev07.red-chesterfield.com` |
+| `PULL_SECRET_FILE` | Path to Red Hat pull secret JSON | `~/pull-secret.json` |
+| `SSH_KEY_FILE` | Path to SSH public key | `~/.ssh/id_ed25519.pub` |
+| `NODE_POOL_REPLICAS` | Number of worker nodes (default: 2) | `2` |
+| `INSTANCE_TYPE` | EC2 instance type (default: m6i.xlarge) | `m6i.xlarge` |
+| `AVAILABILITY_POLICY` | SingleReplica or HighlyAvailable | `SingleReplica` |
+| `RELEASE_VERSION` | Optional: desired OCP version | `4.21.15` |
+
+## Script Details
+
+- **All scripts are idempotent** — safe to re-run, existing resources are skipped
+- **State is stored in `.state/`** — resource IDs shared between scripts. In case of HCP spin-up failure, AWS infra-id will be saved for orphan resources clean-up withoud an actual Hosted Cluster
+
+## Cleanup
+
+```bash
+./04-destroy-hc.sh                # Interactive confirmation
+./04-destroy-hc.sh --yes          # Skip confirmation
+./04-destroy-hc.sh --cleanup-dns  # Also remove Route53 sub-zone
+```
+
+## Contribution
+Open an **Issue** to open a discussion on potetial changes or a **PR** for change proposals.

--- a/dev-scripts/provision-hcp/docs/hcp-aws-spoke-via-addon-guide.md
+++ b/dev-scripts/provision-hcp/docs/hcp-aws-spoke-via-addon-guide.md
@@ -1,0 +1,654 @@
+# HCP on AWS — Spoke Hosting via hypershift-addon
+
+Deployment of a Hosted Control Plane with AWS infrastructure, where the HCP control plane pods run on a spoke cluster managed by an ACM hub. The HyperShift operator is deployed to the spoke via the [`hypershift-addon`](https://github.com/stolostron/hypershift-addon-operator)
+
+---
+
+## Prerequisites
+
+- **An ACM hub cluster** with MCE installed and `hypershift-addon-manager` available
+- **An OCP spoke cluster** with:
+  - `oc` CLI access with cluster-admin
+  - Already imported as a ManagedCluster on the hub
+- AWS CLI
+- AWS IAM user or role with broad permissions (EC2, ELB, Route53, IAM, S3, STS, KMS)
+- AWS credentials configured locally (`~/.aws/credentials` or env vars)
+- A pull secret from https://console.redhat.com/openshift/install/pull-secret (see point 6.3)
+- An SSH public key (`~/.ssh/id_ed25519.pub` or `~/.ssh/id_rsa.pub`)
+
+## How to get your AWS IAM user
+The `observability-team` should get access to the `dev-07` AWS Account.
+
+A list of minimum IAM user policy:
+```json
+
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "EC2",
+        "Effect": "Allow",
+        "Action": [
+          "ec2:CreateVpc", "ec2:DeleteVpc", "ec2:DescribeVpcs", "ec2:ModifyVpcAttribute",
+          "ec2:CreateSubnet", "ec2:DeleteSubnet", "ec2:DescribeSubnets",
+          "ec2:CreateInternetGateway", "ec2:DeleteInternetGateway", "ec2:AttachInternetGateway", "ec2:DetachInternetGateway",
+  "ec2:DescribeInternetGateways",
+          "ec2:CreateNatGateway", "ec2:DeleteNatGateway", "ec2:DescribeNatGateways",
+          "ec2:AllocateAddress", "ec2:ReleaseAddress", "ec2:DescribeAddresses",
+          "ec2:CreateRouteTable", "ec2:DeleteRouteTable", "ec2:DescribeRouteTables",
+          "ec2:CreateRoute", "ec2:DeleteRoute",
+          "ec2:AssociateRouteTable", "ec2:DisassociateRouteTable", "ec2:ReplaceRouteTableAssociation",
+          "ec2:CreateVpcEndpoint", "ec2:DeleteVpcEndpoints", "ec2:DescribeVpcEndpoints",
+          "ec2:CreateDhcpOptions", "ec2:DeleteDhcpOptions", "ec2:AssociateDhcpOptions", "ec2:DescribeDhcpOptions",
+          "ec2:CreateSecurityGroup", "ec2:DeleteSecurityGroup", "ec2:DescribeSecurityGroups",
+          "ec2:AuthorizeSecurityGroupIngress", "ec2:AuthorizeSecurityGroupEgress",
+          "ec2:RevokeSecurityGroupIngress", "ec2:RevokeSecurityGroupEgress",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:CreateTags"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Sid": "Route53",
+        "Effect": "Allow",
+        "Action": [
+          "route53:CreateHostedZone", "route53:DeleteHostedZone",
+          "route53:GetHostedZone", "route53:ListHostedZones",
+          "route53:ChangeResourceRecordSets", "route53:ListResourceRecordSets",
+          "route53:GetChange"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Sid": "IAM",
+        "Effect": "Allow",
+        "Action": [
+          "iam:CreateRole", "iam:DeleteRole", "iam:GetRole", "iam:TagRole",
+          "iam:PutRolePolicy", "iam:DeleteRolePolicy", "iam:GetRolePolicy", "iam:ListRolePolicies",
+          "iam:AttachRolePolicy", "iam:DetachRolePolicy", "iam:ListAttachedRolePolicies",
+          "iam:CreateInstanceProfile", "iam:DeleteInstanceProfile", "iam:GetInstanceProfile",
+          "iam:AddRoleToInstanceProfile", "iam:RemoveRoleFromInstanceProfile",
+          "iam:PassRole",
+          "iam:CreateOpenIDConnectProvider", "iam:DeleteOpenIDConnectProvider",
+          "iam:GetOpenIDConnectProvider", "iam:TagOpenIDConnectProvider",
+          "iam:ListOpenIDConnectProviders"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Sid": "S3",
+        "Effect": "Allow",
+        "Action": [
+          "s3:CreateBucket", "s3:DeleteBucket",
+          "s3:PutBucketPolicy", "s3:GetBucketPolicy",
+          "s3:PutBucketPublicAccessBlock", "s3:GetBucketPublicAccessBlock",
+          "s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Sid": "STS",
+        "Effect": "Allow",
+        "Action": [
+          "sts:GetSessionToken",
+          "sts:AssumeRole",
+          "sts:GetCallerIdentity"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Sid": "KMS",
+        "Effect": "Allow",
+        "Action": ["kms:DescribeKey", "kms:CreateGrant"],
+        "Resource": "*"
+      }
+    ]
+  }
+```
+---
+
+## Conventions
+
+Set these at the start of every session:
+
+```bash
+export HC_NAME=hc-aws                               # HostedCluster name
+export HC_NAMESPACE=clusters                        # Where HC/NodePool CRs live
+export HCP_NAMESPACE=clusters-${HC_NAME}            # Where control plane pods run
+export AWS_REGION=us-east-1                         # AWS region for worker nodes
+export MC_NAME=<managed-cluster-name>               # Spoke name on the hub
+```
+
+Example of base domain for the ACM or observability-team **hcp-capa-myusername.dev07.red-chesterfield.com** composed of `hcp-capa-myusername` subdomain and the existing `dev07.red-chesterfield.com` parent domain.
+
+---
+
+## Step 0 — AWS credentials check
+
+```bash
+aws sts get-caller-identity
+```
+Should output your UserId and Account details.
+
+```bash
+aws configure list
+```
+Should output at least the `access_key` and `secret_key` generated from your AWS account.
+
+---
+
+## Step 1 — Route53 Delegated Sub-Zone
+
+You need a Route53 public hosted zone that you control. If you already have one, skip to Step 2. If you don't own a top-level domain, create a delegated sub-zone under an existing zone.
+
+### 1.1 Check existing zones
+
+```bash
+aws route53 list-hosted-zones --query 'HostedZones[].[Name,Id]' --output table
+```
+
+If you have a usable zone, set `BASE_DOMAIN` and skip ahead. Otherwise continue.
+`dev07.red-chesterfield.com` should be a suitable zone for the ACM team.
+
+### 1.2 Create the sub-zone
+
+```bash
+export BASE_DOMAIN=<your-prefix>.<parent-domain>
+# Example: hcp-capa-myusername.dev07.red-chesterfield.com
+
+aws route53 create-hosted-zone --name ${BASE_DOMAIN} --caller-reference $(date +%s) --query 'HostedZone.Id' --output text
+```
+
+Should return something like `/hostedzone/Z0XXXXXXXXXXXX`
+
+### 1.3 Get the NS records
+
+```bash
+SUBZONE_ID=<zone-id-from-above>
+
+aws route53 get-hosted-zone --id ${SUBZONE_ID} --query 'DelegationSet.NameServers' --output json
+```
+
+### 1.4 Add NS delegation in the parent zone
+
+Name Server delegation is needed for future DNS records registration like `*.apps.hc-aws.hcp-capa-myusername.dev07.red-chesterfield.com`
+
+```bash
+PARENT_DOMAIN=<parent-domain>     # Like dev07.red-chesterfield.com
+
+PARENT_ZONE_ID=$(aws route53 list-hosted-zones --query "HostedZones[?Name=='${PARENT_DOMAIN}.'].[Id]" --output text)
+
+aws route53 change-resource-record-sets --hosted-zone-id ${PARENT_ZONE_ID} --change-batch '{
+  "Changes": [{
+    "Action": "CREATE",
+    "ResourceRecordSet": {
+      "Name": "'${BASE_DOMAIN}'",
+      "Type": "NS",
+      "TTL": 300,
+      "ResourceRecords": [
+        {"Value": "<ns-1>"},
+        {"Value": "<ns-2>"},
+        {"Value": "<ns-3>"},
+        {"Value": "<ns-4>"}
+      ]
+    }
+  }]
+}'
+```
+
+### 1.5 Verify delegation
+
+```bash
+dig +short NS ${BASE_DOMAIN}
+```
+
+Should output the NS configured previously
+
+---
+
+## Step 2 — Configure OIDC S3 Bucket
+
+The AWS Security Token Service (STS) authentication flow requires an S3 bucket to host OIDC discovery documents.
+
+### 2.1 Create the S3 bucket
+
+```bash
+OIDC_BUCKET=hcp-oidc-${USER}-$(date +%s)
+
+aws s3api create-bucket --bucket ${OIDC_BUCKET} --region ${AWS_REGION}
+
+aws s3api put-public-access-block --bucket ${OIDC_BUCKET} --public-access-block-configuration "BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false"
+
+aws s3api put-bucket-policy --bucket ${OIDC_BUCKET} --policy '{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "AllowPublicRead",
+    "Effect": "Allow",
+    "Principal": "*",
+    "Action": "s3:GetObject",
+    "Resource": "arn:aws:s3:::'${OIDC_BUCKET}'/*"
+  }]
+}'
+
+echo "OIDC bucket: ${OIDC_BUCKET}"
+```
+
+### 2.2 Create the OIDC ConfigMap on the spoke
+
+This ConfigMap is used by the `hcp` CLI when rendering the HostedCluster manifest.
+
+```bash
+# On the spoke context
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oidc-storage-provider-s3-config
+  namespace: kube-public
+data:
+  name: ${OIDC_BUCKET}
+  region: ${AWS_REGION}
+EOF
+```
+
+### 2.3 Create the OIDC credentials and config on the hub
+
+**Switch to the hub** and create the secret + AddOnDeploymentConfig in the spoke's ManagedCluster namespace. The addon manager will use these to configure the HyperShift operator.
+
+```bash
+cat > /tmp/aws-creds <<EOF
+[default]
+aws_access_key_id = $(aws configure get aws_access_key_id)
+aws_secret_access_key = $(aws configure get aws_secret_access_key)
+EOF
+
+oc create secret generic hypershift-operator-oidc-provider-s3-credentials --from-file=credentials=/tmp/aws-creds --from-literal=bucket=${OIDC_BUCKET} --from-literal=region=${AWS_REGION} -n ${MC_NAME}
+
+rm /tmp/aws-creds
+
+cat <<EOF | oc apply -f -
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: hypershift-operator-oidc-provider-s3
+  namespace: ${MC_NAME}
+spec:
+  customizedVariables:
+  - name: bucketSecretName
+    value: hypershift-operator-oidc-provider-s3-credentials
+  - name: bucketName
+    value: ${OIDC_BUCKET}
+  - name: bucketRegion
+    value: ${AWS_REGION}
+EOF
+```
+
+---
+
+## Step 3 — Enable hypershift-addon on the Spoke (from Hub)
+
+The HyperShift operator is installed via the hypershift-addon. The operator orchestrates Hosted Clusters lifecycle.
+
+### 3.1 Verify the spoke is imported (on hub)
+
+```bash
+oc get managedcluster ${MC_NAME}
+# Should show JOINED=True, AVAILABLE=True
+```
+
+### 3.2 Create the hypershift-addon ManagedClusterAddOn
+
+Make sure the hypershift-operator-oidc-provider-s3 config has been created in Step 2.
+
+```bash
+cat <<EOF | oc apply -f -
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: hypershift-addon
+  namespace: ${MC_NAME}
+spec:
+  installNamespace: open-cluster-management-agent-addon
+  configs:
+  - group: addon.open-cluster-management.io
+    resource: addondeploymentconfigs
+    name: hypershift-operator-oidc-provider-s3
+    namespace: ${MC_NAME}
+EOF
+```
+
+### 3.3 Verify the addon is available
+
+```bash
+oc get managedclusteraddon -n ${MC_NAME} hypershift-addon
+# Expect: AVAILABLE=True, DEGRADED=False
+```
+
+### 3.4 Verify operator pods on the spoke
+
+Switch to the spoke and confirm the HyperShift operator appeared with the correct OIDC S3 args:
+
+```bash
+oc get pods -n hypershift
+# Expect 2 operator pods Running (may take 2-3 minutes)
+
+oc get deploy -n hypershift operator -o jsonpath='{.spec.template.spec.containers[0].args}' | grep oidc
+# Should show:
+#   --oidc-storage-provider-s3-bucket-name=<bucket>
+#   --oidc-storage-provider-s3-region=<region>
+#   --oidc-storage-provider-s3-credentials=/etc/oidc-storage-provider-s3-creds/credentials
+```
+
+### 3.5 Download the hcp CLI (from the hub)
+
+If you don't already have the `hcp` CLI, download it from the hub's MCE route:
+
+```bash
+# Run against the hub
+HCP_URL=$(oc get route -n multicluster-engine hcp-cli-download -o jsonpath='{.spec.host}')
+
+# Adjust arch: linux/amd64, darwin/arm64, darwin/amd64
+curl -kL -o /tmp/hcp.tar.gz "https://${HCP_URL}/darwin/arm64/hcp.tar.gz"
+tar -xzvf /tmp/hcp.tar.gz -C /tmp/
+sudo mv /tmp/hcp /usr/local/bin/
+hcp version
+```
+
+---
+
+## Step 4 — Create the IAM Role
+
+The hcp CLI requires an IAM role for the STS flow.
+
+### 4.1 Get your IAM identity
+
+```bash
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+AWS_USER_ARN=$(aws sts get-caller-identity --query Arn --output text)
+echo "Account: ${AWS_ACCOUNT_ID}, User: ${AWS_USER_ARN}"
+```
+
+### 4.2 Create the role
+
+```bash
+cat > /tmp/trust-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "AWS": "${AWS_USER_ARN}" },
+    "Action": "sts:AssumeRole"
+  }]
+}
+EOF
+
+aws iam create-role --role-name hcp-hypershift-role --assume-role-policy-document file:///tmp/trust-policy.json --query 'Role.Arn' --output text
+
+rm /tmp/trust-policy.json
+```
+
+This role is used by hcp cli and HyperShift operator to manage AWS resources.
+
+### 4.3 Attach permissions
+
+Find more fine-grained IAM permissions in the official documentation https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/pdf/hosted_control_planes/OpenShift_Container_Platform-4.21-Hosted_control_planes-en-US.pdf
+
+```bash
+cat > /tmp/hypershift-policy.json <<'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {"Sid": "EC2Full", "Effect": "Allow", "Action": "ec2:*", "Resource": "*"},
+    {"Sid": "ELB", "Effect": "Allow", "Action": "elasticloadbalancing:*", "Resource": "*"},
+    {"Sid": "Route53", "Effect": "Allow", "Action": "route53:*", "Resource": "*"},
+    {"Sid": "IAM", "Effect": "Allow", "Action": [
+      "iam:CreateRole", "iam:DeleteRole", "iam:GetRole", "iam:TagRole", "iam:UntagRole",
+      "iam:AttachRolePolicy", "iam:DetachRolePolicy", "iam:PutRolePolicy",
+      "iam:DeleteRolePolicy", "iam:GetRolePolicy", "iam:ListRolePolicies",
+      "iam:ListAttachedRolePolicies",
+      "iam:CreateInstanceProfile", "iam:DeleteInstanceProfile", "iam:GetInstanceProfile",
+      "iam:AddRoleToInstanceProfile", "iam:RemoveRoleFromInstanceProfile",
+      "iam:PassRole", "iam:CreateServiceLinkedRole",
+      "iam:CreateOpenIDConnectProvider", "iam:DeleteOpenIDConnectProvider",
+      "iam:GetOpenIDConnectProvider", "iam:TagOpenIDConnectProvider",
+      "iam:ListOpenIDConnectProviders"
+    ], "Resource": "*"},
+    {"Sid": "S3", "Effect": "Allow", "Action": "s3:*", "Resource": "*"},
+    {"Sid": "STS", "Effect": "Allow", "Action": ["sts:AssumeRole", "sts:AssumeRoleWithWebIdentity", "sts:GetCallerIdentity"], "Resource": "*"},
+    {"Sid": "KMS", "Effect": "Allow", "Action": ["kms:DescribeKey", "kms:CreateGrant"], "Resource": "*"}
+  ]
+}
+EOF
+
+aws iam put-role-policy --role-name hcp-hypershift-role --policy-name hypershift-permissions --policy-document file:///tmp/hypershift-policy.json
+
+rm /tmp/hypershift-policy.json
+```
+
+> For production, scope EC2/ELB/S3 permissions to specific regions and resources.
+
+---
+
+## Step 5 — Determine Release Version
+
+```bash
+# On the spoke
+oc logs -n hypershift -l app=operator --tail=200 | grep "Latest supported OCP"
+# Example: "Latest supported OCP: 4.21.0"
+
+# Find the latest stable patch:
+curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.21/release.txt | grep "Name:"
+```
+
+Set `RELEASE_VERSION` to the result (e.g., `4.21.15`).
+
+```bash
+RELEASE_VERSION=4.21.15
+```
+
+---
+
+## Step 6 — Create the HostedCluster (on Spoke)
+
+All commands in this phase run against the **spoke** cluster.
+
+### 6.1 Generate STS session token
+
+```bash
+aws sts get-session-token --output json > /tmp/sts-creds.json
+```
+
+This token expires in 12 hours. It is only used at render time by the `hcp` CLI.
+
+### 6.2 Enable wildcard routes on the spoke
+
+This is needed to serve requests like `*.apps.<hc-name>.<base-domain>`
+
+```bash
+oc patch ingresscontroller -n openshift-ingress-operator default --type=merge -p '{"spec":{"routeAdmission":{"wildcardPolicy":"WildcardsAllowed"}}}'
+```
+
+### 6.3 If needed, create the image repository pull secret
+
+Download a pull secret from https://console.redhat.com/openshift/install/pull-secret and save it locally:
+
+```bash
+# Save the downloaded JSON to a known path
+PULL_SECRET_FILE=~/pull-secret.json
+ls ${PULL_SECRET_FILE}  # verify the file exists before proceeding
+```
+
+### 6.4 Render and apply the HostedCluster
+
+You can select a different worker instance type, navigate the sizes here: https://aws.amazon.com/ec2/instance-types/general-purpose/
+
+> **IMPORTANT**: The `--render` option creates real AWS resources (VPC, subnets, NAT GW, IGW, route tables, Route53 zones, OIDC provider, IAM roles, instance profiles). If the command fails mid-way (e.g., wrong pull-secret path), you'll have orphaned AWS infra that needs manual cleanup. **Verify `PULL_SECRET_FILE` and `SSH_KEY_FILE` paths exist before running.**
+
+
+```bash
+ROLE_ARN=arn:aws:iam::${AWS_ACCOUNT_ID}:role/hcp-hypershift-role
+PULL_SECRET_FILE=<path-to-pull-secret>    # e.g., ~/pull-secret.json
+SSH_KEY_FILE=<path-to-ssh-pub-key>        # e.g., ~/.ssh/id_ed25519.pub
+
+hcp create cluster aws \
+  --name=${HC_NAME} \
+  --namespace=${HC_NAMESPACE} \
+  --region=${AWS_REGION} \
+  --release-image=quay.io/openshift-release-dev/ocp-release:${RELEASE_VERSION}-x86_64 \
+  --pull-secret=${PULL_SECRET_FILE} \
+  --ssh-key=${SSH_KEY_FILE} \
+  --node-pool-replicas=2 \
+  --instance-type=m6i.xlarge \
+  --base-domain=${BASE_DOMAIN} \
+  --control-plane-availability-policy=SingleReplica \
+  --infra-availability-policy=SingleReplica \
+  --sts-creds=/tmp/sts-creds.json \
+  --role-arn=${ROLE_ARN} \
+  --render --render-sensitive > /tmp/hc-rendered.yaml
+```
+
+> If the render fails and you need to re-run, pass `--infra-id=<infra-id>` (visible in the render logs) to reuse the already-created AWS resources instead of creating duplicates.
+
+### 6.5 Apply
+
+Verify the rendered manifest and apply
+
+```bash
+oc apply -f /tmp/hc-rendered.yaml
+```
+
+---
+
+## Step 7 — Monitor the Deployment
+
+### 7.1 Watch the control plane
+
+```bash
+oc get hostedcluster -n ${HC_NAMESPACE} ${HC_NAME} -w
+
+oc get pods -n ${HCP_NAMESPACE}
+# Expect ~45 pods over 5-10 minutes
+```
+
+### 7.2 Verify OIDC documents were uploaded
+
+```bash
+aws s3 ls s3://${OIDC_BUCKET}/ --recursive
+# Must show:
+#   <infra-id>/.well-known/openid-configuration
+#   <infra-id>/openid/v1/jwks
+```
+
+### 7.3 Watch worker provisioning
+
+```bash
+oc get nodepool -n ${HC_NAMESPACE}
+
+INFRA_ID=$(oc get hostedcluster -n ${HC_NAMESPACE} ${HC_NAME} -o jsonpath='{.spec.infraID}')
+aws ec2 describe-instances \
+  --filters "Name=tag:kubernetes.io/cluster/${INFRA_ID},Values=owned" \
+  --query 'Reservations[].Instances[].[InstanceId,State.Name,InstanceType,PrivateIpAddress]' \
+  --output table --region ${AWS_REGION}
+```
+
+### 7.4 Connect to the hosted cluster
+
+```bash
+oc extract secret/${HC_NAME}-admin-kubeconfig \
+  -n ${HC_NAMESPACE} --to=- > /tmp/${HC_NAME}-kubeconfig
+
+KUBECONFIG=/tmp/${HC_NAME}-kubeconfig oc whoami
+KUBECONFIG=/tmp/${HC_NAME}-kubeconfig oc get nodes
+KUBECONFIG=/tmp/${HC_NAME}-kubeconfig oc get co
+```
+
+---
+
+## Cleanup
+
+### Destroy the hosted cluster
+
+```bash
+ROLE_ARN=arn:aws:iam::${AWS_ACCOUNT_ID}:role/hcp-hypershift-role
+
+hcp destroy cluster aws \
+  --name=${HC_NAME} \
+  --namespace=${HC_NAMESPACE} \
+  --sts-creds=/tmp/sts-creds.json \
+  --role-arn=${ROLE_ARN} \
+  --region=${AWS_REGION}
+```
+
+> This tears down EC2 instances, VPC, subnets, NAT GW, ELBs, security groups, IAM roles, and Route53 records.
+
+### Remove the hypershift-addon (on hub)
+
+```bash
+# Switch to hub context
+oc delete managedclusteraddon -n ${MC_NAME} hypershift-addon
+oc delete addondeploymentconfig -n ${MC_NAME} hypershift-operator-oidc-provider-s3
+oc delete secret -n ${MC_NAME} hypershift-operator-oidc-provider-s3-credentials
+```
+
+### Clean up IAM role and S3 bucket
+
+```bash
+aws iam delete-role-policy --role-name hcp-hypershift-role --policy-name hypershift-permissions
+aws iam delete-role --role-name hcp-hypershift-role
+
+aws s3 rm s3://${OIDC_BUCKET} --recursive
+aws s3api delete-bucket --bucket ${OIDC_BUCKET}
+```
+
+### Clean up Route53 sub-zone delegation (if created)
+
+```bash
+# Delete the NS record from the parent zone
+aws route53 change-resource-record-sets --hosted-zone-id ${PARENT_ZONE_ID} --change-batch '{
+  "Changes": [{"Action": "DELETE", "ResourceRecordSet": {...}}]
+}'
+
+# Delete the sub-zone
+aws route53 delete-hosted-zone --id ${SUBZONE_ID}
+```
+
+### Cleaning up orphaned AWS infra from a failed render
+
+If `hcp create cluster aws --render` fails mid-way, it leaves partial AWS resources. The infra ID is printed in the render logs (e.g., `hc-aws-cdk2x`). Clean up:
+
+```bash
+ORPHAN_INFRA_ID=<infra-id-from-failed-render>
+
+# Delete VPC dependencies first
+# Find resources tagged with kubernetes.io/cluster/${ORPHAN_INFRA_ID}=owned
+aws ec2 describe-vpcs --filters "Name=tag:kubernetes.io/cluster/${ORPHAN_INFRA_ID},Values=owned" \
+  --query 'Vpcs[].VpcId' --output text --region ${AWS_REGION}
+
+# Then delete: NAT GW -> EIP -> subnets -> IGW -> VPC endpoints -> route tables -> VPC
+# Then delete: IAM roles, instance profiles, OIDC provider
+
+# IAM roles (all prefixed with infra ID)
+for role in cloud-network-config-controller openshift-ingress openshift-image-registry aws-ebs-csi-driver-controller cloud-controller node-pool control-plane-operator; do
+  aws iam delete-role-policy --role-name ${ORPHAN_INFRA_ID}-${role} --policy-name ${ORPHAN_INFRA_ID}-${role} 2>/dev/null
+  aws iam delete-role --role-name ${ORPHAN_INFRA_ID}-${role} 2>/dev/null
+done
+
+aws iam remove-role-from-instance-profile --instance-profile-name ${ORPHAN_INFRA_ID}-worker --role-name ${ORPHAN_INFRA_ID}-worker-role 2>/dev/null
+aws iam delete-instance-profile --instance-profile-name ${ORPHAN_INFRA_ID}-worker 2>/dev/null
+aws iam delete-role-policy --role-name ${ORPHAN_INFRA_ID}-worker-role \
+  --policy-name ${ORPHAN_INFRA_ID}-worker-policy 2>/dev/null
+aws iam delete-role --role-name ${ORPHAN_INFRA_ID}-worker-role 2>/dev/null
+
+# OIDC provider
+aws iam delete-open-id-connect-provider \
+  --open-id-connect-provider-arn arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/${OIDC_BUCKET}.s3.${AWS_REGION}.amazonaws.com/${ORPHAN_INFRA_ID}
+```
+
+---
+
+## Files to Keep
+
+- `/tmp/hc-rendered.yaml` — source of truth for what was deployed
+- `/tmp/${HC_NAME}-kubeconfig` — admin kubeconfig for the hosted cluster
+- `/tmp/sts-creds.json` — STS session token (expires in ~12h; regenerate as needed)

--- a/dev-scripts/provision-hcp/env.sh.example
+++ b/dev-scripts/provision-hcp/env.sh.example
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Copy this file to env.sh and fill in your values:
+#   cp env.sh.example env.sh
+
+# --- Cluster access ---
+export HUB_KUBECONFIG=~/.kube/hub-kubeconfig
+export SPOKE_KUBECONFIG=~/.kube/spoke-kubeconfig
+export MC_NAME=<managed-cluster-name>           # ManagedCluster name on the hub
+
+# --- Hosted cluster ---
+export HC_NAME=hc-aws                           # HostedCluster name
+export HC_NAMESPACE=clusters                    # Namespace for the HostedCluster on the spoke
+export AWS_REGION=us-east-1
+
+# --- DNS ---
+# BASE_DOMAIN: e.g. hcp-capa-<yourname>.dev07.red-chesterfield.com
+export BASE_DOMAIN=<your-prefix>.dev07.red-chesterfield.com
+# PARENT_DOMAIN: derived from BASE_DOMAIN, e.g. dev07.red-chesterfield.com
+export PARENT_DOMAIN=dev07.red-chesterfield.com
+
+# --- Files ---
+# Generate pull secret from https://console.redhat.com/openshift/install/pull-secret
+export PULL_SECRET_FILE=~/pull-secret.json
+# SSH public key for cluster access
+export SSH_KEY_FILE=~/.ssh/id_ed25519.pub
+
+# --- HC options (defaults, override if needed) ---
+export NODE_POOL_REPLICAS=2
+export INSTANCE_TYPE=m6i.xlarge
+export AVAILABILITY_POLICY=SingleReplica
+
+# --- Optional: pin a specific release version ---
+# If unset, 03-create-hc.sh auto-detects from the operator + mirror.openshift.com
+# export RELEASE_VERSION=4.21.15


### PR DESCRIPTION
Simplify and standardize HCP provisioning for development and testing workflows.

The script set is composed of the following capabilities to be executed in order:
  01- check the prerequisites
  02- setup AWS depencencies
  03- create HCP
  04- teadown the HyperShift env
  
Requirements:
  - An existing ACM architecute with a Hub and Managed Cluster
  - An AWS account with specific IAM permissions
  
Implemented architecture - Managed Cluster running Hypershift
<img width="6608" height="6607" alt="Untitled-2026-05-21-0907 excalidraw(1)" src="https://github.com/user-attachments/assets/d7990847-dcc9-4c18-bbcf-c1d62371369e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end automated provisioning and teardown for Hosted Clusters on AWS, including prerequisite checks, AWS setup, cluster creation, and safe destruction workflows.

* **Bug Fixes**
  * Stronger validation of credentials, tooling, DNS and resource readiness to reduce failed runs and partial states.

* **Documentation**
  * Comprehensive deployment guide, quick-start steps, and usage notes added.

* **Chores**
  * Environment configuration template added and ignore patterns updated for local state/files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->