### PR TITLE
feat(endpointmetrics): add entrypoint for use by MCOA

### DIFF
--- a/operators/endpointmetrics/cmd/cmo-config-revert/main.go
+++ b/operators/endpointmetrics/cmd/cmo-config-revert/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"time"
 
@@ -17,26 +18,46 @@ import (
 )
 
 func main() {
-	kubeClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{})
-	if err != nil {
-		log.Fatalf("unable to create client: %v", err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
+	var hubID string
+	flag.StringVar(&hubID, "hub-id", "", "The ID of the Hub cluster to revert configuration for (optional).")
 
 	klog.InitFlags(flag.CommandLine)
 	flag.Parse()
 	ctrl.SetLogger(klog.NewKlogr())
 
-	if err := observabilityendpoint.RevertClusterMonitoringConfig(ctx, kubeClient, nil); err != nil {
-		log.Printf("unable to revert cluster monitoring config: %v", err)
-		return
+	if err := run(hubID); err != nil {
+		log.Fatalf("revert offline cleanup failed: %v", err)
 	}
-	log.Println("reverted cluster monitoring config")
-	if err := observabilityendpoint.RevertUserWorkloadMonitoringConfig(ctx, kubeClient, nil); err != nil {
-		log.Printf("unable to revert user workload monitoring config: %v", err)
-		return
+	log.Println("revert offline cleanup completed successfully")
+}
+
+func run(hubID string) error {
+	kubeClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{})
+	if err != nil {
+		return fmt.Errorf("unable to create client: %w", err)
 	}
-	log.Println("reverted user workload monitoring config")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	caSecret := observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmRouterCASecretName, hubID)
+	mtlsSecret := observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmMtlsCASecretName, hubID)
+
+	// Revert the legacy Router CA configurations if present
+	if err := observabilityendpoint.RevertClusterMonitoringConfig(ctx, kubeClient, caSecret); err != nil {
+		return fmt.Errorf("unable to revert cluster monitoring config (Router CA): %w", err)
+	}
+	if err := observabilityendpoint.RevertUserWorkloadMonitoringConfig(ctx, kubeClient, caSecret); err != nil {
+		return fmt.Errorf("unable to revert user workload monitoring config (Router CA): %w", err)
+	}
+
+	// Revert the new mTLS CA configurations if present
+	if err := observabilityendpoint.RevertClusterMonitoringConfig(ctx, kubeClient, mtlsSecret); err != nil {
+		return fmt.Errorf("unable to revert cluster monitoring config (mTLS CA): %w", err)
+	}
+	if err := observabilityendpoint.RevertUserWorkloadMonitoringConfig(ctx, kubeClient, mtlsSecret); err != nil {
+		return fmt.Errorf("unable to revert user workload monitoring config (mTLS CA): %w", err)
+	}
+
+	return nil
 }

--- a/operators/endpointmetrics/controllers/mcoa/cache.go
+++ b/operators/endpointmetrics/controllers/mcoa/cache.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetCacheOptions returns the surgical cache options for the MCOA bridge agent.
+// GetCacheOptions returns the cache options for the MCOA controller.
 // It whitelists only the specific ConfigMaps required for Alertmanager configuration injection.
 func GetCacheOptions() cache.Options {
 	return cache.Options{

--- a/operators/endpointmetrics/controllers/mcoa/cache.go
+++ b/operators/endpointmetrics/controllers/mcoa/cache.go
@@ -1,0 +1,38 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package mcoa
+
+import (
+	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetCacheOptions returns the surgical cache options for the MCOA bridge agent.
+// It whitelists only the specific ConfigMaps and Secrets required for Alertmanager configuration injection.
+func GetCacheOptions() cache.Options {
+	return cache.Options{
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.ConfigMap{}: {
+				Namespaces: map[string]cache.Config{
+					operatorconfig.OCPClusterMonitoringNamespace: {
+						FieldSelector: fields.OneTermEqualSelector("metadata.name", operatorconfig.OCPClusterMonitoringConfigMapName),
+					},
+					operatorconfig.OCPUserWorkloadMonitoringNamespace: {
+						FieldSelector: fields.OneTermEqualSelector("metadata.name", operatorconfig.OCPUserWorkloadMonitoringConfigMap),
+					},
+				},
+			},
+			&corev1.Secret{}: {
+				Namespaces: map[string]cache.Config{
+					operatorconfig.OCPClusterMonitoringNamespace:      {},
+					operatorconfig.OCPUserWorkloadMonitoringNamespace: {},
+				},
+			},
+		},
+	}
+}

--- a/operators/endpointmetrics/controllers/mcoa/cache.go
+++ b/operators/endpointmetrics/controllers/mcoa/cache.go
@@ -13,7 +13,7 @@ import (
 )
 
 // GetCacheOptions returns the surgical cache options for the MCOA bridge agent.
-// It whitelists only the specific ConfigMaps and Secrets required for Alertmanager configuration injection.
+// It whitelists only the specific ConfigMaps required for Alertmanager configuration injection.
 func GetCacheOptions() cache.Options {
 	return cache.Options{
 		ByObject: map[client.Object]cache.ByObject{
@@ -25,12 +25,6 @@ func GetCacheOptions() cache.Options {
 					operatorconfig.OCPUserWorkloadMonitoringNamespace: {
 						FieldSelector: fields.OneTermEqualSelector("metadata.name", operatorconfig.OCPUserWorkloadMonitoringConfigMap),
 					},
-				},
-			},
-			&corev1.Secret{}: {
-				Namespaces: map[string]cache.Config{
-					operatorconfig.OCPClusterMonitoringNamespace:      {},
-					operatorconfig.OCPUserWorkloadMonitoringNamespace: {},
 				},
 			},
 		},

--- a/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
+++ b/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
@@ -59,7 +59,7 @@ func (r *MCOAAgentReconciler) reconcileCMO(ctx context.Context, req client.Objec
 		r.CASecret,
 		r.CertSecret,
 		r.AccessorSecret,
-		"", // Pass empty namespace to skip legacy revert-marker logic
+		"", // Pass empty namespace since MCOA handles cleanup dynamically in the reconciler and bypasses legacy persistent configmap markers.
 	)
 
 	return err

--- a/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
+++ b/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
@@ -13,7 +13,6 @@ import (
 	cmomanifests "github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
-	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -45,6 +44,7 @@ type cmoConfigReconciler struct {
 	Log       logr.Logger
 	Recorder  record.EventRecorder
 	Namespace string
+	ClusterID string
 	HubInfo   *operatorconfig.HubInfo
 }
 
@@ -73,15 +73,10 @@ func (r *cmoConfigReconciler) reconcile(ctx context.Context, req client.ObjectKe
 		}
 	}
 
-	clusterID, err := mcoconfig.GetClusterID(ctx, r.Client)
-	if err != nil {
-		return fmt.Errorf("failed to get cluster id: %w", err)
-	}
-
 	_, err = observabilityendpoint.CreateOrUpdateCMOConfig(
 		ctx,
 		r.Client,
-		clusterID,
+		r.ClusterID,
 		r.HubInfo,
 		"", // Pass empty namespace to skip legacy revert-marker logic
 	)

--- a/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
+++ b/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
@@ -1,0 +1,133 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package mcoa
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/go-logr/logr"
+	cmomanifests "github.com/openshift/cluster-monitoring-operator/pkg/manifests"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
+	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	cmoConfigConflictsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "mcoa_cmo_config_conflicts_total",
+			Help: "Total number of conflicts detected in the cluster-monitoring-config ConfigMap.",
+		},
+	)
+	registerMetricsOnce sync.Once
+)
+
+func registerMetrics() {
+	registerMetricsOnce.Do(func() {
+		metrics.Registry.MustRegister(cmoConfigConflictsTotal)
+	})
+}
+
+// cmoConfigReconciler handles the reconciliation of the Cluster Monitoring Operator configuration.
+type cmoConfigReconciler struct {
+	client.Client
+	Log       logr.Logger
+	Recorder  record.EventRecorder
+	Namespace string
+	HubInfo   *operatorconfig.HubInfo
+}
+
+func (r *cmoConfigReconciler) reconcile(ctx context.Context, req client.ObjectKey) error {
+	// If Alertmanager forwarding is disabled, we ensure our config is removed.
+	if r.HubInfo.AlertmanagerEndpoint == "" {
+		r.Log.Info("Alertmanager endpoint is empty, ensuring Hub configuration is removed")
+		return observabilityendpoint.RevertClusterMonitoringConfig(ctx, r.Client, r.HubInfo)
+	}
+
+	cm := &corev1.ConfigMap{}
+	err := r.Get(ctx, req, cm)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+		cm = nil
+	}
+
+	// We trigger a repair if the config is missing or corrupted.
+	if cm != nil {
+		if r.detectConflict(cm, r.HubInfo) {
+			cmoConfigConflictsTotal.Inc()
+			r.Recorder.Event(cm, corev1.EventTypeWarning, "ConfigConflict", "Detected external mutation overwriting Alertmanager configuration. Re-applying Hub Alertmanager config.")
+			r.Log.Info("Detected conflict in CMO ConfigMap, re-applying configuration", "name", cm.Name, "namespace", cm.Namespace)
+		}
+	}
+
+	clusterID, err := mcoconfig.GetClusterID(ctx, r.Client)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster id: %w", err)
+	}
+
+	_, err = observabilityendpoint.CreateOrUpdateCMOConfig(
+		ctx,
+		r.Client,
+		clusterID,
+		r.HubInfo,
+		"", // Pass empty namespace to skip legacy revert-marker logic
+	)
+
+	return err
+}
+
+func (r *cmoConfigReconciler) reconcileUWLConfig(ctx context.Context) error {
+	if err := observabilityendpoint.CreateOrUpdateUserWorkloadMonitoringConfig(
+		ctx,
+		r.Client,
+		r.HubInfo,
+	); err != nil {
+		return fmt.Errorf("failed to create or update user workload monitoring config: %w", err)
+	}
+	return nil
+}
+
+func (r *cmoConfigReconciler) detectConflict(cm *corev1.ConfigMap, hubInfo *operatorconfig.HubInfo) bool {
+	// If ACM didn't create/update this config, we don't treat it as a conflict yet.
+	if !observabilityendpoint.InManagedFields(cm) {
+		return false
+	}
+
+	configYAML, ok := observabilityendpoint.HasClusterMonitoringConfigData(cm)
+	if !ok {
+		return true
+	}
+
+	parsed := &cmomanifests.ClusterMonitoringConfiguration{}
+	if err := yaml.Unmarshal([]byte(configYAML), parsed); err != nil {
+		// Corrupted YAML is a conflict that needs repair.
+		return true
+	}
+
+	if parsed.PrometheusK8sConfig == nil || parsed.PrometheusK8sConfig.AlertmanagerConfigs == nil {
+		return true
+	}
+
+	foundManaged := false
+	for _, amc := range parsed.PrometheusK8sConfig.AlertmanagerConfigs {
+		if observabilityendpoint.IsManaged(amc, hubInfo) {
+			foundManaged = true
+			break
+		}
+	}
+
+	return !foundManaged
+}

--- a/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
+++ b/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
@@ -9,14 +9,11 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/go-logr/logr"
 	cmomanifests "github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
-	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/yaml"
@@ -38,24 +35,11 @@ func registerMetrics() {
 	})
 }
 
-// cmoConfigReconciler handles the reconciliation of the Cluster Monitoring Operator configuration.
-type cmoConfigReconciler struct {
-	client.Client
-	Log            logr.Logger
-	Recorder       record.EventRecorder
-	Namespace      string
-	ClusterID      string
-	HubInfo        *operatorconfig.HubInfo
-	CASecret       string
-	CertSecret     string
-	AccessorSecret string
-}
-
-func (r *cmoConfigReconciler) reconcile(ctx context.Context, req client.ObjectKey) error {
+func (r *MCOAAgentReconciler) reconcileCMO(ctx context.Context, req client.ObjectKey) error {
 	// If Alertmanager forwarding is disabled, we ensure our config is removed.
-	if r.HubInfo.AlertmanagerEndpoint == "" {
+	if r.AlertmanagerEndpoint == "" {
 		r.Log.Info("Alertmanager endpoint is empty, ensuring Hub configuration is removed")
-		return observabilityendpoint.RevertClusterMonitoringConfig(ctx, r.Client, r.HubInfo)
+		return observabilityendpoint.RevertClusterMonitoringConfig(ctx, r.Client, r.CASecret)
 	}
 
 	cm := &corev1.ConfigMap{}
@@ -69,7 +53,7 @@ func (r *cmoConfigReconciler) reconcile(ctx context.Context, req client.ObjectKe
 
 	// We trigger a repair if the config is missing or corrupted.
 	if cm != nil {
-		if r.detectConflict(cm, r.HubInfo) {
+		if r.detectConflict(cm) {
 			cmoConfigConflictsTotal.Inc()
 			r.Recorder.Event(cm, corev1.EventTypeWarning, "ConfigConflict", "Detected external mutation overwriting Alertmanager configuration. Re-applying Hub Alertmanager config.")
 			r.Log.Info("Detected conflict in CMO ConfigMap, re-applying configuration", "name", cm.Name, "namespace", cm.Namespace)
@@ -80,7 +64,7 @@ func (r *cmoConfigReconciler) reconcile(ctx context.Context, req client.ObjectKe
 		ctx,
 		r.Client,
 		r.ClusterID,
-		r.HubInfo,
+		r.AlertmanagerEndpoint,
 		r.CASecret,
 		r.CertSecret,
 		r.AccessorSecret,
@@ -90,11 +74,12 @@ func (r *cmoConfigReconciler) reconcile(ctx context.Context, req client.ObjectKe
 	return err
 }
 
-func (r *cmoConfigReconciler) reconcileUWLConfig(ctx context.Context) error {
+func (r *MCOAAgentReconciler) reconcileUWLConfig(ctx context.Context) error {
 	if err := observabilityendpoint.CreateOrUpdateUserWorkloadMonitoringConfig(
 		ctx,
 		r.Client,
-		r.HubInfo,
+		r.AlertmanagerEndpoint,
+		!r.EnableUWLAlertForwarding, // uwmAlertingDisabled
 		r.CASecret,
 		r.CertSecret,
 		r.AccessorSecret,
@@ -104,7 +89,7 @@ func (r *cmoConfigReconciler) reconcileUWLConfig(ctx context.Context) error {
 	return nil
 }
 
-func (r *cmoConfigReconciler) detectConflict(cm *corev1.ConfigMap, hubInfo *operatorconfig.HubInfo) bool {
+func (r *MCOAAgentReconciler) detectConflict(cm *corev1.ConfigMap) bool {
 	// If ACM didn't create/update this config, we don't treat it as a conflict yet.
 	if !observabilityendpoint.InManagedFields(cm) {
 		return false
@@ -127,7 +112,7 @@ func (r *cmoConfigReconciler) detectConflict(cm *corev1.ConfigMap, hubInfo *oper
 
 	foundManaged := false
 	for _, amc := range parsed.PrometheusK8sConfig.AlertmanagerConfigs {
-		if observabilityendpoint.IsManaged(amc, hubInfo, r.CASecret) {
+		if observabilityendpoint.IsManaged(amc, r.CASecret) {
 			foundManaged = true
 			break
 		}

--- a/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
+++ b/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
@@ -7,10 +7,10 @@ package mcoa
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	cmomanifests "github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -19,21 +19,12 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-var (
-	cmoConfigConflictsTotal = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "mcoa_cmo_config_conflicts_total",
-			Help: "Total number of conflicts detected in the cluster-monitoring-config ConfigMap.",
-		},
-	)
-	registerMetricsOnce sync.Once
+var cmoConfigConflictsTotal = promauto.With(metrics.Registry).NewCounter(
+	prometheus.CounterOpts{
+		Name: "mcoa_cmo_config_conflicts_total",
+		Help: "Total number of conflicts detected in the cluster-monitoring-config ConfigMap.",
+	},
 )
-
-func registerMetrics() {
-	registerMetricsOnce.Do(func() {
-		metrics.Registry.MustRegister(cmoConfigConflictsTotal)
-	})
-}
 
 func (r *MCOAAgentReconciler) reconcileCMO(ctx context.Context, req client.ObjectKey) error {
 	// If Alertmanager forwarding is disabled, we ensure our config is removed.

--- a/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
+++ b/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
@@ -41,11 +41,14 @@ func registerMetrics() {
 // cmoConfigReconciler handles the reconciliation of the Cluster Monitoring Operator configuration.
 type cmoConfigReconciler struct {
 	client.Client
-	Log       logr.Logger
-	Recorder  record.EventRecorder
-	Namespace string
-	ClusterID string
-	HubInfo   *operatorconfig.HubInfo
+	Log            logr.Logger
+	Recorder       record.EventRecorder
+	Namespace      string
+	ClusterID      string
+	HubInfo        *operatorconfig.HubInfo
+	CASecret       string
+	CertSecret     string
+	AccessorSecret string
 }
 
 func (r *cmoConfigReconciler) reconcile(ctx context.Context, req client.ObjectKey) error {
@@ -73,22 +76,60 @@ func (r *cmoConfigReconciler) reconcile(ctx context.Context, req client.ObjectKe
 		}
 	}
 
+	accessorSecret := r.AccessorSecret
+	if accessorSecret == "" {
+		accessorSecret = observabilityendpoint.HubAmAccessorSecretName
+	}
+
+	if err := observabilityendpoint.CreateHubAmAccessorTokenSecret(
+		ctx,
+		r.Client,
+		accessorSecret,
+		r.Namespace,
+		operatorconfig.OCPClusterMonitoringNamespace,
+		r.HubInfo,
+	); err != nil {
+		return fmt.Errorf("failed to create or update the alertmanager accessor token secret: %w", err)
+	}
+
 	_, err = observabilityendpoint.CreateOrUpdateCMOConfig(
 		ctx,
 		r.Client,
 		r.ClusterID,
 		r.HubInfo,
-		"", // Pass empty namespace to skip legacy revert-marker logic
+		r.CASecret,
+		r.CertSecret,
+		false, // omitBearerToken
+		"",    // Pass empty namespace to skip legacy revert-marker logic
 	)
 
 	return err
 }
 
 func (r *cmoConfigReconciler) reconcileUWLConfig(ctx context.Context) error {
+	accessorSecret := r.AccessorSecret
+	if accessorSecret == "" {
+		accessorSecret = observabilityendpoint.HubAmAccessorSecretName
+	}
+
+	if err := observabilityendpoint.CreateHubAmAccessorTokenSecret(
+		ctx,
+		r.Client,
+		accessorSecret,
+		r.Namespace,
+		operatorconfig.OCPUserWorkloadMonitoringNamespace,
+		r.HubInfo,
+	); err != nil {
+		return fmt.Errorf("failed to create or update alertmanager accessor token in UWM namespace: %w", err)
+	}
+
 	if err := observabilityendpoint.CreateOrUpdateUserWorkloadMonitoringConfig(
 		ctx,
 		r.Client,
 		r.HubInfo,
+		r.CASecret,
+		r.CertSecret,
+		false, // omitBearerToken
 	); err != nil {
 		return fmt.Errorf("failed to create or update user workload monitoring config: %w", err)
 	}

--- a/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
+++ b/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
@@ -76,22 +76,6 @@ func (r *cmoConfigReconciler) reconcile(ctx context.Context, req client.ObjectKe
 		}
 	}
 
-	accessorSecret := r.AccessorSecret
-	if accessorSecret == "" {
-		accessorSecret = observabilityendpoint.HubAmAccessorSecretName
-	}
-
-	if err := observabilityendpoint.CreateHubAmAccessorTokenSecret(
-		ctx,
-		r.Client,
-		accessorSecret,
-		r.Namespace,
-		operatorconfig.OCPClusterMonitoringNamespace,
-		r.HubInfo,
-	); err != nil {
-		return fmt.Errorf("failed to create or update the alertmanager accessor token secret: %w", err)
-	}
-
 	_, err = observabilityendpoint.CreateOrUpdateCMOConfig(
 		ctx,
 		r.Client,
@@ -99,37 +83,21 @@ func (r *cmoConfigReconciler) reconcile(ctx context.Context, req client.ObjectKe
 		r.HubInfo,
 		r.CASecret,
 		r.CertSecret,
-		false, // omitBearerToken
-		"",    // Pass empty namespace to skip legacy revert-marker logic
+		r.AccessorSecret,
+		"", // Pass empty namespace to skip legacy revert-marker logic
 	)
 
 	return err
 }
 
 func (r *cmoConfigReconciler) reconcileUWLConfig(ctx context.Context) error {
-	accessorSecret := r.AccessorSecret
-	if accessorSecret == "" {
-		accessorSecret = observabilityendpoint.HubAmAccessorSecretName
-	}
-
-	if err := observabilityendpoint.CreateHubAmAccessorTokenSecret(
-		ctx,
-		r.Client,
-		accessorSecret,
-		r.Namespace,
-		operatorconfig.OCPUserWorkloadMonitoringNamespace,
-		r.HubInfo,
-	); err != nil {
-		return fmt.Errorf("failed to create or update alertmanager accessor token in UWM namespace: %w", err)
-	}
-
 	if err := observabilityendpoint.CreateOrUpdateUserWorkloadMonitoringConfig(
 		ctx,
 		r.Client,
 		r.HubInfo,
 		r.CASecret,
 		r.CertSecret,
-		false, // omitBearerToken
+		r.AccessorSecret,
 	); err != nil {
 		return fmt.Errorf("failed to create or update user workload monitoring config: %w", err)
 	}
@@ -159,7 +127,7 @@ func (r *cmoConfigReconciler) detectConflict(cm *corev1.ConfigMap, hubInfo *oper
 
 	foundManaged := false
 	for _, amc := range parsed.PrometheusK8sConfig.AlertmanagerConfigs {
-		if observabilityendpoint.IsManaged(amc, hubInfo) {
+		if observabilityendpoint.IsManaged(amc, hubInfo, r.CASecret) {
 			foundManaged = true
 			break
 		}

--- a/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package mcoa
+
+import (
+	"testing"
+
+	cmomanifests "github.com/openshift/cluster-monitoring-operator/pkg/manifests"
+	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
+	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/yaml"
+)
+
+func TestCMOConfigReconciler_detectConflict(t *testing.T) {
+	t.Parallel()
+	hubInfo := &operatorconfig.HubInfo{
+		HubClusterID: "hub-id",
+	}
+
+	validCfg := cmomanifests.ClusterMonitoringConfiguration{
+		PrometheusK8sConfig: &cmomanifests.PrometheusK8sConfig{
+			AlertmanagerConfigs: []cmomanifests.AdditionalAlertmanagerConfig{
+				{
+					TLSConfig: cmomanifests.TLSConfig{
+						CA: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "hub-alertmanager-router-ca-hub-id",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	validYAML, _ := yaml.Marshal(validCfg)
+
+	tests := []struct {
+		name     string
+		cm       *corev1.ConfigMap
+		expected bool
+	}{
+		{
+			name:     "Not managed yet",
+			cm:       &corev1.ConfigMap{},
+			expected: false,
+		},
+		{
+			name: "Managed but missing data",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{Manager: observabilityendpoint.EndpointMonitoringOperatorMgr},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Managed and correct config",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{Manager: observabilityendpoint.EndpointMonitoringOperatorMgr},
+					},
+				},
+				Data: map[string]string{
+					observabilityendpoint.ClusterMonitoringConfigDataKey: string(validYAML),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Managed and incorrect config (conflict)",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{Manager: observabilityendpoint.EndpointMonitoringOperatorMgr},
+					},
+				},
+				Data: map[string]string{
+					observabilityendpoint.ClusterMonitoringConfigDataKey: "prometheusK8s: {}",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Managed and corrupted YAML",
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{Manager: observabilityendpoint.EndpointMonitoringOperatorMgr},
+					},
+				},
+				Data: map[string]string{
+					observabilityendpoint.ClusterMonitoringConfigDataKey: "{invalid: yaml: :}",
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &cmoConfigReconciler{
+				Log: ctrl.Log.WithName("test"),
+			}
+			assert.Equal(t, tt.expected, r.detectConflict(tt.cm, hubInfo))
+		})
+	}
+}

--- a/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler_test.go
@@ -9,7 +9,6 @@ import (
 
 	cmomanifests "github.com/openshift/cluster-monitoring-operator/pkg/manifests"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
-	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,9 +18,6 @@ import (
 
 func TestCMOConfigReconciler_detectConflict(t *testing.T) {
 	t.Parallel()
-	hubInfo := &operatorconfig.HubInfo{
-		HubClusterID: "hub-id",
-	}
 
 	validCfg := cmomanifests.ClusterMonitoringConfiguration{
 		PrometheusK8sConfig: &cmomanifests.PrometheusK8sConfig{
@@ -107,10 +103,11 @@ func TestCMOConfigReconciler_detectConflict(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &cmoConfigReconciler{
-				Log: ctrl.Log.WithName("test"),
+			r := &MCOAAgentReconciler{
+				Log:      ctrl.Log.WithName("test"),
+				CASecret: "hub-alertmanager-router-ca-hub-id", // Match the validCfg Name exactly
 			}
-			assert.Equal(t, tt.expected, r.detectConflict(tt.cm, hubInfo))
+			assert.Equal(t, tt.expected, r.detectConflict(tt.cm))
 		})
 	}
 }

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
@@ -1,0 +1,116 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package mcoa
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
+	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+// MCOAAgentReconciler reconciles the MCOA components on the managed cluster.
+type MCOAAgentReconciler struct {
+	client.Client
+	Log       logr.Logger
+	Scheme    *runtime.Scheme
+	Recorder  record.EventRecorder
+	Namespace string
+	HubInfo   *operatorconfig.HubInfo
+
+	cmoReconciler *cmoConfigReconciler
+}
+
+// NewMCOAAgentReconciler creates a new MCOAAgentReconciler and initializes its sub-reconcilers.
+func NewMCOAAgentReconciler(client client.Client, log logr.Logger, scheme *runtime.Scheme, recorder record.EventRecorder, namespace string, hubInfo *operatorconfig.HubInfo) *MCOAAgentReconciler {
+	registerMetrics()
+	return &MCOAAgentReconciler{
+		Client:    client,
+		Log:       log,
+		Scheme:    scheme,
+		Recorder:  recorder,
+		Namespace: namespace,
+		HubInfo:   hubInfo,
+		cmoReconciler: &cmoConfigReconciler{
+			Client:    client,
+			Log:       log.WithName("CMO"),
+			Recorder:  recorder,
+			Namespace: namespace,
+			HubInfo:   hubInfo,
+		},
+	}
+}
+
+func (r *MCOAAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.Log.Info("Reconciling MCOA Agent", "name", req.Name, "namespace", req.Namespace)
+
+	switch {
+	case req.Name == operatorconfig.OCPClusterMonitoringConfigMapName && req.Namespace == operatorconfig.OCPClusterMonitoringNamespace:
+		if err := r.cmoReconciler.reconcile(ctx, req.NamespacedName); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to reconcile CMO config: %w", err)
+		}
+	case req.Name == operatorconfig.OCPUserWorkloadMonitoringConfigMap && req.Namespace == operatorconfig.OCPUserWorkloadMonitoringNamespace:
+		if err := r.cmoReconciler.reconcileUWLConfig(ctx); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to reconcile UWL config: %w", err)
+		}
+	default:
+		r.Log.V(1).Info("Ignoring event for unmanaged resource", "name", req.Name, "namespace", req.Namespace)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *MCOAAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		// Watch ConfigMaps we manage across multiple namespaces.
+		// The cache FieldSelectors already limit this to exactly the CMs we need.
+		For(&corev1.ConfigMap{}, ctrlbuilder.WithPredicates(observabilityendpoint.ConfigMapDataChangedPredicate("", ""))).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+				hubAmAccessorSecret := observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmAccessorSecretName, r.HubInfo)
+				hubAmRouterCASecret := observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmRouterCASecretName, r.HubInfo)
+
+				if obj.GetName() != hubAmAccessorSecret && obj.GetName() != hubAmRouterCASecret {
+					return nil
+				}
+
+				var requests []ctrl.Request
+				// Monitoring stacks in OpenShift are namespace-scoped for secrets.
+				// We only trigger the ConfigMap in the same namespace as the secret.
+				switch obj.GetNamespace() {
+				case operatorconfig.OCPClusterMonitoringNamespace:
+					requests = append(requests, ctrl.Request{
+						NamespacedName: types.NamespacedName{
+							Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+							Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+						},
+					})
+				case operatorconfig.OCPUserWorkloadMonitoringNamespace:
+					requests = append(requests, ctrl.Request{
+						NamespacedName: types.NamespacedName{
+							Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+							Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+						},
+					})
+				}
+				return requests
+			}),
+			// Only react to secrets in the namespaces we monitor
+			ctrlbuilder.WithPredicates(observabilityendpoint.SecretDataChangedPredicate("", "")),
+		).
+		Complete(r)
+}

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
@@ -48,7 +48,6 @@ func NewMCOAAgentReconciler(
 	accessorSecret string,
 	enableUWLAlertForwarding bool,
 ) *MCOAAgentReconciler {
-	registerMetrics()
 	return &MCOAAgentReconciler{
 		Client:                   client,
 		Log:                      log,

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
@@ -22,20 +22,19 @@ import (
 // MCOAAgentReconciler reconciles the MCOA components on the managed cluster.
 type MCOAAgentReconciler struct {
 	client.Client
-	Log            logr.Logger
-	Scheme         *runtime.Scheme
-	Recorder       record.EventRecorder
-	Namespace      string
-	ClusterID      string
-	HubInfo        *operatorconfig.HubInfo
-	CASecret       string
-	CertSecret     string
-	AccessorSecret string
-
-	cmoReconciler *cmoConfigReconciler
+	Log                      logr.Logger
+	Scheme                   *runtime.Scheme
+	Recorder                 record.EventRecorder
+	Namespace                string
+	ClusterID                string
+	AlertmanagerEndpoint     string
+	CASecret                 string
+	CertSecret               string
+	AccessorSecret           string
+	EnableUWLAlertForwarding bool
 }
 
-// NewMCOAAgentReconciler creates a new MCOAAgentReconciler and initializes its sub-reconcilers.
+// NewMCOAAgentReconciler creates a new MCOAAgentReconciler.
 func NewMCOAAgentReconciler(
 	client client.Client,
 	log logr.Logger,
@@ -43,34 +42,25 @@ func NewMCOAAgentReconciler(
 	recorder record.EventRecorder,
 	namespace string,
 	clusterID string,
-	hubInfo *operatorconfig.HubInfo,
+	alertmanagerEndpoint string,
 	caSecret string,
 	certSecret string,
 	accessorSecret string,
+	enableUWLAlertForwarding bool,
 ) *MCOAAgentReconciler {
 	registerMetrics()
 	return &MCOAAgentReconciler{
-		Client:         client,
-		Log:            log,
-		Scheme:         scheme,
-		Recorder:       recorder,
-		Namespace:      namespace,
-		ClusterID:      clusterID,
-		HubInfo:        hubInfo,
-		CASecret:       caSecret,
-		CertSecret:     certSecret,
-		AccessorSecret: accessorSecret,
-		cmoReconciler: &cmoConfigReconciler{
-			Client:         client,
-			Log:            log.WithName("CMO"),
-			Recorder:       recorder,
-			Namespace:      namespace,
-			ClusterID:      clusterID,
-			HubInfo:        hubInfo,
-			CASecret:       caSecret,
-			CertSecret:     certSecret,
-			AccessorSecret: accessorSecret,
-		},
+		Client:                   client,
+		Log:                      log,
+		Scheme:                   scheme,
+		Recorder:                 recorder,
+		Namespace:                namespace,
+		ClusterID:                clusterID,
+		AlertmanagerEndpoint:     alertmanagerEndpoint,
+		CASecret:                 caSecret,
+		CertSecret:               certSecret,
+		AccessorSecret:           accessorSecret,
+		EnableUWLAlertForwarding: enableUWLAlertForwarding,
 	}
 }
 
@@ -79,11 +69,11 @@ func (r *MCOAAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	switch {
 	case req.Name == operatorconfig.OCPClusterMonitoringConfigMapName && req.Namespace == operatorconfig.OCPClusterMonitoringNamespace:
-		if err := r.cmoReconciler.reconcile(ctx, req.NamespacedName); err != nil {
+		if err := r.reconcileCMO(ctx, req.NamespacedName); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile CMO config: %w", err)
 		}
 	case req.Name == operatorconfig.OCPUserWorkloadMonitoringConfigMap && req.Namespace == operatorconfig.OCPUserWorkloadMonitoringNamespace:
-		if err := r.cmoReconciler.reconcileUWLConfig(ctx); err != nil {
+		if err := r.reconcileUWLConfig(ctx); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile UWL config: %w", err)
 		}
 	default:

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
@@ -28,13 +28,22 @@ type MCOAAgentReconciler struct {
 	Scheme    *runtime.Scheme
 	Recorder  record.EventRecorder
 	Namespace string
+	ClusterID string
 	HubInfo   *operatorconfig.HubInfo
 
 	cmoReconciler *cmoConfigReconciler
 }
 
 // NewMCOAAgentReconciler creates a new MCOAAgentReconciler and initializes its sub-reconcilers.
-func NewMCOAAgentReconciler(client client.Client, log logr.Logger, scheme *runtime.Scheme, recorder record.EventRecorder, namespace string, hubInfo *operatorconfig.HubInfo) *MCOAAgentReconciler {
+func NewMCOAAgentReconciler(
+	client client.Client,
+	log logr.Logger,
+	scheme *runtime.Scheme,
+	recorder record.EventRecorder,
+	namespace string,
+	clusterID string,
+	hubInfo *operatorconfig.HubInfo,
+) *MCOAAgentReconciler {
 	registerMetrics()
 	return &MCOAAgentReconciler{
 		Client:    client,
@@ -42,12 +51,14 @@ func NewMCOAAgentReconciler(client client.Client, log logr.Logger, scheme *runti
 		Scheme:    scheme,
 		Recorder:  recorder,
 		Namespace: namespace,
+		ClusterID: clusterID,
 		HubInfo:   hubInfo,
 		cmoReconciler: &cmoConfigReconciler{
 			Client:    client,
 			Log:       log.WithName("CMO"),
 			Recorder:  recorder,
 			Namespace: namespace,
+			ClusterID: clusterID,
 			HubInfo:   hubInfo,
 		},
 	}

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
@@ -13,12 +13,10 @@ import (
 	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
 // MCOAAgentReconciler reconciles the MCOA components on the managed cluster.
@@ -101,39 +99,5 @@ func (r *MCOAAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch ConfigMaps we manage across multiple namespaces.
 		// The cache FieldSelectors already limit this to exactly the CMs we need.
 		For(&corev1.ConfigMap{}, ctrlbuilder.WithPredicates(observabilityendpoint.ConfigMapDataChangedPredicate("", ""))).
-		Watches(
-			&corev1.Secret{},
-			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
-				hubAmAccessorSecret := observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmAccessorSecretName, r.HubInfo)
-				hubAmRouterCASecret := observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmRouterCASecretName, r.HubInfo)
-
-				if obj.GetName() != hubAmAccessorSecret && obj.GetName() != hubAmRouterCASecret {
-					return nil
-				}
-
-				var requests []ctrl.Request
-				// Monitoring stacks in OpenShift are namespace-scoped for secrets.
-				// We only trigger the ConfigMap in the same namespace as the secret.
-				switch obj.GetNamespace() {
-				case operatorconfig.OCPClusterMonitoringNamespace:
-					requests = append(requests, ctrl.Request{
-						NamespacedName: types.NamespacedName{
-							Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
-							Namespace: operatorconfig.OCPClusterMonitoringNamespace,
-						},
-					})
-				case operatorconfig.OCPUserWorkloadMonitoringNamespace:
-					requests = append(requests, ctrl.Request{
-						NamespacedName: types.NamespacedName{
-							Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
-							Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
-						},
-					})
-				}
-				return requests
-			}),
-			// Only react to secrets in the namespaces we monitor
-			ctrlbuilder.WithPredicates(observabilityendpoint.SecretDataChangedPredicate("", "")),
-		).
 		Complete(r)
 }

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
@@ -64,7 +64,7 @@ func NewMCOAAgentReconciler(
 }
 
 func (r *MCOAAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Log.Info("Reconciling MCOA Agent", "name", req.Name, "namespace", req.Namespace)
+	r.Log.V(1).Info("Reconciling MCOA Agent", "name", req.Name, "namespace", req.Namespace)
 
 	switch {
 	case req.Name == operatorconfig.OCPClusterMonitoringConfigMapName && req.Namespace == operatorconfig.OCPClusterMonitoringNamespace:

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
@@ -24,12 +24,15 @@ import (
 // MCOAAgentReconciler reconciles the MCOA components on the managed cluster.
 type MCOAAgentReconciler struct {
 	client.Client
-	Log       logr.Logger
-	Scheme    *runtime.Scheme
-	Recorder  record.EventRecorder
-	Namespace string
-	ClusterID string
-	HubInfo   *operatorconfig.HubInfo
+	Log            logr.Logger
+	Scheme         *runtime.Scheme
+	Recorder       record.EventRecorder
+	Namespace      string
+	ClusterID      string
+	HubInfo        *operatorconfig.HubInfo
+	CASecret       string
+	CertSecret     string
+	AccessorSecret string
 
 	cmoReconciler *cmoConfigReconciler
 }
@@ -43,23 +46,32 @@ func NewMCOAAgentReconciler(
 	namespace string,
 	clusterID string,
 	hubInfo *operatorconfig.HubInfo,
+	caSecret string,
+	certSecret string,
+	accessorSecret string,
 ) *MCOAAgentReconciler {
 	registerMetrics()
 	return &MCOAAgentReconciler{
-		Client:    client,
-		Log:       log,
-		Scheme:    scheme,
-		Recorder:  recorder,
-		Namespace: namespace,
-		ClusterID: clusterID,
-		HubInfo:   hubInfo,
+		Client:         client,
+		Log:            log,
+		Scheme:         scheme,
+		Recorder:       recorder,
+		Namespace:      namespace,
+		ClusterID:      clusterID,
+		HubInfo:        hubInfo,
+		CASecret:       caSecret,
+		CertSecret:     certSecret,
+		AccessorSecret: accessorSecret,
 		cmoReconciler: &cmoConfigReconciler{
-			Client:    client,
-			Log:       log.WithName("CMO"),
-			Recorder:  recorder,
-			Namespace: namespace,
-			ClusterID: clusterID,
-			HubInfo:   hubInfo,
+			Client:         client,
+			Log:            log.WithName("CMO"),
+			Recorder:       recorder,
+			Namespace:      namespace,
+			ClusterID:      clusterID,
+			HubInfo:        hubInfo,
+			CASecret:       caSecret,
+			CertSecret:     certSecret,
+			AccessorSecret: accessorSecret,
 		},
 	}
 }

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller_test.go
@@ -128,19 +128,8 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 			existingObjs: []client.Object{},
 		},
 		{
-			name: "Cluster ID failure - Error returned",
-			req: ctrl.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
-					Namespace: operatorconfig.OCPClusterMonitoringNamespace,
-				},
-			},
-			hubInfo:       hubInfo,
-			existingObjs:  []client.Object{amAccessorSecret}, // Missing ClusterVersion
-			expectedError: true,
-		},
-		{
 			name: "AlertmanagerEndpoint empty - Revert path",
+
 			req: ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
@@ -173,7 +162,7 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 			// Capture initial metric value
 			initialMetric := testutil.ToFloat64(cmoConfigConflictsTotal)
 
-			r := NewMCOAAgentReconciler(c, ctrl.Log.WithName("test"), s, recorder, namespace, tt.hubInfo)
+			r := NewMCOAAgentReconciler(c, ctrl.Log.WithName("test"), s, recorder, namespace, clusterID, tt.hubInfo)
 
 			_, err := r.Reconcile(context.Background(), tt.req)
 

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller_test.go
@@ -173,7 +173,18 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 			// Capture initial metric value
 			initialMetric := testutil.ToFloat64(cmoConfigConflictsTotal)
 
-			r := NewMCOAAgentReconciler(c, ctrl.Log.WithName("test"), s, recorder, namespace, clusterID, tt.hubInfo, "", "", "")
+			r := NewMCOAAgentReconciler(
+				c,
+				ctrl.Log.WithName("test"),
+				s,
+				recorder,
+				namespace,
+				clusterID,
+				tt.hubInfo,
+				"hub-alertmanager-router-ca",
+				"obs-alertmanager-mtls-cert",
+				"observability-alertmanager-accessor",
+			)
 
 			_, err := r.Reconcile(context.Background(), tt.req)
 

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller_test.go
@@ -48,6 +48,16 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 		},
 	}
 
+	sourceAmAccessorSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      observabilityendpoint.HubAmAccessorSecretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"token": []byte("test-token"),
+		},
+	}
+
 	clusterVersion := &ocinfrav1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "version",
@@ -75,7 +85,7 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			hubInfo:      hubInfo,
-			existingObjs: []client.Object{amAccessorSecret, clusterVersion},
+			existingObjs: []client.Object{amAccessorSecret, sourceAmAccessorSecret, clusterVersion},
 		},
 		{
 			name: "CMO Config Conflict - Metric incremented and event emitted",
@@ -88,6 +98,7 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 			hubInfo: hubInfo,
 			existingObjs: []client.Object{
 				amAccessorSecret,
+				sourceAmAccessorSecret,
 				clusterVersion,
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -114,7 +125,7 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 				},
 			},
 			hubInfo:      hubInfo,
-			existingObjs: []client.Object{amAccessorSecret, clusterVersion},
+			existingObjs: []client.Object{amAccessorSecret, sourceAmAccessorSecret, clusterVersion},
 		},
 		{
 			name: "Ignored resource - No action",
@@ -162,7 +173,7 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 			// Capture initial metric value
 			initialMetric := testutil.ToFloat64(cmoConfigConflictsTotal)
 
-			r := NewMCOAAgentReconciler(c, ctrl.Log.WithName("test"), s, recorder, namespace, clusterID, tt.hubInfo)
+			r := NewMCOAAgentReconciler(c, ctrl.Log.WithName("test"), s, recorder, namespace, clusterID, tt.hubInfo, "", "", "")
 
 			_, err := r.Reconcile(context.Background(), tt.req)
 

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller_test.go
@@ -1,0 +1,219 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package mcoa
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	ocinfrav1 "github.com/openshift/api/config/v1"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
+	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
+	t.Parallel()
+
+	s := scheme.Scheme
+	_ = ocinfrav1.AddToScheme(s)
+
+	namespace := "test-ns"
+	clusterID := "test-cluster-id"
+	hubInfo := &operatorconfig.HubInfo{
+		AlertmanagerEndpoint: "https://hub-am.example.com",
+		HubClusterID:         "hub-id",
+	}
+
+	amAccessorSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmAccessorSecretName, hubInfo),
+			Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+		},
+		Data: map[string][]byte{
+			"token": []byte("test-token"),
+		},
+	}
+
+	clusterVersion := &ocinfrav1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Spec: ocinfrav1.ClusterVersionSpec{
+			ClusterID: ocinfrav1.ClusterID(clusterID),
+		},
+	}
+
+	tests := []struct {
+		name           string
+		req            ctrl.Request
+		hubInfo        *operatorconfig.HubInfo
+		existingObjs   []client.Object
+		expectedMetric float64
+		expectedEvent  bool
+		expectedError  bool
+	}{
+		{
+			name: "CMO ConfigMap missing - Successful create",
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+					Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+				},
+			},
+			hubInfo:      hubInfo,
+			existingObjs: []client.Object{amAccessorSecret, clusterVersion},
+		},
+		{
+			name: "CMO Config Conflict - Metric incremented and event emitted",
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+					Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+				},
+			},
+			hubInfo: hubInfo,
+			existingObjs: []client.Object{
+				amAccessorSecret,
+				clusterVersion,
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+						Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+						ManagedFields: []metav1.ManagedFieldsEntry{
+							{Manager: observabilityendpoint.EndpointMonitoringOperatorMgr},
+						},
+					},
+					Data: map[string]string{
+						observabilityendpoint.ClusterMonitoringConfigDataKey: "prometheusK8s: {}",
+					},
+				},
+			},
+			expectedMetric: 1.0,
+			expectedEvent:  true,
+		},
+		{
+			name: "UWL ConfigMap missing - Successful create",
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+					Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+				},
+			},
+			hubInfo:      hubInfo,
+			existingObjs: []client.Object{amAccessorSecret, clusterVersion},
+		},
+		{
+			name: "Ignored resource - No action",
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "some-other-cm",
+					Namespace: "some-other-ns",
+				},
+			},
+			hubInfo:      hubInfo,
+			existingObjs: []client.Object{},
+		},
+		{
+			name: "Cluster ID failure - Error returned",
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+					Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+				},
+			},
+			hubInfo:       hubInfo,
+			existingObjs:  []client.Object{amAccessorSecret}, // Missing ClusterVersion
+			expectedError: true,
+		},
+		{
+			name: "AlertmanagerEndpoint empty - Revert path",
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+					Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+				},
+			},
+			hubInfo: &operatorconfig.HubInfo{AlertmanagerEndpoint: "", HubClusterID: "hub-id"},
+			existingObjs: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+						Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+						ManagedFields: []metav1.ManagedFieldsEntry{
+							{Manager: observabilityendpoint.EndpointMonitoringOperatorMgr},
+						},
+					},
+					Data: map[string]string{
+						observabilityendpoint.ClusterMonitoringConfigDataKey: "prometheusK8s: { additionalAlertmanagerConfigs: [ { scheme: https, tlsConfig: { ca: { name: hub-alertmanager-router-ca-hub-id } }, staticConfigs: [ hub.com ] } ] }",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(s).WithObjects(tt.existingObjs...).Build()
+			recorder := record.NewFakeRecorder(10)
+
+			// Capture initial metric value
+			initialMetric := testutil.ToFloat64(cmoConfigConflictsTotal)
+
+			r := NewMCOAAgentReconciler(c, ctrl.Log.WithName("test"), s, recorder, namespace, tt.hubInfo)
+
+			_, err := r.Reconcile(context.Background(), tt.req)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.expectedMetric > 0 {
+				assert.Equal(t, initialMetric+tt.expectedMetric, testutil.ToFloat64(cmoConfigConflictsTotal))
+			}
+
+			if tt.expectedEvent {
+				select {
+				case event := <-recorder.Events:
+					assert.Contains(t, event, "ConfigConflict")
+				default:
+					t.Errorf("Expected event was not emitted")
+				}
+			}
+
+			// Verify object creation/update for CMO/UWL
+			if !tt.expectedError {
+				found := &corev1.ConfigMap{}
+				err := c.Get(context.Background(), tt.req.NamespacedName, found)
+				if tt.hubInfo.AlertmanagerEndpoint != "" {
+					if tt.req.Name == operatorconfig.OCPClusterMonitoringConfigMapName || tt.req.Name == operatorconfig.OCPUserWorkloadMonitoringConfigMap {
+						require.NoError(t, err)
+						// staticConfigs contains the host only
+						host := strings.TrimPrefix(tt.hubInfo.AlertmanagerEndpoint, "https://")
+						assert.Contains(t, found.Data[observabilityendpoint.ClusterMonitoringConfigDataKey], host)
+					}
+				} else if tt.req.Name == operatorconfig.OCPClusterMonitoringConfigMapName {
+					// Revert path
+					if err == nil {
+						assert.NotContains(t, found.Data[observabilityendpoint.ClusterMonitoringConfigDataKey], "hub.com")
+					}
+				}
+			}
+		})
+	}
+}

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller_test.go
@@ -6,7 +6,6 @@ package mcoa
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	ocinfrav1 "github.com/openshift/api/config/v1"
@@ -16,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -33,14 +33,12 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 
 	namespace := "test-ns"
 	clusterID := "test-cluster-id"
-	hubInfo := &operatorconfig.HubInfo{
-		AlertmanagerEndpoint: "https://hub-am.example.com",
-		HubClusterID:         "hub-id",
-	}
+	alertmanagerEndpoint := "https://hub-am.example.com"
+	hubClusterID := "hub-id"
 
 	amAccessorSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmAccessorSecretName, hubInfo),
+			Name:      observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmAccessorSecretName, hubClusterID),
 			Namespace: operatorconfig.OCPClusterMonitoringNamespace,
 		},
 		Data: map[string][]byte{
@@ -68,13 +66,16 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		req            ctrl.Request
-		hubInfo        *operatorconfig.HubInfo
-		existingObjs   []client.Object
-		expectedMetric float64
-		expectedEvent  bool
-		expectedError  bool
+		name                      string
+		req                       ctrl.Request
+		alertmanagerEndpoint      string
+		hubClusterID              string
+		existingObjs              []client.Object
+		expectedMetric            float64
+		expectedEvent             bool
+		expectedError             bool
+		disableUWLAlertForwarding bool
+		validate                  func(t *testing.T, c client.Client)
 	}{
 		{
 			name: "CMO ConfigMap missing - Successful create",
@@ -84,8 +85,18 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 					Namespace: operatorconfig.OCPClusterMonitoringNamespace,
 				},
 			},
-			hubInfo:      hubInfo,
-			existingObjs: []client.Object{amAccessorSecret, sourceAmAccessorSecret, clusterVersion},
+			alertmanagerEndpoint: alertmanagerEndpoint,
+			hubClusterID:         hubClusterID,
+			existingObjs:         []client.Object{amAccessorSecret, sourceAmAccessorSecret, clusterVersion},
+			validate: func(t *testing.T, c client.Client) {
+				found := &corev1.ConfigMap{}
+				err := c.Get(context.Background(), types.NamespacedName{
+					Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+					Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+				}, found)
+				require.NoError(t, err)
+				assert.Contains(t, found.Data[observabilityendpoint.ClusterMonitoringConfigDataKey], "hub-am.example.com")
+			},
 		},
 		{
 			name: "CMO Config Conflict - Metric incremented and event emitted",
@@ -95,7 +106,8 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 					Namespace: operatorconfig.OCPClusterMonitoringNamespace,
 				},
 			},
-			hubInfo: hubInfo,
+			alertmanagerEndpoint: alertmanagerEndpoint,
+			hubClusterID:         hubClusterID,
 			existingObjs: []client.Object{
 				amAccessorSecret,
 				sourceAmAccessorSecret,
@@ -115,6 +127,15 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 			},
 			expectedMetric: 1.0,
 			expectedEvent:  true,
+			validate: func(t *testing.T, c client.Client) {
+				found := &corev1.ConfigMap{}
+				err := c.Get(context.Background(), types.NamespacedName{
+					Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+					Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+				}, found)
+				require.NoError(t, err)
+				assert.Contains(t, found.Data[observabilityendpoint.ClusterMonitoringConfigDataKey], "hub-am.example.com")
+			},
 		},
 		{
 			name: "UWL ConfigMap missing - Successful create",
@@ -124,8 +145,18 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 					Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
 				},
 			},
-			hubInfo:      hubInfo,
-			existingObjs: []client.Object{amAccessorSecret, sourceAmAccessorSecret, clusterVersion},
+			alertmanagerEndpoint: alertmanagerEndpoint,
+			hubClusterID:         hubClusterID,
+			existingObjs:         []client.Object{amAccessorSecret, sourceAmAccessorSecret, clusterVersion},
+			validate: func(t *testing.T, c client.Client) {
+				found := &corev1.ConfigMap{}
+				err := c.Get(context.Background(), types.NamespacedName{
+					Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+					Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+				}, found)
+				require.NoError(t, err)
+				assert.Contains(t, found.Data["config.yaml"], "hub-am.example.com")
+			},
 		},
 		{
 			name: "Ignored resource - No action",
@@ -135,19 +166,28 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 					Namespace: "some-other-ns",
 				},
 			},
-			hubInfo:      hubInfo,
-			existingObjs: []client.Object{},
+			alertmanagerEndpoint: alertmanagerEndpoint,
+			hubClusterID:         hubClusterID,
+			existingObjs:         []client.Object{},
+			validate: func(t *testing.T, c client.Client) {
+				found := &corev1.ConfigMap{}
+				err := c.Get(context.Background(), types.NamespacedName{
+					Name:      "some-other-cm",
+					Namespace: "some-other-ns",
+				}, found)
+				assert.True(t, apierrors.IsNotFound(err))
+			},
 		},
 		{
 			name: "AlertmanagerEndpoint empty - Revert path",
-
 			req: ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
 					Namespace: operatorconfig.OCPClusterMonitoringNamespace,
 				},
 			},
-			hubInfo: &operatorconfig.HubInfo{AlertmanagerEndpoint: "", HubClusterID: "hub-id"},
+			alertmanagerEndpoint: "",
+			hubClusterID:         "hub-id",
 			existingObjs: []client.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -162,6 +202,39 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 					},
 				},
 			},
+			validate: func(t *testing.T, c client.Client) {
+				found := &corev1.ConfigMap{}
+				err := c.Get(context.Background(), types.NamespacedName{
+					Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+					Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+				}, found)
+				if err == nil {
+					assert.NotContains(t, found.Data[observabilityendpoint.ClusterMonitoringConfigDataKey], "hub.com")
+				}
+			},
+		},
+		{
+			name: "UWL ConfigMap - UWL alert forwarding disabled",
+			req: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+					Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+				},
+			},
+			alertmanagerEndpoint:      alertmanagerEndpoint,
+			hubClusterID:              hubClusterID,
+			existingObjs:              []client.Object{amAccessorSecret, sourceAmAccessorSecret, clusterVersion},
+			disableUWLAlertForwarding: true,
+			validate: func(t *testing.T, c client.Client) {
+				found := &corev1.ConfigMap{}
+				err := c.Get(context.Background(), types.NamespacedName{
+					Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+					Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+				}, found)
+				if err == nil {
+					assert.NotContains(t, found.Data["config.yaml"], "hub.com")
+				}
+			},
 		},
 	}
 
@@ -173,6 +246,8 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 			// Capture initial metric value
 			initialMetric := testutil.ToFloat64(cmoConfigConflictsTotal)
 
+			caSecretName := observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmRouterCASecretName, tt.hubClusterID)
+
 			r := NewMCOAAgentReconciler(
 				c,
 				ctrl.Log.WithName("test"),
@@ -180,10 +255,11 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 				recorder,
 				namespace,
 				clusterID,
-				tt.hubInfo,
-				"hub-alertmanager-router-ca",
+				tt.alertmanagerEndpoint,
+				caSecretName,
 				"obs-alertmanager-mtls-cert",
 				"observability-alertmanager-accessor",
+				!tt.disableUWLAlertForwarding,
 			)
 
 			_, err := r.Reconcile(context.Background(), tt.req)
@@ -207,23 +283,9 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 				}
 			}
 
-			// Verify object creation/update for CMO/UWL
-			if !tt.expectedError {
-				found := &corev1.ConfigMap{}
-				err := c.Get(context.Background(), tt.req.NamespacedName, found)
-				if tt.hubInfo.AlertmanagerEndpoint != "" {
-					if tt.req.Name == operatorconfig.OCPClusterMonitoringConfigMapName || tt.req.Name == operatorconfig.OCPUserWorkloadMonitoringConfigMap {
-						require.NoError(t, err)
-						// staticConfigs contains the host only
-						host := strings.TrimPrefix(tt.hubInfo.AlertmanagerEndpoint, "https://")
-						assert.Contains(t, found.Data[observabilityendpoint.ClusterMonitoringConfigDataKey], host)
-					}
-				} else if tt.req.Name == operatorconfig.OCPClusterMonitoringConfigMapName {
-					// Revert path
-					if err == nil {
-						assert.NotContains(t, found.Data[observabilityendpoint.ClusterMonitoringConfigDataKey], "hub.com")
-					}
-				}
+			// Run custom explicit validations
+			if tt.validate != nil {
+				tt.validate(t, c)
 			}
 		})
 	}

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+//go:build integration
+
+package mcoa
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	ocinfrav1 "github.com/openshift/api/config/v1"
+	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
+	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	"k8s.io/apimachinery/pkg/types"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	testEnv *envtest.Environment
+	cfg     *rest.Config
+)
+
+func TestMain(m *testing.M) {
+	opts := zap.Options{
+		Development: true,
+	}
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	cvCRD := readCRDFiles(
+		filepath.Join("..", "observabilityendpoint", "testdata", "crd", "clusterversions-crd.yaml"),
+	)
+
+	testEnv = &envtest.Environment{
+		CRDs: cvCRD,
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to start test environment: %v", err))
+	}
+
+	code := m.Run()
+
+	err = testEnv.Stop()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to stop test environment: %v", err))
+	}
+
+	os.Exit(code)
+}
+
+func readCRDFiles(crdPaths ...string) []*apiextensionsv1.CustomResourceDefinition {
+	ret := []*apiextensionsv1.CustomResourceDefinition{}
+
+	for _, crdPath := range crdPaths {
+		crdYamlData, err := os.ReadFile(crdPath)
+		if err != nil {
+			panic(fmt.Sprintf("Failed to read CRD file: %v", err))
+		}
+
+		dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+		var crd apiextensionsv1.CustomResourceDefinition
+		_, _, err = dec.Decode(crdYamlData, nil, &crd)
+		if err != nil {
+			panic(fmt.Sprintf("Failed to decode CRD: %v", err))
+		}
+
+		ret = append(ret, &crd)
+	}
+
+	return ret
+}
+
+func TestMCOAAgentIntegration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	s := runtime.NewScheme()
+	require.NoError(t, kubescheme.AddToScheme(s))
+	require.NoError(t, ocinfrav1.AddToScheme(s))
+
+	namespace := "test-mcoa-agent"
+	hubInfo := &operatorconfig.HubInfo{
+		AlertmanagerEndpoint: "https://hub-am.example.com",
+		HubClusterID:         "hub-id",
+	}
+
+	// Initialize Manager with surgical filtered cache configuration identical to main.go
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: s,
+		Cache:  GetCacheOptions(),
+	})
+	require.NoError(t, err)
+
+	reconciler := NewMCOAAgentReconciler(
+		mgr.GetClient(),
+		mgr.GetLogger(),
+		mgr.GetScheme(),
+		mgr.GetEventRecorderFor("mcoa-agent-test"),
+		namespace,
+		hubInfo,
+	)
+	err = reconciler.SetupWithManager(mgr)
+	require.NoError(t, err)
+
+	go func() {
+		if err := mgr.Start(ctx); err != nil {
+			fmt.Printf("Manager failed: %v\n", err)
+		}
+	}()
+
+	k8sClient := mgr.GetClient()
+	directClient, err := client.New(cfg, client.Options{Scheme: s})
+	require.NoError(t, err)
+
+	// Setup required platform resources
+	setupResources := []client.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: operatorconfig.OCPClusterMonitoringNamespace}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: operatorconfig.OCPUserWorkloadMonitoringNamespace}},
+		&ocinfrav1.ClusterVersion{
+			ObjectMeta: metav1.ObjectMeta{Name: "version"},
+			Spec:       ocinfrav1.ClusterVersionSpec{ClusterID: "test-cluster-id"},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmAccessorSecretName, hubInfo),
+				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+			},
+			Data: map[string][]byte{"token": []byte("test-token")},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmRouterCASecretName, hubInfo),
+				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+			},
+			Data: map[string][]byte{"service-ca.crt": []byte("test-ca")},
+		},
+	}
+	for _, obj := range setupResources {
+		err = directClient.Create(ctx, obj)
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			require.NoError(t, err)
+		}
+	}
+
+	t.Run("Surgical cache filter: Unmanaged ConfigMap is invisible to the cached client", func(t *testing.T) {
+		unmanagedName := "unmanaged-cm"
+		unmanagedCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: unmanagedName, Namespace: operatorconfig.OCPClusterMonitoringNamespace},
+			Data:       map[string]string{"foo": "bar"},
+		}
+		require.NoError(t, directClient.Create(ctx, unmanagedCM))
+
+		found := &corev1.ConfigMap{}
+		err = k8sClient.Get(ctx, types.NamespacedName{Name: unmanagedName, Namespace: operatorconfig.OCPClusterMonitoringNamespace}, found)
+		require.Error(t, err)
+		require.True(t, apierrors.IsNotFound(err))
+	})
+}

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -92,7 +93,7 @@ func readCRDFiles(crdPaths ...string) []*apiextensionsv1.CustomResourceDefinitio
 }
 
 func TestMCOAAgentIntegration(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
 	defer cancel()
 
 	s := runtime.NewScheme()
@@ -112,6 +113,11 @@ func TestMCOAAgentIntegration(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	caSecretName := "hub-alertmanager-router-ca"
+	if hubInfo.HubClusterID != "" {
+		caSecretName = "hub-alertmanager-router-ca-" + hubInfo.HubClusterID
+	}
+
 	reconciler := NewMCOAAgentReconciler(
 		mgr.GetClient(),
 		mgr.GetLogger(),
@@ -119,10 +125,11 @@ func TestMCOAAgentIntegration(t *testing.T) {
 		mgr.GetEventRecorderFor("mcoa-agent-test"),
 		namespace,
 		"test-cluster-id",
-		hubInfo,
-		"hub-alertmanager-router-ca",
+		hubInfo.AlertmanagerEndpoint,
+		caSecretName,
 		"obs-alertmanager-mtls-cert",
 		"observability-alertmanager-accessor",
+		true,
 	)
 	err = reconciler.SetupWithManager(mgr)
 	require.NoError(t, err)
@@ -147,14 +154,14 @@ func TestMCOAAgentIntegration(t *testing.T) {
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmAccessorSecretName, hubInfo),
+				Name:      observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmAccessorSecretName, hubInfo.HubClusterID),
 				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
 			},
 			Data: map[string][]byte{"token": []byte("test-token")},
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmRouterCASecretName, hubInfo),
+				Name:      observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmRouterCASecretName, hubInfo.HubClusterID),
 				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
 			},
 			Data: map[string][]byte{"service-ca.crt": []byte("test-ca")},
@@ -179,5 +186,127 @@ func TestMCOAAgentIntegration(t *testing.T) {
 		err = k8sClient.Get(ctx, types.NamespacedName{Name: unmanagedName, Namespace: operatorconfig.OCPClusterMonitoringNamespace}, found)
 		require.Error(t, err)
 		require.True(t, apierrors.IsNotFound(err))
+	})
+
+	t.Run("Reconcile CMO Config: Managed ConfigMap is successfully populated with Alertmanager configuration", func(t *testing.T) {
+		cmoCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+			},
+			Data: map[string]string{
+				observabilityendpoint.ClusterMonitoringConfigDataKey: "prometheusK8s: {}",
+			},
+		}
+		require.NoError(t, directClient.Create(ctx, cmoCM, client.FieldOwner(observabilityendpoint.EndpointMonitoringOperatorMgr)))
+
+		// Wait for the reconciler to populate our Alertmanager configs
+		require.Eventually(t, func() bool {
+			found := &corev1.ConfigMap{}
+			err := directClient.Get(ctx, types.NamespacedName{
+				Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+			}, found)
+			if err != nil {
+				return false
+			}
+			data := found.Data[observabilityendpoint.ClusterMonitoringConfigDataKey]
+			return strings.Contains(data, "hub-alertmanager-router-ca-hub-id") && strings.Contains(data, "hub-am.example.com")
+		}, 5*time.Second, 100*time.Millisecond)
+	})
+
+	t.Run("Reconcile Revert path: Empty AlertmanagerEndpoint cleanly reverts the Alertmanager configuration", func(t *testing.T) {
+		// Disable alert forwarding on the active reconciler
+		reconciler.AlertmanagerEndpoint = ""
+
+		// Trigger reconcile by updating the CMO ConfigMap
+		found := &corev1.ConfigMap{}
+		require.NoError(t, directClient.Get(ctx, types.NamespacedName{
+			Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+			Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+		}, found))
+		found.Data["trigger"] = "reconcile"
+		require.NoError(t, directClient.Update(ctx, found, client.FieldOwner(observabilityendpoint.EndpointMonitoringOperatorMgr)))
+
+		// Wait for the reconciler to clean up our Alertmanager configs (or cleanly delete the empty ConfigMap)
+		require.Eventually(t, func() bool {
+			foundCM := &corev1.ConfigMap{}
+			err := directClient.Get(ctx, types.NamespacedName{
+				Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+			}, foundCM)
+			if apierrors.IsNotFound(err) {
+				return true
+			}
+			if err != nil {
+				fmt.Printf("Get ConfigMap error: %v\n", err)
+				return false
+			}
+			data := foundCM.Data[observabilityendpoint.ClusterMonitoringConfigDataKey]
+			return !strings.Contains(data, "hub-alertmanager-router-ca-hub-id") && !strings.Contains(data, "hub-am.example.com")
+		}, 5*time.Second, 100*time.Millisecond)
+	})
+
+	t.Run("Reconcile UWL Config: Managed ConfigMap is successfully populated with Alertmanager configuration", func(t *testing.T) {
+		// Set AlertmanagerEndpoint and EnableUWLAlertForwarding back to active state
+		reconciler.AlertmanagerEndpoint = "https://hub-am.example.com"
+		reconciler.EnableUWLAlertForwarding = true
+
+		uwlCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+				Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+			},
+			Data: map[string]string{
+				"config.yaml": "prometheus: {}",
+			},
+		}
+		require.NoError(t, directClient.Create(ctx, uwlCM, client.FieldOwner(observabilityendpoint.EndpointMonitoringOperatorMgr)))
+
+		// Wait for the reconciler to populate our Alertmanager configs in UWL ConfigMap
+		require.Eventually(t, func() bool {
+			found := &corev1.ConfigMap{}
+			err := directClient.Get(ctx, types.NamespacedName{
+				Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+				Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+			}, found)
+			if err != nil {
+				return false
+			}
+			data := found.Data["config.yaml"]
+			return strings.Contains(data, "hub-alertmanager-router-ca-hub-id") && strings.Contains(data, "hub-am.example.com")
+		}, 5*time.Second, 100*time.Millisecond)
+	})
+
+	t.Run("Reconcile UWL Revert path: Disabled EnableUWLAlertForwarding cleanly reverts the Alertmanager configuration", func(t *testing.T) {
+		// Disable UWL alert forwarding on the active reconciler
+		reconciler.EnableUWLAlertForwarding = false
+
+		// Trigger reconcile by updating the UWL ConfigMap
+		found := &corev1.ConfigMap{}
+		require.NoError(t, directClient.Get(ctx, types.NamespacedName{
+			Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+			Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+		}, found))
+		found.Data["trigger"] = "reconcile"
+		require.NoError(t, directClient.Update(ctx, found, client.FieldOwner(observabilityendpoint.EndpointMonitoringOperatorMgr)))
+
+		// Wait for the reconciler to clean up our Alertmanager configs from UWL ConfigMap
+		require.Eventually(t, func() bool {
+			foundCM := &corev1.ConfigMap{}
+			err := directClient.Get(ctx, types.NamespacedName{
+				Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+				Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+			}, foundCM)
+			if apierrors.IsNotFound(err) {
+				return true
+			}
+			if err != nil {
+				fmt.Printf("Get ConfigMap error: %v\n", err)
+				return false
+			}
+			data := foundCM.Data["config.yaml"]
+			return !strings.Contains(data, "hub-alertmanager-router-ca-hub-id") && !strings.Contains(data, "hub-am.example.com")
+		}, 5*time.Second, 100*time.Millisecond)
 	})
 }

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
@@ -219,14 +219,14 @@ func TestMCOAAgentIntegration(t *testing.T) {
 		// Disable alert forwarding on the active reconciler
 		reconciler.AlertmanagerEndpoint = ""
 
-		// Trigger reconcile by updating the CMO ConfigMap
-		found := &corev1.ConfigMap{}
-		require.NoError(t, directClient.Get(ctx, types.NamespacedName{
-			Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
-			Namespace: operatorconfig.OCPClusterMonitoringNamespace,
-		}, found))
-		found.Data["trigger"] = "reconcile"
-		require.NoError(t, directClient.Update(ctx, found, client.FieldOwner(observabilityendpoint.EndpointMonitoringOperatorMgr)))
+		// Trigger reconcile by directly calling the Reconcile method on the reconciler, emulating the real flow.
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+			},
+		})
+		require.NoError(t, err)
 
 		// Wait for the reconciler to clean up our Alertmanager configs (or cleanly delete the empty ConfigMap)
 		require.Eventually(t, func() bool {
@@ -282,14 +282,14 @@ func TestMCOAAgentIntegration(t *testing.T) {
 		// Disable UWL alert forwarding on the active reconciler
 		reconciler.EnableUWLAlertForwarding = false
 
-		// Trigger reconcile by updating the UWL ConfigMap
-		found := &corev1.ConfigMap{}
-		require.NoError(t, directClient.Get(ctx, types.NamespacedName{
-			Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
-			Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
-		}, found))
-		found.Data["trigger"] = "reconcile"
-		require.NoError(t, directClient.Update(ctx, found, client.FieldOwner(observabilityendpoint.EndpointMonitoringOperatorMgr)))
+		// Trigger reconcile by directly calling the Reconcile method on the reconciler, emulating the real flow.
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+				Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+			},
+		})
+		require.NoError(t, err)
 
 		// Wait for the reconciler to clean up our Alertmanager configs from UWL ConfigMap
 		require.Eventually(t, func() bool {

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
@@ -118,6 +118,7 @@ func TestMCOAAgentIntegration(t *testing.T) {
 		mgr.GetScheme(),
 		mgr.GetEventRecorderFor("mcoa-agent-test"),
 		namespace,
+		"test-cluster-id",
 		hubInfo,
 	)
 	err = reconciler.SetupWithManager(mgr)

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
@@ -120,9 +120,9 @@ func TestMCOAAgentIntegration(t *testing.T) {
 		namespace,
 		"test-cluster-id",
 		hubInfo,
-		"",
-		"",
-		"",
+		"hub-alertmanager-router-ca",
+		"obs-alertmanager-mtls-cert",
+		"observability-alertmanager-accessor",
 	)
 	err = reconciler.SetupWithManager(mgr)
 	require.NoError(t, err)

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
@@ -120,6 +120,9 @@ func TestMCOAAgentIntegration(t *testing.T) {
 		namespace,
 		"test-cluster-id",
 		hubInfo,
+		"",
+		"",
+		"",
 	)
 	err = reconciler.SetupWithManager(mgr)
 	require.NoError(t, err)

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -52,7 +52,7 @@ const (
 	mtlsCertName                    = "observability-controller-open-cluster-management.io-observability-signer-client-cert"
 	mtlsCaName                      = "observability-managed-cluster-certs"
 	amMtlsCertName                  = "obs-alertmanager-mtls-cert"
-	amMtlsCaName                    = "obs-alertmanager-mtls-ca"
+	amMtlsCaName                    = HubAmMtlsCASecretName
 	metricsCollectorName            = "metrics-collector-deployment"
 	uwlMetricsCollectorName         = "uwl-metrics-collector-deployment"
 	uwlNamespace                    = "openshift-user-workload-monitoring"
@@ -349,13 +349,14 @@ func (r *ObservabilityAddonReconciler) initFinalization(
 		}
 
 		// revert the change to cluster monitoring stack
-		err := RevertClusterMonitoringConfig(ctx, r.Client, hubInfo)
+		caSecret := AppendHubClusterID(HubAmRouterCASecretName, hubInfo.HubClusterID)
+		err := RevertClusterMonitoringConfig(ctx, r.Client, caSecret)
 		if err != nil {
 			return false, err
 		}
 
 		// revert the change to user workload monitoring stack
-		err = RevertUserWorkloadMonitoringConfig(ctx, r.Client, hubInfo)
+		err = RevertUserWorkloadMonitoringConfig(ctx, r.Client, caSecret)
 		if err != nil {
 			return false, err
 		}

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -570,7 +570,7 @@ func (r *ObservabilityAddonReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Watches(
 			&corev1.Secret{},
 			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(getPred(hubAmAccessorSecretName, r.Namespace, true, true, false)),
+			builder.WithPredicates(getPred(HubAmAccessorSecretName, r.Namespace, true, true, false)),
 		).
 		Watches(
 			&corev1.ConfigMap{},
@@ -600,12 +600,12 @@ func (r *ObservabilityAddonReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Watches(
 			&corev1.ConfigMap{},
 			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(configMapDataChangedPredicate(clusterMonitoringConfigName, promNamespace)),
+			builder.WithPredicates(ConfigMapDataChangedPredicate(clusterMonitoringConfigName, promNamespace)),
 		).
 		Watches(
 			&corev1.ConfigMap{},
 			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(configMapDataChangedPredicate(
+			builder.WithPredicates(ConfigMapDataChangedPredicate(
 				operatorconfig.OCPUserWorkloadMonitoringConfigMap,
 				operatorconfig.OCPUserWorkloadMonitoringNamespace)),
 		).

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -361,6 +361,17 @@ func (r *ObservabilityAddonReconciler) initFinalization(
 			return false, err
 		}
 
+		// revert the mTLS CA configurations as well (mirroring the two-pass behavior in cmo-config-revert)
+		mtlsCASecret := AppendHubClusterID(HubAmMtlsCASecretName, hubInfo.HubClusterID)
+		err = RevertClusterMonitoringConfig(ctx, r.Client, mtlsCASecret)
+		if err != nil {
+			return false, err
+		}
+		err = RevertUserWorkloadMonitoringConfig(ctx, r.Client, mtlsCASecret)
+		if err != nil {
+			return false, err
+		}
+
 		if isHypershift {
 			err = hypershift.DeleteServiceMonitors(ctx, r.Client)
 			if err != nil {

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_integration_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_integration_test.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,6 +25,7 @@ import (
 	oav1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -59,7 +62,6 @@ func TestIntegrationCMOConfigWatching(t *testing.T) {
 	namespace := "test-cmo-config"
 
 	scheme := createBaseScheme()
-	ocinfrav1.AddToScheme(scheme)
 
 	k8sClient, err := client.New(restCfgHub, client.Options{Scheme: scheme})
 	if err != nil {
@@ -143,7 +145,7 @@ alertmanager-endpoint: "http://test-alertamanger-endpoint"
 	err = reconciler.SetupWithManager(mgr)
 	assert.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	go func() {
@@ -152,16 +154,10 @@ alertmanager-endpoint: "http://test-alertamanger-endpoint"
 	}()
 
 	cm := &corev1.ConfigMap{}
-	err = wait.Poll(1*time.Second, time.Minute, func() (bool, error) {
-		err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: promNamespace, Name: clusterMonitoringConfigName}, cm)
-		if err != nil && errors.IsNotFound(err) {
-			return false, nil
-		}
-
-		return true, err
-	})
-	assert.NoError(t, err)
-	assert.NotEmpty(t, cm.Data[ClusterMonitoringConfigDataKey])
+	assert.Eventually(t, func() bool {
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: promNamespace, Name: clusterMonitoringConfigName}, cm)
+		return err == nil && cm.Data != nil && cm.Data[ClusterMonitoringConfigDataKey] != ""
+	}, time.Minute, 1*time.Second)
 
 	foundClusterMonitoringConfiguration := &cmomanifests.ClusterMonitoringConfiguration{}
 	err = yaml2.Unmarshal([]byte(cm.Data[ClusterMonitoringConfigDataKey]), foundClusterMonitoringConfiguration)
@@ -176,34 +172,176 @@ alertmanager-endpoint: "http://test-alertamanger-endpoint"
 	b, err := yaml2.Marshal(foundClusterMonitoringConfiguration)
 	assert.NoError(t, err)
 	cm.Data[ClusterMonitoringConfigDataKey] = string(b)
-	err = k8sClient.Update(context.Background(), cm)
+	err = k8sClient.Update(ctx, cm)
 	assert.NoError(t, err)
 
 	// repeat the test and expect a partial revert
-	err = wait.Poll(1*time.Second, time.Minute, func() (bool, error) {
+	assert.Eventually(t, func() bool {
 		updated := &corev1.ConfigMap{}
-		err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: promNamespace, Name: clusterMonitoringConfigName}, updated)
-		if err != nil && errors.IsNotFound(err) {
-			return false, nil
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: promNamespace, Name: clusterMonitoringConfigName}, updated)
+		if err != nil {
+			return false
 		}
 
 		foundUpdatedClusterMonitoringConfiguration := &cmomanifests.ClusterMonitoringConfiguration{}
 		err = yaml2.Unmarshal([]byte(updated.Data[ClusterMonitoringConfigDataKey]), foundUpdatedClusterMonitoringConfiguration)
 		if err != nil {
-			return false, nil
+			return false
+		}
+
+		if foundUpdatedClusterMonitoringConfiguration.PrometheusK8sConfig == nil ||
+			len(foundUpdatedClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs) == 0 {
+			return false
 		}
 
 		if foundUpdatedClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs[0].Scheme != "https" {
-			return false, nil
+			return false
 		}
 
 		if foundUpdatedClusterMonitoringConfiguration.PrometheusK8sConfig.Retention != "infinity-and-beyond" {
-			return false, nil
+			return false
 		}
 
-		return true, err
+		return true
+	}, time.Minute, 1*time.Second)
+}
+
+// TestIntegrationCMOConfigRevertOnDeletion tests that the finalizer cleanly reverts the CMO ConfigMap on addon deletion.
+func TestIntegrationCMOConfigRevertOnDeletion(t *testing.T) {
+	namespace := "test-cmo-revert"
+
+	scheme := createBaseScheme()
+
+	k8sClient, err := client.New(restCfgHub, client.Options{Scheme: scheme})
+	require.NoError(t, err)
+
+	defer func() {
+		_ = k8sClient.Delete(t.Context(), makeNamespace(namespace))
+	}()
+
+	// Create resources needed for reconciliation
+	resourcesDeps := []client.Object{
+		makeNamespace(promNamespace),
+		makeNamespace(namespace),
+		newImagesCM(namespace),
+		&ocinfrav1.ClusterVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "version",
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "prometheus-k8s",
+				Namespace: "openshift-monitoring",
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "web",
+						Port: 9090,
+					},
+				},
+			},
+		},
+		newHubInfoSecret([]byte(`
+endpoint: "http://test-endpoint"
+hub-cluster-id: "test-hub-cluster"
+alertmanager-endpoint: "http://test-alertamanger-endpoint"
+alertmanager-router-ca: |
+    -----BEGIN CERTIFICATE-----
+    xxxxxxxxxxxxxxxxxxxxxxxxxxx
+    -----END CERTIFICATE-----
+`), namespace),
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      HubAmAccessorSecretName,
+				Namespace: namespace,
+			},
+			StringData: map[string]string{hubAmAccessorSecretKey: "lol"},
+		},
+		&oav1beta1.ObservabilityAddon{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "observability-addon",
+				Namespace: namespace,
+			},
+		},
+	}
+	for _, obj := range newMtlsTestSecrets(namespace) {
+		resourcesDeps = append(resourcesDeps, obj.(client.Object))
+	}
+	require.NoError(t, createResources(k8sClient, resourcesDeps...))
+
+	mgr, err := ctrl.NewManager(testEnvHub.Config, ctrl.Options{
+		Scheme:  k8sClient.Scheme(),
+		Metrics: metricsserver.Options{BindAddress: "0"},
+		Controller: config.Controller{
+			SkipNameValidation: ptr.To(true),
+		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
+
+	hubClientWithReload, err := util.NewReloadableHubClientWithReloadFunc(func() (client.Client, error) {
+		return k8sClient, nil
+	})
+	require.NoError(t, err)
+
+	reconciler := ObservabilityAddonReconciler{
+		Client:                k8sClient,
+		HubClient:             hubClientWithReload,
+		IsHubMetricsCollector: false,
+		Scheme:                scheme,
+		Namespace:             namespace,
+		HubNamespace:          namespace,
+		ServiceAccountName:    "endpoint-monitoring-operator",
+		InstallPrometheus:     false,
+	}
+	require.NoError(t, reconciler.SetupWithManager(mgr))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
+		require.NoError(t, mgr.Start(ctx))
+	}()
+
+	// 1. Wait for Alertmanager config to be populated on start
+	cm := &corev1.ConfigMap{}
+	assert.Eventually(t, func() bool {
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: promNamespace, Name: clusterMonitoringConfigName}, cm)
+		return err == nil && cm.Data != nil && cm.Data[ClusterMonitoringConfigDataKey] != ""
+	}, time.Minute, 1*time.Second)
+
+	// 2. Wait for finalizer to be present on the addon
+	assert.Eventually(t, func() bool {
+		foundAddon := &oav1beta1.ObservabilityAddon{}
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "observability-addon"}, foundAddon)
+		return err == nil && slices.Contains(foundAddon.GetFinalizers(), "observability.open-cluster-management.io/addon-cleanup")
+	}, time.Minute, 1*time.Second)
+
+	// Now delete the ObservabilityAddon (this triggers the finalizer)
+	addon := &oav1beta1.ObservabilityAddon{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "observability-addon",
+			Namespace: namespace,
+		},
+	}
+	require.NoError(t, k8sClient.Delete(ctx, addon))
+
+	// 3. Wait for the finalizer to run and cleanly delete/revert the CMO ConfigMap
+	assert.Eventually(t, func() bool {
+		foundCM := &corev1.ConfigMap{}
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: promNamespace, Name: clusterMonitoringConfigName}, foundCM)
+		if errors.IsNotFound(err) {
+			return true
+		}
+		if err != nil {
+			fmt.Printf("Revert CMO ConfigMap Get error: %v\n", err)
+			return false
+		}
+		data := foundCM.Data[ClusterMonitoringConfigDataKey]
+		fmt.Printf("Found ConfigMap Data: %s\n", data)
+		return !strings.Contains(data, "obs-alertmanager-mtls-ca") && !strings.Contains(data, "test-alertamanger-endpoint")
+	}, time.Minute, 1*time.Second)
 }
 
 // TestIntegrationReconcileHypershiftOnHub tests the reconcile function for hypershift CRDs on a Hub cluster.
@@ -211,10 +349,6 @@ func TestIntegrationReconcileHypershiftOnHub(t *testing.T) {
 	testNamespace := "test-ns"
 
 	scheme := createBaseScheme()
-	err := hyperv1.AddToScheme(scheme)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	k8sClient, err := client.New(restCfgHub, client.Options{Scheme: scheme})
 	if err != nil {
@@ -267,7 +401,7 @@ func TestIntegrationReconcileHypershiftOnHub(t *testing.T) {
 	err = reconciler.SetupWithManager(mgr)
 	assert.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	go func() {
@@ -331,10 +465,6 @@ func TestIntegrationReconcileHypershiftOnSpoke(t *testing.T) {
 	mcNamespace := "test-mc-hub-ns"
 
 	scheme := createBaseScheme()
-	err := hyperv1.AddToScheme(scheme)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	// Setup spoke cluster resources
 	k8sClient, err := client.New(restCfgSpoke, client.Options{Scheme: scheme})
@@ -489,6 +619,8 @@ func TestMain(m *testing.M) {
 
 	hubCRDs := readCRDFiles(
 		filepath.Join(rootPath, "multiclusterobservability", "config", "crd", "bases", "observability.open-cluster-management.io_multiclusterobservabilities.yaml"),
+		filepath.Join(rootPath, "endpointmetrics", "manifests", "prometheus", "crd", "servicemonitor_crd_0_53_1.yaml"),
+		filepath.Join(rootPath, "endpointmetrics", "manifests", "prometheus", "crd", "prometheusrule_crd_0_53_1.yaml"),
 	)
 	hubCRDs = append(hubCRDs, spokeCrds...)
 
@@ -524,6 +656,8 @@ func createBaseScheme() *runtime.Scheme {
 	promv1.AddToScheme(scheme)
 	oav1beta1.AddToScheme(scheme)
 	mcov1beta2.AddToScheme(scheme)
+	ocinfrav1.AddToScheme(scheme)
+	hyperv1.AddToScheme(scheme)
 	return scheme
 }
 
@@ -569,7 +703,7 @@ func tearDownCommonSpokeResources(t *testing.T, k8sClient client.Client) {
 		makeNamespace(obAddonNs),
 	}
 	for _, resource := range resourcesDeps {
-		if err := k8sClient.Delete(context.Background(), resource); err != nil {
+		if err := k8sClient.Delete(t.Context(), resource); err != nil {
 			t.Fatalf("Failed to delete resource: %v", err)
 		}
 	}
@@ -608,7 +742,7 @@ func makeNamespace(name string) *corev1.Namespace {
 // createResources creates the given resources in the cluster.
 func createResources(client client.Client, resources ...client.Object) error {
 	for _, resource := range resources {
-		if err := client.Create(context.Background(), resource); err != nil {
+		if err := client.Create(context.Background(), resource); err != nil && !errors.IsAlreadyExists(err) {
 			return err
 		}
 	}
@@ -652,33 +786,6 @@ func newServiceMonitor(name, namespace string) *promv1.ServiceMonitor {
 			},
 			Selector:          metav1.LabelSelector{},
 			NamespaceSelector: promv1.NamespaceSelector{},
-		},
-	}
-}
-
-func newMicroshiftVersionCM(namespace string) *corev1.ConfigMap {
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "microshift-version",
-			Namespace: namespace,
-		},
-		Data: map[string]string{
-			"version": "v4.15.15",
-		},
-	}
-}
-
-func newMetricsAllowlistCM(namespace string) *corev1.ConfigMap {
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "observability-metrics-allowlist",
-			Namespace: namespace,
-		},
-		Data: map[string]string{
-			"metrics_list.yaml": `
-names:
-  - apiserver_watch_events_sizes_bucket
-`,
 		},
 	}
 }

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_integration_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_integration_test.go
@@ -95,7 +95,7 @@ alertmanager-endpoint: "http://test-alertamanger-endpoint"
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      hubAmAccessorSecretName,
+				Name:      HubAmAccessorSecretName,
 				Namespace: namespace,
 			},
 			Immutable:  nil,
@@ -161,10 +161,10 @@ alertmanager-endpoint: "http://test-alertamanger-endpoint"
 		return true, err
 	})
 	assert.NoError(t, err)
-	assert.NotEmpty(t, cm.Data[clusterMonitoringConfigDataKey])
+	assert.NotEmpty(t, cm.Data[ClusterMonitoringConfigDataKey])
 
 	foundClusterMonitoringConfiguration := &cmomanifests.ClusterMonitoringConfiguration{}
-	err = yaml2.Unmarshal([]byte(cm.Data[clusterMonitoringConfigDataKey]), foundClusterMonitoringConfiguration)
+	err = yaml2.Unmarshal([]byte(cm.Data[ClusterMonitoringConfigDataKey]), foundClusterMonitoringConfiguration)
 	assert.NoError(t, err)
 
 	assert.Len(t, foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs, 1)
@@ -175,7 +175,7 @@ alertmanager-endpoint: "http://test-alertamanger-endpoint"
 
 	b, err := yaml2.Marshal(foundClusterMonitoringConfiguration)
 	assert.NoError(t, err)
-	cm.Data[clusterMonitoringConfigDataKey] = string(b)
+	cm.Data[ClusterMonitoringConfigDataKey] = string(b)
 	err = k8sClient.Update(context.Background(), cm)
 	assert.NoError(t, err)
 
@@ -188,7 +188,7 @@ alertmanager-endpoint: "http://test-alertamanger-endpoint"
 		}
 
 		foundUpdatedClusterMonitoringConfiguration := &cmomanifests.ClusterMonitoringConfiguration{}
-		err = yaml2.Unmarshal([]byte(updated.Data[clusterMonitoringConfigDataKey]), foundUpdatedClusterMonitoringConfiguration)
+		err = yaml2.Unmarshal([]byte(updated.Data[ClusterMonitoringConfigDataKey]), foundUpdatedClusterMonitoringConfiguration)
 		if err != nil {
 			return false, nil
 		}

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_integration_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/util"
 	oav1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
+	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -340,6 +341,140 @@ alertmanager-router-ca: |
 		}
 		data := foundCM.Data[ClusterMonitoringConfigDataKey]
 		fmt.Printf("Found ConfigMap Data: %s\n", data)
+		return !strings.Contains(data, "obs-alertmanager-mtls-ca") && !strings.Contains(data, "test-alertamanger-endpoint")
+	}, time.Minute, 1*time.Second)
+}
+
+// TestIntegrationCMOConfigDisableAlertForwarding tests that updating the hub-info secret to have an empty
+// alertmanager-endpoint correctly triggers reconciliation and reverts the Alertmanager configuration.
+func TestIntegrationCMOConfigDisableAlertForwarding(t *testing.T) {
+	namespace := "test-cmo-disable"
+
+	scheme := createBaseScheme()
+
+	k8sClient, err := client.New(restCfgHub, client.Options{Scheme: scheme})
+	require.NoError(t, err)
+
+	defer func() {
+		_ = k8sClient.Delete(t.Context(), makeNamespace(namespace))
+	}()
+
+	// Create resources needed for reconciliation
+	resourcesDeps := []client.Object{
+		makeNamespace(promNamespace),
+		makeNamespace(namespace),
+		newImagesCM(namespace),
+		&ocinfrav1.ClusterVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "version",
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "prometheus-k8s",
+				Namespace: "openshift-monitoring",
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "web",
+						Port: 9090,
+					},
+				},
+			},
+		},
+		newHubInfoSecret([]byte(`
+endpoint: "http://test-endpoint"
+hub-cluster-id: "test-hub-cluster"
+alertmanager-endpoint: "http://test-alertamanger-endpoint"
+alertmanager-router-ca: |
+    -----BEGIN CERTIFICATE-----
+    xxxxxxxxxxxxxxxxxxxxxxxxxxx
+    -----END CERTIFICATE-----
+`), namespace),
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      HubAmAccessorSecretName,
+				Namespace: namespace,
+			},
+			StringData: map[string]string{hubAmAccessorSecretKey: "lol"},
+		},
+		&oav1beta1.ObservabilityAddon{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "observability-addon",
+				Namespace: namespace,
+			},
+		},
+	}
+	for _, obj := range newMtlsTestSecrets(namespace) {
+		resourcesDeps = append(resourcesDeps, obj.(client.Object))
+	}
+	require.NoError(t, createResources(k8sClient, resourcesDeps...))
+
+	mgr, err := ctrl.NewManager(testEnvHub.Config, ctrl.Options{
+		Scheme:  k8sClient.Scheme(),
+		Metrics: metricsserver.Options{BindAddress: "0"},
+		Controller: config.Controller{
+			SkipNameValidation: ptr.To(true),
+		},
+	})
+	require.NoError(t, err)
+
+	hubClientWithReload, err := util.NewReloadableHubClientWithReloadFunc(func() (client.Client, error) {
+		return k8sClient, nil
+	})
+	require.NoError(t, err)
+
+	reconciler := ObservabilityAddonReconciler{
+		Client:                k8sClient,
+		HubClient:             hubClientWithReload,
+		IsHubMetricsCollector: false,
+		Scheme:                scheme,
+		Namespace:             namespace,
+		HubNamespace:          namespace,
+		ServiceAccountName:    "endpoint-monitoring-operator",
+		InstallPrometheus:     false,
+	}
+	require.NoError(t, reconciler.SetupWithManager(mgr))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
+		require.NoError(t, mgr.Start(ctx))
+	}()
+
+	// 1. Wait for Alertmanager config to be populated on start
+	cm := &corev1.ConfigMap{}
+	assert.Eventually(t, func() bool {
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: promNamespace, Name: clusterMonitoringConfigName}, cm)
+		return err == nil && cm.Data != nil && cm.Data[ClusterMonitoringConfigDataKey] != ""
+	}, time.Minute, 1*time.Second)
+
+	// 2. Now emulate disabling alert forwarding by updating the hub-info secret to have empty alertmanager-endpoint
+	hubInfoSecret := &corev1.Secret{}
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: operatorconfig.HubInfoSecretName}, hubInfoSecret))
+
+	updatedHubInfoBytes := []byte(`
+endpoint: "http://test-endpoint"
+hub-cluster-id: "test-hub-cluster"
+alertmanager-endpoint: ""
+`)
+	hubInfoSecret.Data[operatorconfig.HubInfoSecretKey] = updatedHubInfoBytes
+	require.NoError(t, k8sClient.Update(ctx, hubInfoSecret))
+
+	// 3. Wait for the controller to react, reconcile, and cleanly delete/revert the CMO ConfigMap
+	assert.Eventually(t, func() bool {
+		foundCM := &corev1.ConfigMap{}
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: promNamespace, Name: clusterMonitoringConfigName}, foundCM)
+		if errors.IsNotFound(err) {
+			return true
+		}
+		if err != nil {
+			fmt.Printf("Revert CMO ConfigMap Get error: %v\n", err)
+			return false
+		}
+		data := foundCM.Data[ClusterMonitoringConfigDataKey]
 		return !strings.Contains(data, "obs-alertmanager-mtls-ca") && !strings.Contains(data, "test-alertamanger-endpoint")
 	}, time.Minute, 1*time.Second)
 }

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_test.go
@@ -94,7 +94,7 @@ func newHubInfoSecret(data []byte, ns string) *corev1.Secret {
 func newAMAccessorSecret(ns string, val string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hubAmAccessorSecretName,
+			Name:      HubAmAccessorSecretName,
 			Namespace: ns,
 		},
 		Data: map[string][]byte{
@@ -116,7 +116,7 @@ func newClusterMonitoringConfigCM(configDataStr string, mgr string) *corev1.Conf
 			},
 		},
 		Data: map[string]string{
-			clusterMonitoringConfigDataKey: configDataStr,
+			ClusterMonitoringConfigDataKey: configDataStr,
 		},
 	}
 }

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
@@ -149,13 +149,13 @@ func unsetConfigReverted(ctx context.Context, client client.Client, ns string) e
 	return nil
 }
 
-// createHubAmAccessorTokenSecret creates the secret that contains access token of the Hub's Alertmanager.
-func createHubAmAccessorTokenSecret(ctx context.Context, client client.Client, namespace, targetNamespace string, hubInfo *operatorconfig.HubInfo) error {
+// CreateHubAmAccessorTokenSecret creates the secret that contains access token of the Hub's Alertmanager.
+func CreateHubAmAccessorTokenSecret(ctx context.Context, client client.Client, sourceName, namespace, targetNamespace string, hubInfo *operatorconfig.HubInfo) error {
 	hubAmAccessorSecret := AppendHubClusterID(HubAmAccessorSecretName, hubInfo)
 	found := &corev1.Secret{}
 	targetErr := client.Get(ctx, types.NamespacedName{Name: hubAmAccessorSecret, Namespace: targetNamespace}, found)
 
-	amAccessorToken, err := getAmAccessorToken(ctx, client, namespace)
+	amAccessorToken, err := getAmAccessorToken(ctx, client, sourceName, namespace)
 	if err != nil {
 		// If the source secret is missing but the target already exists, we skip the sync.
 		// This avoids reconcile failures during MCOA transition where legacy source secrets
@@ -164,7 +164,7 @@ func createHubAmAccessorTokenSecret(ctx context.Context, client client.Client, n
 			log.Info("target accessor secret already exists and source secret is missing, skipping sync", "target", targetNamespace+"/"+hubAmAccessorSecret, "source_ns", namespace)
 			return nil
 		}
-		return fmt.Errorf("fail to get %s/%s secret: %w", namespace, HubAmAccessorSecretName, err)
+		return fmt.Errorf("fail to get %s/%s secret: %w", namespace, sourceName, err)
 	}
 
 	dataMap := map[string][]byte{hubAmAccessorSecretKey: []byte(amAccessorToken)}
@@ -205,11 +205,11 @@ func createHubAmAccessorTokenSecret(ctx context.Context, client client.Client, n
 	}
 }
 
-// getAmAccessorToken retrieves the alertmanager access token from observability-alertmanager-accessor secret.
-func getAmAccessorToken(ctx context.Context, client client.Client, ns string) (string, error) {
+// getAmAccessorToken retrieves the alertmanager access token from source secret.
+func getAmAccessorToken(ctx context.Context, client client.Client, sourceName, ns string) (string, error) {
 	amAccessorSecret := &corev1.Secret{}
 	if err := client.Get(ctx, types.NamespacedName{
-		Name:      HubAmAccessorSecretName,
+		Name:      sourceName,
 		Namespace: ns,
 	}, amAccessorSecret); err != nil {
 		return "", err
@@ -217,7 +217,7 @@ func getAmAccessorToken(ctx context.Context, client client.Client, ns string) (s
 
 	amAccessorToken := amAccessorSecret.Data[hubAmAccessorSecretKey]
 	if amAccessorToken == nil {
-		return "", fmt.Errorf("no token in secret %s", HubAmAccessorSecretName)
+		return "", fmt.Errorf("no token in secret %s", sourceName)
 	}
 
 	return string(amAccessorToken), nil
@@ -288,9 +288,26 @@ func AppendHubClusterID(secretName string, hubInfo *operatorconfig.HubInfo) stri
 	return secretName + "-" + hubInfo.HubClusterID
 }
 
-func newAdditionalAlertmanagerConfig(hubInfo *operatorconfig.HubInfo) cmomanifests.AdditionalAlertmanagerConfig {
-	amMtlsCARef := AppendHubClusterID(amMtlsCaName, hubInfo)
-	amMtlsCertRef := AppendHubClusterID(amMtlsCertName, hubInfo)
+func newAdditionalAlertmanagerConfig(hubInfo *operatorconfig.HubInfo, caSecret string, certSecret string, omitBearerToken bool) cmomanifests.AdditionalAlertmanagerConfig {
+	amMtlsCARef := caSecret
+	if amMtlsCARef == "" {
+		amMtlsCARef = AppendHubClusterID(amMtlsCaName, hubInfo)
+	}
+	amMtlsCertRef := certSecret
+	if amMtlsCertRef == "" {
+		amMtlsCertRef = AppendHubClusterID(amMtlsCertName, hubInfo)
+	}
+
+	var bearerToken *corev1.SecretKeySelector
+	if !omitBearerToken {
+		bearerToken = &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: AppendHubClusterID(HubAmAccessorSecretName, hubInfo),
+			},
+			Key: hubAmAccessorSecretKey,
+		}
+	}
+
 	config := cmomanifests.AdditionalAlertmanagerConfig{
 		Scheme:     "https",
 		PathPrefix: "/",
@@ -316,12 +333,7 @@ func newAdditionalAlertmanagerConfig(hubInfo *operatorconfig.HubInfo) cmomanifes
 			},
 			InsecureSkipVerify: false,
 		},
-		BearerToken: &corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: AppendHubClusterID(HubAmAccessorSecretName, hubInfo),
-			},
-			Key: hubAmAccessorSecretKey,
-		},
+		BearerToken:   bearerToken,
 		StaticConfigs: []string{},
 	}
 	amURL, err := url.Parse(hubInfo.AlertmanagerEndpoint)
@@ -408,13 +420,13 @@ func createOrUpdateClusterMonitoringConfig(
 	}
 
 	// create the observability-alertmanager-accessor secret if it doesn't exist or update it if needed
-	if err := createHubAmAccessorTokenSecret(ctx, client, namespace, targetNamespace, hubInfo); err != nil {
+	if err := CreateHubAmAccessorTokenSecret(ctx, client, HubAmAccessorSecretName, namespace, targetNamespace, hubInfo); err != nil {
 		return false, fmt.Errorf("failed to create or update the alertmanager accessor token secret: %w", err)
 	}
 
 	mtlsRename := map[string]string{mtlsCertName: amMtlsCertName, mtlsCaName: amMtlsCaName}
 	for name, rename := range mtlsRename {
-		if err := createMtlsSecretInNamespace(ctx, client, namespace, targetNamespace, name, rename, hubInfo); err != nil {
+		if err := CreateMtlsSecretInNamespace(ctx, client, namespace, targetNamespace, name, rename, hubInfo); err != nil {
 			return false, fmt.Errorf("failed to copy mTLS secret %s to %s: %w", name, targetNamespace, err)
 		}
 	}
@@ -423,11 +435,11 @@ func createOrUpdateClusterMonitoringConfig(
 	// Create Router CA and Accessor Token secrets in the UWM namespace even when alert forwarding is disabled,
 	// so an external policy can configure UWM alert forwarding later if needed.
 	if nsExists {
-		if err := createHubAmAccessorTokenSecret(ctx, client, namespace, operatorconfig.OCPUserWorkloadMonitoringNamespace, hubInfo); err != nil {
+		if err := CreateHubAmAccessorTokenSecret(ctx, client, HubAmAccessorSecretName, namespace, operatorconfig.OCPUserWorkloadMonitoringNamespace, hubInfo); err != nil {
 			return false, fmt.Errorf("failed to create or update alertmanager accessor token in UWM namespace: %w", err)
 		}
 		for name, rename := range mtlsRename {
-			if err := createMtlsSecretInNamespace(ctx, client, namespace, operatorconfig.OCPUserWorkloadMonitoringNamespace, name, rename, hubInfo); err != nil {
+			if err := CreateMtlsSecretInNamespace(ctx, client, namespace, operatorconfig.OCPUserWorkloadMonitoringNamespace, name, rename, hubInfo); err != nil {
 				return false, fmt.Errorf("failed to copy mTLS secret %s to UWM namespace: %w", name, err)
 			}
 		}
@@ -464,7 +476,7 @@ func createOrUpdateClusterMonitoringConfig(
 		return false, unset(ctx, client, namespace)
 	}
 
-	updated, err := CreateOrUpdateCMOConfig(ctx, client, clusterID, hubInfo, namespace)
+	updated, err := CreateOrUpdateCMOConfig(ctx, client, clusterID, hubInfo, "", "", false, namespace)
 	if err != nil {
 		return false, err
 	}
@@ -482,7 +494,7 @@ func createOrUpdateClusterMonitoringConfig(
 	if nsExists {
 		if uwmEnabled {
 			// UWL is enabled, create or update the config
-			if err := CreateOrUpdateUserWorkloadMonitoringConfig(ctx, client, hubInfo); err != nil {
+			if err := CreateOrUpdateUserWorkloadMonitoringConfig(ctx, client, hubInfo, "", "", false); err != nil {
 				return updated, fmt.Errorf("failed to create or update user workload monitoring config: %w", err)
 			}
 		} else {
@@ -584,10 +596,13 @@ func CreateOrUpdateCMOConfig(
 	client client.Client,
 	clusterID string,
 	hubInfo *operatorconfig.HubInfo,
+	caSecret string,
+	certSecret string,
+	omitBearerToken bool,
 	namespace string,
 ) (bool, error) {
 	newExternalLabels := map[string]string{operatorconfig.ClusterLabelKeyForAlerts: clusterID}
-	newAlertmanagerConfigs := []cmomanifests.AdditionalAlertmanagerConfig{newAdditionalAlertmanagerConfig(hubInfo)}
+	newAlertmanagerConfigs := []cmomanifests.AdditionalAlertmanagerConfig{newAdditionalAlertmanagerConfig(hubInfo, caSecret, certSecret, omitBearerToken)}
 	newPmK8sConfig := &cmomanifests.PrometheusK8sConfig{
 		ExternalLabels:      newExternalLabels,
 		AlertmanagerConfigs: newAlertmanagerConfigs,
@@ -656,9 +671,12 @@ func CreateOrUpdateCMOConfig(
 			}
 		}
 		if existing {
-			updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs[index] = newAdditionalAlertmanagerConfig(hubInfo)
+			updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs[index] = newAdditionalAlertmanagerConfig(hubInfo, caSecret, certSecret, omitBearerToken)
 		} else {
-			updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs = append(updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs, newAdditionalAlertmanagerConfig(hubInfo))
+			updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs = append(
+				updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs,
+				newAdditionalAlertmanagerConfig(hubInfo, caSecret, certSecret, omitBearerToken),
+			)
 		}
 
 		// remove am configs from previous versions if any prior to Global Hub Changes (ACM 2.15.0)
@@ -694,6 +712,9 @@ func CreateOrUpdateUserWorkloadMonitoringConfig(
 	ctx context.Context,
 	client client.Client,
 	hubInfo *operatorconfig.HubInfo,
+	caSecret string,
+	certSecret string,
+	omitBearerToken bool,
 ) error {
 	// handle the case when alert forwarding is disabled globally or UWM alerting is disabled specifically
 	if hubInfo.AlertmanagerEndpoint == "" || hubInfo.UWMAlertingDisabled {
@@ -702,7 +723,7 @@ func CreateOrUpdateUserWorkloadMonitoringConfig(
 	}
 
 	alertCfg := cmomanifests.PrometheusRestrictedConfig{
-		AlertmanagerConfigs: []cmomanifests.AdditionalAlertmanagerConfig{newAdditionalAlertmanagerConfig(hubInfo)},
+		AlertmanagerConfigs: []cmomanifests.AdditionalAlertmanagerConfig{newAdditionalAlertmanagerConfig(hubInfo, caSecret, certSecret, omitBearerToken)},
 	}
 	newCfg := cmomanifests.UserWorkloadConfiguration{
 		Prometheus: &alertCfg,
@@ -758,9 +779,9 @@ func CreateOrUpdateUserWorkloadMonitoringConfig(
 			}
 		}
 		if !exists {
-			parsed.Prometheus.AlertmanagerConfigs = append(parsed.Prometheus.AlertmanagerConfigs, newAdditionalAlertmanagerConfig(hubInfo))
+			parsed.Prometheus.AlertmanagerConfigs = append(parsed.Prometheus.AlertmanagerConfigs, newAdditionalAlertmanagerConfig(hubInfo, caSecret, certSecret, omitBearerToken))
 		} else {
-			parsed.Prometheus.AlertmanagerConfigs[index] = newAdditionalAlertmanagerConfig(hubInfo)
+			parsed.Prometheus.AlertmanagerConfigs[index] = newAdditionalAlertmanagerConfig(hubInfo, caSecret, certSecret, omitBearerToken)
 		}
 
 		// remove am configs from previous versions if any prior to Global Hub Changes (ACM 2.15.0)
@@ -978,7 +999,7 @@ func RevertUserWorkloadMonitoringConfig(ctx context.Context, client client.Clien
 	return client.Update(ctx, found)
 }
 
-func createMtlsSecretInNamespace(ctx context.Context, c client.Client, sourceNamespace, targetNamespace, secretName string, secretRename string, hubInfo *operatorconfig.HubInfo) error {
+func CreateMtlsSecretInNamespace(ctx context.Context, c client.Client, sourceNamespace, targetNamespace, secretName string, secretRename string, hubInfo *operatorconfig.HubInfo) error {
 	source := &corev1.Secret{}
 	if err := c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: sourceNamespace}, source); err != nil {
 		return fmt.Errorf("failed to get source secret %s/%s: %w", sourceNamespace, secretName, err)

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	cmomanifests "github.com/openshift/cluster-monitoring-operator/pkg/manifests"
-	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -29,6 +28,7 @@ const (
 	HubAmAccessorSecretName        = "observability-alertmanager-accessor" // #nosec G101 -- Not a hardcoded credential.
 	hubAmAccessorSecretKey         = "token"                               // #nosec G101 -- Not a hardcoded credential.
 	HubAmRouterCASecretName        = "hub-alertmanager-router-ca"
+	HubAmMtlsCASecretName          = "obs-alertmanager-mtls-ca"
 	clusterMonitoringConfigName    = "cluster-monitoring-config"
 	clusterMonitoringRevertedName  = "cluster-monitoring-reverted"
 	ClusterMonitoringConfigDataKey = "config.yaml"
@@ -39,8 +39,6 @@ var (
 	log                             = ctrl.Log.WithName("controllers").WithName("ObservabilityAddon")
 	clusterMonitoringConfigReverted = false
 	persistedRevertStateRead        = false
-	AMSecretCleanupDone             = false
-	AMSecretCleanupDoneUWL          = false
 )
 
 // initializes clusterMonitoringConfigReverted based on the presence of clusterMonitoringRevertedName
@@ -151,7 +149,7 @@ func unsetConfigReverted(ctx context.Context, client client.Client, ns string) e
 
 // CreateHubAmAccessorTokenSecret creates the secret that contains access token of the Hub's Alertmanager.
 func CreateHubAmAccessorTokenSecret(ctx context.Context, client client.Client, sourceName, namespace, targetNamespace string, hubInfo *operatorconfig.HubInfo) error {
-	hubAmAccessorSecret := AppendHubClusterID(HubAmAccessorSecretName, hubInfo)
+	hubAmAccessorSecret := AppendHubClusterID(HubAmAccessorSecretName, hubInfo.HubClusterID)
 	found := &corev1.Secret{}
 	targetErr := client.Get(ctx, types.NamespacedName{Name: hubAmAccessorSecret, Namespace: targetNamespace}, found)
 
@@ -223,69 +221,11 @@ func getAmAccessorToken(ctx context.Context, client client.Client, sourceName, n
 	return string(amAccessorToken), nil
 }
 
-func cleanUpOldAMSecrets(ctx context.Context, client client.Client, targetNamespace string, hubInfo *operatorconfig.HubInfo, uwlNsExists bool, installProm bool) error {
-	var errs []string
-	clusterDomain := ""
-	if hubInfo != nil && hubInfo.ObservatoriumAPIEndpoint != "" {
-		clusterDomain = config.GetClusterName(hubInfo.ObservatoriumAPIEndpoint)
-	} else {
-		log.V(1).Info("hubInfo or ObservatoriumAPIEndpoint missing; skipping cluster-domain-specific secret deletions")
-	}
-
-	deleteSecret := func(name string, namespace string) {
-		sec := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-			},
-		}
-		if err := client.Delete(ctx, sec); err != nil {
-			if errors.IsNotFound(err) {
-				return
-			}
-			log.Error(err, fmt.Sprintf("failed to delete old secret %s/%s", targetNamespace, name))
-			errs = append(errs, fmt.Sprintf("%s: %v", name, err))
-		}
-	}
-
-	if !installProm {
-		// we do not cleanup in *KS scenario as those secrets reside in the addon namespace and not openshift-monitoring
-		// and are referenced for creating AM accessor token secret
-		deleteSecret(HubAmAccessorSecretName, targetNamespace)
-		deleteSecret(HubAmRouterCASecretName, targetNamespace)
-	}
-	if clusterDomain != "" {
-		deleteSecret(HubAmAccessorSecretName+"-"+clusterDomain, targetNamespace)
-		deleteSecret(HubAmRouterCASecretName+"-"+clusterDomain, targetNamespace)
-	}
-	if hubInfo != nil && hubInfo.HubClusterID != "" {
-		deleteSecret(AppendHubClusterID(HubAmRouterCASecretName, hubInfo), targetNamespace)
-	}
-
-	if uwlNsExists {
-		ns := operatorconfig.OCPUserWorkloadMonitoringNamespace
-		deleteSecret(HubAmAccessorSecretName, ns)
-		deleteSecret(HubAmRouterCASecretName, ns)
-		if clusterDomain != "" {
-			deleteSecret(HubAmAccessorSecretName+"-"+clusterDomain, ns)
-			deleteSecret(HubAmRouterCASecretName+"-"+clusterDomain, ns)
-		}
-		if hubInfo != nil && hubInfo.HubClusterID != "" {
-			deleteSecret(AppendHubClusterID(HubAmRouterCASecretName, hubInfo), ns)
-		}
-	}
-
-	if len(errs) > 0 {
-		return fmt.Errorf("failed to delete one or more old secrets: %s", strings.Join(errs, "; "))
-	}
-	return nil
-}
-
-func AppendHubClusterID(secretName string, hubInfo *operatorconfig.HubInfo) string {
-	if hubInfo == nil || hubInfo.HubClusterID == "" {
+func AppendHubClusterID(secretName string, hubClusterID string) string {
+	if hubClusterID == "" {
 		return secretName
 	}
-	return secretName + "-" + hubInfo.HubClusterID
+	return secretName + "-" + hubClusterID
 }
 
 func newAdditionalAlertmanagerConfig(alertmanagerEndpoint string, caSecret string, certSecret string, accessorSecret string) cmomanifests.AdditionalAlertmanagerConfig {
@@ -400,13 +340,6 @@ func createOrUpdateClusterMonitoringConfig(
 		nsExists = namespaceExists(ctx, client, operatorconfig.OCPUserWorkloadMonitoringNamespace)
 	}
 
-	if !AMSecretCleanupDone {
-		// ACM-27841 - this is to clean up old alertmanager secrets created using cluster domain for Global Hu
-		if err := cleanUpOldAMSecrets(ctx, client, targetNamespace, hubInfo, nsExists, installProm); err != nil {
-			return false, fmt.Errorf("failed to clean up old alertmanager secrets: %w", err)
-		}
-	}
-
 	// create the observability-alertmanager-accessor secret if it doesn't exist or update it if needed
 	if err := CreateHubAmAccessorTokenSecret(ctx, client, HubAmAccessorSecretName, namespace, targetNamespace, hubInfo); err != nil {
 		return false, fmt.Errorf("failed to create or update the alertmanager accessor token secret: %w", err)
@@ -442,11 +375,12 @@ func createOrUpdateClusterMonitoringConfig(
 			return false, err
 		}
 		if !revertedAlready {
-			if err = RevertClusterMonitoringConfig(ctx, client, hubInfo); err != nil {
+			caSecret := AppendHubClusterID(amMtlsCaName, hubInfo.HubClusterID)
+			if err = RevertClusterMonitoringConfig(ctx, client, caSecret); err != nil {
 				return false, err
 			}
 			if nsExists {
-				if err = RevertUserWorkloadMonitoringConfig(ctx, client, hubInfo); err != nil {
+				if err = RevertUserWorkloadMonitoringConfig(ctx, client, caSecret); err != nil {
 					return false, err
 				}
 			}
@@ -464,7 +398,20 @@ func createOrUpdateClusterMonitoringConfig(
 		return false, unset(ctx, client, namespace)
 	}
 
-	updated, err := CreateOrUpdateCMOConfig(ctx, client, clusterID, hubInfo, "", "", "", namespace)
+	caSecret := AppendHubClusterID(amMtlsCaName, hubInfo.HubClusterID)
+	certSecret := AppendHubClusterID(amMtlsCertName, hubInfo.HubClusterID)
+	accessorSecret := AppendHubClusterID(HubAmAccessorSecretName, hubInfo.HubClusterID)
+
+	updated, err := CreateOrUpdateCMOConfig(
+		ctx,
+		client,
+		clusterID,
+		hubInfo.AlertmanagerEndpoint,
+		caSecret,
+		certSecret,
+		accessorSecret,
+		namespace,
+	)
 	if err != nil {
 		return false, err
 	}
@@ -482,12 +429,20 @@ func createOrUpdateClusterMonitoringConfig(
 	if nsExists {
 		if uwmEnabled {
 			// UWL is enabled, create or update the config
-			if err := CreateOrUpdateUserWorkloadMonitoringConfig(ctx, client, hubInfo, "", "", ""); err != nil {
+			if err := CreateOrUpdateUserWorkloadMonitoringConfig(
+				ctx,
+				client,
+				hubInfo.AlertmanagerEndpoint,
+				hubInfo.UWMAlertingDisabled,
+				caSecret,
+				certSecret,
+				accessorSecret,
+			); err != nil {
 				return updated, fmt.Errorf("failed to create or update user workload monitoring config: %w", err)
 			}
 		} else {
 			// UWL is disabled, clean up the configmap
-			if err := RevertUserWorkloadMonitoringConfig(ctx, client, hubInfo); err != nil {
+			if err := RevertUserWorkloadMonitoringConfig(ctx, client, caSecret); err != nil {
 				return updated, fmt.Errorf("failed to revert user workload monitoring config: %w", err)
 			}
 		}
@@ -498,7 +453,7 @@ func createOrUpdateClusterMonitoringConfig(
 
 // RevertClusterMonitoringConfig reverts the configmap cluster-monitoring-config and relevant resources
 // (observability-alertmanager-accessor and hub-alertmanager-router-ca) for the openshift cluster monitoring stack.
-func RevertClusterMonitoringConfig(ctx context.Context, client client.Client, hubInfo *operatorconfig.HubInfo) error {
+func RevertClusterMonitoringConfig(ctx context.Context, client client.Client, caSecret string) error {
 	log.Info("RevertClusterMonitoringConfig called")
 
 	found := &corev1.ConfigMap{}
@@ -545,7 +500,7 @@ func RevertClusterMonitoringConfig(ctx context.Context, client client.Client, hu
 	if foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs != nil {
 		copiedAlertmanagerConfigs := make([]cmomanifests.AdditionalAlertmanagerConfig, 0)
 		for _, v := range foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs {
-			if !IsManaged(v, hubInfo, "") {
+			if !IsManaged(v, caSecret) {
 				copiedAlertmanagerConfigs = append(copiedAlertmanagerConfigs, v)
 			}
 		}
@@ -583,28 +538,14 @@ func CreateOrUpdateCMOConfig(
 	ctx context.Context,
 	client client.Client,
 	clusterID string,
-	hubInfo *operatorconfig.HubInfo,
+	alertmanagerEndpoint string,
 	caSecret string,
 	certSecret string,
 	accessorSecret string,
 	namespace string,
 ) (bool, error) {
-	amMtlsCARef := caSecret
-	if amMtlsCARef == "" {
-		amMtlsCARef = AppendHubClusterID(amMtlsCaName, hubInfo)
-	}
-	amMtlsCertRef := certSecret
-	if amMtlsCertRef == "" {
-		amMtlsCertRef = AppendHubClusterID(amMtlsCertName, hubInfo)
-	}
-
-	amAccessorRef := accessorSecret
-	if amAccessorRef == "" {
-		amAccessorRef = AppendHubClusterID(HubAmAccessorSecretName, hubInfo)
-	}
-
 	newExternalLabels := map[string]string{operatorconfig.ClusterLabelKeyForAlerts: clusterID}
-	newAlertmanagerConfigs := []cmomanifests.AdditionalAlertmanagerConfig{newAdditionalAlertmanagerConfig(hubInfo.AlertmanagerEndpoint, amMtlsCARef, amMtlsCertRef, amAccessorRef)}
+	newAlertmanagerConfigs := []cmomanifests.AdditionalAlertmanagerConfig{newAdditionalAlertmanagerConfig(alertmanagerEndpoint, caSecret, certSecret, accessorSecret)}
 	newPmK8sConfig := &cmomanifests.PrometheusK8sConfig{
 		ExternalLabels:      newExternalLabels,
 		AlertmanagerConfigs: newAlertmanagerConfigs,
@@ -663,35 +604,21 @@ func CreateOrUpdateCMOConfig(
 			updatedCMOCfg.PrometheusK8sConfig.ExternalLabels = newExternalLabels
 		}
 
-		existing := false
-		var index int
-		for i, cfg := range updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs {
-			if IsManaged(cfg, hubInfo, caSecret) {
-				existing = true
-				index = i
-				break
+		// Filter out any of our pre-existing managed Alertmanager configurations (including legacy ones).
+		// This guarantees we only ever have exactly one active ACM/MCOA alertmanager configuration,
+		// and handles the upgrade path (Router CA -> mTLS CA) cleanly.
+		cleanAlertmanagerConfigs := make([]cmomanifests.AdditionalAlertmanagerConfig, 0)
+		for _, cfg := range updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs {
+			if !IsManaged(cfg, caSecret) {
+				cleanAlertmanagerConfigs = append(cleanAlertmanagerConfigs, cfg)
 			}
 		}
-		if existing {
-			updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs[index] = newAdditionalAlertmanagerConfig(hubInfo.AlertmanagerEndpoint, amMtlsCARef, amMtlsCertRef, amAccessorRef)
-		} else {
-			updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs = append(
-				updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs,
-				newAdditionalAlertmanagerConfig(hubInfo.AlertmanagerEndpoint, amMtlsCARef, amMtlsCertRef, amAccessorRef),
-			)
-		}
-
-		// remove am configs from previous versions if any prior to Global Hub Changes (ACM 2.15.0)
-		if !AMSecretCleanupDone {
-			updatedCMOCfgTmp := make([]cmomanifests.AdditionalAlertmanagerConfig, 0)
-			for i, cfg := range updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs {
-				if !isOldManagedConfig(cfg, hubInfo) {
-					updatedCMOCfgTmp = append(updatedCMOCfgTmp, updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs[i])
-				}
-			}
-			AMSecretCleanupDone = true
-			updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs = updatedCMOCfgTmp
-		}
+		// Append exactly one fresh configured stanza
+		cleanAlertmanagerConfigs = append(
+			cleanAlertmanagerConfigs,
+			newAdditionalAlertmanagerConfig(alertmanagerEndpoint, caSecret, certSecret, accessorSecret),
+		)
+		updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs = cleanAlertmanagerConfigs
 	} else {
 		updatedCMOCfg.PrometheusK8sConfig = newPmK8sConfig
 	}
@@ -712,34 +639,21 @@ func CreateOrUpdateCMOConfig(
 // CreateOrUpdateUserWorkloadMonitoringConfig creates/updates the user-workload-monitoring-config configmap
 func CreateOrUpdateUserWorkloadMonitoringConfig(
 	ctx context.Context,
-	client client.Client,
-	hubInfo *operatorconfig.HubInfo,
+	c client.Client,
+	alertmanagerEndpoint string,
+	uwmAlertingDisabled bool,
 	caSecret string,
 	certSecret string,
 	accessorSecret string,
 ) error {
 	// handle the case when alert forwarding is disabled globally or UWM alerting is disabled specifically
-	if hubInfo.AlertmanagerEndpoint == "" || hubInfo.UWMAlertingDisabled {
+	if alertmanagerEndpoint == "" || uwmAlertingDisabled {
 		log.Info("request to disable alert forwarding")
-		return RevertUserWorkloadMonitoringConfig(ctx, client, hubInfo)
-	}
-
-	amMtlsCARef := caSecret
-	if amMtlsCARef == "" {
-		amMtlsCARef = AppendHubClusterID(amMtlsCaName, hubInfo)
-	}
-	amMtlsCertRef := certSecret
-	if amMtlsCertRef == "" {
-		amMtlsCertRef = AppendHubClusterID(amMtlsCertName, hubInfo)
-	}
-
-	amAccessorRef := accessorSecret
-	if amAccessorRef == "" {
-		amAccessorRef = AppendHubClusterID(HubAmAccessorSecretName, hubInfo)
+		return RevertUserWorkloadMonitoringConfig(ctx, c, caSecret)
 	}
 
 	alertCfg := cmomanifests.PrometheusRestrictedConfig{
-		AlertmanagerConfigs: []cmomanifests.AdditionalAlertmanagerConfig{newAdditionalAlertmanagerConfig(hubInfo.AlertmanagerEndpoint, amMtlsCARef, amMtlsCertRef, amAccessorRef)},
+		AlertmanagerConfigs: []cmomanifests.AdditionalAlertmanagerConfig{newAdditionalAlertmanagerConfig(alertmanagerEndpoint, caSecret, certSecret, accessorSecret)},
 	}
 	newCfg := cmomanifests.UserWorkloadConfiguration{
 		Prometheus: &alertCfg,
@@ -750,7 +664,7 @@ func CreateOrUpdateUserWorkloadMonitoringConfig(
 	}
 
 	existing := &corev1.ConfigMap{}
-	err = client.Get(ctx, types.NamespacedName{
+	err = c.Get(ctx, types.NamespacedName{
 		Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
 		Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
 	}, existing)
@@ -763,7 +677,7 @@ func CreateOrUpdateUserWorkloadMonitoringConfig(
 			Data: map[string]string{"config.yaml": string(yamlBytes)},
 		}
 		log.Info("user workload monitoring configmap not found, creating it", "name", operatorconfig.OCPUserWorkloadMonitoringConfigMap)
-		return client.Create(ctx, newCM)
+		return c.Create(ctx, newCM)
 	} else if err != nil {
 		return fmt.Errorf("failed to retrieve user workload monitoring configmap: %w", err)
 	}
@@ -776,7 +690,7 @@ func CreateOrUpdateUserWorkloadMonitoringConfig(
 			existing.Data["config.yaml"] = string(yamlBytes)
 		}
 		log.Info("user workload monitoring configmap missing config.yaml, updating")
-		return client.Update(ctx, existing)
+		return c.Update(ctx, existing)
 	}
 
 	parsed := &cmomanifests.UserWorkloadConfiguration{}
@@ -785,35 +699,19 @@ func CreateOrUpdateUserWorkloadMonitoringConfig(
 	}
 
 	if parsed.Prometheus != nil {
-		exists := false
-		var index int
-		for i, cfg := range parsed.Prometheus.AlertmanagerConfigs {
-			if IsManaged(cfg, hubInfo, caSecret) {
-				exists = true
-				index = i
-				break
+		// Filter out any of our pre-existing managed Alertmanager configurations (including legacy ones).
+		cleanAlertmanagerConfigs := make([]cmomanifests.AdditionalAlertmanagerConfig, 0)
+		for _, cfg := range parsed.Prometheus.AlertmanagerConfigs {
+			if !IsManaged(cfg, caSecret) {
+				cleanAlertmanagerConfigs = append(cleanAlertmanagerConfigs, cfg)
 			}
 		}
-		if !exists {
-			parsed.Prometheus.AlertmanagerConfigs = append(
-				parsed.Prometheus.AlertmanagerConfigs,
-				newAdditionalAlertmanagerConfig(hubInfo.AlertmanagerEndpoint, amMtlsCARef, amMtlsCertRef, amAccessorRef),
-			)
-		} else {
-			parsed.Prometheus.AlertmanagerConfigs[index] = newAdditionalAlertmanagerConfig(hubInfo.AlertmanagerEndpoint, amMtlsCARef, amMtlsCertRef, amAccessorRef)
-		}
-
-		// remove am configs from previous versions if any prior to Global Hub Changes (ACM 2.15.0)
-		if !AMSecretCleanupDoneUWL {
-			updatedCMOCfgTmp := make([]cmomanifests.AdditionalAlertmanagerConfig, 0)
-			for i, cfg := range parsed.Prometheus.AlertmanagerConfigs {
-				if !isOldManagedConfig(cfg, hubInfo) {
-					updatedCMOCfgTmp = append(updatedCMOCfgTmp, parsed.Prometheus.AlertmanagerConfigs[i])
-				}
-			}
-			AMSecretCleanupDoneUWL = true
-			parsed.Prometheus.AlertmanagerConfigs = updatedCMOCfgTmp
-		}
+		// Append exactly one fresh configured stanza
+		cleanAlertmanagerConfigs = append(
+			cleanAlertmanagerConfigs,
+			newAdditionalAlertmanagerConfig(alertmanagerEndpoint, caSecret, certSecret, accessorSecret),
+		)
+		parsed.Prometheus.AlertmanagerConfigs = cleanAlertmanagerConfigs
 	} else {
 		parsed.Prometheus = &alertCfg
 	}
@@ -829,23 +727,23 @@ func CreateOrUpdateUserWorkloadMonitoringConfig(
 
 	existing.Data["config.yaml"] = string(updatedYAMLBytes)
 	log.Info("user workload monitoring configmap changed, updating")
-	return client.Update(ctx, existing)
+	return c.Update(ctx, existing, client.FieldOwner(EndpointMonitoringOperatorMgr))
 }
 
 // createCMOConfigMapAndUnset creates the configmap cluster-monitoring-config in the openshift-monitoring namespace.
 // the namespace parameter is used to call unset function.
-func createCMOConfigMapAndUnset(ctx context.Context, client client.Client, obj client.Object, namespace string) error {
-	err := client.Create(ctx, obj)
+func createCMOConfigMapAndUnset(ctx context.Context, c client.Client, obj client.Object, namespace string) error {
+	err := c.Create(ctx, obj, client.FieldOwner(EndpointMonitoringOperatorMgr))
 	if err != nil {
 		log.Error(err, "failed to create configmap", "name", clusterMonitoringConfigName)
 		return err
 	}
 	log.Info("configmap created", "name", clusterMonitoringConfigName)
-	return unset(ctx, client, namespace)
+	return unset(ctx, c, namespace)
 }
 
-func updateClusterMonitoringConfig(ctx context.Context, client client.Client, obj client.Object) error {
-	err := client.Update(ctx, obj)
+func updateClusterMonitoringConfig(ctx context.Context, c client.Client, obj client.Object) error {
+	err := c.Update(ctx, obj, client.FieldOwner(EndpointMonitoringOperatorMgr))
 	if err != nil {
 		return fmt.Errorf("failed to update configmap %s: %w", clusterMonitoringConfigName, err)
 	}
@@ -855,23 +753,23 @@ func updateClusterMonitoringConfig(ctx context.Context, client client.Client, ob
 
 // updateClusterMonitoringConfigAndUnset updates the configmap cluster-monitoring-config in the openshift-monitoring namespace.
 // the namespace parameter is used to call unset function.
-func updateClusterMonitoringConfigAndUnset(ctx context.Context, client client.Client, obj client.Object, namespace string) error {
-	err := updateClusterMonitoringConfig(ctx, client, obj)
+func updateClusterMonitoringConfigAndUnset(ctx context.Context, c client.Client, obj client.Object, namespace string) error {
+	err := updateClusterMonitoringConfig(ctx, c, obj)
 	if err != nil {
 		return err
 	}
-	return unset(ctx, client, namespace)
+	return unset(ctx, c, namespace)
 }
 
 // unset config reverted flag after successfully updating cluster-monitoring-config
-func unset(ctx context.Context, client client.Client, ns string) error {
+func unset(ctx context.Context, c client.Client, ns string) error {
 	if ns == "" {
 		return nil
 	}
 	// if reverted before, reset so we can revert again
-	revertedAlready, err := isRevertedAlready(ctx, client, ns)
+	revertedAlready, err := isRevertedAlready(ctx, c, ns)
 	if err == nil && revertedAlready {
-		err = unsetConfigReverted(ctx, client, ns)
+		err = unsetConfigReverted(ctx, c, ns)
 	}
 	return err
 }
@@ -891,44 +789,47 @@ func InManagedFields(cm *corev1.ConfigMap) bool {
 	return false
 }
 
-// IsManaged checks if the additional alertmanager config is managed by ACM
-func IsManaged(amc cmomanifests.AdditionalAlertmanagerConfig, hubInfo *operatorconfig.HubInfo, caSecret string) bool {
+// IsManaged checks if the additional alertmanager config is managed by ACM.
+//
+// This checks both the exact caSecret name and any matching legacy names with the same suffix.
+// Suffix matching is necessary when migrating a managed cluster from the legacy flow to the new mTLS flow:
+// - Legacy: We targeted the hub Alertmanager directly using the router CA (e.g. hub-alertmanager-router-ca-<hub-id>).
+//   - New: We target the Observatorium API instead, which handles fanning out alerts to all instances,
+//     using the new mTLS CA (e.g. obs-alertmanager-mtls-ca-<hub-id>).
+//
+// Extracting the suffix and comparing CA names ensures that the legacy configuration stanza is correctly
+// identified as managed and replaced in-place, rather than being treated as unmanaged and duplicated.
+func IsManaged(amc cmomanifests.AdditionalAlertmanagerConfig, caSecret string) bool {
 	if amc.TLSConfig.CA == nil {
 		return false
 	}
 	caName := amc.TLSConfig.CA.Name
 
-	if caSecret != "" && caName == caSecret {
+	if caSecret == "" {
+		return false
+	}
+
+	if caName == caSecret {
 		return true
 	}
 
-	if hubInfo != nil {
-		switch caName {
-		case HubAmRouterCASecretName + "-" + hubInfo.HubClusterID,
-			amMtlsCaName + "-" + hubInfo.HubClusterID:
-			return true
-		default:
-			return false
-		}
+	// Suffix extraction and legacy upgrade matching:
+	// Extract the suffix (e.g. "-<hub-id>") from the expected caSecret.
+	var suffix string
+	if strings.HasPrefix(caSecret, amMtlsCaName+"-") {
+		suffix = strings.TrimPrefix(caSecret, amMtlsCaName)
+	} else if strings.HasPrefix(caSecret, HubAmRouterCASecretName+"-") {
+		suffix = strings.TrimPrefix(caSecret, HubAmRouterCASecretName)
 	}
-	return strings.Contains(caName, HubAmRouterCASecretName) ||
-		strings.Contains(caName, amMtlsCaName)
-}
 
-// isOldManagedConfig checks if the additional alertmanager config is managed by ACM with old secret names prior to Global Hub changes
-func isOldManagedConfig(amc cmomanifests.AdditionalAlertmanagerConfig, hubInfo *operatorconfig.HubInfo) bool {
-	// In MCOA mode, ObservatoriumAPIEndpoint is not provided, so we skip the domain-based lookup
-	// to avoid unnecessary error logging from GetClusterName.
-	if hubInfo != nil && hubInfo.ObservatoriumAPIEndpoint != "" && amc.TLSConfig.CA != nil {
-		clusterDomainName := config.GetClusterName(hubInfo.ObservatoriumAPIEndpoint)
-		switch amc.TLSConfig.CA.Name {
-		case HubAmRouterCASecretName, HubAmRouterCASecretName + "-" + clusterDomainName:
-			return true
-		// check if managed by ACM with old secret prior to alertmanager fanout change
-		case HubAmRouterCASecretName + "-" + hubInfo.HubClusterID:
+	// Ensure we found a valid, non-empty suffix (e.g. "-12345", meaning length > 1) before matching.
+	if len(suffix) > 1 {
+		isOurBase := strings.HasPrefix(caName, HubAmRouterCASecretName+"-") || strings.HasPrefix(caName, amMtlsCaName+"-")
+		if isOurBase && strings.HasSuffix(caName, suffix) {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -949,7 +850,7 @@ func HasClusterMonitoringConfigData(cm *corev1.ConfigMap) (string, bool) {
 
 // RevertUserWorkloadMonitoringConfig reverts the configmap user-workload-monitoring-config
 // in the openshift-user-workload-monitoring namespace.
-func RevertUserWorkloadMonitoringConfig(ctx context.Context, client client.Client, hubInfo *operatorconfig.HubInfo) error {
+func RevertUserWorkloadMonitoringConfig(ctx context.Context, client client.Client, caSecret string) error {
 	log.Info("RevertUserWorkloadMonitoringConfig called")
 
 	found := &corev1.ConfigMap{}
@@ -990,7 +891,7 @@ func RevertUserWorkloadMonitoringConfig(ctx context.Context, client client.Clien
 	if parsed.Prometheus.AlertmanagerConfigs != nil {
 		copiedAlertmanagerConfigs := make([]cmomanifests.AdditionalAlertmanagerConfig, 0)
 		for _, v := range parsed.Prometheus.AlertmanagerConfigs {
-			if !IsManaged(v, hubInfo, "") {
+			if !IsManaged(v, caSecret) {
 				copiedAlertmanagerConfigs = append(copiedAlertmanagerConfigs, v)
 			}
 		}
@@ -1029,7 +930,7 @@ func CreateMtlsSecretInNamespace(ctx context.Context, c client.Client, sourceNam
 		return fmt.Errorf("failed to get source secret %s/%s: %w", sourceNamespace, secretName, err)
 	}
 
-	targetName := AppendHubClusterID(secretRename, hubInfo)
+	targetName := AppendHubClusterID(secretRename, hubInfo.HubClusterID)
 	target := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      targetName,

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
@@ -26,13 +26,13 @@ import (
 )
 
 const (
-	hubAmAccessorSecretName        = "observability-alertmanager-accessor" // #nosec G101 -- Not a hardcoded credential.
+	HubAmAccessorSecretName        = "observability-alertmanager-accessor" // #nosec G101 -- Not a hardcoded credential.
 	hubAmAccessorSecretKey         = "token"                               // #nosec G101 -- Not a hardcoded credential.
-	hubAmRouterCASecretName        = "hub-alertmanager-router-ca"
+	HubAmRouterCASecretName        = "hub-alertmanager-router-ca"
 	clusterMonitoringConfigName    = "cluster-monitoring-config"
 	clusterMonitoringRevertedName  = "cluster-monitoring-reverted"
-	clusterMonitoringConfigDataKey = "config.yaml"
-	endpointMonitoringOperatorMgr  = "endpoint-monitoring-operator"
+	ClusterMonitoringConfigDataKey = "config.yaml"
+	EndpointMonitoringOperatorMgr  = "endpoint-monitoring-operator"
 )
 
 var (
@@ -144,10 +144,10 @@ func unsetConfigReverted(ctx context.Context, client client.Client, ns string) e
 func createHubAmAccessorTokenSecret(ctx context.Context, client client.Client, namespace, targetNamespace string, hubInfo *operatorconfig.HubInfo) error {
 	amAccessorToken, err := getAmAccessorToken(ctx, client, namespace)
 	if err != nil {
-		return fmt.Errorf("fail to get %s/%s secret: %w", namespace, hubAmAccessorSecretName, err)
+		return fmt.Errorf("fail to get %s/%s secret: %w", namespace, HubAmAccessorSecretName, err)
 	}
 
-	hubAmAccessorSecret := appendHubClusterID(hubAmAccessorSecretName, hubInfo)
+	hubAmAccessorSecret := AppendHubClusterID(HubAmAccessorSecretName, hubInfo)
 	dataMap := map[string][]byte{hubAmAccessorSecretKey: []byte(amAccessorToken)}
 	hubAmAccessorTokenSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -192,7 +192,7 @@ func createHubAmAccessorTokenSecret(ctx context.Context, client client.Client, n
 func getAmAccessorToken(ctx context.Context, client client.Client, ns string) (string, error) {
 	amAccessorSecret := &corev1.Secret{}
 	if err := client.Get(ctx, types.NamespacedName{
-		Name:      hubAmAccessorSecretName,
+		Name:      HubAmAccessorSecretName,
 		Namespace: ns,
 	}, amAccessorSecret); err != nil {
 		return "", err
@@ -200,7 +200,7 @@ func getAmAccessorToken(ctx context.Context, client client.Client, ns string) (s
 
 	amAccessorToken := amAccessorSecret.Data[hubAmAccessorSecretKey]
 	if amAccessorToken == nil {
-		return "", fmt.Errorf("no token in secret %s", hubAmAccessorSecretName)
+		return "", fmt.Errorf("no token in secret %s", HubAmAccessorSecretName)
 	}
 
 	return string(amAccessorToken), nil
@@ -234,27 +234,27 @@ func cleanUpOldAMSecrets(ctx context.Context, client client.Client, targetNamesp
 	if !installProm {
 		// we do not cleanup in *KS scenario as those secrets reside in the addon namespace and not openshift-monitoring
 		// and are referenced for creating AM accessor token secret
-		deleteSecret(hubAmAccessorSecretName, targetNamespace)
-		deleteSecret(hubAmRouterCASecretName, targetNamespace)
+		deleteSecret(HubAmAccessorSecretName, targetNamespace)
+		deleteSecret(HubAmRouterCASecretName, targetNamespace)
 	}
 	if clusterDomain != "" {
-		deleteSecret(hubAmAccessorSecretName+"-"+clusterDomain, targetNamespace)
-		deleteSecret(hubAmRouterCASecretName+"-"+clusterDomain, targetNamespace)
+		deleteSecret(HubAmAccessorSecretName+"-"+clusterDomain, targetNamespace)
+		deleteSecret(HubAmRouterCASecretName+"-"+clusterDomain, targetNamespace)
 	}
 	if hubInfo != nil && hubInfo.HubClusterID != "" {
-		deleteSecret(appendHubClusterID(hubAmRouterCASecretName, hubInfo), targetNamespace)
+		deleteSecret(AppendHubClusterID(HubAmRouterCASecretName, hubInfo), targetNamespace)
 	}
 
 	if uwlNsExists {
 		ns := operatorconfig.OCPUserWorkloadMonitoringNamespace
-		deleteSecret(hubAmAccessorSecretName, ns)
-		deleteSecret(hubAmRouterCASecretName, ns)
+		deleteSecret(HubAmAccessorSecretName, ns)
+		deleteSecret(HubAmRouterCASecretName, ns)
 		if clusterDomain != "" {
-			deleteSecret(hubAmAccessorSecretName+"-"+clusterDomain, ns)
-			deleteSecret(hubAmRouterCASecretName+"-"+clusterDomain, ns)
+			deleteSecret(HubAmAccessorSecretName+"-"+clusterDomain, ns)
+			deleteSecret(HubAmRouterCASecretName+"-"+clusterDomain, ns)
 		}
 		if hubInfo != nil && hubInfo.HubClusterID != "" {
-			deleteSecret(appendHubClusterID(hubAmRouterCASecretName, hubInfo), ns)
+			deleteSecret(AppendHubClusterID(HubAmRouterCASecretName, hubInfo), ns)
 		}
 	}
 
@@ -264,7 +264,7 @@ func cleanUpOldAMSecrets(ctx context.Context, client client.Client, targetNamesp
 	return nil
 }
 
-func appendHubClusterID(secretName string, hubInfo *operatorconfig.HubInfo) string {
+func AppendHubClusterID(secretName string, hubInfo *operatorconfig.HubInfo) string {
 	if hubInfo == nil || hubInfo.HubClusterID == "" {
 		return secretName
 	}
@@ -272,8 +272,8 @@ func appendHubClusterID(secretName string, hubInfo *operatorconfig.HubInfo) stri
 }
 
 func newAdditionalAlertmanagerConfig(hubInfo *operatorconfig.HubInfo) cmomanifests.AdditionalAlertmanagerConfig {
-	amMtlsCARef := appendHubClusterID(amMtlsCaName, hubInfo)
-	amMtlsCertRef := appendHubClusterID(amMtlsCertName, hubInfo)
+	amMtlsCARef := AppendHubClusterID(amMtlsCaName, hubInfo)
+	amMtlsCertRef := AppendHubClusterID(amMtlsCertName, hubInfo)
 	config := cmomanifests.AdditionalAlertmanagerConfig{
 		Scheme:     "https",
 		PathPrefix: "/",
@@ -301,7 +301,7 @@ func newAdditionalAlertmanagerConfig(hubInfo *operatorconfig.HubInfo) cmomanifes
 		},
 		BearerToken: &corev1.SecretKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{
-				Name: appendHubClusterID(hubAmAccessorSecretName, hubInfo),
+				Name: AppendHubClusterID(HubAmAccessorSecretName, hubInfo),
 			},
 			Key: hubAmAccessorSecretKey,
 		},
@@ -447,7 +447,7 @@ func createOrUpdateClusterMonitoringConfig(
 		return false, unset(ctx, client, namespace)
 	}
 
-	updated, err := createOrUpdateCMOConfig(ctx, client, clusterID, hubInfo, namespace)
+	updated, err := CreateOrUpdateCMOConfig(ctx, client, clusterID, hubInfo, namespace)
 	if err != nil {
 		return false, err
 	}
@@ -465,7 +465,7 @@ func createOrUpdateClusterMonitoringConfig(
 	if nsExists {
 		if uwmEnabled {
 			// UWL is enabled, create or update the config
-			if err := createOrUpdateUserWorkloadMonitoringConfig(ctx, client, hubInfo); err != nil {
+			if err := CreateOrUpdateUserWorkloadMonitoringConfig(ctx, client, hubInfo); err != nil {
 				return updated, fmt.Errorf("failed to create or update user workload monitoring config: %w", err)
 			}
 		} else {
@@ -496,11 +496,11 @@ func RevertClusterMonitoringConfig(ctx context.Context, client client.Client, hu
 
 	log.Info("checking if cluster monitoring config needs revert", "name", clusterMonitoringConfigName)
 	found = found.DeepCopy()
-	if !inManagedFields(found) {
+	if !InManagedFields(found) {
 		return nil
 	}
 
-	foundClusterMonitoringConfigurationYAML, ok := hasClusterMonitoringConfigData(found)
+	foundClusterMonitoringConfigurationYAML, ok := HasClusterMonitoringConfigData(found)
 	if !ok {
 		return nil
 	}
@@ -528,7 +528,7 @@ func RevertClusterMonitoringConfig(ctx context.Context, client client.Client, hu
 	if foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs != nil {
 		copiedAlertmanagerConfigs := make([]cmomanifests.AdditionalAlertmanagerConfig, 0)
 		for _, v := range foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs {
-			if !isManaged(v, hubInfo) {
+			if !IsManaged(v, hubInfo) {
 				copiedAlertmanagerConfigs = append(copiedAlertmanagerConfigs, v)
 			}
 		}
@@ -557,12 +557,12 @@ func RevertClusterMonitoringConfig(ctx context.Context, client client.Client, hu
 		return fmt.Errorf("failed to marshal the cluster monitoring config: %w", err)
 	}
 
-	found.Data[clusterMonitoringConfigDataKey] = string(updatedClusterMonitoringConfigurationYAMLBytes)
+	found.Data[ClusterMonitoringConfigDataKey] = string(updatedClusterMonitoringConfigurationYAMLBytes)
 	return updateClusterMonitoringConfig(ctx, client, found)
 }
 
-// createOrUpdateCMOConfig encapsulates logic to create or update the cluster-monitoring-config configmap.
-func createOrUpdateCMOConfig(
+// CreateOrUpdateCMOConfig encapsulates logic to create or update the cluster-monitoring-config configmap.
+func CreateOrUpdateCMOConfig(
 	ctx context.Context,
 	client client.Client,
 	clusterID string,
@@ -597,7 +597,7 @@ func createOrUpdateCMOConfig(
 					Name:      clusterMonitoringConfigName,
 					Namespace: promNamespace,
 				},
-				Data: map[string]string{clusterMonitoringConfigDataKey: string(yamlBytes)},
+				Data: map[string]string{ClusterMonitoringConfigDataKey: string(yamlBytes)},
 			}
 			log.Info("cluster monitoring configmap not found, trying to create it", "name", clusterMonitoringConfigName)
 			return true, createCMOConfigMapAndUnset(ctx, client, newCM, namespace)
@@ -605,9 +605,9 @@ func createOrUpdateCMOConfig(
 		return false, fmt.Errorf("failed to check configmap %s: %w", clusterMonitoringConfigName, err)
 	}
 
-	currentYAML, ok := hasClusterMonitoringConfigData(found)
+	currentYAML, ok := HasClusterMonitoringConfigData(found)
 	if !ok {
-		found.Data[clusterMonitoringConfigDataKey] = string(yamlBytes)
+		found.Data[ClusterMonitoringConfigDataKey] = string(yamlBytes)
 		return true, updateClusterMonitoringConfigAndUnset(ctx, client, found, namespace)
 	}
 
@@ -632,7 +632,7 @@ func createOrUpdateCMOConfig(
 		existing := false
 		var index int
 		for i, cfg := range updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs {
-			if isManaged(cfg, hubInfo) {
+			if IsManaged(cfg, hubInfo) {
 				existing = true
 				index = i
 				break
@@ -668,12 +668,12 @@ func createOrUpdateCMOConfig(
 		return false, nil
 	}
 
-	found.Data[clusterMonitoringConfigDataKey] = string(updatedYAML)
+	found.Data[ClusterMonitoringConfigDataKey] = string(updatedYAML)
 	return true, updateClusterMonitoringConfigAndUnset(ctx, client, found, namespace)
 }
 
-// createOrUpdateUserWorkloadMonitoringConfig creates/updates the user-workload-monitoring-config configmap
-func createOrUpdateUserWorkloadMonitoringConfig(
+// CreateOrUpdateUserWorkloadMonitoringConfig creates/updates the user-workload-monitoring-config configmap
+func CreateOrUpdateUserWorkloadMonitoringConfig(
 	ctx context.Context,
 	client client.Client,
 	hubInfo *operatorconfig.HubInfo,
@@ -734,7 +734,7 @@ func createOrUpdateUserWorkloadMonitoringConfig(
 		exists := false
 		var index int
 		for i, cfg := range parsed.Prometheus.AlertmanagerConfigs {
-			if isManaged(cfg, hubInfo) {
+			if IsManaged(cfg, hubInfo) {
 				exists = true
 				index = i
 				break
@@ -816,10 +816,10 @@ func unset(ctx context.Context, client client.Client, ns string) error {
 	return err
 }
 
-// inManagedFields checks if the configmap has had a CRUD operation by endpoint-monitoring-operator
-func inManagedFields(cm *corev1.ConfigMap) bool {
+// InManagedFields checks if the configmap has had a CRUD operation by endpoint-monitoring-operator
+func InManagedFields(cm *corev1.ConfigMap) bool {
 	for _, field := range cm.GetManagedFields() {
-		if field.Manager == endpointMonitoringOperatorMgr {
+		if field.Manager == EndpointMonitoringOperatorMgr {
 			return true
 		}
 	}
@@ -831,22 +831,22 @@ func inManagedFields(cm *corev1.ConfigMap) bool {
 	return false
 }
 
-// isManaged checks if the additional alertmanager config is managed by ACM
-func isManaged(amc cmomanifests.AdditionalAlertmanagerConfig, hubInfo *operatorconfig.HubInfo) bool {
+// IsManaged checks if the additional alertmanager config is managed by ACM
+func IsManaged(amc cmomanifests.AdditionalAlertmanagerConfig, hubInfo *operatorconfig.HubInfo) bool {
 	if amc.TLSConfig.CA == nil {
 		return false
 	}
 	caName := amc.TLSConfig.CA.Name
 	if hubInfo != nil {
 		switch caName {
-		case hubAmRouterCASecretName + "-" + hubInfo.HubClusterID,
+		case HubAmRouterCASecretName + "-" + hubInfo.HubClusterID,
 			amMtlsCaName + "-" + hubInfo.HubClusterID:
 			return true
 		default:
 			return false
 		}
 	}
-	return strings.Contains(caName, hubAmRouterCASecretName) ||
+	return strings.Contains(caName, HubAmRouterCASecretName) ||
 		strings.Contains(caName, amMtlsCaName)
 }
 
@@ -855,26 +855,26 @@ func isOldManagedConfig(amc cmomanifests.AdditionalAlertmanagerConfig, hubInfo *
 	if hubInfo != nil && amc.TLSConfig.CA != nil {
 		clusterDomainName := config.GetClusterName(hubInfo.ObservatoriumAPIEndpoint)
 		switch amc.TLSConfig.CA.Name {
-		case hubAmRouterCASecretName, hubAmRouterCASecretName + "-" + clusterDomainName:
+		case HubAmRouterCASecretName, HubAmRouterCASecretName + "-" + clusterDomainName:
 			return true
 		// check if managed by ACM with old secret prior to alertmanager fanout change
-		case hubAmRouterCASecretName + "-" + hubInfo.HubClusterID:
+		case HubAmRouterCASecretName + "-" + hubInfo.HubClusterID:
 			return true
 		}
 	}
 	return false
 }
 
-// hasClusterMonitoringConfigData checks if the configmap has the required key and logs if not
-func hasClusterMonitoringConfigData(cm *corev1.ConfigMap) (string, bool) {
-	data, ok := cm.Data[clusterMonitoringConfigDataKey]
+// HasClusterMonitoringConfigData checks if the configmap has the required key and logs if not
+func HasClusterMonitoringConfigData(cm *corev1.ConfigMap) (string, bool) {
+	data, ok := cm.Data[ClusterMonitoringConfigDataKey]
 	if !ok {
 		log.Info(
 			"configmap doesn't contain required key",
 			"name",
 			clusterMonitoringConfigName,
 			"key",
-			clusterMonitoringConfigDataKey,
+			ClusterMonitoringConfigDataKey,
 		)
 	}
 	return data, ok
@@ -900,7 +900,7 @@ func RevertUserWorkloadMonitoringConfig(ctx context.Context, client client.Clien
 
 	log.Info("checking if user workload monitoring config needs revert", "name", operatorconfig.OCPUserWorkloadMonitoringConfigMap)
 	found = found.DeepCopy()
-	if !inManagedFields(found) {
+	if !InManagedFields(found) {
 		return nil
 	}
 
@@ -923,7 +923,7 @@ func RevertUserWorkloadMonitoringConfig(ctx context.Context, client client.Clien
 	if parsed.Prometheus.AlertmanagerConfigs != nil {
 		copiedAlertmanagerConfigs := make([]cmomanifests.AdditionalAlertmanagerConfig, 0)
 		for _, v := range parsed.Prometheus.AlertmanagerConfigs {
-			if !isManaged(v, hubInfo) {
+			if !IsManaged(v, hubInfo) {
 				copiedAlertmanagerConfigs = append(copiedAlertmanagerConfigs, v)
 			}
 		}
@@ -962,7 +962,7 @@ func createMtlsSecretInNamespace(ctx context.Context, c client.Client, sourceNam
 		return fmt.Errorf("failed to get source secret %s/%s: %w", sourceNamespace, secretName, err)
 	}
 
-	targetName := appendHubClusterID(secretRename, hubInfo)
+	targetName := AppendHubClusterID(secretRename, hubInfo)
 	target := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      targetName,

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
@@ -288,24 +288,12 @@ func AppendHubClusterID(secretName string, hubInfo *operatorconfig.HubInfo) stri
 	return secretName + "-" + hubInfo.HubClusterID
 }
 
-func newAdditionalAlertmanagerConfig(hubInfo *operatorconfig.HubInfo, caSecret string, certSecret string, omitBearerToken bool) cmomanifests.AdditionalAlertmanagerConfig {
-	amMtlsCARef := caSecret
-	if amMtlsCARef == "" {
-		amMtlsCARef = AppendHubClusterID(amMtlsCaName, hubInfo)
-	}
-	amMtlsCertRef := certSecret
-	if amMtlsCertRef == "" {
-		amMtlsCertRef = AppendHubClusterID(amMtlsCertName, hubInfo)
-	}
-
-	var bearerToken *corev1.SecretKeySelector
-	if !omitBearerToken {
-		bearerToken = &corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: AppendHubClusterID(HubAmAccessorSecretName, hubInfo),
-			},
-			Key: hubAmAccessorSecretKey,
-		}
+func newAdditionalAlertmanagerConfig(alertmanagerEndpoint string, caSecret string, certSecret string, accessorSecret string) cmomanifests.AdditionalAlertmanagerConfig {
+	bearerToken := &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
+			Name: accessorSecret,
+		},
+		Key: hubAmAccessorSecretKey,
 	}
 
 	config := cmomanifests.AdditionalAlertmanagerConfig{
@@ -315,19 +303,19 @@ func newAdditionalAlertmanagerConfig(hubInfo *operatorconfig.HubInfo, caSecret s
 		TLSConfig: cmomanifests.TLSConfig{
 			CA: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: amMtlsCARef,
+					Name: caSecret,
 				},
 				Key: "ca.crt",
 			},
 			Cert: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: amMtlsCertRef,
+					Name: certSecret,
 				},
 				Key: "tls.crt",
 			},
 			Key: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: amMtlsCertRef,
+					Name: certSecret,
 				},
 				Key: "tls.key",
 			},
@@ -336,9 +324,9 @@ func newAdditionalAlertmanagerConfig(hubInfo *operatorconfig.HubInfo, caSecret s
 		BearerToken:   bearerToken,
 		StaticConfigs: []string{},
 	}
-	amURL, err := url.Parse(hubInfo.AlertmanagerEndpoint)
+	amURL, err := url.Parse(alertmanagerEndpoint)
 	if err != nil {
-		log.Error(err, "failed to parse alertmanager endpoint. ignoring it", "endpoint", hubInfo.AlertmanagerEndpoint)
+		log.Error(err, "failed to parse alertmanager endpoint. ignoring it", "endpoint", alertmanagerEndpoint)
 		return config
 	}
 
@@ -476,7 +464,7 @@ func createOrUpdateClusterMonitoringConfig(
 		return false, unset(ctx, client, namespace)
 	}
 
-	updated, err := CreateOrUpdateCMOConfig(ctx, client, clusterID, hubInfo, "", "", false, namespace)
+	updated, err := CreateOrUpdateCMOConfig(ctx, client, clusterID, hubInfo, "", "", "", namespace)
 	if err != nil {
 		return false, err
 	}
@@ -494,7 +482,7 @@ func createOrUpdateClusterMonitoringConfig(
 	if nsExists {
 		if uwmEnabled {
 			// UWL is enabled, create or update the config
-			if err := CreateOrUpdateUserWorkloadMonitoringConfig(ctx, client, hubInfo, "", "", false); err != nil {
+			if err := CreateOrUpdateUserWorkloadMonitoringConfig(ctx, client, hubInfo, "", "", ""); err != nil {
 				return updated, fmt.Errorf("failed to create or update user workload monitoring config: %w", err)
 			}
 		} else {
@@ -557,7 +545,7 @@ func RevertClusterMonitoringConfig(ctx context.Context, client client.Client, hu
 	if foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs != nil {
 		copiedAlertmanagerConfigs := make([]cmomanifests.AdditionalAlertmanagerConfig, 0)
 		for _, v := range foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs {
-			if !IsManaged(v, hubInfo) {
+			if !IsManaged(v, hubInfo, "") {
 				copiedAlertmanagerConfigs = append(copiedAlertmanagerConfigs, v)
 			}
 		}
@@ -598,11 +586,25 @@ func CreateOrUpdateCMOConfig(
 	hubInfo *operatorconfig.HubInfo,
 	caSecret string,
 	certSecret string,
-	omitBearerToken bool,
+	accessorSecret string,
 	namespace string,
 ) (bool, error) {
+	amMtlsCARef := caSecret
+	if amMtlsCARef == "" {
+		amMtlsCARef = AppendHubClusterID(amMtlsCaName, hubInfo)
+	}
+	amMtlsCertRef := certSecret
+	if amMtlsCertRef == "" {
+		amMtlsCertRef = AppendHubClusterID(amMtlsCertName, hubInfo)
+	}
+
+	amAccessorRef := accessorSecret
+	if amAccessorRef == "" {
+		amAccessorRef = AppendHubClusterID(HubAmAccessorSecretName, hubInfo)
+	}
+
 	newExternalLabels := map[string]string{operatorconfig.ClusterLabelKeyForAlerts: clusterID}
-	newAlertmanagerConfigs := []cmomanifests.AdditionalAlertmanagerConfig{newAdditionalAlertmanagerConfig(hubInfo, caSecret, certSecret, omitBearerToken)}
+	newAlertmanagerConfigs := []cmomanifests.AdditionalAlertmanagerConfig{newAdditionalAlertmanagerConfig(hubInfo.AlertmanagerEndpoint, amMtlsCARef, amMtlsCertRef, amAccessorRef)}
 	newPmK8sConfig := &cmomanifests.PrometheusK8sConfig{
 		ExternalLabels:      newExternalLabels,
 		AlertmanagerConfigs: newAlertmanagerConfigs,
@@ -664,18 +666,18 @@ func CreateOrUpdateCMOConfig(
 		existing := false
 		var index int
 		for i, cfg := range updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs {
-			if IsManaged(cfg, hubInfo) {
+			if IsManaged(cfg, hubInfo, caSecret) {
 				existing = true
 				index = i
 				break
 			}
 		}
 		if existing {
-			updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs[index] = newAdditionalAlertmanagerConfig(hubInfo, caSecret, certSecret, omitBearerToken)
+			updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs[index] = newAdditionalAlertmanagerConfig(hubInfo.AlertmanagerEndpoint, amMtlsCARef, amMtlsCertRef, amAccessorRef)
 		} else {
 			updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs = append(
 				updatedCMOCfg.PrometheusK8sConfig.AlertmanagerConfigs,
-				newAdditionalAlertmanagerConfig(hubInfo, caSecret, certSecret, omitBearerToken),
+				newAdditionalAlertmanagerConfig(hubInfo.AlertmanagerEndpoint, amMtlsCARef, amMtlsCertRef, amAccessorRef),
 			)
 		}
 
@@ -714,7 +716,7 @@ func CreateOrUpdateUserWorkloadMonitoringConfig(
 	hubInfo *operatorconfig.HubInfo,
 	caSecret string,
 	certSecret string,
-	omitBearerToken bool,
+	accessorSecret string,
 ) error {
 	// handle the case when alert forwarding is disabled globally or UWM alerting is disabled specifically
 	if hubInfo.AlertmanagerEndpoint == "" || hubInfo.UWMAlertingDisabled {
@@ -722,8 +724,22 @@ func CreateOrUpdateUserWorkloadMonitoringConfig(
 		return RevertUserWorkloadMonitoringConfig(ctx, client, hubInfo)
 	}
 
+	amMtlsCARef := caSecret
+	if amMtlsCARef == "" {
+		amMtlsCARef = AppendHubClusterID(amMtlsCaName, hubInfo)
+	}
+	amMtlsCertRef := certSecret
+	if amMtlsCertRef == "" {
+		amMtlsCertRef = AppendHubClusterID(amMtlsCertName, hubInfo)
+	}
+
+	amAccessorRef := accessorSecret
+	if amAccessorRef == "" {
+		amAccessorRef = AppendHubClusterID(HubAmAccessorSecretName, hubInfo)
+	}
+
 	alertCfg := cmomanifests.PrometheusRestrictedConfig{
-		AlertmanagerConfigs: []cmomanifests.AdditionalAlertmanagerConfig{newAdditionalAlertmanagerConfig(hubInfo, caSecret, certSecret, omitBearerToken)},
+		AlertmanagerConfigs: []cmomanifests.AdditionalAlertmanagerConfig{newAdditionalAlertmanagerConfig(hubInfo.AlertmanagerEndpoint, amMtlsCARef, amMtlsCertRef, amAccessorRef)},
 	}
 	newCfg := cmomanifests.UserWorkloadConfiguration{
 		Prometheus: &alertCfg,
@@ -772,16 +788,19 @@ func CreateOrUpdateUserWorkloadMonitoringConfig(
 		exists := false
 		var index int
 		for i, cfg := range parsed.Prometheus.AlertmanagerConfigs {
-			if IsManaged(cfg, hubInfo) {
+			if IsManaged(cfg, hubInfo, caSecret) {
 				exists = true
 				index = i
 				break
 			}
 		}
 		if !exists {
-			parsed.Prometheus.AlertmanagerConfigs = append(parsed.Prometheus.AlertmanagerConfigs, newAdditionalAlertmanagerConfig(hubInfo, caSecret, certSecret, omitBearerToken))
+			parsed.Prometheus.AlertmanagerConfigs = append(
+				parsed.Prometheus.AlertmanagerConfigs,
+				newAdditionalAlertmanagerConfig(hubInfo.AlertmanagerEndpoint, amMtlsCARef, amMtlsCertRef, amAccessorRef),
+			)
 		} else {
-			parsed.Prometheus.AlertmanagerConfigs[index] = newAdditionalAlertmanagerConfig(hubInfo, caSecret, certSecret, omitBearerToken)
+			parsed.Prometheus.AlertmanagerConfigs[index] = newAdditionalAlertmanagerConfig(hubInfo.AlertmanagerEndpoint, amMtlsCARef, amMtlsCertRef, amAccessorRef)
 		}
 
 		// remove am configs from previous versions if any prior to Global Hub Changes (ACM 2.15.0)
@@ -873,11 +892,16 @@ func InManagedFields(cm *corev1.ConfigMap) bool {
 }
 
 // IsManaged checks if the additional alertmanager config is managed by ACM
-func IsManaged(amc cmomanifests.AdditionalAlertmanagerConfig, hubInfo *operatorconfig.HubInfo) bool {
+func IsManaged(amc cmomanifests.AdditionalAlertmanagerConfig, hubInfo *operatorconfig.HubInfo, caSecret string) bool {
 	if amc.TLSConfig.CA == nil {
 		return false
 	}
 	caName := amc.TLSConfig.CA.Name
+
+	if caSecret != "" && caName == caSecret {
+		return true
+	}
+
 	if hubInfo != nil {
 		switch caName {
 		case HubAmRouterCASecretName + "-" + hubInfo.HubClusterID,
@@ -966,7 +990,7 @@ func RevertUserWorkloadMonitoringConfig(ctx context.Context, client client.Clien
 	if parsed.Prometheus.AlertmanagerConfigs != nil {
 		copiedAlertmanagerConfigs := make([]cmomanifests.AdditionalAlertmanagerConfig, 0)
 		for _, v := range parsed.Prometheus.AlertmanagerConfigs {
-			if !IsManaged(v, hubInfo) {
+			if !IsManaged(v, hubInfo, "") {
 				copiedAlertmanagerConfigs = append(copiedAlertmanagerConfigs, v)
 			}
 		}

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
@@ -46,6 +46,9 @@ var (
 // initializes clusterMonitoringConfigReverted based on the presence of clusterMonitoringRevertedName
 // configmap in openshift-monitoring namespace.
 func initPersistedRevertState(ctx context.Context, client client.Client, ns string) error {
+	if ns == "" {
+		return nil
+	}
 	if !persistedRevertStateRead {
 		// check if reverted configmap is present
 		found := &corev1.ConfigMap{}
@@ -73,6 +76,9 @@ func initPersistedRevertState(ctx context.Context, client client.Client, ns stri
 
 func isRevertedAlready(ctx context.Context, client client.Client, ns string) (bool, error) {
 	log.Info("in isRevertedAlready")
+	if ns == "" {
+		return false, nil
+	}
 	err := initPersistedRevertState(ctx, client, ns)
 	if err != nil {
 		log.Info("isRevertedAlready: error from initPersistedRevertState", "error:", err.Error())
@@ -84,6 +90,9 @@ func isRevertedAlready(ctx context.Context, client client.Client, ns string) (bo
 }
 
 func setConfigReverted(ctx context.Context, client client.Client, ns string) error {
+	if ns == "" {
+		return nil
+	}
 	err := initPersistedRevertState(ctx, client, ns)
 	if err != nil {
 		return err
@@ -816,6 +825,9 @@ func updateClusterMonitoringConfigAndUnset(ctx context.Context, client client.Cl
 
 // unset config reverted flag after successfully updating cluster-monitoring-config
 func unset(ctx context.Context, client client.Client, ns string) error {
+	if ns == "" {
+		return nil
+	}
 	// if reverted before, reset so we can revert again
 	revertedAlready, err := isRevertedAlready(ctx, client, ns)
 	if err == nil && revertedAlready {

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
@@ -142,12 +142,22 @@ func unsetConfigReverted(ctx context.Context, client client.Client, ns string) e
 
 // createHubAmAccessorTokenSecret creates the secret that contains access token of the Hub's Alertmanager.
 func createHubAmAccessorTokenSecret(ctx context.Context, client client.Client, namespace, targetNamespace string, hubInfo *operatorconfig.HubInfo) error {
+	hubAmAccessorSecret := AppendHubClusterID(HubAmAccessorSecretName, hubInfo)
+	found := &corev1.Secret{}
+	targetErr := client.Get(ctx, types.NamespacedName{Name: hubAmAccessorSecret, Namespace: targetNamespace}, found)
+
 	amAccessorToken, err := getAmAccessorToken(ctx, client, namespace)
 	if err != nil {
+		// If the source secret is missing but the target already exists, we skip the sync.
+		// This avoids reconcile failures during MCOA transition where legacy source secrets
+		// might be removed before or during the bridge agent's operation.
+		if targetErr == nil {
+			log.Info("target accessor secret already exists and source secret is missing, skipping sync", "target", targetNamespace+"/"+hubAmAccessorSecret, "source_ns", namespace)
+			return nil
+		}
 		return fmt.Errorf("fail to get %s/%s secret: %w", namespace, HubAmAccessorSecretName, err)
 	}
 
-	hubAmAccessorSecret := AppendHubClusterID(HubAmAccessorSecretName, hubInfo)
 	dataMap := map[string][]byte{hubAmAccessorSecretKey: []byte(amAccessorToken)}
 	hubAmAccessorTokenSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -157,10 +167,8 @@ func createHubAmAccessorTokenSecret(ctx context.Context, client client.Client, n
 		Data: dataMap,
 	}
 
-	found := &corev1.Secret{}
-	err = client.Get(ctx, types.NamespacedName{Name: hubAmAccessorSecret, Namespace: targetNamespace}, found)
-	if err != nil {
-		if errors.IsNotFound(err) {
+	if targetErr != nil {
+		if errors.IsNotFound(targetErr) {
 			err = client.Create(ctx, hubAmAccessorTokenSecret)
 			if err != nil {
 				log.Error(err, "failed to create the observability-alertmanager-accessor secret")
@@ -169,12 +177,12 @@ func createHubAmAccessorTokenSecret(ctx context.Context, client client.Client, n
 			log.Info("the observability-alertmanager-accessor secret is created")
 			return nil
 		} else {
-			log.Error(err, "failed to check the observability-alertmanager-accessor secret")
-			return err
+			log.Error(targetErr, "failed to check the observability-alertmanager-accessor secret")
+			return targetErr
 		}
 	}
 
-	if reflect.DeepEqual(found.Data, dataMap) {
+	if equality.Semantic.DeepEqual(found.Data, dataMap) {
 		log.Info("no change for the observability-alertmanager-accessor secret")
 		return nil
 	} else {
@@ -212,7 +220,7 @@ func cleanUpOldAMSecrets(ctx context.Context, client client.Client, targetNamesp
 	if hubInfo != nil && hubInfo.ObservatoriumAPIEndpoint != "" {
 		clusterDomain = config.GetClusterName(hubInfo.ObservatoriumAPIEndpoint)
 	} else {
-		log.Info("hubInfo or ObservatoriumAPIEndpoint missing; skipping cluster-domain-specific secret deletions")
+		log.V(1).Info("hubInfo or ObservatoriumAPIEndpoint missing; skipping cluster-domain-specific secret deletions")
 	}
 
 	deleteSecret := func(name string, namespace string) {
@@ -852,7 +860,9 @@ func IsManaged(amc cmomanifests.AdditionalAlertmanagerConfig, hubInfo *operatorc
 
 // isOldManagedConfig checks if the additional alertmanager config is managed by ACM with old secret names prior to Global Hub changes
 func isOldManagedConfig(amc cmomanifests.AdditionalAlertmanagerConfig, hubInfo *operatorconfig.HubInfo) bool {
-	if hubInfo != nil && amc.TLSConfig.CA != nil {
+	// In MCOA mode, ObservatoriumAPIEndpoint is not provided, so we skip the domain-based lookup
+	// to avoid unnecessary error logging from GetClusterName.
+	if hubInfo != nil && hubInfo.ObservatoriumAPIEndpoint != "" && amc.TLSConfig.CA != nil {
 		clusterDomainName := config.GetClusterName(hubInfo.ObservatoriumAPIEndpoint)
 		switch amc.TLSConfig.CA.Name {
 		case HubAmRouterCASecretName, HubAmRouterCASecretName + "-" + clusterDomainName:

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
@@ -43,6 +43,9 @@ var (
 
 // initializes clusterMonitoringConfigReverted based on the presence of clusterMonitoringRevertedName
 // configmap in openshift-monitoring namespace.
+// Note: In MCOA, cleanup/reverting is handled dynamically via the controller loop rather than a static
+// cleanup command or persistent revert-state configmaps. We set the namespace param to empty ("")
+// in MCOA mode to skip this legacy state tracker logic.
 func initPersistedRevertState(ctx context.Context, client client.Client, ns string) error {
 	if ns == "" {
 		return nil

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
@@ -175,7 +175,7 @@ func TestClusterMonitoringConfig(t *testing.T) {
 			name:                                    "cluster-monitoring-config with empty config.yaml",
 			ClusterMonitoringConfigCMExist:          true,
 			ClusterMonitoringConfigDataYaml:         "",
-			Manager:                                 endpointMonitoringOperatorMgr,
+			Manager:                                 EndpointMonitoringOperatorMgr,
 			ExpectedDeleteClusterMonitoringConfigCM: false,
 		},
 		{
@@ -197,7 +197,7 @@ prometheusK8s:
 		{
 			name:                           "cluster-monitoring-config with non-empty config.yaml and empty prometheusK8s with endpoint-monitoring-operator manager",
 			ClusterMonitoringConfigCMExist: true,
-			Manager:                        endpointMonitoringOperatorMgr,
+			Manager:                        EndpointMonitoringOperatorMgr,
 			ClusterMonitoringConfigDataYaml: `
 prometheusK8s: null`,
 			ExpectedDeleteClusterMonitoringConfigCM: false,
@@ -253,7 +253,7 @@ func TestClusterMonitoringConfigUnchanged(t *testing.T) {
 		AlertmanagerEndpoint:     "http://test-alertamanger-endpoint",
 		HubClusterID:             "1a9af6dc0801433cb28a200af81",
 	}
-	cmoCfg := newClusterMonitoringConfigCM(clusterMonitoringConfigDataYaml, endpointMonitoringOperatorMgr)
+	cmoCfg := newClusterMonitoringConfigCM(clusterMonitoringConfigDataYaml, EndpointMonitoringOperatorMgr)
 	objs := []runtime.Object{newHubInfoSecret([]byte(hubInfoYAML), testNamespace), cmoCfg, amAccessSrt}
 	objs = append(objs, newMtlsTestSecrets(testNamespace)...)
 	client := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
@@ -351,9 +351,9 @@ func TestClusterMonitoringConfigAlertsDisabled(t *testing.T) {
 			t.Fatalf("could not retrieve configmap %s: %v", clusterMonitoringConfigName, err)
 		}
 
-		foundClusterMonitoringConfigurationYAML, ok := foundCusterMonitoringConfigMap.Data[clusterMonitoringConfigDataKey]
+		foundClusterMonitoringConfigurationYAML, ok := foundCusterMonitoringConfigMap.Data[ClusterMonitoringConfigDataKey]
 		if !ok {
-			t.Fatalf("configmap: %s doesn't contain key: %s", clusterMonitoringConfigName, clusterMonitoringConfigDataKey)
+			t.Fatalf("configmap: %s doesn't contain key: %s", clusterMonitoringConfigName, ClusterMonitoringConfigDataKey)
 		}
 		foundClusterMonitoringConfigurationJSON, err := yamltool.YAMLToJSON([]byte(foundClusterMonitoringConfigurationYAML))
 		if err != nil {
@@ -397,9 +397,9 @@ func testCreateOrUpdateClusterMonitoringConfig(t *testing.T, hubInfo *operatorco
 		t.Fatalf("failed to check configmap %s: %v", clusterMonitoringConfigName, err)
 	}
 
-	foundClusterMonitoringConfigurationYAML, ok := foundCusterMonitoringConfigMap.Data[clusterMonitoringConfigDataKey]
+	foundClusterMonitoringConfigurationYAML, ok := foundCusterMonitoringConfigMap.Data[ClusterMonitoringConfigDataKey]
 	if !ok {
-		t.Fatalf("configmap: %s doesn't contain key: %s", clusterMonitoringConfigName, clusterMonitoringConfigDataKey)
+		t.Fatalf("configmap: %s doesn't contain key: %s", clusterMonitoringConfigName, ClusterMonitoringConfigDataKey)
 	}
 	foundClusterMonitoringConfigurationJSON, err := yamltool.YAMLToJSON([]byte(foundClusterMonitoringConfigurationYAML))
 	if err != nil {
@@ -420,8 +420,8 @@ func testCreateOrUpdateClusterMonitoringConfig(t *testing.T, hubInfo *operatorco
 	}
 
 	containsOCMAlertmanagerConfig := false
-	amMtlsCARef := appendHubClusterID(amMtlsCaName, hubInfo)
-	amMtlsCertRef := appendHubClusterID(amMtlsCertName, hubInfo)
+	amMtlsCARef := AppendHubClusterID(amMtlsCaName, hubInfo)
+	amMtlsCertRef := AppendHubClusterID(amMtlsCertName, hubInfo)
 	for _, v := range foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs {
 		if v.TLSConfig.CA != nil && v.TLSConfig.CA.Name == amMtlsCARef &&
 			v.TLSConfig.Cert != nil && v.TLSConfig.Cert.Name == amMtlsCertRef &&
@@ -451,11 +451,11 @@ func testCreateOrUpdateClusterMonitoringConfig(t *testing.T, hubInfo *operatorco
 
 	foundHubAmAccessorSecret := &corev1.Secret{}
 	err = c.Get(ctx, types.NamespacedName{
-		Name:      hubAmAccessorSecretName + "-" + hubInfo.HubClusterID,
+		Name:      HubAmAccessorSecretName + "-" + hubInfo.HubClusterID,
 		Namespace: promNamespace,
 	}, foundHubAmAccessorSecret)
 	if err != nil {
-		t.Fatalf("the secret %s should not be deleted", hubAmAccessorSecretName+"-"+hubInfo.HubClusterID)
+		t.Fatalf("the secret %s should not be deleted", HubAmAccessorSecretName+"-"+hubInfo.HubClusterID)
 	}
 
 	foundMtlsCASecret := &corev1.Secret{}
@@ -502,7 +502,7 @@ func TestUserWorkloadMonitoringConfig(t *testing.T) {
 			name:                                   "user-workload-monitoring-config with empty config.yaml",
 			UserWorkloadMonitoringConfigCMExist:    true,
 			UserWorkloadMonitoringConfigDataYaml:   "",
-			Manager:                                endpointMonitoringOperatorMgr,
+			Manager:                                EndpointMonitoringOperatorMgr,
 			ExpectedDeleteUserWorkloadMonitoringCM: false,
 		},
 		{
@@ -524,7 +524,7 @@ prometheus:
 		{
 			name:                                "user-workload-monitoring-config with non-empty config.yaml and empty prometheus with endpoint-monitoring-operator manager",
 			UserWorkloadMonitoringConfigCMExist: true,
-			Manager:                             endpointMonitoringOperatorMgr,
+			Manager:                             EndpointMonitoringOperatorMgr,
 			UserWorkloadMonitoringConfigDataYaml: `
 prometheus: null`,
 			ExpectedDeleteUserWorkloadMonitoringCM: false,
@@ -560,7 +560,7 @@ prometheus:
 
 	uwlAccessSrt := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hubAmAccessorSecretName + "-" + hubInfo.HubClusterID,
+			Name:      HubAmAccessorSecretName + "-" + hubInfo.HubClusterID,
 			Namespace: uwlTestNamespace,
 		},
 		Data: map[string][]byte{
@@ -599,7 +599,7 @@ func newUserWorkloadMonitoringConfigCM(configDataStr string, mgr string) *corev1
 
 func testCreateOrUpdateUserWorkloadMonitoringConfig(t *testing.T, hubInfo *operatorconfig.HubInfo, c client.Client, expectedCMDelete bool, tokenValue string) {
 	ctx := context.TODO()
-	err := createOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
+	err := CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -636,8 +636,8 @@ func testCreateOrUpdateUserWorkloadMonitoringConfig(t *testing.T, hubInfo *opera
 	}
 
 	containsOCMAlertmanagerConfig := false
-	amMtlsCARef := appendHubClusterID(amMtlsCaName, hubInfo)
-	amMtlsCertRef := appendHubClusterID(amMtlsCertName, hubInfo)
+	amMtlsCARef := AppendHubClusterID(amMtlsCaName, hubInfo)
+	amMtlsCertRef := AppendHubClusterID(amMtlsCertName, hubInfo)
 	for _, v := range foundUserWorkloadConfiguration.Prometheus.AlertmanagerConfigs {
 		if v.TLSConfig.CA != nil && v.TLSConfig.CA.Name == amMtlsCARef &&
 			v.TLSConfig.Cert != nil && v.TLSConfig.Cert.Name == amMtlsCertRef &&
@@ -667,11 +667,11 @@ func testCreateOrUpdateUserWorkloadMonitoringConfig(t *testing.T, hubInfo *opera
 
 	foundHubAmAccessorSecret := &corev1.Secret{}
 	err = c.Get(ctx, types.NamespacedName{
-		Name:      hubAmAccessorSecretName + "-" + hubInfo.HubClusterID,
+		Name:      HubAmAccessorSecretName + "-" + hubInfo.HubClusterID,
 		Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
 	}, foundHubAmAccessorSecret)
 	if err != nil {
-		t.Fatalf("the secret %s should not be deleted", hubAmAccessorSecretName+"-"+hubInfo.HubClusterID)
+		t.Fatalf("the secret %s should not be deleted", HubAmAccessorSecretName+"-"+hubInfo.HubClusterID)
 	}
 
 	err = RevertUserWorkloadMonitoringConfig(ctx, c, hubInfo)
@@ -712,7 +712,7 @@ prometheus:
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
 	// Test disabling alert forwarding
-	err = createOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
+	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -757,7 +757,7 @@ prometheus:
 		t.Fatalf("Failed to unmarshal hubInfo: (%v)", err)
 	}
 
-	err = createOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
+	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -795,8 +795,8 @@ prometheus:
 	}
 
 	containsOCMAlertmanagerConfig := false
-	amMtlsCARef := appendHubClusterID(amMtlsCaName, hubInfo)
-	amMtlsCertRef := appendHubClusterID(amMtlsCertName, hubInfo)
+	amMtlsCARef := AppendHubClusterID(amMtlsCaName, hubInfo)
+	amMtlsCertRef := AppendHubClusterID(amMtlsCertName, hubInfo)
 	for _, v := range foundUserWorkloadConfiguration.Prometheus.AlertmanagerConfigs {
 		if v.TLSConfig.CA != nil && v.TLSConfig.CA.Name == amMtlsCARef &&
 			v.TLSConfig.Cert != nil && v.TLSConfig.Cert.Name == amMtlsCertRef &&
@@ -843,7 +843,7 @@ prometheus:
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
 	// Test with UWM alerting disabled
-	err = createOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
+	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -888,7 +888,7 @@ prometheus:
 		t.Fatalf("Failed to unmarshal hubInfo: (%v)", err)
 	}
 
-	err = createOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
+	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -926,8 +926,8 @@ prometheus:
 	}
 
 	containsOCMAlertmanagerConfig := false
-	amMtlsCARef := appendHubClusterID(amMtlsCaName, hubInfo)
-	amMtlsCertRef := appendHubClusterID(amMtlsCertName, hubInfo)
+	amMtlsCARef := AppendHubClusterID(amMtlsCaName, hubInfo)
+	amMtlsCertRef := AppendHubClusterID(amMtlsCertName, hubInfo)
 	for _, v := range foundUserWorkloadConfiguration.Prometheus.AlertmanagerConfigs {
 		if v.TLSConfig.CA != nil && v.TLSConfig.CA.Name == amMtlsCARef &&
 			v.TLSConfig.Cert != nil && v.TLSConfig.Cert.Name == amMtlsCertRef &&
@@ -1009,7 +1009,7 @@ userWorkloadEnabled: false
 	// Create required secrets
 	alertmanagerAccessorSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hubAmAccessorSecretName,
+			Name:      HubAmAccessorSecretName,
 			Namespace: "test-ns",
 		},
 		Data: map[string][]byte{
@@ -1048,7 +1048,7 @@ userWorkloadEnabled: false
 				for _, config := range parsed.Prometheus.AlertmanagerConfigs {
 					if config.TLSConfig.CA != nil &&
 						(config.TLSConfig.CA.Name == amMtlsCaName ||
-							config.TLSConfig.CA.Name == appendHubClusterID(amMtlsCaName, hubInfo)) {
+							config.TLSConfig.CA.Name == AppendHubClusterID(amMtlsCaName, hubInfo)) {
 						t.Fatalf("UWL configmap still contains ACM alertmanager configuration when it should be cleaned up")
 					}
 				}
@@ -1104,7 +1104,7 @@ enableUserWorkload: true
 	// Create required secrets
 	alertmanagerAccessorSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hubAmAccessorSecretName,
+			Name:      HubAmAccessorSecretName,
 			Namespace: "test-ns",
 		},
 		Data: map[string][]byte{
@@ -1162,7 +1162,7 @@ enableUserWorkload: true
 	}
 
 	// Verify that the ACM alertmanager configuration is present by checking for the mTLS CA secret
-	if !strings.Contains(configYAML, appendHubClusterID(amMtlsCaName, hubInfo)) {
+	if !strings.Contains(configYAML, AppendHubClusterID(amMtlsCaName, hubInfo)) {
 		t.Fatalf("UWL configmap should contain ACM alertmanager configuration with mTLS CA secret reference")
 	}
 
@@ -1230,7 +1230,7 @@ prometheusK8s:
 `
 
 	amAccessSrt := newAMAccessorSecret(testNamespace, "test-token")
-	cmoCfg := newClusterMonitoringConfigCM(diffYAML, endpointMonitoringOperatorMgr)
+	cmoCfg := newClusterMonitoringConfigCM(diffYAML, EndpointMonitoringOperatorMgr)
 	objs := []runtime.Object{cmoCfg, amAccessSrt}
 	objs = append(objs, newMtlsTestSecrets(testNamespace)...)
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
@@ -1246,9 +1246,9 @@ prometheusK8s:
 	if err != nil {
 		t.Fatalf("get configmap: %v", err)
 	}
-	yamlStr, ok := found.Data[clusterMonitoringConfigDataKey]
+	yamlStr, ok := found.Data[ClusterMonitoringConfigDataKey]
 	if !ok {
-		t.Fatalf("configmap missing %s", clusterMonitoringConfigDataKey)
+		t.Fatalf("configmap missing %s", ClusterMonitoringConfigDataKey)
 	}
 	foundJSON, err := yamltool.YAMLToJSON([]byte(yamlStr))
 	if err != nil {
@@ -1265,10 +1265,10 @@ prometheusK8s:
 	if len(amCfgs) != 1 {
 		t.Fatalf("expected exactly 1 additionalAlertmanagerConfig after dedupe, got %d", len(amCfgs))
 	}
-	if amCfgs[0].TLSConfig.CA == nil || amCfgs[0].TLSConfig.CA.Name != appendHubClusterID(amMtlsCaName, hubInfo) {
-		t.Fatalf("expected single mTLS ACM alertmanager config (CA %q), got %#v", appendHubClusterID(amMtlsCaName, hubInfo), amCfgs[0].TLSConfig.CA)
+	if amCfgs[0].TLSConfig.CA == nil || amCfgs[0].TLSConfig.CA.Name != AppendHubClusterID(amMtlsCaName, hubInfo) {
+		t.Fatalf("expected single mTLS ACM alertmanager config (CA %q), got %#v", AppendHubClusterID(amMtlsCaName, hubInfo), amCfgs[0].TLSConfig.CA)
 	}
-	if amCfgs[0].TLSConfig.Cert == nil || amCfgs[0].TLSConfig.Cert.Name != appendHubClusterID(amMtlsCertName, hubInfo) {
+	if amCfgs[0].TLSConfig.Cert == nil || amCfgs[0].TLSConfig.Cert.Name != AppendHubClusterID(amMtlsCertName, hubInfo) {
 		t.Fatalf("expected mTLS client cert on deduped config, got cert ref %#v", amCfgs[0].TLSConfig.Cert)
 	}
 }
@@ -1284,7 +1284,7 @@ func TestClusterMonitoringCleanupGlobalHub(t *testing.T) {
 		AlertmanagerEndpoint:     "http://test-alertamanger-endpoint",
 		HubClusterID:             "1a9af6dc0801433cb28a200af81",
 	}
-	cmoCfg := newClusterMonitoringConfigCM(clusterMonitoringConfigDataYamlCleanupGH, endpointMonitoringOperatorMgr)
+	cmoCfg := newClusterMonitoringConfigCM(clusterMonitoringConfigDataYamlCleanupGH, EndpointMonitoringOperatorMgr)
 	ghObjs := []runtime.Object{newHubInfoSecret([]byte(hubInfoYAML), testNamespace), cmoCfg, amAccessSrt}
 	ghObjs = append(ghObjs, newMtlsTestSecrets(testNamespace)...)
 	client := fake.NewClientBuilder().WithRuntimeObjects(ghObjs...).Build()
@@ -1302,7 +1302,7 @@ func TestClusterMonitoringCleanupGlobalHub(t *testing.T) {
 
 	// After reconcile, legacy hub-alertmanager-router-ca stanzas must be gone (including
 	// unsuffixed, cluster-domain-suffixed, and HubClusterID-suffixed names — see isOldManagedConfig).
-	foundClusterMonitoringConfigurationYAML, ok := hasClusterMonitoringConfigData(cmoCfgBeforeUpdate)
+	foundClusterMonitoringConfigurationYAML, ok := HasClusterMonitoringConfigData(cmoCfgBeforeUpdate)
 	if !ok {
 		t.Fatalf("configmap: %s doesn't contain key: config.yaml", clusterMonitoringConfigName)
 	}
@@ -1326,9 +1326,9 @@ func TestClusterMonitoringCleanupGlobalHub(t *testing.T) {
 			}
 			name := v.TLSConfig.CA.Name
 			switch name {
-			case hubAmRouterCASecretName,
-				hubAmRouterCASecretName + "-" + clusterDomain,
-				hubAmRouterCASecretName + "-" + hubInfo.HubClusterID:
+			case HubAmRouterCASecretName,
+				HubAmRouterCASecretName + "-" + clusterDomain,
+				HubAmRouterCASecretName + "-" + hubInfo.HubClusterID:
 				t.Fatalf("%q secret reference should be removed from the cluster-monitoring-config configmap (legacy router CA)", name)
 			}
 		}

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
@@ -599,7 +599,7 @@ func newUserWorkloadMonitoringConfigCM(configDataStr string, mgr string) *corev1
 
 func testCreateOrUpdateUserWorkloadMonitoringConfig(t *testing.T, hubInfo *operatorconfig.HubInfo, c client.Client, expectedCMDelete bool, tokenValue string) {
 	ctx := context.TODO()
-	err := CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", false)
+	err := CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", "")
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -712,7 +712,7 @@ prometheus:
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
 	// Test disabling alert forwarding
-	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", false)
+	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", "")
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -757,7 +757,7 @@ prometheus:
 		t.Fatalf("Failed to unmarshal hubInfo: (%v)", err)
 	}
 
-	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", false)
+	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", "")
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -843,7 +843,7 @@ prometheus:
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
 	// Test with UWM alerting disabled
-	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", false)
+	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", "")
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -888,7 +888,7 @@ prometheus:
 		t.Fatalf("Failed to unmarshal hubInfo: (%v)", err)
 	}
 
-	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", false)
+	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", "")
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
@@ -599,7 +599,7 @@ func newUserWorkloadMonitoringConfigCM(configDataStr string, mgr string) *corev1
 
 func testCreateOrUpdateUserWorkloadMonitoringConfig(t *testing.T, hubInfo *operatorconfig.HubInfo, c client.Client, expectedCMDelete bool, tokenValue string) {
 	ctx := context.TODO()
-	err := CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
+	err := CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -712,7 +712,7 @@ prometheus:
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
 	// Test disabling alert forwarding
-	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
+	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -757,7 +757,7 @@ prometheus:
 		t.Fatalf("Failed to unmarshal hubInfo: (%v)", err)
 	}
 
-	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
+	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -843,7 +843,7 @@ prometheus:
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
 	// Test with UWM alerting disabled
-	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
+	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -888,7 +888,7 @@ prometheus:
 		t.Fatalf("Failed to unmarshal hubInfo: (%v)", err)
 	}
 
-	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo)
+	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", false)
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	cmomanifests "github.com/openshift/cluster-monitoring-operator/pkg/manifests"
-	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
@@ -82,54 +81,6 @@ prometheusK8s:
         key: tls.key
         name: obs-alertmanager-mtls-cert-1a9af6dc0801433cb28a200af81
       insecureSkipVerify: false`
-
-	clusterMonitoringConfigDataYamlCleanupGH = `
-prometheusK8s:
-  externalLabels:
-    managed_cluster: kind-cluster-id
-  additionalAlertManagerConfigs:
-  - apiVersion: v2
-    bearerToken:
-      key: token
-      name: foo
-    pathPrefix: /
-    scheme: https
-    staticConfigs:
-    - test-host.com
-    tlsConfig:
-      ServerName: ""
-      ca:
-        key: service-ca.crt
-        name: hub-alertmanager-router-ca-12345
-      insecureSkipVerify: true
-  - apiVersion: v2
-    bearerToken:
-      key: token
-      name: foo
-    pathPrefix: /
-    scheme: https
-    staticConfigs:
-    - test-host.com
-    tlsConfig:
-      ServerName: ""
-      ca:
-        key: service-ca.crt
-        name: hub-alertmanager-router-ca
-      insecureSkipVerify: true
-  - apiVersion: v2
-    bearerToken:
-      key: token
-      name: foo
-    pathPrefix: /
-    scheme: https
-    staticConfigs:
-    - test-host.com
-    tlsConfig:
-      ServerName: ""
-      ca:
-        key: service-ca.crt
-        name: hub-alertmanager-router-ca-1a9af6dc0801433cb28a200af81
-      insecureSkipVerify: true`
 )
 
 func newMtlsTestSecrets(namespace string) []runtime.Object {
@@ -420,8 +371,8 @@ func testCreateOrUpdateClusterMonitoringConfig(t *testing.T, hubInfo *operatorco
 	}
 
 	containsOCMAlertmanagerConfig := false
-	amMtlsCARef := AppendHubClusterID(amMtlsCaName, hubInfo)
-	amMtlsCertRef := AppendHubClusterID(amMtlsCertName, hubInfo)
+	amMtlsCARef := AppendHubClusterID(amMtlsCaName, hubInfo.HubClusterID)
+	amMtlsCertRef := AppendHubClusterID(amMtlsCertName, hubInfo.HubClusterID)
 	for _, v := range foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs {
 		if v.TLSConfig.CA != nil && v.TLSConfig.CA.Name == amMtlsCARef &&
 			v.TLSConfig.Cert != nil && v.TLSConfig.Cert.Name == amMtlsCertRef &&
@@ -434,7 +385,7 @@ func testCreateOrUpdateClusterMonitoringConfig(t *testing.T, hubInfo *operatorco
 		t.Fatalf("no AlertmanagerConfig for OCM in ClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs: %v", foundClusterMonitoringConfiguration)
 	}
 
-	err = RevertClusterMonitoringConfig(ctx, c, hubInfo)
+	err = RevertClusterMonitoringConfig(ctx, c, amMtlsCARef)
 	if err != nil {
 		t.Fatalf("Failed to revert cluster-monitoring-config configmap: (%v)", err)
 	}
@@ -451,11 +402,11 @@ func testCreateOrUpdateClusterMonitoringConfig(t *testing.T, hubInfo *operatorco
 
 	foundHubAmAccessorSecret := &corev1.Secret{}
 	err = c.Get(ctx, types.NamespacedName{
-		Name:      HubAmAccessorSecretName + "-" + hubInfo.HubClusterID,
+		Name:      AppendHubClusterID(HubAmAccessorSecretName, hubInfo.HubClusterID),
 		Namespace: promNamespace,
 	}, foundHubAmAccessorSecret)
 	if err != nil {
-		t.Fatalf("the secret %s should not be deleted", HubAmAccessorSecretName+"-"+hubInfo.HubClusterID)
+		t.Fatalf("the secret %s should not be deleted", AppendHubClusterID(HubAmAccessorSecretName, hubInfo.HubClusterID))
 	}
 
 	foundMtlsCASecret := &corev1.Secret{}
@@ -476,7 +427,7 @@ func testCreateOrUpdateClusterMonitoringConfig(t *testing.T, hubInfo *operatorco
 		t.Fatalf("the secret %s should not be deleted", amMtlsCertRef)
 	}
 
-	err = RevertClusterMonitoringConfig(ctx, c, hubInfo)
+	err = RevertClusterMonitoringConfig(ctx, c, amMtlsCARef)
 	if err != nil {
 		t.Fatalf("Run into error when try to revert cluster-monitoring-config configmap twice: (%v)", err)
 	}
@@ -599,7 +550,19 @@ func newUserWorkloadMonitoringConfigCM(configDataStr string, mgr string) *corev1
 
 func testCreateOrUpdateUserWorkloadMonitoringConfig(t *testing.T, hubInfo *operatorconfig.HubInfo, c client.Client, expectedCMDelete bool, tokenValue string) {
 	ctx := context.TODO()
-	err := CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", "")
+	amMtlsCARef := AppendHubClusterID(amMtlsCaName, hubInfo.HubClusterID)
+	amMtlsCertRef := AppendHubClusterID(amMtlsCertName, hubInfo.HubClusterID)
+	amAccessorRef := AppendHubClusterID(HubAmAccessorSecretName, hubInfo.HubClusterID)
+
+	err := CreateOrUpdateUserWorkloadMonitoringConfig(
+		ctx,
+		c,
+		hubInfo.AlertmanagerEndpoint,
+		hubInfo.UWMAlertingDisabled,
+		amMtlsCARef,
+		amMtlsCertRef,
+		amAccessorRef,
+	)
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -636,8 +599,8 @@ func testCreateOrUpdateUserWorkloadMonitoringConfig(t *testing.T, hubInfo *opera
 	}
 
 	containsOCMAlertmanagerConfig := false
-	amMtlsCARef := AppendHubClusterID(amMtlsCaName, hubInfo)
-	amMtlsCertRef := AppendHubClusterID(amMtlsCertName, hubInfo)
+	amMtlsCARef = AppendHubClusterID(amMtlsCaName, hubInfo.HubClusterID)
+	amMtlsCertRef = AppendHubClusterID(amMtlsCertName, hubInfo.HubClusterID)
 	for _, v := range foundUserWorkloadConfiguration.Prometheus.AlertmanagerConfigs {
 		if v.TLSConfig.CA != nil && v.TLSConfig.CA.Name == amMtlsCARef &&
 			v.TLSConfig.Cert != nil && v.TLSConfig.Cert.Name == amMtlsCertRef &&
@@ -650,7 +613,7 @@ func testCreateOrUpdateUserWorkloadMonitoringConfig(t *testing.T, hubInfo *opera
 		t.Fatalf("no AlertmanagerConfig for OCM in UserWorkloadConfiguration.Prometheus.AlertmanagerConfigs: %v", foundUserWorkloadConfiguration)
 	}
 
-	err = RevertUserWorkloadMonitoringConfig(ctx, c, hubInfo)
+	err = RevertUserWorkloadMonitoringConfig(ctx, c, amMtlsCARef)
 	if err != nil {
 		t.Fatalf("Failed to revert user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -667,14 +630,14 @@ func testCreateOrUpdateUserWorkloadMonitoringConfig(t *testing.T, hubInfo *opera
 
 	foundHubAmAccessorSecret := &corev1.Secret{}
 	err = c.Get(ctx, types.NamespacedName{
-		Name:      HubAmAccessorSecretName + "-" + hubInfo.HubClusterID,
+		Name:      AppendHubClusterID(HubAmAccessorSecretName, hubInfo.HubClusterID),
 		Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
 	}, foundHubAmAccessorSecret)
 	if err != nil {
-		t.Fatalf("the secret %s should not be deleted", HubAmAccessorSecretName+"-"+hubInfo.HubClusterID)
+		t.Fatalf("the secret %s should not be deleted", AppendHubClusterID(HubAmAccessorSecretName, hubInfo.HubClusterID))
 	}
 
-	err = RevertUserWorkloadMonitoringConfig(ctx, c, hubInfo)
+	err = RevertUserWorkloadMonitoringConfig(ctx, c, amMtlsCARef)
 	if err != nil {
 		t.Fatalf("Run into error when try to revert user-workload-monitoring-config configmap twice: (%v)", err)
 	}
@@ -712,7 +675,15 @@ prometheus:
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
 	// Test disabling alert forwarding
-	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", "")
+	err = CreateOrUpdateUserWorkloadMonitoringConfig(
+		ctx,
+		c,
+		hubInfo.AlertmanagerEndpoint,
+		hubInfo.UWMAlertingDisabled,
+		AppendHubClusterID(amMtlsCaName, hubInfo.HubClusterID),
+		AppendHubClusterID(amMtlsCertName, hubInfo.HubClusterID),
+		AppendHubClusterID(HubAmAccessorSecretName, hubInfo.HubClusterID),
+	)
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -757,7 +728,15 @@ prometheus:
 		t.Fatalf("Failed to unmarshal hubInfo: (%v)", err)
 	}
 
-	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", "")
+	err = CreateOrUpdateUserWorkloadMonitoringConfig(
+		ctx,
+		c,
+		hubInfo.AlertmanagerEndpoint,
+		hubInfo.UWMAlertingDisabled,
+		AppendHubClusterID(amMtlsCaName, hubInfo.HubClusterID),
+		AppendHubClusterID(amMtlsCertName, hubInfo.HubClusterID),
+		AppendHubClusterID(HubAmAccessorSecretName, hubInfo.HubClusterID),
+	)
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -795,8 +774,8 @@ prometheus:
 	}
 
 	containsOCMAlertmanagerConfig := false
-	amMtlsCARef := AppendHubClusterID(amMtlsCaName, hubInfo)
-	amMtlsCertRef := AppendHubClusterID(amMtlsCertName, hubInfo)
+	amMtlsCARef := AppendHubClusterID(amMtlsCaName, hubInfo.HubClusterID)
+	amMtlsCertRef := AppendHubClusterID(amMtlsCertName, hubInfo.HubClusterID)
 	for _, v := range foundUserWorkloadConfiguration.Prometheus.AlertmanagerConfigs {
 		if v.TLSConfig.CA != nil && v.TLSConfig.CA.Name == amMtlsCARef &&
 			v.TLSConfig.Cert != nil && v.TLSConfig.Cert.Name == amMtlsCertRef &&
@@ -843,7 +822,15 @@ prometheus:
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
 	// Test with UWM alerting disabled
-	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", "")
+	err = CreateOrUpdateUserWorkloadMonitoringConfig(
+		ctx,
+		c,
+		hubInfo.AlertmanagerEndpoint,
+		hubInfo.UWMAlertingDisabled,
+		AppendHubClusterID(amMtlsCaName, hubInfo.HubClusterID),
+		AppendHubClusterID(amMtlsCertName, hubInfo.HubClusterID),
+		AppendHubClusterID(HubAmAccessorSecretName, hubInfo.HubClusterID),
+	)
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -888,7 +875,15 @@ prometheus:
 		t.Fatalf("Failed to unmarshal hubInfo: (%v)", err)
 	}
 
-	err = CreateOrUpdateUserWorkloadMonitoringConfig(ctx, c, hubInfo, "", "", "")
+	err = CreateOrUpdateUserWorkloadMonitoringConfig(
+		ctx,
+		c,
+		hubInfo.AlertmanagerEndpoint,
+		hubInfo.UWMAlertingDisabled,
+		AppendHubClusterID(amMtlsCaName, hubInfo.HubClusterID),
+		AppendHubClusterID(amMtlsCertName, hubInfo.HubClusterID),
+		AppendHubClusterID(HubAmAccessorSecretName, hubInfo.HubClusterID),
+	)
 	if err != nil {
 		t.Fatalf("Failed to create or update the user-workload-monitoring-config configmap: (%v)", err)
 	}
@@ -926,8 +921,8 @@ prometheus:
 	}
 
 	containsOCMAlertmanagerConfig := false
-	amMtlsCARef := AppendHubClusterID(amMtlsCaName, hubInfo)
-	amMtlsCertRef := AppendHubClusterID(amMtlsCertName, hubInfo)
+	amMtlsCARef := AppendHubClusterID(amMtlsCaName, hubInfo.HubClusterID)
+	amMtlsCertRef := AppendHubClusterID(amMtlsCertName, hubInfo.HubClusterID)
 	for _, v := range foundUserWorkloadConfiguration.Prometheus.AlertmanagerConfigs {
 		if v.TLSConfig.CA != nil && v.TLSConfig.CA.Name == amMtlsCARef &&
 			v.TLSConfig.Cert != nil && v.TLSConfig.Cert.Name == amMtlsCertRef &&
@@ -1048,7 +1043,7 @@ userWorkloadEnabled: false
 				for _, config := range parsed.Prometheus.AlertmanagerConfigs {
 					if config.TLSConfig.CA != nil &&
 						(config.TLSConfig.CA.Name == amMtlsCaName ||
-							config.TLSConfig.CA.Name == AppendHubClusterID(amMtlsCaName, hubInfo)) {
+							config.TLSConfig.CA.Name == AppendHubClusterID(amMtlsCaName, hubInfo.HubClusterID)) {
 						t.Fatalf("UWL configmap still contains ACM alertmanager configuration when it should be cleaned up")
 					}
 				}
@@ -1162,7 +1157,7 @@ enableUserWorkload: true
 	}
 
 	// Verify that the ACM alertmanager configuration is present by checking for the mTLS CA secret
-	if !strings.Contains(configYAML, AppendHubClusterID(amMtlsCaName, hubInfo)) {
+	if !strings.Contains(configYAML, AppendHubClusterID(amMtlsCaName, hubInfo.HubClusterID)) {
 		t.Fatalf("UWL configmap should contain ACM alertmanager configuration with mTLS CA secret reference")
 	}
 
@@ -1177,8 +1172,6 @@ enableUserWorkload: true
 // When two stanzas target the same hub Alertmanager URL with different TLS (legacy router CA vs mTLS),
 // reconcile must leave a single fresh ACM stanza, not both.
 func TestClusterMonitoringConfigDedupeMultipleAdditionalAlertmanagers(t *testing.T) {
-	AMSecretCleanupDone = false
-	AMSecretCleanupDoneUWL = false
 	testNamespace := "test-ns"
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
 
@@ -1206,7 +1199,7 @@ prometheusK8s:
     tlsConfig:
       ca:
         key: service-ca.crt
-        name: hub-alertmanager-router-ca
+        name: hub-alertmanager-router-ca-1a9af6dc0801433cb28a200af81
       insecureSkipVerify: true
   - apiVersion: v2
     bearerToken:
@@ -1227,7 +1220,7 @@ prometheusK8s:
         key: tls.key
         name: obs-alertmanager-mtls-cert-1a9af6dc0801433cb28a200af81
       insecureSkipVerify: false
-`
+ `
 
 	amAccessSrt := newAMAccessorSecret(testNamespace, "test-token")
 	cmoCfg := newClusterMonitoringConfigCM(diffYAML, EndpointMonitoringOperatorMgr)
@@ -1246,14 +1239,17 @@ prometheusK8s:
 	if err != nil {
 		t.Fatalf("get configmap: %v", err)
 	}
-	yamlStr, ok := found.Data[ClusterMonitoringConfigDataKey]
+
+	foundClusterMonitoringConfigurationYAML, ok := HasClusterMonitoringConfigData(found)
 	if !ok {
-		t.Fatalf("configmap missing %s", ClusterMonitoringConfigDataKey)
+		t.Fatalf("configmap: %s doesn't contain key: config.yaml", clusterMonitoringConfigName)
 	}
-	foundJSON, err := yamltool.YAMLToJSON([]byte(yamlStr))
+
+	foundJSON, err := yamltool.YAMLToJSON([]byte(foundClusterMonitoringConfigurationYAML))
 	if err != nil {
-		t.Fatalf("YAMLToJSON: %v", err)
+		t.Fatalf("failed to transform YAML to JSON:\n%s\n", foundClusterMonitoringConfigurationYAML)
 	}
+
 	parsed := &cmomanifests.ClusterMonitoringConfiguration{}
 	if err := json.Unmarshal(foundJSON, parsed); err != nil {
 		t.Fatalf("unmarshal cluster monitoring config: %v", err)
@@ -1265,72 +1261,103 @@ prometheusK8s:
 	if len(amCfgs) != 1 {
 		t.Fatalf("expected exactly 1 additionalAlertmanagerConfig after dedupe, got %d", len(amCfgs))
 	}
-	if amCfgs[0].TLSConfig.CA == nil || amCfgs[0].TLSConfig.CA.Name != AppendHubClusterID(amMtlsCaName, hubInfo) {
-		t.Fatalf("expected single mTLS ACM alertmanager config (CA %q), got %#v", AppendHubClusterID(amMtlsCaName, hubInfo), amCfgs[0].TLSConfig.CA)
+	if amCfgs[0].TLSConfig.CA == nil || amCfgs[0].TLSConfig.CA.Name != AppendHubClusterID(amMtlsCaName, hubInfo.HubClusterID) {
+		t.Fatalf("expected single mTLS ACM alertmanager config (CA %q), got %#v", AppendHubClusterID(amMtlsCaName, hubInfo.HubClusterID), amCfgs[0].TLSConfig.CA)
 	}
-	if amCfgs[0].TLSConfig.Cert == nil || amCfgs[0].TLSConfig.Cert.Name != AppendHubClusterID(amMtlsCertName, hubInfo) {
+	if amCfgs[0].TLSConfig.Cert == nil || amCfgs[0].TLSConfig.Cert.Name != AppendHubClusterID(amMtlsCertName, hubInfo.HubClusterID) {
 		t.Fatalf("expected mTLS client cert on deduped config, got cert ref %#v", amCfgs[0].TLSConfig.Cert)
 	}
 }
 
-func TestClusterMonitoringCleanupGlobalHub(t *testing.T) {
-	AMSecretCleanupDone = false
-	AMSecretCleanupDoneUWL = false
-	testNamespace := "test-ns"
-	amAccessSrt := newAMAccessorSecret(testNamespace, "test-token")
-	hubInfo := &operatorconfig.HubInfo{
-		ClusterName:              "test-cluster",
-		ObservatoriumAPIEndpoint: "http://test-endpoint.abc.12345.com",
-		AlertmanagerEndpoint:     "http://test-alertamanger-endpoint",
-		HubClusterID:             "1a9af6dc0801433cb28a200af81",
-	}
-	cmoCfg := newClusterMonitoringConfigCM(clusterMonitoringConfigDataYamlCleanupGH, EndpointMonitoringOperatorMgr)
-	ghObjs := []runtime.Object{newHubInfoSecret([]byte(hubInfoYAML), testNamespace), cmoCfg, amAccessSrt}
-	ghObjs = append(ghObjs, newMtlsTestSecrets(testNamespace)...)
-	client := fake.NewClientBuilder().WithRuntimeObjects(ghObjs...).Build()
-	wasUpdated, err := createOrUpdateClusterMonitoringConfig(context.Background(), hubInfo, testClusterID, client, false, testNamespace)
-	if err != nil {
-		t.Fatalf("Failed to create or update the cluster-monitoring-config configmap: (%v)", err)
-	}
-	assert.True(t, wasUpdated)
+func TestIsManaged(t *testing.T) {
+	t.Parallel()
 
-	cmoCfgBeforeUpdate := &corev1.ConfigMap{}
-	err = client.Get(context.Background(), types.NamespacedName{Name: clusterMonitoringConfigName, Namespace: promNamespace}, cmoCfgBeforeUpdate)
-	if err != nil {
-		t.Fatalf("failed to check configmap %s: %v", clusterMonitoringConfigName, err)
+	tests := []struct {
+		name     string
+		caName   string
+		caSecret string
+		expected bool
+	}{
+		{
+			name:     "Nil CA config",
+			caName:   "",
+			caSecret: "obs-alertmanager-mtls-ca-AAAA",
+			expected: false,
+		},
+		{
+			name:     "Empty caSecret",
+			caName:   "obs-alertmanager-mtls-ca-AAAA",
+			caSecret: "",
+			expected: false,
+		},
+		{
+			name:     "Exact match",
+			caName:   "obs-alertmanager-mtls-ca-AAAA",
+			caSecret: "obs-alertmanager-mtls-ca-AAAA",
+			expected: true,
+		},
+		{
+			name:     "Cross-base suffix match (migration/upgrade path)",
+			caName:   "hub-alertmanager-router-ca-AAAA",
+			caSecret: "obs-alertmanager-mtls-ca-AAAA",
+			expected: true,
+		},
+		{
+			name:     "Reverse cross-base suffix match",
+			caName:   "obs-alertmanager-mtls-ca-AAAA",
+			caSecret: "hub-alertmanager-router-ca-AAAA",
+			expected: true,
+		},
+		{
+			name:     "No suffix (bare base name exact match)",
+			caName:   "obs-alertmanager-mtls-ca",
+			caSecret: "obs-alertmanager-mtls-ca",
+			expected: true,
+		},
+		{
+			name:     "No suffix (bare base name cross-base match - should be false since suffix requires hyphen)",
+			caName:   "hub-alertmanager-router-ca",
+			caSecret: "obs-alertmanager-mtls-ca",
+			expected: false,
+		},
+		{
+			name:     "Mismatched suffixes",
+			caName:   "obs-alertmanager-mtls-ca-AAAA",
+			caSecret: "hub-alertmanager-router-ca-BBBB",
+			expected: false,
+		},
+		{
+			name:     "Coincidental ending matching suffix but not our base",
+			caName:   "some-other-secret-ca-AAAA",
+			caSecret: "obs-alertmanager-mtls-ca-AAAA",
+			expected: false,
+		},
+		{
+			name:     "Only hyphen as suffix",
+			caName:   "obs-alertmanager-mtls-ca-",
+			caSecret: "obs-alertmanager-mtls-ca-",
+			expected: true,
+		},
+		{
+			name:     "Only hyphen cross-base match (should fail since suffix must have length > 1)",
+			caName:   "hub-alertmanager-router-ca-",
+			caSecret: "obs-alertmanager-mtls-ca-",
+			expected: false,
+		},
 	}
 
-	// After reconcile, legacy hub-alertmanager-router-ca stanzas must be gone (including
-	// unsuffixed, cluster-domain-suffixed, and HubClusterID-suffixed names — see isOldManagedConfig).
-	foundClusterMonitoringConfigurationYAML, ok := HasClusterMonitoringConfigData(cmoCfgBeforeUpdate)
-	if !ok {
-		t.Fatalf("configmap: %s doesn't contain key: config.yaml", clusterMonitoringConfigName)
-	}
-
-	foundClusterMonitoringConfigurationJSON, err := yamltool.YAMLToJSON([]byte(foundClusterMonitoringConfigurationYAML))
-	if err != nil {
-		t.Fatalf("failed to transform YAML to JSON:\n%s\n", foundClusterMonitoringConfigurationYAML)
-	}
-
-	foundClusterMonitoringConfiguration := &cmomanifests.ClusterMonitoringConfiguration{}
-	if err := json.Unmarshal([]byte(foundClusterMonitoringConfigurationJSON), foundClusterMonitoringConfiguration); err != nil {
-		t.Fatalf("failed to marshal the cluster monitoring config: %v:\n%s\n", err, foundClusterMonitoringConfigurationJSON)
-	}
-
-	clusterDomain := mcoconfig.GetClusterName(hubInfo.ObservatoriumAPIEndpoint)
-	if foundClusterMonitoringConfiguration.PrometheusK8sConfig != nil &&
-		foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs != nil {
-		for _, v := range foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs {
-			if v.TLSConfig.CA == nil {
-				continue
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var amc cmomanifests.AdditionalAlertmanagerConfig
+			if tt.caName != "" {
+				amc.TLSConfig.CA = &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: tt.caName,
+					},
+				}
 			}
-			name := v.TLSConfig.CA.Name
-			switch name {
-			case HubAmRouterCASecretName,
-				HubAmRouterCASecretName + "-" + clusterDomain,
-				HubAmRouterCASecretName + "-" + hubInfo.HubClusterID:
-				t.Fatalf("%q secret reference should be removed from the cluster-monitoring-config configmap (legacy router CA)", name)
-			}
-		}
+			result := IsManaged(amc, tt.caSecret)
+			assert.Equal(t, tt.expected, result)
+		})
 	}
 }

--- a/operators/endpointmetrics/controllers/observabilityendpoint/predicate_func.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/predicate_func.go
@@ -52,8 +52,10 @@ func getPred(name string, namespace string,
 					}
 				case e.ObjectNew.GetName() == obAddonName ||
 					e.ObjectNew.GetObjectKind().GroupVersionKind().Kind == "ObservabilityAddon":
-					if !reflect.DeepEqual(e.ObjectNew.(*oav1beta1.ObservabilityAddon).Spec,
-						e.ObjectOld.(*oav1beta1.ObservabilityAddon).Spec) {
+					specChanged := !reflect.DeepEqual(e.ObjectNew.(*oav1beta1.ObservabilityAddon).Spec,
+						e.ObjectOld.(*oav1beta1.ObservabilityAddon).Spec)
+					delChanged := e.ObjectNew.GetDeletionTimestamp() != e.ObjectOld.GetDeletionTimestamp()
+					if specChanged || delChanged {
 						return true
 					}
 				default:

--- a/operators/endpointmetrics/controllers/observabilityendpoint/predicate_func.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/predicate_func.go
@@ -10,8 +10,9 @@ import (
 	"strings"
 
 	oav1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -45,8 +46,8 @@ func getPred(name string, namespace string,
 				switch {
 				case strings.HasPrefix(fmt.Sprint(e.ObjectNew), "&Deployment") ||
 					e.ObjectNew.GetObjectKind().GroupVersionKind().Kind == "Deployment":
-					if !reflect.DeepEqual(e.ObjectNew.(*v1.Deployment).Spec.Template.Spec,
-						e.ObjectOld.(*v1.Deployment).Spec.Template.Spec) {
+					if !reflect.DeepEqual(e.ObjectNew.(*appsv1.Deployment).Spec.Template.Spec,
+						e.ObjectOld.(*appsv1.Deployment).Spec.Template.Spec) {
 						return true
 					}
 				case e.ObjectNew.GetName() == obAddonName ||
@@ -77,28 +78,44 @@ func getPred(name string, namespace string,
 	}
 }
 
-func configMapDataChangedPredicate(name, namespace string) predicate.Funcs {
+// DataChangedPredicate builder for resources where we only care about Data changes (ConfigMaps, Secrets).
+func DataChangedPredicate[T client.Object](name, namespace string, getData func(T) any) predicate.Funcs {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			oldCM, okOld := e.ObjectOld.(*corev1.ConfigMap)
-			newCM, okNew := e.ObjectNew.(*corev1.ConfigMap)
-			if !okOld || !okNew {
+			oldObj, okOld := e.ObjectOld.(T)
+			newObj, okNew := e.ObjectNew.(T)
+			// Ensure objects are non-nil to avoid panics on method calls (GetName, GetNamespace)
+			if !okOld || !okNew || reflect.ValueOf(oldObj).IsNil() || reflect.ValueOf(newObj).IsNil() {
 				return false
 			}
 
-			if newCM.Name != name || newCM.Namespace != namespace {
+			if (name != "" && newObj.GetName() != name) || (namespace != "" && newObj.GetNamespace() != namespace) {
 				return false
 			}
 
-			return !reflect.DeepEqual(oldCM.Data, newCM.Data)
+			return !reflect.DeepEqual(getData(oldObj), getData(newObj))
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
-			cm, ok := e.Object.(*corev1.ConfigMap)
-			return ok && cm.Name == name && cm.Namespace == namespace
+			obj, ok := e.Object.(T)
+			return ok && !reflect.ValueOf(obj).IsNil() && (name == "" || obj.GetName() == name) && (namespace == "" || obj.GetNamespace() == namespace)
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			cm, ok := e.Object.(*corev1.ConfigMap)
-			return ok && cm.Name == name && cm.Namespace == namespace
+			obj, ok := e.Object.(T)
+			return ok && !reflect.ValueOf(obj).IsNil() && (name == "" || obj.GetName() == name) && (namespace == "" || obj.GetNamespace() == namespace)
 		},
 	}
+}
+
+// ConfigMapDataChangedPredicate returns a predicate that filters for ConfigMap data changes.
+func ConfigMapDataChangedPredicate(name, namespace string) predicate.Funcs {
+	return DataChangedPredicate(name, namespace, func(cm *corev1.ConfigMap) any {
+		return cm.Data
+	})
+}
+
+// SecretDataChangedPredicate returns a predicate that filters for Secret data changes.
+func SecretDataChangedPredicate(name, namespace string) predicate.Funcs {
+	return DataChangedPredicate(name, namespace, func(s *corev1.Secret) any {
+		return s.Data
+	})
 }

--- a/operators/endpointmetrics/controllers/observabilityendpoint/predicate_func_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/predicate_func_test.go
@@ -163,3 +163,182 @@ func TestPredFunc(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigMapDataChangedPredicate(t *testing.T) {
+	name := "test-cm"
+	namespace := "test-ns"
+
+	tests := []struct {
+		name      string
+		predName  string
+		predNS    string
+		oldCM     *v1.ConfigMap
+		newCM     *v1.ConfigMap
+		expUpdate bool
+		expCreate bool
+		expDelete bool
+	}{
+		{
+			name:     "Wildcard - Data changed",
+			predName: "",
+			predNS:   "",
+			oldCM: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data:       map[string]string{"foo": "bar"},
+			},
+			newCM: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data:       map[string]string{"foo": "baz"},
+			},
+			expUpdate: true,
+			expCreate: true,
+			expDelete: true,
+		},
+		{
+			name:     "Wildcard - Data unchanged",
+			predName: "",
+			predNS:   "",
+			oldCM: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data:       map[string]string{"foo": "bar"},
+			},
+			newCM: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data:       map[string]string{"foo": "bar"},
+			},
+			expUpdate: false,
+			expCreate: true,
+			expDelete: true,
+		},
+		{
+			name:     "Specific match - Name mismatch",
+			predName: "other-cm",
+			predNS:   namespace,
+			oldCM: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			},
+			newCM: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data:       map[string]string{"foo": "bar"},
+			},
+			expUpdate: false,
+			expCreate: false,
+			expDelete: false,
+		},
+		{
+			name:     "Specific match - Namespace mismatch",
+			predName: name,
+			predNS:   "other-ns",
+			oldCM: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			},
+			newCM: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data:       map[string]string{"foo": "bar"},
+			},
+			expUpdate: false,
+			expCreate: false,
+			expDelete: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pred := ConfigMapDataChangedPredicate(tt.predName, tt.predNS)
+
+			ce := event.CreateEvent{Object: tt.newCM}
+			if pred.CreateFunc(ce) != tt.expCreate {
+				t.Errorf("CreateFunc expected %v", tt.expCreate)
+			}
+
+			de := event.DeleteEvent{Object: tt.newCM}
+			if pred.DeleteFunc(de) != tt.expDelete {
+				t.Errorf("DeleteFunc expected %v", tt.expDelete)
+			}
+
+			ue := event.UpdateEvent{ObjectOld: tt.oldCM, ObjectNew: tt.newCM}
+			if pred.UpdateFunc(ue) != tt.expUpdate {
+				t.Errorf("UpdateFunc expected %v", tt.expUpdate)
+			}
+		})
+	}
+}
+
+func TestSecretDataChangedPredicate(t *testing.T) {
+	name := "test-secret"
+	namespace := "test-ns"
+
+	tests := []struct {
+		name      string
+		predName  string
+		predNS    string
+		oldSrt    *v1.Secret
+		newSrt    *v1.Secret
+		expUpdate bool
+		expCreate bool
+		expDelete bool
+	}{
+		{
+			name:     "Wildcard - Data changed",
+			predName: "",
+			predNS:   "",
+			oldSrt: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data:       map[string][]byte{"token": []byte("old")},
+			},
+			newSrt: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data:       map[string][]byte{"token": []byte("new")},
+			},
+			expUpdate: true,
+			expCreate: true,
+			expDelete: true,
+		},
+		{
+			name:     "Specific match - Name match",
+			predName: name,
+			predNS:   namespace,
+			oldSrt: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			},
+			newSrt: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data:       map[string][]byte{"token": []byte("new")},
+			},
+			expUpdate: true,
+			expCreate: true,
+			expDelete: true,
+		},
+		{
+			name:      "Type mismatch",
+			predName:  "",
+			predNS:    "",
+			oldSrt:    &v1.Secret{},
+			newSrt:    nil, // This should trigger the !ok check
+			expUpdate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pred := SecretDataChangedPredicate(tt.predName, tt.predNS)
+
+			if tt.newSrt != nil {
+				ce := event.CreateEvent{Object: tt.newSrt}
+				if pred.CreateFunc(ce) != tt.expCreate {
+					t.Errorf("CreateFunc expected %v", tt.expCreate)
+				}
+
+				de := event.DeleteEvent{Object: tt.newSrt}
+				if pred.DeleteFunc(de) != tt.expDelete {
+					t.Errorf("DeleteFunc expected %v", tt.expDelete)
+				}
+			}
+
+			ue := event.UpdateEvent{ObjectOld: tt.oldSrt, ObjectNew: tt.newSrt}
+			if pred.UpdateFunc(ue) != tt.expUpdate {
+				t.Errorf("UpdateFunc expected %v", tt.expUpdate)
+			}
+		})
+	}
+}

--- a/operators/endpointmetrics/main.go
+++ b/operators/endpointmetrics/main.go
@@ -71,9 +71,9 @@ func printVersion() {
 }
 
 var (
-	mcoaRunner    = runMCOA
-	legacyRunner  = runLegacy
-	cleanupRunner = runCleanup
+	mcoaRunner     = runMCOA
+	standardRunner = runStandard
+	cleanupRunner  = runCleanup
 )
 
 func main() {
@@ -82,7 +82,7 @@ func main() {
 }
 
 func execute(args []string) {
-	cmd := "legacy"
+	cmd := "standard"
 	if len(args) > 1 {
 		cmd = args[1]
 	}
@@ -91,20 +91,20 @@ func execute(args []string) {
 	case "mcoa":
 		// len(args) >= 2 is guaranteed since args[1] matches "mcoa"
 		mcoaRunner(args[2:])
-	case "legacy":
-		// Guard against len(args) == 1 (no arguments) defaulting to legacy mode
+	case "standard", "legacy":
+		// Guard against len(args) == 1 (no arguments) defaulting to standard mode
 		subArgs := []string{}
 		if len(args) > 2 {
 			subArgs = args[2:]
 		}
-		legacyRunner(subArgs)
+		standardRunner(subArgs)
 	case "cleanup":
 		// len(args) >= 2 is guaranteed since args[1] matches "cleanup"
 		cleanupRunner(args[2:])
 	default:
-		// default to legacy for backward compatibility if argument is just a flag
+		// default to standard for backward compatibility if argument is just a flag
 		// len(args) >= 2 is guaranteed since len(args) > 1 and it did not match subcommands above
-		legacyRunner(args[1:])
+		standardRunner(args[1:])
 	}
 }
 
@@ -124,6 +124,7 @@ func doCleanup(args []string) error {
 
 	fs.StringVar(&hubID, "hub-id", "", "The ID of the Hub cluster to clean up.")
 	klog.InitFlags(fs)
+	// Parse will exit on error due to flag.ExitOnError, so we can ignore the error return value.
 	_ = fs.Parse(args)
 
 	if hubID == "" {
@@ -146,22 +147,48 @@ func doCleanup(args []string) error {
 	var errs []error
 
 	caSecret := obsepctl.AppendHubClusterID(obsepctl.HubAmRouterCASecretName, hubInfo.HubClusterID)
+	mtlsCASecret := obsepctl.AppendHubClusterID(obsepctl.HubAmMtlsCASecretName, hubInfo.HubClusterID)
 
-	setupLog.Info("Reverting Platform monitoring configuration")
+	setupLog.Info("Reverting Platform monitoring configuration (Router CA)")
 	if err := obsepctl.RevertClusterMonitoringConfig(ctx, cl, caSecret); err != nil {
-		setupLog.Error(err, "failed to revert platform monitoring config")
+		setupLog.Error(err, "failed to revert platform monitoring config (Router CA)")
 		errs = append(errs, err)
 	}
 
 	if ctx.Err() != nil {
 		setupLog.Error(ctx.Err(), "cleanup context canceled or timed out, aborting remaining steps")
 		errs = append(errs, ctx.Err())
-	} else {
-		setupLog.Info("Reverting User Workload monitoring configuration")
-		if err := obsepctl.RevertUserWorkloadMonitoringConfig(ctx, cl, caSecret); err != nil {
-			setupLog.Error(err, "failed to revert user workload monitoring config")
-			errs = append(errs, err)
-		}
+		return fmt.Errorf("cleanup failed: %w", errors.Join(errs...))
+	}
+
+	setupLog.Info("Reverting User Workload monitoring configuration (Router CA)")
+	if err := obsepctl.RevertUserWorkloadMonitoringConfig(ctx, cl, caSecret); err != nil {
+		setupLog.Error(err, "failed to revert user workload monitoring config (Router CA)")
+		errs = append(errs, err)
+	}
+
+	if ctx.Err() != nil {
+		setupLog.Error(ctx.Err(), "cleanup context canceled or timed out, aborting remaining steps")
+		errs = append(errs, ctx.Err())
+		return fmt.Errorf("cleanup failed: %w", errors.Join(errs...))
+	}
+
+	setupLog.Info("Reverting Platform monitoring configuration (mTLS CA)")
+	if err := obsepctl.RevertClusterMonitoringConfig(ctx, cl, mtlsCASecret); err != nil {
+		setupLog.Error(err, "failed to revert platform monitoring config (mTLS CA)")
+		errs = append(errs, err)
+	}
+
+	if ctx.Err() != nil {
+		setupLog.Error(ctx.Err(), "cleanup context canceled or timed out, aborting remaining steps")
+		errs = append(errs, ctx.Err())
+		return fmt.Errorf("cleanup failed: %w", errors.Join(errs...))
+	}
+
+	setupLog.Info("Reverting User Workload monitoring configuration (mTLS CA)")
+	if err := obsepctl.RevertUserWorkloadMonitoringConfig(ctx, cl, mtlsCASecret); err != nil {
+		setupLog.Error(err, "failed to revert user workload monitoring config (mTLS CA)")
+		errs = append(errs, err)
 	}
 
 	if len(errs) > 0 {
@@ -199,6 +226,7 @@ func runMCOA(args []string) {
 	fs.BoolVar(&enableUWLAlertForwarding, "enable-uwl-alert-forwarding", true, "Enable or disable forwarding of user workload monitoring alerts.")
 
 	klog.InitFlags(fs)
+	// Parse will exit on error due to flag.ExitOnError, so we can ignore the error return value.
 	_ = fs.Parse(args)
 
 	ctrl.SetLogger(klog.NewKlogr())
@@ -252,9 +280,9 @@ func runMCOA(args []string) {
 
 	if err = mcoa.NewMCOAAgentReconciler(
 		mgr.GetClient(),
-		ctrl.Log.WithName("controllers").WithName("MCOA-Agent"),
+		ctrl.Log.WithName("controllers").WithName("mcoa-endpoint-controller"),
 		mgr.GetScheme(),
-		mgr.GetEventRecorderFor("mcoa-agent-controller"),
+		mgr.GetEventRecorderFor("mcoa-endpoint-controller"),
 		namespace,
 		clusterID,
 		hubAmURL,
@@ -263,7 +291,7 @@ func runMCOA(args []string) {
 		hubAmAccessorSecret,
 		enableUWLAlertForwarding,
 	).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "MCOA-Agent")
+		setupLog.Error(err, "unable to create controller", "controller", "mcoa-endpoint-controller")
 		os.Exit(1)
 	}
 
@@ -279,9 +307,9 @@ func runMCOA(args []string) {
 	}
 }
 
-func runLegacy(args []string) {
+func runStandard(args []string) {
 	ctrl.SetLogger(klog.NewKlogr())
-	setupLog.Info("Starting legacy mode")
+	setupLog.Info("Starting standard mode")
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
@@ -292,6 +320,7 @@ func runLegacy(args []string) {
 			"Enabling this will ensure there is only one active controller manager.")
 
 	klog.InitFlags(flag.CommandLine)
+	// flag.CommandLine is configured to exit on error (flag.ExitOnError), so we can ignore the error return value.
 	_ = flag.CommandLine.Parse(args)
 
 	namespaceSelector := fmt.Sprintf("metadata.namespace==%s", os.Getenv("WATCH_NAMESPACE"))

--- a/operators/endpointmetrics/main.go
+++ b/operators/endpointmetrics/main.go
@@ -134,14 +134,16 @@ func runCleanup(args []string) {
 	ctx := context.Background()
 	var errs []error
 
+	caSecret := obsepctl.AppendHubClusterID(obsepctl.HubAmRouterCASecretName, hubInfo.HubClusterID)
+
 	setupLog.Info("Reverting Platform monitoring configuration")
-	if err := obsepctl.RevertClusterMonitoringConfig(ctx, cl, hubInfo); err != nil {
+	if err := obsepctl.RevertClusterMonitoringConfig(ctx, cl, caSecret); err != nil {
 		setupLog.Error(err, "failed to revert platform monitoring config")
 		errs = append(errs, err)
 	}
 
 	setupLog.Info("Reverting User Workload monitoring configuration")
-	if err := obsepctl.RevertUserWorkloadMonitoringConfig(ctx, cl, hubInfo); err != nil {
+	if err := obsepctl.RevertUserWorkloadMonitoringConfig(ctx, cl, caSecret); err != nil {
 		setupLog.Error(err, "failed to revert user workload monitoring config")
 		errs = append(errs, err)
 	}
@@ -166,6 +168,7 @@ func runMCOA(args []string) {
 	var hubAmCASecret string
 	var hubAmCertSecret string
 	var hubAmAccessorSecret string
+	var enableUWLAlertForwarding bool
 
 	fs.StringVar(&metricsAddr, "metrics-bind-address", ":8383", "The address the metric endpoint binds to.")
 	fs.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -178,6 +181,7 @@ func runMCOA(args []string) {
 	fs.StringVar(&hubAmCASecret, "hub-alertmanager-ca-secret", "", "The name of the CA secret for the Hub's Alertmanager.")
 	fs.StringVar(&hubAmCertSecret, "hub-alertmanager-cert-secret", "", "The name of the TLS cert/key secret for the Hub's Alertmanager.")
 	fs.StringVar(&hubAmAccessorSecret, "hub-alertmanager-accessor-secret", "", "The name of the accessor token secret for the Hub's Alertmanager.")
+	fs.BoolVar(&enableUWLAlertForwarding, "enable-uwl-alert-forwarding", true, "Enable or disable forwarding of user workload monitoring alerts.")
 
 	klog.InitFlags(fs)
 	_ = fs.Parse(args)
@@ -218,10 +222,6 @@ func runMCOA(args []string) {
 		os.Exit(1)
 	}
 
-	hubInfo := &operatorconfig.HubInfo{
-		AlertmanagerEndpoint: hubAmURL,
-	}
-
 	if err = mcoa.NewMCOAAgentReconciler(
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName("MCOA-Agent"),
@@ -229,10 +229,11 @@ func runMCOA(args []string) {
 		mgr.GetEventRecorderFor("mcoa-agent-controller"),
 		namespace,
 		clusterID,
-		hubInfo,
+		hubAmURL,
 		hubAmCASecret,
 		hubAmCertSecret,
 		hubAmAccessorSecret,
+		enableUWLAlertForwarding,
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MCOA-Agent")
 		os.Exit(1)

--- a/operators/endpointmetrics/main.go
+++ b/operators/endpointmetrics/main.go
@@ -92,14 +92,14 @@ func main() {
 func runCleanup(args []string) {
 	setupLog.Info("Starting MCOA cleanup")
 	fs := flag.NewFlagSet("cleanup", flag.ExitOnError)
-	var hubClusterID string
+	var hubID string
 
-	fs.StringVar(&hubClusterID, "hub-cluster-id", "", "The ID of the Hub cluster to clean up.")
+	fs.StringVar(&hubID, "hub-id", "", "The ID of the Hub cluster to clean up.")
 	klog.InitFlags(fs)
 	_ = fs.Parse(args)
 
-	if hubClusterID == "" {
-		setupLog.Error(fmt.Errorf("hub-cluster-id flag not set"), "unable to perform cleanup")
+	if hubID == "" {
+		setupLog.Error(fmt.Errorf("hub-id flag not set"), "unable to perform cleanup")
 		os.Exit(1)
 	}
 
@@ -111,7 +111,7 @@ func runCleanup(args []string) {
 	}
 
 	hubInfo := &operatorconfig.HubInfo{
-		HubClusterID: hubClusterID,
+		HubClusterID: hubID,
 	}
 
 	ctx := context.Background()
@@ -144,7 +144,9 @@ func runMCOA(args []string) {
 	var enableLeaderElection bool
 	var probeAddr string
 	var hubAmURL string
-	var hubClusterID string
+	var hubID string
+	var clusterID string
+	var namespace string
 
 	fs.StringVar(&metricsAddr, "metrics-bind-address", ":8383", "The address the metric endpoint binds to.")
 	fs.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -152,24 +154,22 @@ func runMCOA(args []string) {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	fs.StringVar(&hubAmURL, "hub-alertmanager-url", "", "The URL of the Hub's Alertmanager.")
-	fs.StringVar(&hubClusterID, "hub-cluster-id", "", "The ID of the Hub cluster.")
+	fs.StringVar(&hubID, "hub-id", "", "The ID of the Hub cluster.")
+	fs.StringVar(&clusterID, "cluster-id", "", "The ID of the managed cluster.")
+	fs.StringVar(&namespace, "namespace", "", "The namespace the operator is running in.")
 
 	klog.InitFlags(fs)
 	_ = fs.Parse(args)
 
 	ctrl.SetLogger(klog.NewKlogr())
 
-	namespace := os.Getenv("NAMESPACE")
 	if namespace == "" {
-		namespace = os.Getenv("WATCH_NAMESPACE")
-	}
-	if namespace == "" {
-		setupLog.Error(fmt.Errorf("NAMESPACE environment variable not set"), "unable to start manager")
+		setupLog.Error(fmt.Errorf("namespace flag not set"), "unable to start manager")
 		os.Exit(1)
 	}
 
-	if hubClusterID == "" {
-		setupLog.Error(fmt.Errorf("hub-cluster-id flag not set"), "unable to start manager")
+	if hubID == "" {
+		setupLog.Error(fmt.Errorf("hub-id flag not set"), "unable to start manager")
 		os.Exit(1)
 	}
 
@@ -189,7 +189,7 @@ func runMCOA(args []string) {
 
 	hubInfo := &operatorconfig.HubInfo{
 		AlertmanagerEndpoint: hubAmURL,
-		HubClusterID:         hubClusterID,
+		HubClusterID:         hubID,
 	}
 
 	if err = mcoa.NewMCOAAgentReconciler(
@@ -198,6 +198,7 @@ func runMCOA(args []string) {
 		mgr.GetScheme(),
 		mgr.GetEventRecorderFor("mcoa-agent-controller"),
 		namespace,
+		clusterID,
 		hubInfo,
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MCOA-Agent")

--- a/operators/endpointmetrics/main.go
+++ b/operators/endpointmetrics/main.go
@@ -164,6 +164,9 @@ func runMCOA(args []string) {
 	var hubID string
 	var clusterID string
 	var namespace string
+	var hubAmCASecret string
+	var hubAmCertSecret string
+	var hubAmAccessorSecret string
 
 	fs.StringVar(&metricsAddr, "metrics-bind-address", ":8383", "The address the metric endpoint binds to.")
 	fs.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -174,6 +177,9 @@ func runMCOA(args []string) {
 	fs.StringVar(&hubID, "hub-id", "", "The ID of the Hub cluster.")
 	fs.StringVar(&clusterID, "cluster-id", "", "The ID of the managed cluster.")
 	fs.StringVar(&namespace, "namespace", "", "The namespace the operator is running in.")
+	fs.StringVar(&hubAmCASecret, "hub-alertmanager-ca-secret", "", "The name of the CA secret for the Hub's Alertmanager.")
+	fs.StringVar(&hubAmCertSecret, "hub-alertmanager-cert-secret", "", "The name of the TLS cert/key secret for the Hub's Alertmanager.")
+	fs.StringVar(&hubAmAccessorSecret, "hub-alertmanager-accessor-secret", "", "The name of the accessor token secret for the Hub's Alertmanager.")
 
 	klog.InitFlags(fs)
 	_ = fs.Parse(args)
@@ -217,6 +223,9 @@ func runMCOA(args []string) {
 		namespace,
 		clusterID,
 		hubInfo,
+		hubAmCASecret,
+		hubAmCertSecret,
+		hubAmAccessorSecret,
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MCOA-Agent")
 		os.Exit(1)

--- a/operators/endpointmetrics/main.go
+++ b/operators/endpointmetrics/main.go
@@ -161,7 +161,6 @@ func runMCOA(args []string) {
 	var enableLeaderElection bool
 	var probeAddr string
 	var hubAmURL string
-	var hubID string
 	var clusterID string
 	var namespace string
 	var hubAmCASecret string
@@ -174,7 +173,6 @@ func runMCOA(args []string) {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	fs.StringVar(&hubAmURL, "hub-alertmanager-url", "", "The URL of the Hub's Alertmanager.")
-	fs.StringVar(&hubID, "hub-id", "", "The ID of the Hub cluster.")
 	fs.StringVar(&clusterID, "cluster-id", "", "The ID of the managed cluster.")
 	fs.StringVar(&namespace, "namespace", "", "The namespace the operator is running in.")
 	fs.StringVar(&hubAmCASecret, "hub-alertmanager-ca-secret", "", "The name of the CA secret for the Hub's Alertmanager.")
@@ -191,8 +189,18 @@ func runMCOA(args []string) {
 		os.Exit(1)
 	}
 
-	if hubID == "" {
-		setupLog.Error(fmt.Errorf("hub-id flag not set"), "unable to start manager")
+	if hubAmCASecret == "" {
+		setupLog.Error(fmt.Errorf("hub-alertmanager-ca-secret flag not set"), "unable to start manager")
+		os.Exit(1)
+	}
+
+	if hubAmCertSecret == "" {
+		setupLog.Error(fmt.Errorf("hub-alertmanager-cert-secret flag not set"), "unable to start manager")
+		os.Exit(1)
+	}
+
+	if hubAmAccessorSecret == "" {
+		setupLog.Error(fmt.Errorf("hub-alertmanager-accessor-secret flag not set"), "unable to start manager")
 		os.Exit(1)
 	}
 
@@ -212,7 +220,6 @@ func runMCOA(args []string) {
 
 	hubInfo := &operatorconfig.HubInfo{
 		AlertmanagerEndpoint: hubAmURL,
-		HubClusterID:         hubID,
 	}
 
 	if err = mcoa.NewMCOAAgentReconciler(

--- a/operators/endpointmetrics/main.go
+++ b/operators/endpointmetrics/main.go
@@ -6,8 +6,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"runtime"
 	"strconv"
@@ -107,7 +109,16 @@ func execute(args []string) {
 }
 
 func runCleanup(args []string) {
+	ctrl.SetLogger(klog.NewKlogr())
 	setupLog.Info("Starting MCOA cleanup")
+	if err := doCleanup(args); err != nil {
+		setupLog.Error(err, "best-effort cleanup incomplete")
+		os.Exit(1)
+	}
+	setupLog.Info("Cleanup completed successfully")
+}
+
+func doCleanup(args []string) error {
 	fs := flag.NewFlagSet("cleanup", flag.ExitOnError)
 	var hubID string
 
@@ -116,22 +127,22 @@ func runCleanup(args []string) {
 	_ = fs.Parse(args)
 
 	if hubID == "" {
-		setupLog.Error(fmt.Errorf("hub-id flag not set"), "unable to perform cleanup")
-		os.Exit(1)
+		return fmt.Errorf("hub-id flag not set")
 	}
 
 	cfg := ctrl.GetConfigOrDie()
 	cl, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
-		setupLog.Error(err, "unable to create client for cleanup")
-		os.Exit(1)
+		return fmt.Errorf("unable to create client for cleanup: %w", err)
 	}
 
 	hubInfo := &operatorconfig.HubInfo{
 		HubClusterID: hubID,
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
 	var errs []error
 
 	caSecret := obsepctl.AppendHubClusterID(obsepctl.HubAmRouterCASecretName, hubInfo.HubClusterID)
@@ -142,18 +153,22 @@ func runCleanup(args []string) {
 		errs = append(errs, err)
 	}
 
-	setupLog.Info("Reverting User Workload monitoring configuration")
-	if err := obsepctl.RevertUserWorkloadMonitoringConfig(ctx, cl, caSecret); err != nil {
-		setupLog.Error(err, "failed to revert user workload monitoring config")
-		errs = append(errs, err)
+	if ctx.Err() != nil {
+		setupLog.Error(ctx.Err(), "cleanup context canceled or timed out, aborting remaining steps")
+		errs = append(errs, ctx.Err())
+	} else {
+		setupLog.Info("Reverting User Workload monitoring configuration")
+		if err := obsepctl.RevertUserWorkloadMonitoringConfig(ctx, cl, caSecret); err != nil {
+			setupLog.Error(err, "failed to revert user workload monitoring config")
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {
-		setupLog.Error(fmt.Errorf("cleanup failed with %d errors", len(errs)), "best-effort cleanup incomplete")
-		os.Exit(1)
+		return fmt.Errorf("cleanup failed: %w", errors.Join(errs...))
 	}
 
-	setupLog.Info("Cleanup completed successfully")
+	return nil
 }
 
 func runMCOA(args []string) {
@@ -193,19 +208,32 @@ func runMCOA(args []string) {
 		os.Exit(1)
 	}
 
-	if hubAmCASecret == "" {
-		setupLog.Error(fmt.Errorf("hub-alertmanager-ca-secret flag not set"), "unable to start manager")
-		os.Exit(1)
-	}
+	if hubAmURL != "" {
+		parsedURL, err := url.Parse(hubAmURL)
+		if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+			setupLog.Error(fmt.Errorf("invalid hub-alertmanager-url %q: must be a valid absolute URL", hubAmURL), "unable to start manager")
+			os.Exit(1)
+		}
 
-	if hubAmCertSecret == "" {
-		setupLog.Error(fmt.Errorf("hub-alertmanager-cert-secret flag not set"), "unable to start manager")
-		os.Exit(1)
-	}
+		if clusterID == "" {
+			setupLog.Error(fmt.Errorf("cluster-id flag not set"), "unable to start manager")
+			os.Exit(1)
+		}
 
-	if hubAmAccessorSecret == "" {
-		setupLog.Error(fmt.Errorf("hub-alertmanager-accessor-secret flag not set"), "unable to start manager")
-		os.Exit(1)
+		if hubAmCASecret == "" {
+			setupLog.Error(fmt.Errorf("hub-alertmanager-ca-secret flag not set"), "unable to start manager")
+			os.Exit(1)
+		}
+
+		if hubAmCertSecret == "" {
+			setupLog.Error(fmt.Errorf("hub-alertmanager-cert-secret flag not set"), "unable to start manager")
+			os.Exit(1)
+		}
+
+		if hubAmAccessorSecret == "" {
+			setupLog.Error(fmt.Errorf("hub-alertmanager-accessor-secret flag not set"), "unable to start manager")
+			os.Exit(1)
+		}
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
@@ -252,6 +280,7 @@ func runMCOA(args []string) {
 }
 
 func runLegacy(args []string) {
+	ctrl.SetLogger(klog.NewKlogr())
 	setupLog.Info("Starting legacy mode")
 	var metricsAddr string
 	var enableLeaderElection bool
@@ -264,8 +293,6 @@ func runLegacy(args []string) {
 
 	klog.InitFlags(flag.CommandLine)
 	_ = flag.CommandLine.Parse(args)
-
-	ctrl.SetLogger(klog.NewKlogr())
 
 	namespaceSelector := fmt.Sprintf("metadata.namespace==%s", os.Getenv("WATCH_NAMESPACE"))
 	gvkLabelMap := map[schema.GroupVersionKind][]filteredcache.Selector{

--- a/operators/endpointmetrics/main.go
+++ b/operators/endpointmetrics/main.go
@@ -68,24 +68,41 @@ func printVersion() {
 	setupLog.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 }
 
+var (
+	mcoaRunner    = runMCOA
+	legacyRunner  = runLegacy
+	cleanupRunner = runCleanup
+)
+
 func main() {
 	printVersion()
+	execute(os.Args)
+}
 
+func execute(args []string) {
 	cmd := "legacy"
-	if len(os.Args) > 1 {
-		cmd = os.Args[1]
+	if len(args) > 1 {
+		cmd = args[1]
 	}
 
 	switch cmd {
 	case "mcoa":
-		runMCOA(os.Args[2:])
+		// len(args) >= 2 is guaranteed since args[1] matches "mcoa"
+		mcoaRunner(args[2:])
 	case "legacy":
-		runLegacy(os.Args[2:])
+		// Guard against len(args) == 1 (no arguments) defaulting to legacy mode
+		subArgs := []string{}
+		if len(args) > 2 {
+			subArgs = args[2:]
+		}
+		legacyRunner(subArgs)
 	case "cleanup":
-		runCleanup(os.Args[2:])
+		// len(args) >= 2 is guaranteed since args[1] matches "cleanup"
+		cleanupRunner(args[2:])
 	default:
 		// default to legacy for backward compatibility if argument is just a flag
-		runLegacy(os.Args[1:])
+		// len(args) >= 2 is guaranteed since len(args) > 1 and it did not match subcommands above
+		legacyRunner(args[1:])
 	}
 }
 

--- a/operators/endpointmetrics/main.go
+++ b/operators/endpointmetrics/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -18,6 +19,7 @@ import (
 	ocinfrav1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/mcoa"
 	obsepctl "github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
 	statusctl "github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/status"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/openshift"
@@ -38,6 +40,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -67,6 +70,154 @@ func printVersion() {
 
 func main() {
 	printVersion()
+
+	cmd := "legacy"
+	if len(os.Args) > 1 {
+		cmd = os.Args[1]
+	}
+
+	switch cmd {
+	case "mcoa":
+		runMCOA(os.Args[2:])
+	case "legacy":
+		runLegacy(os.Args[2:])
+	case "cleanup":
+		runCleanup(os.Args[2:])
+	default:
+		// default to legacy for backward compatibility if argument is just a flag
+		runLegacy(os.Args[1:])
+	}
+}
+
+func runCleanup(args []string) {
+	setupLog.Info("Starting MCOA cleanup")
+	fs := flag.NewFlagSet("cleanup", flag.ExitOnError)
+	var hubClusterID string
+
+	fs.StringVar(&hubClusterID, "hub-cluster-id", "", "The ID of the Hub cluster to clean up.")
+	klog.InitFlags(fs)
+	_ = fs.Parse(args)
+
+	if hubClusterID == "" {
+		setupLog.Error(fmt.Errorf("hub-cluster-id flag not set"), "unable to perform cleanup")
+		os.Exit(1)
+	}
+
+	cfg := ctrl.GetConfigOrDie()
+	cl, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "unable to create client for cleanup")
+		os.Exit(1)
+	}
+
+	hubInfo := &operatorconfig.HubInfo{
+		HubClusterID: hubClusterID,
+	}
+
+	ctx := context.Background()
+	var errs []error
+
+	setupLog.Info("Reverting Platform monitoring configuration")
+	if err := obsepctl.RevertClusterMonitoringConfig(ctx, cl, hubInfo); err != nil {
+		setupLog.Error(err, "failed to revert platform monitoring config")
+		errs = append(errs, err)
+	}
+
+	setupLog.Info("Reverting User Workload monitoring configuration")
+	if err := obsepctl.RevertUserWorkloadMonitoringConfig(ctx, cl, hubInfo); err != nil {
+		setupLog.Error(err, "failed to revert user workload monitoring config")
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		setupLog.Error(fmt.Errorf("cleanup failed with %d errors", len(errs)), "best-effort cleanup incomplete")
+		os.Exit(1)
+	}
+
+	setupLog.Info("Cleanup completed successfully")
+}
+
+func runMCOA(args []string) {
+	setupLog.Info("Starting MCOA mode")
+	fs := flag.NewFlagSet("mcoa", flag.ExitOnError)
+	var metricsAddr string
+	var enableLeaderElection bool
+	var probeAddr string
+	var hubAmURL string
+	var hubClusterID string
+
+	fs.StringVar(&metricsAddr, "metrics-bind-address", ":8383", "The address the metric endpoint binds to.")
+	fs.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active controller manager.")
+	fs.StringVar(&hubAmURL, "hub-alertmanager-url", "", "The URL of the Hub's Alertmanager.")
+	fs.StringVar(&hubClusterID, "hub-cluster-id", "", "The ID of the Hub cluster.")
+
+	klog.InitFlags(fs)
+	_ = fs.Parse(args)
+
+	ctrl.SetLogger(klog.NewKlogr())
+
+	namespace := os.Getenv("NAMESPACE")
+	if namespace == "" {
+		namespace = os.Getenv("WATCH_NAMESPACE")
+	}
+	if namespace == "" {
+		setupLog.Error(fmt.Errorf("NAMESPACE environment variable not set"), "unable to start manager")
+		os.Exit(1)
+	}
+
+	if hubClusterID == "" {
+		setupLog.Error(fmt.Errorf("hub-cluster-id flag not set"), "unable to start manager")
+		os.Exit(1)
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                server.Options{BindAddress: metricsAddr},
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "mcoa-cmo-config.open-cluster-management.io",
+		Cache:                  mcoa.GetCacheOptions(),
+		WebhookServer:          ctrlwebhook.NewServer(ctrlwebhook.Options{Port: 9443}),
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	hubInfo := &operatorconfig.HubInfo{
+		AlertmanagerEndpoint: hubAmURL,
+		HubClusterID:         hubClusterID,
+	}
+
+	if err = mcoa.NewMCOAAgentReconciler(
+		mgr.GetClient(),
+		ctrl.Log.WithName("controllers").WithName("MCOA-Agent"),
+		mgr.GetScheme(),
+		mgr.GetEventRecorderFor("mcoa-agent-controller"),
+		namespace,
+		hubInfo,
+	).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "MCOA-Agent")
+		os.Exit(1)
+	}
+
+	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+
+	setupLog.Info("starting mcoa manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+}
+
+func runLegacy(args []string) {
+	setupLog.Info("Starting legacy mode")
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
@@ -77,7 +228,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 
 	klog.InitFlags(flag.CommandLine)
-	flag.Parse()
+	_ = flag.CommandLine.Parse(args)
 
 	ctrl.SetLogger(klog.NewKlogr())
 

--- a/operators/endpointmetrics/main_test.go
+++ b/operators/endpointmetrics/main_test.go
@@ -10,48 +10,60 @@ import (
 )
 
 func TestExecute(t *testing.T) {
-	// NOTE: This test mutates package-level global runner variables (mcoaRunner, legacyRunner, cleanupRunner).
+	// NOTE: This test mutates package-level global runner variables (mcoaRunner, standardRunner, cleanupRunner).
 	// To prevent data races and ensure test isolation, do NOT use t.Parallel() here or in any other
 	// tests in this package that modify these globals.
 
 	// Save original runners
 	origMcoa := mcoaRunner
-	origLegacy := legacyRunner
+	origStandard := standardRunner
 	origCleanup := cleanupRunner
 	defer func() {
 		mcoaRunner = origMcoa
-		legacyRunner = origLegacy
+		standardRunner = origStandard
 		cleanupRunner = origCleanup
 	}()
 
 	tests := []struct {
 		name         string
 		args         []string
-		expectedCmd  string // "mcoa", "legacy", "cleanup"
+		expectedCmd  string // "mcoa", "standard", "cleanup"
 		expectedArgs []string
 	}{
 		{
 			name:         "no args",
 			args:         []string{"./endpointmetrics"},
-			expectedCmd:  "legacy",
+			expectedCmd:  "standard",
 			expectedArgs: []string{},
+		},
+		{
+			name:         "standard with no flags",
+			args:         []string{"./endpointmetrics", "standard"},
+			expectedCmd:  "standard",
+			expectedArgs: []string{},
+		},
+		{
+			name:         "standard with flags",
+			args:         []string{"./endpointmetrics", "standard", "--metrics-bind-address=:8080"},
+			expectedCmd:  "standard",
+			expectedArgs: []string{"--metrics-bind-address=:8080"},
 		},
 		{
 			name:         "legacy with no flags",
 			args:         []string{"./endpointmetrics", "legacy"},
-			expectedCmd:  "legacy",
+			expectedCmd:  "standard",
 			expectedArgs: []string{},
 		},
 		{
 			name:         "legacy with flags",
 			args:         []string{"./endpointmetrics", "legacy", "--metrics-bind-address=:8080"},
-			expectedCmd:  "legacy",
+			expectedCmd:  "standard",
 			expectedArgs: []string{"--metrics-bind-address=:8080"},
 		},
 		{
-			name:         "only flags default to legacy",
+			name:         "only flags default to standard",
 			args:         []string{"./endpointmetrics", "--metrics-bind-address=:8080"},
-			expectedCmd:  "legacy",
+			expectedCmd:  "standard",
 			expectedArgs: []string{"--metrics-bind-address=:8080"},
 		},
 		{
@@ -77,8 +89,8 @@ func TestExecute(t *testing.T) {
 				calledCmd = "mcoa"
 				calledArgs = args
 			}
-			legacyRunner = func(args []string) {
-				calledCmd = "legacy"
+			standardRunner = func(args []string) {
+				calledCmd = "standard"
 				calledArgs = args
 			}
 			cleanupRunner = func(args []string) {

--- a/operators/endpointmetrics/main_test.go
+++ b/operators/endpointmetrics/main_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExecute(t *testing.T) {
+	// NOTE: This test mutates package-level global runner variables (mcoaRunner, legacyRunner, cleanupRunner).
+	// To prevent data races and ensure test isolation, do NOT use t.Parallel() here or in any other
+	// tests in this package that modify these globals.
+
+	// Save original runners
+	origMcoa := mcoaRunner
+	origLegacy := legacyRunner
+	origCleanup := cleanupRunner
+	defer func() {
+		mcoaRunner = origMcoa
+		legacyRunner = origLegacy
+		cleanupRunner = origCleanup
+	}()
+
+	tests := []struct {
+		name         string
+		args         []string
+		expectedCmd  string // "mcoa", "legacy", "cleanup"
+		expectedArgs []string
+	}{
+		{
+			name:         "no args",
+			args:         []string{"./endpointmetrics"},
+			expectedCmd:  "legacy",
+			expectedArgs: []string{},
+		},
+		{
+			name:         "legacy with no flags",
+			args:         []string{"./endpointmetrics", "legacy"},
+			expectedCmd:  "legacy",
+			expectedArgs: []string{},
+		},
+		{
+			name:         "legacy with flags",
+			args:         []string{"./endpointmetrics", "legacy", "--metrics-bind-address=:8080"},
+			expectedCmd:  "legacy",
+			expectedArgs: []string{"--metrics-bind-address=:8080"},
+		},
+		{
+			name:         "only flags default to legacy",
+			args:         []string{"./endpointmetrics", "--metrics-bind-address=:8080"},
+			expectedCmd:  "legacy",
+			expectedArgs: []string{"--metrics-bind-address=:8080"},
+		},
+		{
+			name:         "mcoa with flags",
+			args:         []string{"./endpointmetrics", "mcoa", "--hub-id=123"},
+			expectedCmd:  "mcoa",
+			expectedArgs: []string{"--hub-id=123"},
+		},
+		{
+			name:         "cleanup with flags",
+			args:         []string{"./endpointmetrics", "cleanup", "--hub-id=456"},
+			expectedCmd:  "cleanup",
+			expectedArgs: []string{"--hub-id=456"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calledCmd string
+			var calledArgs []string
+
+			mcoaRunner = func(args []string) {
+				calledCmd = "mcoa"
+				calledArgs = args
+			}
+			legacyRunner = func(args []string) {
+				calledCmd = "legacy"
+				calledArgs = args
+			}
+			cleanupRunner = func(args []string) {
+				calledCmd = "cleanup"
+				calledArgs = args
+			}
+
+			execute(tt.args)
+
+			if calledCmd != tt.expectedCmd {
+				t.Errorf("expected cmd %q, got %q", tt.expectedCmd, calledCmd)
+			}
+			if !reflect.DeepEqual(calledArgs, tt.expectedArgs) {
+				t.Errorf("expected args %v, got %v", tt.expectedArgs, calledArgs)
+			}
+		})
+	}
+}

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -1013,7 +1013,7 @@ func GetTrimmedClusterID(c client.Client) (string, error) {
 }
 
 func GetClusterName(obsApiURL string) string {
-	// In MCOA mode or other minimalist bridge modes, the obsApiURL (Thanos Receive endpoint)
+	// In MCOA mode, the obsApiURL (Thanos Receive endpoint)
 	// might not be provided because the agent doesn't need to perform legacy metric labeling.
 	// We return early to avoid unnecessary error logging from URL parsing or hostname splitting.
 	if obsApiURL == "" {

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -1013,6 +1013,12 @@ func GetTrimmedClusterID(c client.Client) (string, error) {
 }
 
 func GetClusterName(obsApiURL string) string {
+	// In MCOA mode or other minimalist bridge modes, the obsApiURL (Thanos Receive endpoint)
+	// might not be provided because the agent doesn't need to perform legacy metric labeling.
+	// We return early to avoid unnecessary error logging from URL parsing or hostname splitting.
+	if obsApiURL == "" {
+		return ""
+	}
 	u, err := url.Parse(obsApiURL)
 	if err != nil {
 		log.Error(err, "Failed to parse observatorium api url", "url", obsApiURL)


### PR DESCRIPTION
Implement the endpoint controller for MCOA as a new command mode in the endpointmetrics binary.

Key changes:
- Add MCOAAgentReconciler with cache filtering to minimize memory footprint by only watching specific monitoring resources.
- Implement conflict detection when updating the CMO configmaps.
- Introduce a 'cleanup' command for best-effort removal of hub configurations from the managed cluster. It will be used by MCOA when uninstalling the addon on a managed cluster.
- Refactor existing monitoring logic and predicates into exported, reusable components.
- Include unit and integration tests for the new MCOA reconciler and cache filtering logic.

Fixes:
- Update predicate to trigger reconciliation when a deletion timestamp is added on the ObservabilityAddon CR to cleanup resource on time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCOA agent/controller to manage Alertmanager and user-workload monitoring configs per hub
  * New startup modes including a hub-scoped cleanup command to revert hub monitoring configs

* **Improvements**
  * Hub-scoped CA handling and id-suffixed secrets for safer per-hub config operations
  * Filtered/surgical caching and refined event predicates to reduce reconciler noise
  * Centralized conflict detection with metrics/events on detected config mutations

* **Tests**
  * Expanded unit, integration, and end-to-end tests covering reconciliation, revert, and cache behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->