### PR TITLE
[ACM-30479] <MCO>: <Fix Issue Where ViolatedPolicyGuidelines rule would break when additional labels are added to managed cluster that is violating policy guidelines>

### DIFF
--- a/operators/multiclusterobservability/manifests/base/alertmanager/alert_rules.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/alert_rules.yaml
@@ -37,7 +37,7 @@ data:
           annotations:
             summary: "There is a policy report violation with a {{ $labels.severity }} severity level detected."
             description: "The policy: {{ $labels.policy }} has a severity of {{ $labels.severity }} on cluster: {{ $labels.cluster }}"
-          expr: sum without (managed_cluster_id) (label_replace((sum without (clusterID) (label_replace((sum(policyreport_info * on (managed_cluster_id) group_left (cluster) label_replace(acm_managed_cluster_labels, "cluster", "$1", "name", "(.*)")) by (cluster, category, clusterID, managed_cluster_id, policy, severity) > 0),"hub_cluster_id", "$1", "clusterID", "(.*)"))),"clusterID", "$1", "managed_cluster_id", "(.*)"))
+          expr: sum without (managed_cluster_id) (label_replace((sum without (clusterID) (label_replace((sum(policyreport_info * on (managed_cluster_id) group_left (cluster) max by (managed_cluster_id, cluster) (label_replace(acm_managed_cluster_labels, "cluster", "$1", "name", "(.*)"))) by (cluster, category, clusterID, managed_cluster_id, policy, severity) > 0),"hub_cluster_id", "$1", "clusterID", "(.*)"))),"clusterID", "$1", "managed_cluster_id", "(.*)"))
           for: 1m
           labels:
             severity: critical

--- a/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/prometheus-rule.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/prometheus-rule.yaml
@@ -217,7 +217,7 @@ spec:
         annotations:
           summary: "There is a policy report violation with a {{ $labels.severity }} severity level detected."
           description: "The policy: {{ $labels.policy }} has a severity of {{ $labels.severity }} on cluster: {{ $labels.cluster }}"
-        expr: sum without (managed_cluster_id) (label_replace((sum without (clusterID) (label_replace((sum(policyreport_info * on (managed_cluster_id) group_left (cluster) label_replace(acm_managed_cluster_labels, "cluster", "$1", "name", "(.*)")) by (cluster, category, clusterID, managed_cluster_id, policy, severity) > 0),"hub_cluster_id", "$1", "clusterID", "(.*)"))),"clusterID", "$1", "managed_cluster_id", "(.*)"))
+        expr: sum without (managed_cluster_id) (label_replace((sum without (clusterID) (label_replace((sum(policyreport_info * on (managed_cluster_id) group_left (cluster) max by (managed_cluster_id, cluster) (label_replace(acm_managed_cluster_labels, "cluster", "$1", "name", "(.*)"))) by (cluster, category, clusterID, managed_cluster_id, policy, severity) > 0),"hub_cluster_id", "$1", "clusterID", "(.*)"))),"clusterID", "$1", "managed_cluster_id", "(.*)"))
         for: 1m
         labels:
           severity: critical


### PR DESCRIPTION
Summary:
Fixes [ACM-30479](https://redhat.atlassian.net/browse/ACM-30479)

Problem:

When a managed cluster had additional label(s) added to it, the ViolatedPolicyGuidelines rule would break, if that managed cluster was currently experiencing a policy violation. 

Root Cause:
The root cause of this issue is that this query uses group left. When group_left is used it assumes that whatever is on the right side (in our case, the acm_managed_cluster_labels metric), has only one match for a managed_cluster_id value that the policyreport_info has. This turns out not to be the case, as when labels are changed on a managed cluster, the acm_managed_cluster_labels metric has two time series for the same managed_cluster_id for, as Prometheus/Thanos keeps both sets of labels as unique time series for a period of time (the old set before editing labels, and the new set of labels before).

Fix:

This fix is completed by adding a max-by clause. Since this query only needs the cluster value from these unique series with the same managed_cluster_id, in the acm_managed_cluster_label metric, the max by (managed_cluster_id, cluster) tells PromQL that “for each group of managed_cluster_id, cluster, take the series that has the maximum value for that group and return a new series consisting of only the managed_cluster_id and cluster labels with the maximum value for that group. Since the values are all one, and this part of the query is only exporting the cluster label, this max by clause edits our series so that each series in it has a managed_cluster_id, causing the join command not to error out. 

Files Changed:

Modified:

```
operators/multiclusterobservability/manifests/base/alertmanager/alert_rules.yaml
operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/prometheus-rule.yaml
```
Test:
Spun up hub and spoke cluster and verified that when additional labels were added, the error did not reappear. 

[ACM-30479]: https://redhat.atlassian.net/browse/ACM-30479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved aggregation logic for cluster label enrichment in policy violation alert reports. Updated how managed cluster labels are processed during metric evaluation to ensure consistent and accurate cluster identification in alerting queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->