### PR TITLE
[ACM-34416] feat(endpoint-operator): Add HCP SM watchers

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller.go
@@ -8,10 +8,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"slices"
 
 	"github.com/go-logr/logr"
+	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/collector"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/hypershift"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/openshift"
@@ -88,18 +88,15 @@ type ObservabilityAddonReconciler struct {
 func (r *ObservabilityAddonReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Logger.Info("Reconciling", "Request", req.String())
 
-	isHypershift := true
-	if os.Getenv("UNIT_TEST") != "true" {
-		var err error
-		isHypershift, err = hypershift.IsHypershiftCluster()
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to check if the cluster is hypershift: %w", err)
-		}
+	var err error
+	isHypershift, err := hypershift.IsHypershiftCluster()
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to check if the cluster is hypershift: %w", err)
 	}
 
 	// retrieve the hubInfo
 	hubSecret := &corev1.Secret{}
-	err := r.Client.Get(
+	err = r.Client.Get(
 		ctx,
 		types.NamespacedName{Name: operatorconfig.HubInfoSecretName, Namespace: r.Namespace},
 		hubSecret,
@@ -540,6 +537,18 @@ func (r *ObservabilityAddonReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		).Watches(&rbacv1.ClusterRoleBinding{},
 			&handler.EnqueueRequestForObject{},
 			builder.WithPredicates(getPred(openshift.HubClusterRoleBindingName, "", false, true, true)))
+	}
+
+	if isHypershift, err := hypershift.IsHypershiftCluster(); err == nil && isHypershift {
+		ctrlBuilder = ctrlBuilder.Watches(
+			&prometheusv1.ServiceMonitor{},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(getPred(hypershift.EtcdSmName, "", true, false, false)),
+		).Watches(
+			&prometheusv1.ServiceMonitor{},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(getPred(hypershift.ApiServerSmName, "", true, false, false)),
+		)
 	}
 
 	return ctrlBuilder.

--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_integration_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_integration_test.go
@@ -20,7 +20,6 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/hypershift"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/util"
-	observabilityshared "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/shared"
 	oav1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	"github.com/stretchr/testify/assert"
@@ -52,6 +51,10 @@ var (
 	restCfgHub   *rest.Config
 )
 
+const (
+	obAddonNs = "open-cluster-management-addon-observability"
+)
+
 func TestIntegrationCMOConfigWatching(t *testing.T) {
 	namespace := "test-cmo-config"
 
@@ -74,10 +77,6 @@ func TestIntegrationCMOConfigWatching(t *testing.T) {
 endpoint: "http://test-endpoint"
 hub-cluster-id: "test-hub-cluster"
 alertmanager-endpoint: "http://test-alertamanger-endpoint"
-alertmanager-router-ca: |
-    -----BEGIN CERTIFICATE-----
-    xxxxxxxxxxxxxxxxxxxxxxxxxxx
-    -----END CERTIFICATE-----
 `), namespace),
 		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -207,12 +206,15 @@ alertmanager-router-ca: |
 	assert.NoError(t, err)
 }
 
-// TestIntegrationReconcileHypershift tests the reconcile function for hypershift CRDs.
-func TestIntegrationReconcileHypershift(t *testing.T) {
+// TestIntegrationReconcileHypershiftOnHub tests the reconcile function for hypershift CRDs on a Hub cluster.
+func TestIntegrationReconcileHypershiftOnHub(t *testing.T) {
 	testNamespace := "test-ns"
 
 	scheme := createBaseScheme()
-	hyperv1.AddToScheme(scheme)
+	err := hyperv1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	k8sClient, err := client.New(restCfgHub, client.Options{Scheme: scheme})
 	if err != nil {
@@ -222,17 +224,17 @@ func TestIntegrationReconcileHypershift(t *testing.T) {
 	setupCommonHubResources(t, k8sClient, testNamespace)
 	defer tearDownCommonHubResources(t, k8sClient, testNamespace)
 
-	hostedClusterNs := "hosted-cluster-ns"
-	hostedClusterName := "myhostedcluster"
-	hostedCluster := newHostedCluster(hostedClusterName, hostedClusterNs)
+	hostedClustersNs := "hosted-clusters-ns"
+	preStartHostedClusterName := "myhostedcluster-0"
+	preStartHostedCluster := newHostedCluster(preStartHostedClusterName, hostedClustersNs)
 
 	// Create resources required for the hypershift case
 	resourcesDeps := []client.Object{
-		makeNamespace(hostedClusterNs),
-		makeNamespace(hypershift.HostedClusterNamespace(hostedCluster)),
-		hostedCluster,
-		newServiceMonitor(hypershift.EtcdSmName, hypershift.HostedClusterNamespace(hostedCluster)),
-		newServiceMonitor(hypershift.ApiServerSmName, hypershift.HostedClusterNamespace(hostedCluster)),
+		makeNamespace(hostedClustersNs),
+		makeNamespace(hypershift.HostedClusterNamespace(preStartHostedCluster)),
+		preStartHostedCluster,
+		newServiceMonitor(hypershift.EtcdSmName, hypershift.HostedClusterNamespace(preStartHostedCluster)),
+		newServiceMonitor(hypershift.ApiServerSmName, hypershift.HostedClusterNamespace(preStartHostedCluster)),
 	}
 	if err := createResources(k8sClient, resourcesDeps...); err != nil {
 		t.Fatalf("Failed to create resources: %v", err)
@@ -273,10 +275,186 @@ func TestIntegrationReconcileHypershift(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	// Hypershift service monitors must be created
+	// ACM service monitors must be created for existing HCP
 	err = wait.Poll(1*time.Second, 5*time.Second, func() (bool, error) {
 		hypershiftEtcdSm := &promv1.ServiceMonitor{}
-		err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: hostedClusterNs + "-" + hostedClusterName, Name: hypershift.AcmEtcdSmName}, hypershiftEtcdSm)
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: hostedClustersNs + "-" + preStartHostedClusterName, Name: hypershift.AcmEtcdSmName}, hypershiftEtcdSm)
+		if err != nil && errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		hypershiftApiServerSm := &promv1.ServiceMonitor{}
+		err = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: hostedClustersNs + "-" + preStartHostedClusterName, Name: hypershift.AcmApiServerSmName}, hypershiftApiServerSm)
+		if err != nil && errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return true, err
+	})
+	assert.NoError(t, err)
+
+	runtimeHostedClusterName := "myhostedcluster-1"
+	runtimeHostedCluster := newHostedCluster(runtimeHostedClusterName, hostedClustersNs)
+
+	resourcesDeps = []client.Object{
+		makeNamespace(hypershift.HostedClusterNamespace(runtimeHostedCluster)),
+		runtimeHostedCluster,
+		newServiceMonitor(hypershift.EtcdSmName, hypershift.HostedClusterNamespace(runtimeHostedCluster)),
+		newServiceMonitor(hypershift.ApiServerSmName, hypershift.HostedClusterNamespace(runtimeHostedCluster)),
+	}
+
+	if err := createResources(k8sClient, resourcesDeps...); err != nil {
+		t.Fatalf("Failed to create resources: %v", err)
+	}
+
+	// OBA Reconciler should watch new HostedClusters and create SM consequently
+	err = wait.Poll(1*time.Second, 5*time.Second, func() (bool, error) {
+		hypershiftEtcdSm := &promv1.ServiceMonitor{}
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: hostedClustersNs + "-" + runtimeHostedClusterName, Name: hypershift.AcmEtcdSmName}, hypershiftEtcdSm)
+		if err != nil && errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		hypershiftApiServerSm := &promv1.ServiceMonitor{}
+		err = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: hostedClustersNs + "-" + runtimeHostedClusterName, Name: hypershift.AcmApiServerSmName}, hypershiftApiServerSm)
+		if err != nil && errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return true, err
+	})
+	assert.NoError(t, err)
+}
+
+// TestIntegrationReconcileHypershiftOnSpoke tests the reconcile function for hypershift CRDs on a spoke cluster.
+func TestIntegrationReconcileHypershiftOnSpoke(t *testing.T) {
+	mcNamespace := "test-mc-hub-ns"
+
+	scheme := createBaseScheme()
+	err := hyperv1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup spoke cluster resources
+	k8sClient, err := client.New(restCfgSpoke, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	setupCommonSpokeResources(t, k8sClient)
+	defer tearDownCommonSpokeResources(t, k8sClient)
+
+	hostedClustersNs := "hosted-clusters-ns"
+	preStartHostedClusterName := "myhostedcluster-0"
+	preStartHostedCluster := newHostedCluster(preStartHostedClusterName, hostedClustersNs)
+
+	// Create resources required for the hypershift case
+	resourcesDeps := []client.Object{
+		makeNamespace(hostedClustersNs),
+		makeNamespace(hypershift.HostedClusterNamespace(preStartHostedCluster)),
+		preStartHostedCluster,
+		newServiceMonitor(hypershift.EtcdSmName, hypershift.HostedClusterNamespace(preStartHostedCluster)),
+		newServiceMonitor(hypershift.ApiServerSmName, hypershift.HostedClusterNamespace(preStartHostedCluster)),
+		newObservabilityAddon(obAddonName, obAddonNs),
+	}
+
+	if err := createResources(k8sClient, resourcesDeps...); err != nil {
+		t.Fatalf("Failed to create resources: %v", err)
+	}
+
+	// Setup hub cluster resources using a separate envtest API server
+	hubClient, err := client.New(restCfgHub, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hubClientWithReload, err := util.NewReloadableHubClientWithReloadFunc(func() (client.Client, error) {
+		return hubClient, nil
+	})
+	assert.NoError(t, err)
+
+	resourcesDeps = []client.Object{
+		makeNamespace(mcNamespace),
+		newObservabilityAddon(obAddonName, mcNamespace),
+	}
+	if err := createResources(hubClient, resourcesDeps...); err != nil {
+		t.Fatalf("Failed to create hub resources: %v", err)
+	}
+
+	mgr, err := ctrl.NewManager(testEnvSpoke.Config, ctrl.Options{
+		Scheme:  k8sClient.Scheme(),
+		Metrics: metricsserver.Options{BindAddress: "0"},
+		Controller: config.Controller{
+			SkipNameValidation: ptr.To(true),
+		},
+	})
+	assert.NoError(t, err)
+
+	reconciler := ObservabilityAddonReconciler{
+		Client:                k8sClient,
+		HubClient:             hubClientWithReload,
+		IsHubMetricsCollector: false,
+		Scheme:                scheme,
+		Namespace:             obAddonNs,
+		HubNamespace:          mcNamespace,
+		ServiceAccountName:    "endpoint-monitoring-operator",
+		InstallPrometheus:     false,
+	}
+
+	err = reconciler.SetupWithManager(mgr)
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		err = mgr.Start(ctx)
+		assert.NoError(t, err)
+	}()
+
+	// ACM service monitors must be created for existing HCP
+	err = wait.Poll(1*time.Second, 5*time.Second, func() (bool, error) {
+		hypershiftEtcdSm := &promv1.ServiceMonitor{}
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: hostedClustersNs + "-" + preStartHostedClusterName, Name: hypershift.AcmEtcdSmName}, hypershiftEtcdSm)
+		if err != nil && errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		hypershiftApiServerSm := &promv1.ServiceMonitor{}
+		err = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: hostedClustersNs + "-" + preStartHostedClusterName, Name: hypershift.AcmApiServerSmName}, hypershiftApiServerSm)
+		if err != nil && errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return true, err
+	})
+	assert.NoError(t, err)
+
+	runtimeHostedClusterName := "myhostedcluster-1"
+	runtimeHostedCluster := newHostedCluster(runtimeHostedClusterName, hostedClustersNs)
+
+	resourcesDeps = []client.Object{
+		makeNamespace(hypershift.HostedClusterNamespace(runtimeHostedCluster)),
+		runtimeHostedCluster,
+		newServiceMonitor(hypershift.EtcdSmName, hypershift.HostedClusterNamespace(runtimeHostedCluster)),
+		newServiceMonitor(hypershift.ApiServerSmName, hypershift.HostedClusterNamespace(runtimeHostedCluster)),
+	}
+
+	if err := createResources(k8sClient, resourcesDeps...); err != nil {
+		t.Fatalf("Failed to create resources: %v", err)
+	}
+
+	// OBA Reconciler should watch new HostedClusters and create SM consequently
+	err = wait.Poll(1*time.Second, 5*time.Second, func() (bool, error) {
+		hypershiftEtcdSm := &promv1.ServiceMonitor{}
+		err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: hostedClustersNs + "-" + runtimeHostedClusterName, Name: hypershift.AcmEtcdSmName}, hypershiftEtcdSm)
+		if err != nil && errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		hypershiftApiServerSm := &promv1.ServiceMonitor{}
+		err = k8sClient.Get(context.Background(), types.NamespacedName{Namespace: hostedClustersNs + "-" + runtimeHostedClusterName, Name: hypershift.AcmApiServerSmName}, hypershiftApiServerSm)
 		if err != nil && errors.IsNotFound(err) {
 			return false, nil
 		}
@@ -295,6 +473,7 @@ func TestMain(m *testing.M) {
 	rootPath := filepath.Join("..", "..", "..")
 	spokeCrds := readCRDFiles(
 		filepath.Join(rootPath, "multiclusterobservability", "config", "crd", "bases", "observability.open-cluster-management.io_observabilityaddons.yaml"),
+		filepath.Join(rootPath, "endpointmetrics", "manifests", "prometheus", "crd", "servicemonitor_crd_0_53_1.yaml"),
 	)
 	testEnvSpoke = &envtest.Environment{
 		CRDDirectoryPaths:       []string{filepath.Join("testdata", "crd"), filepath.Join("..", "..", "config", "crd", "bases")},
@@ -310,7 +489,6 @@ func TestMain(m *testing.M) {
 
 	hubCRDs := readCRDFiles(
 		filepath.Join(rootPath, "multiclusterobservability", "config", "crd", "bases", "observability.open-cluster-management.io_multiclusterobservabilities.yaml"),
-		filepath.Join(rootPath, "endpointmetrics", "manifests", "prometheus", "crd", "servicemonitor_crd_0_53_1.yaml"),
 	)
 	hubCRDs = append(hubCRDs, spokeCrds...)
 
@@ -376,9 +554,9 @@ func tearDownCommonHubResources(t *testing.T, k8sClient client.Client, ns string
 func setupCommonSpokeResources(t *testing.T, k8sClient client.Client) {
 	// Create resources required for the observability addon controller
 	resourcesDeps := []client.Object{
-		makeNamespace("open-cluster-management-addon-observability"),
-		newHubInfoSecret([]byte{}, "open-cluster-management-addon-observability"),
-		newImagesCM("open-cluster-management-addon-observability"),
+		makeNamespace(obAddonNs),
+		newHubInfoSecret([]byte{}, obAddonNs),
+		newImagesCM(obAddonNs),
 	}
 	if err := createResources(k8sClient, resourcesDeps...); err != nil {
 		t.Fatalf("Failed to create resources: %v", err)
@@ -388,7 +566,7 @@ func setupCommonSpokeResources(t *testing.T, k8sClient client.Client) {
 func tearDownCommonSpokeResources(t *testing.T, k8sClient client.Client) {
 	// Delete resources required for the observability addon controller
 	resourcesDeps := []client.Object{
-		makeNamespace("open-cluster-management-addon-observability"),
+		makeNamespace(obAddonNs),
 	}
 	for _, resource := range resourcesDeps {
 		if err := k8sClient.Delete(context.Background(), resource); err != nil {
@@ -435,18 +613,6 @@ func createResources(client client.Client, resources ...client.Object) error {
 		}
 	}
 	return nil
-}
-
-func newObservabilityAddonBis(name, ns string) *oav1beta1.ObservabilityAddon {
-	return &oav1beta1.ObservabilityAddon{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: ns,
-		},
-		Spec: observabilityshared.ObservabilityAddonSpec{
-			EnableMetrics: true,
-		},
-	}
 }
 
 func newHostedCluster(name, ns string) *hyperv1.HostedCluster {

--- a/operators/endpointmetrics/pkg/hypershift/hypershift.go
+++ b/operators/endpointmetrics/pkg/hypershift/hypershift.go
@@ -7,6 +7,7 @@ package hypershift
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 
@@ -32,8 +33,6 @@ const (
 // For each hosted cluster, it adds a ServiceMonitor for etcd and kube-apiserver
 // so that metrics are scraped by the user workload cluster's prometheus
 // with relevant labels added for ACM.
-// No watcher is set on hypershift CRDs. Adding the CRDs after the controller is started
-// will not trigger the reconcile function. The controller must be restarted to watch the new CRDs.
 func ReconcileHostedClustersServiceMonitors(ctx context.Context, c client.Client) (int, error) {
 	hostedClusters := &hyperv1.HostedClusterList{}
 	if err := c.List(ctx, hostedClusters, &client.ListOptions{}); err != nil {
@@ -42,27 +41,34 @@ func ReconcileHostedClustersServiceMonitors(ctx context.Context, c client.Client
 
 	reconciledHCsCount := 0
 	for _, cluster := range hostedClusters.Items {
+		reconciledSMsCount := 0
 		namespace := fmt.Sprintf("%s-%s", cluster.Namespace, cluster.Name)
 
 		etcdSMDesired, err := getEtcdServiceMonitor(ctx, c, namespace, cluster.Spec.ClusterID, cluster.Name)
-		if err != nil {
+		// In case hypershift's etcd ServiceMonitor is not created yet,
+		// we can skip this cluster and wait for the next reconciliation loop
+		if err == nil {
+			if err := createOrUpdateSM(ctx, c, etcdSMDesired); err != nil {
+				return reconciledHCsCount, fmt.Errorf("failed to create/update etcd ServiceMonitor %s/%s: %w", etcdSMDesired.GetNamespace(), etcdSMDesired.GetName(), err)
+			}
+			reconciledSMsCount++
+		} else if !errors.IsNotFound(err) {
 			return reconciledHCsCount, fmt.Errorf("failed to get etcd ServiceMonitor: %w", err)
 		}
 
-		if err := createOrUpdateSM(ctx, c, etcdSMDesired); err != nil {
-			return reconciledHCsCount, fmt.Errorf("failed to create/update etcd ServiceMonitor %s/%s: %w", etcdSMDesired.GetNamespace(), etcdSMDesired.GetName(), err)
-		}
-
 		apiServerSMDesired, err := getKubeServiceMonitor(ctx, c, namespace, cluster.Spec.ClusterID, cluster.Name)
-		if err != nil {
-			return reconciledHCsCount, fmt.Errorf("failed to get kube-apiserver ServiceMonitor: %w", err)
+		if err == nil {
+			if err := createOrUpdateSM(ctx, c, apiServerSMDesired); err != nil {
+				return reconciledHCsCount, fmt.Errorf("failed to create/update api-server ServiceMonitor %s/%s: %w", apiServerSMDesired.GetNamespace(), apiServerSMDesired.GetName(), err)
+			}
+			reconciledSMsCount++
+		} else if !errors.IsNotFound(err) {
+			return reconciledHCsCount, fmt.Errorf("failed to get api-server ServiceMonitor: %w", err)
 		}
 
-		if err := createOrUpdateSM(ctx, c, apiServerSMDesired); err != nil {
-			return reconciledHCsCount, fmt.Errorf("failed to create/update api-server ServiceMonitor %s/%s: %w", apiServerSMDesired.GetNamespace(), apiServerSMDesired.GetName(), err)
+		if reconciledSMsCount > 0 {
+			reconciledHCsCount++
 		}
-
-		reconciledHCsCount++
 	}
 
 	return reconciledHCsCount, nil
@@ -96,15 +102,17 @@ func HostedClusterNamespace(cluster *hyperv1.HostedCluster) string {
 }
 
 func IsHypershiftCluster() (bool, error) {
-	var isHypershift bool
-	crdClient, err := operatorutil.GetOrCreateCRDClient()
-	if err != nil {
-		return false, fmt.Errorf("failed to get/create CRD client: %w", err)
-	}
+	isHypershift := true
+	if os.Getenv("UNIT_TEST") != "true" {
+		crdClient, err := operatorutil.GetOrCreateCRDClient()
+		if err != nil {
+			return false, fmt.Errorf("failed to get/create CRD client: %w", err)
+		}
 
-	isHypershift, err = operatorutil.CheckCRDExist(crdClient, "hostedclusters.hypershift.openshift.io")
-	if err != nil {
-		return false, fmt.Errorf("failed to check if the CRD hostedclusters.hypershift.openshift.io exists: %w", err)
+		isHypershift, err = operatorutil.CheckCRDExist(crdClient, "hostedclusters.hypershift.openshift.io")
+		if err != nil {
+			return false, fmt.Errorf("failed to check if the CRD hostedclusters.hypershift.openshift.io exists: %w", err)
+		}
 	}
 
 	return isHypershift, nil

--- a/operators/endpointmetrics/pkg/hypershift/hypershift_test.go
+++ b/operators/endpointmetrics/pkg/hypershift/hypershift_test.go
@@ -109,35 +109,56 @@ func TestHypershiftServiceMonitors(t *testing.T) {
 	promv1.AddToScheme(scheme)
 
 	testCases := map[string]struct {
-		getClient   func() client.Client
-		expectError bool
-		expectSMs   bool
+		getClient          func() client.Client
+		expectError        bool
+		expectEtcdSMs      bool
+		expectApiServerSMs bool
 	}{
 		"no hyperfhift cluster": {
-			getClient:   func() client.Client { return fake.NewClientBuilder().WithScheme(scheme).Build() },
-			expectError: false,
-			expectSMs:   false,
+			getClient:          func() client.Client { return fake.NewClientBuilder().WithScheme(scheme).Build() },
+			expectError:        false,
+			expectEtcdSMs:      false,
+			expectApiServerSMs: false,
 		},
-		"original hypershift sm is missing": {
+		"original hypershift sm are missing": {
 			getClient: func() client.Client {
 				return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(hCluster).Build()
 			},
-			expectError: true,
-			expectSMs:   false,
+			expectError:        false,
+			expectEtcdSMs:      false,
+			expectApiServerSMs: false,
+		},
+		"only original etcd sm exists": {
+			getClient: func() client.Client {
+				return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(hCluster, hypershiftEtcdSM).Build()
+			},
+			expectError:        false,
+			expectEtcdSMs:      true,
+			expectApiServerSMs: false,
+		},
+		"only original apiserver sm exists": {
+			getClient: func() client.Client {
+				return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(hCluster, hypershiftApiServerSM).Build()
+			},
+			expectError:        false,
+			expectEtcdSMs:      false,
+			expectApiServerSMs: true,
 		},
 		"create": {
 			getClient: func() client.Client {
 				return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(hCluster, hypershiftEtcdSM, hypershiftApiServerSM).Build()
 			},
-			expectError: false,
-			expectSMs:   true,
+			expectError:        false,
+			expectEtcdSMs:      true,
+			expectApiServerSMs: true,
 		},
 		"update": {
 			getClient: func() client.Client {
 				return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(hCluster, etcdSm, hypershiftEtcdSM, hypershiftApiServerSM).Build()
 			},
-			expectError: false,
-			expectSMs:   true,
+			expectError:        false,
+			expectEtcdSMs:      true,
+			expectApiServerSMs: true,
 		},
 	}
 
@@ -168,34 +189,35 @@ func TestHypershiftServiceMonitors(t *testing.T) {
 			}
 			assert.NoError(t, err)
 
-			if !tc.expectSMs {
-				assert.Equal(t, 0, hostedClustersReconciled, "expected 0 hosted cluster reconciled")
-				return
+			if tc.expectEtcdSMs || tc.expectApiServerSMs {
+				assert.Equal(t, 1, hostedClustersReconciled, "expected 1 hosted cluster reconciled")
 			}
-
-			assert.Equal(t, 1, hostedClustersReconciled, "expected 1 hosted cluster reconciled")
 
 			// check etcd and kube-apiserver ServiceMonitors are created
 			sm := &promv1.ServiceMonitor{}
-			err = client.Get(context.Background(), types.NamespacedName{
-				Name:      hypershift.AcmEtcdSmName,
-				Namespace: fmt.Sprintf("%s-%s", hosteClusterNamespace, hostedClusterName),
-			}, sm)
-			assert.NoError(t, err)
-			assert.Equal(t, hypershiftEtcdSM.Spec.Endpoints[0].TLSConfig, sm.Spec.Endpoints[0].TLSConfig)
-			assert.Equal(t, hypershiftEtcdSM.Spec.Selector, sm.Spec.Selector)
-			assert.Equal(t, hypershiftEtcdSM.Spec.NamespaceSelector, sm.Spec.NamespaceSelector)
-			checkRelabelConfigs(t, sm)
+			if tc.expectEtcdSMs {
+				err = client.Get(context.Background(), types.NamespacedName{
+					Name:      hypershift.AcmEtcdSmName,
+					Namespace: fmt.Sprintf("%s-%s", hosteClusterNamespace, hostedClusterName),
+				}, sm)
+				assert.NoError(t, err)
+				assert.Equal(t, hypershiftEtcdSM.Spec.Endpoints[0].TLSConfig, sm.Spec.Endpoints[0].TLSConfig)
+				assert.Equal(t, hypershiftEtcdSM.Spec.Selector, sm.Spec.Selector)
+				assert.Equal(t, hypershiftEtcdSM.Spec.NamespaceSelector, sm.Spec.NamespaceSelector)
+				checkRelabelConfigs(t, sm)
+			}
 
-			err = client.Get(context.Background(), types.NamespacedName{
-				Name:      hypershift.AcmApiServerSmName,
-				Namespace: fmt.Sprintf("%s-%s", hosteClusterNamespace, hostedClusterName),
-			}, sm)
-			assert.NoError(t, err)
-			assert.Equal(t, hypershiftApiServerSM.Spec.Endpoints[0].TLSConfig, sm.Spec.Endpoints[0].TLSConfig)
-			assert.Equal(t, hypershiftApiServerSM.Spec.Selector, sm.Spec.Selector)
-			assert.Equal(t, hypershiftApiServerSM.Spec.NamespaceSelector, sm.Spec.NamespaceSelector)
-			checkRelabelConfigs(t, sm)
+			if tc.expectApiServerSMs {
+				err = client.Get(context.Background(), types.NamespacedName{
+					Name:      hypershift.AcmApiServerSmName,
+					Namespace: fmt.Sprintf("%s-%s", hosteClusterNamespace, hostedClusterName),
+				}, sm)
+				assert.NoError(t, err)
+				assert.Equal(t, hypershiftApiServerSM.Spec.Endpoints[0].TLSConfig, sm.Spec.Endpoints[0].TLSConfig)
+				assert.Equal(t, hypershiftApiServerSM.Spec.Selector, sm.Spec.Selector)
+				assert.Equal(t, hypershiftApiServerSM.Spec.NamespaceSelector, sm.Spec.NamespaceSelector)
+				checkRelabelConfigs(t, sm)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Whatch HCP-related ServiceMonitors so if a new Hosted Cluster is created, the observability-addon reconciles, creating the expected ACM ServiceMonitors (`acm-etcd` `acm-kube-apiserver`)

## Integration Tests
- Edited `TestIntegrationReconcileHypershiftOnHub` to include a more comprehensive testset
- Added `TestIntegrationReconcileHypershiftOnSpoke`

## Manual e2e tests
Tested on a Managed Cluster running Hypershift. 
1. Spin up a  new HCPs while the operator is running.
2. Check the ACM ServiceMonitor get created after the HC ServiceMonitors. ✔
3. Check the ACM ServiceMonitor get deleted after HC teardown. ✔

Logs from `endpoint-observability-operator`:
```
12:57:35.271031 1 observabilityaddon_controller.go:87] "Reconciling" logger="controllers.ObservabilityAddon" Request="clusters-hc-aws-1/etcd"
12:57:53.696389 1 observabilityaddon_controller.go:87] "Reconciling" logger="controllers.ObservabilityAddon" Request="clusters-hc-aws-1/kube-apiserver"
12:57:53.724795 1 observabilityaddon_controller.go:179] "Reconciled hypershift service monitors" logger="controllers.ObservabilityAddon" updatedHCs=1
```

---
## Summary by CodeRabbit

* **New Features**
  * Improved Hypershift detection and conditional addition of Hypershift-specific monitoring watches for ServiceMonitor resources.

* **Bug Fixes**
  * Reconciliation now surfaces failures when Hypershift detection encounters errors (no longer bypassed by test-only gating).

* **Tests**
  * Expanded integration tests to validate observability reconciliation separately on Hub and Spoke environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hypershift detection now runs during reconciliation and returns errors immediately if detection fails; missing upstream monitoring objects are treated as non-fatal and skipped.
  * Hypershift-specific watches are registered only when Hypershift is confirmed.

* **Tests**
  * Integration tests split into Hub and Spoke scenarios; CRD loading and namespace setup improved.
  * Unit/integration tests updated to verify selective creation and counting of monitoring resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->