### PR TITLE
fix(endpoint-operator): Integration test missing hubInfoSecret key

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_integration_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_integration_test.go
@@ -35,8 +35,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -50,7 +52,7 @@ var (
 	restCfgHub   *rest.Config
 )
 
-func TestCMOConfigWatching(t *testing.T) {
+func TestIntegrationCMOConfigWatching(t *testing.T) {
 	namespace := "test-cmo-config"
 
 	scheme := createBaseScheme()
@@ -70,6 +72,7 @@ func TestCMOConfigWatching(t *testing.T) {
 		newImagesCM(namespace),
 		newHubInfoSecret([]byte(`
 endpoint: "http://test-endpoint"
+hub-cluster-id: "test-hub-cluster"
 alertmanager-endpoint: "http://test-alertamanger-endpoint"
 alertmanager-router-ca: |
     -----BEGIN CERTIFICATE-----
@@ -114,6 +117,9 @@ alertmanager-router-ca: |
 	mgr, err := ctrl.NewManager(testEnvHub.Config, ctrl.Options{
 		Scheme:  k8sClient.Scheme(),
 		Metrics: metricsserver.Options{BindAddress: "0"}, // Avoids port conflict with the default port 8080
+		Controller: config.Controller{
+			SkipNameValidation: ptr.To(true),
+		},
 	})
 	assert.NoError(t, err)
 
@@ -231,6 +237,9 @@ func TestIntegrationReconcileHypershift(t *testing.T) {
 	mgr, err := ctrl.NewManager(testEnvHub.Config, ctrl.Options{
 		Scheme:  k8sClient.Scheme(),
 		Metrics: metricsserver.Options{BindAddress: "0"}, // Avoids port conflict with the default port 8080
+		Controller: config.Controller{
+			SkipNameValidation: ptr.To(true),
+		},
 	})
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Integration test TestCMOConfigWatching was not being tested because the pipeline is running `go test -tags integration -run=Integration ./operators/...`

## Changes
- Added Integration in the test name
- Added missing `HubInfoSecret` key `hub-cluster-id` which was causing the test to fail
- Added `SkipNameValidation: true` on the controller manager so subsequent tests running on the same go process does not cause a controller names collision error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test configuration and setup for observability endpoint metrics, providing improved test reliability and comprehensive validation coverage for endpoint monitoring functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->