### PR TITLE
ACM-34594(MCO) <Add Support For Additional Thanos Compact Flags In MCO CR Spec> 

### DIFF
--- a/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
+++ b/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
@@ -508,6 +508,27 @@ type CompactSpec struct {
 	// lead to an unrecoverable state, data loss, or both, which is not covered by Red Hat Support.
 	// +optional
 	Containers []corev1.Container `json:"containers,omitempty"`
+
+	// Debug defines the configuration for debugging and tuning the compactor.
+	// +optional
+	Debug *CompactDebugSpec `json:"debug,omitempty"`
+}
+
+type CompactDebugSpec struct {
+	// LogLevel for the compactor (e.g., debug, info, warn, error).
+	// +optional
+	LogLevel string `json:"logLevel,omitempty"`
+	// WaitInterval is the time to wait between compaction cycles.
+	// Setting this will also synchronize --compact.cleanup-interval and --compact.progress-interval.
+	// +optional
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$`
+	WaitInterval string `json:"waitInterval,omitempty"`
+	// BlockMetaFetchConcurrency is the number of concurrent requests to fetch block metadata.
+	// +optional
+	BlockMetaFetchConcurrency string `json:"blockMetaFetchConcurrency,omitempty"`
+	// DownsampleConcurrency is the number of goroutines to use when downsampling blocks.
+	// +optional
+	DownsampleConcurrency string `json:"downsampleConcurrency,omitempty"`
 }
 
 // CacheConfig is the spec of memcached.

--- a/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
+++ b/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
@@ -517,6 +517,7 @@ type CompactSpec struct {
 type CompactDebugSpec struct {
 	// LogLevel for the compactor (e.g., debug, info, warn, error).
 	// +optional
+	// +kubebuilder:validation:Enum=debug;info;warn;error
 	LogLevel string `json:"logLevel,omitempty"`
 	// WaitInterval is the time to wait between compaction cycles.
 	// Setting this will also synchronize --compact.cleanup-interval and --compact.progress-interval.
@@ -525,9 +526,11 @@ type CompactDebugSpec struct {
 	WaitInterval string `json:"waitInterval,omitempty"`
 	// BlockMetaFetchConcurrency is the number of concurrent requests to fetch block metadata.
 	// +optional
+	// +kubebuilder:validation:Minimum=0
 	BlockMetaFetchConcurrency *int32 `json:"blockMetaFetchConcurrency,omitempty"`
 	// DownsampleConcurrency is the number of goroutines to use when downsampling blocks.
 	// +optional
+	// +kubebuilder:validation:Minimum=0
 	DownsampleConcurrency *int32 `json:"downsampleConcurrency,omitempty"`
 }
 

--- a/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
+++ b/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
@@ -525,10 +525,10 @@ type CompactDebugSpec struct {
 	WaitInterval string `json:"waitInterval,omitempty"`
 	// BlockMetaFetchConcurrency is the number of concurrent requests to fetch block metadata.
 	// +optional
-	BlockMetaFetchConcurrency string `json:"blockMetaFetchConcurrency,omitempty"`
+	BlockMetaFetchConcurrency *int32 `json:"blockMetaFetchConcurrency,omitempty"`
 	// DownsampleConcurrency is the number of goroutines to use when downsampling blocks.
 	// +optional
-	DownsampleConcurrency string `json:"downsampleConcurrency,omitempty"`
+	DownsampleConcurrency *int32 `json:"downsampleConcurrency,omitempty"`
 }
 
 // CacheConfig is the spec of memcached.

--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -49,7 +49,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-06-01T15:42:15Z"
+    createdAt: "2026-06-10T17:28:22Z"
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-observability-operator.v0.1.0

--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -49,11 +49,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-<<<<<<< HEAD
-    createdAt: "2026-05-20T19:29:43Z"
-=======
     createdAt: "2026-06-01T15:42:15Z"
->>>>>>> c7a0f0cb (Add manifest file)
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-observability-operator.v0.1.0

--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -49,7 +49,11 @@ metadata:
         }
       ]
     capabilities: Basic Install
+<<<<<<< HEAD
     createdAt: "2026-05-20T19:29:43Z"
+=======
+    createdAt: "2026-06-01T15:42:15Z"
+>>>>>>> c7a0f0cb (Add manifest file)
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-observability-operator.v0.1.0

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -2025,6 +2025,31 @@ spec:
                           - name
                           type: object
                         type: array
+                      debug:
+                        description: Debug defines the configuration for debugging
+                          and tuning the compactor.
+                        properties:
+                          blockMetaFetchConcurrency:
+                            description: BlockMetaFetchConcurrency is the number of
+                              concurrent requests to fetch block metadata.
+                            format: int32
+                            type: integer
+                          downsampleConcurrency:
+                            description: DownsampleConcurrency is the number of goroutines
+                              to use when downsampling blocks.
+                            format: int32
+                            type: integer
+                          logLevel:
+                            description: LogLevel for the compactor (e.g., debug,
+                              info, warn, error).
+                            type: string
+                          waitInterval:
+                            description: |-
+                              WaitInterval is the time to wait between compaction cycles.
+                              Setting this will also synchronize --compact.cleanup-interval and --compact.progress-interval.
+                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                            type: string
+                        type: object
                       resources:
                         description: Compute Resources required by the compact.
                         properties:

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -2033,15 +2033,22 @@ spec:
                             description: BlockMetaFetchConcurrency is the number of
                               concurrent requests to fetch block metadata.
                             format: int32
+                            minimum: 0
                             type: integer
                           downsampleConcurrency:
                             description: DownsampleConcurrency is the number of goroutines
                               to use when downsampling blocks.
                             format: int32
+                            minimum: 0
                             type: integer
                           logLevel:
                             description: LogLevel for the compactor (e.g., debug,
                               info, warn, error).
+                            enum:
+                            - debug
+                            - info
+                            - warn
+                            - error
                             type: string
                           waitInterval:
                             description: |-

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -2010,6 +2010,31 @@ spec:
                           - name
                           type: object
                         type: array
+                      debug:
+                        description: Debug defines the configuration for debugging
+                          and tuning the compactor.
+                        properties:
+                          blockMetaFetchConcurrency:
+                            description: BlockMetaFetchConcurrency is the number of
+                              concurrent requests to fetch block metadata.
+                            format: int32
+                            type: integer
+                          downsampleConcurrency:
+                            description: DownsampleConcurrency is the number of goroutines
+                              to use when downsampling blocks.
+                            format: int32
+                            type: integer
+                          logLevel:
+                            description: LogLevel for the compactor (e.g., debug,
+                              info, warn, error).
+                            type: string
+                          waitInterval:
+                            description: |-
+                              WaitInterval is the time to wait between compaction cycles.
+                              Setting this will also synchronize --compact.cleanup-interval and --compact.progress-interval.
+                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                            type: string
+                        type: object
                       resources:
                         description: Compute Resources required by the compact.
                         properties:

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -2018,15 +2018,22 @@ spec:
                             description: BlockMetaFetchConcurrency is the number of
                               concurrent requests to fetch block metadata.
                             format: int32
+                            minimum: 0
                             type: integer
                           downsampleConcurrency:
                             description: DownsampleConcurrency is the number of goroutines
                               to use when downsampling blocks.
                             format: int32
+                            minimum: 0
                             type: integer
                           logLevel:
                             description: LogLevel for the compactor (e.g., debug,
                               info, warn, error).
+                            enum:
+                            - debug
+                            - info
+                            - warn
+                            - error
                             type: string
                           waitInterval:
                             description: |-

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -1041,7 +1041,7 @@ func newCompactSpec(mco *mcov1beta2.MultiClusterObservability, scSelected string
 		compactSpec.Args = append(compactSpec.Args, fmt.Sprintf("--block-meta-fetch-concurrency=%d", *mco.Spec.AdvancedConfig.Compact.Debug.BlockMetaFetchConcurrency))
 	}
 	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.DownsampleConcurrency != nil {
-		compactSpec.Args = append(compactSpec.Args, fmt.Sprintf("--downsample-concurrency=%d", *mco.Spec.AdvancedConfig.Compact.Debug.DownsampleConcurrency))
+		compactSpec.Args = append(compactSpec.Args, fmt.Sprintf("--downsample.concurrency=%d", *mco.Spec.AdvancedConfig.Compact.Debug.DownsampleConcurrency))
 	}
 
 	compactSpec.VolumeClaimTemplate = newVolumeClaimTemplate(

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -1032,9 +1032,7 @@ func newCompactSpec(mco *mcov1beta2.MultiClusterObservability, scSelected string
 		duration, err := time.ParseDuration(mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval)
 		if err != nil {
 			log.Error(err, "Failed to parse wait interval", "waitInterval", mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval)
-			return compactSpec
-		}
-		if duration > 5*time.Minute {
+		} else if duration > 5*time.Minute {
 			compactSpec.Args = append(compactSpec.Args, "--web.disable")
 		}
 	}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -1036,7 +1036,8 @@ func newCompactSpec(mco *mcov1beta2.MultiClusterObservability, scSelected string
 			compactSpec.Args = append(compactSpec.Args, "--web.disable")
 		}
 	}
-	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.BlockMetaFetchConcurrency != nil {
+	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil &&
+		mco.Spec.AdvancedConfig.Compact.Debug.BlockMetaFetchConcurrency != nil {
 		compactSpec.Args = append(compactSpec.Args, fmt.Sprintf("--block-meta-fetch-concurrency=%d", *mco.Spec.AdvancedConfig.Compact.Debug.BlockMetaFetchConcurrency))
 	}
 	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.DownsampleConcurrency != nil {

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -1016,6 +1016,34 @@ func newCompactSpec(mco *mcov1beta2.MultiClusterObservability, scSelected string
 	if rendering.MCOAEnabled(mco) && (mco.Spec.AdvancedConfig == nil || mco.Spec.AdvancedConfig.Compact == nil || mco.Spec.AdvancedConfig.Compact.Containers == nil) {
 		compactSpec.Args = []string{"--compact.enable-vertical-compaction"}
 	}
+	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.LogLevel != "" {
+		compactSpec.Args = append(compactSpec.Args, "--log.level="+mco.Spec.AdvancedConfig.Compact.Debug.LogLevel)
+	}
+	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval != "" {
+		compactSpec.Args = append(compactSpec.Args, "--wait-interval="+mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval)
+	}
+	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval != "" {
+		compactSpec.Args = append(compactSpec.Args, "--compact.cleanup-interval="+mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval)
+	}
+	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval != "" {
+		compactSpec.Args = append(compactSpec.Args, "--compact.progress-interval="+mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval)
+	}
+	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval != "" {
+		duration, err := time.ParseDuration(mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval)
+		if err != nil {
+			log.Error(err, "Failed to parse wait interval", "waitInterval", mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval)
+			return compactSpec
+		}
+		if duration > 5*time.Minute {
+			compactSpec.Args = append(compactSpec.Args, "--web.disable")
+		}
+	}
+	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.BlockMetaFetchConcurrency != "" {
+		compactSpec.Args = append(compactSpec.Args, "--block-meta-fetch-concurrency="+mco.Spec.AdvancedConfig.Compact.Debug.BlockMetaFetchConcurrency)
+	}
+	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.DownsampleConcurrency != "" {
+		compactSpec.Args = append(compactSpec.Args, "--downsample-concurrency="+mco.Spec.AdvancedConfig.Compact.Debug.DownsampleConcurrency)
+	}
 
 	compactSpec.VolumeClaimTemplate = newVolumeClaimTemplate(
 		mco.Spec.StorageConfig.CompactStorageSize,

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -1016,25 +1016,21 @@ func newCompactSpec(mco *mcov1beta2.MultiClusterObservability, scSelected string
 	if rendering.MCOAEnabled(mco) && (mco.Spec.AdvancedConfig == nil || mco.Spec.AdvancedConfig.Compact == nil || mco.Spec.AdvancedConfig.Compact.Containers == nil) {
 		compactSpec.Args = []string{"--compact.enable-vertical-compaction"}
 	}
-	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.LogLevel != "" {
-		compactSpec.Args = append(compactSpec.Args, "--log.level="+mco.Spec.AdvancedConfig.Compact.Debug.LogLevel)
-	}
-	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval != "" {
-		compactSpec.Args = append(compactSpec.Args, "--wait-interval="+mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval)
-	}
-	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval != "" {
-		compactSpec.Args = append(compactSpec.Args, "--compact.cleanup-interval="+mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval)
-	}
-	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval != "" {
-		compactSpec.Args = append(compactSpec.Args, "--compact.progress-interval="+mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval)
-	}
 	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval != "" {
 		duration, err := time.ParseDuration(mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval)
 		if err != nil {
 			log.Error(err, "Failed to parse wait interval", "waitInterval", mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval)
-		} else if duration > 5*time.Minute {
-			compactSpec.Args = append(compactSpec.Args, "--web.disable")
+		} else {
+			compactSpec.Args = append(compactSpec.Args, "--wait-interval="+mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval)
+			compactSpec.Args = append(compactSpec.Args, "--compact.cleanup-interval="+mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval)
+			compactSpec.Args = append(compactSpec.Args, "--compact.progress-interval="+mco.Spec.AdvancedConfig.Compact.Debug.WaitInterval)
+			if duration > 5*time.Minute {
+				compactSpec.Args = append(compactSpec.Args, "--web.disable")
+			}
 		}
+	}
+	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.LogLevel != "" {
+		compactSpec.Args = append(compactSpec.Args, "--log.level="+mco.Spec.AdvancedConfig.Compact.Debug.LogLevel)
 	}
 	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil &&
 		mco.Spec.AdvancedConfig.Compact.Debug.BlockMetaFetchConcurrency != nil {

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -1038,11 +1038,11 @@ func newCompactSpec(mco *mcov1beta2.MultiClusterObservability, scSelected string
 			compactSpec.Args = append(compactSpec.Args, "--web.disable")
 		}
 	}
-	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.BlockMetaFetchConcurrency != "" {
-		compactSpec.Args = append(compactSpec.Args, "--block-meta-fetch-concurrency="+mco.Spec.AdvancedConfig.Compact.Debug.BlockMetaFetchConcurrency)
+	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.BlockMetaFetchConcurrency != nil {
+		compactSpec.Args = append(compactSpec.Args, fmt.Sprintf("--block-meta-fetch-concurrency=%d", *mco.Spec.AdvancedConfig.Compact.Debug.BlockMetaFetchConcurrency))
 	}
-	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.DownsampleConcurrency != "" {
-		compactSpec.Args = append(compactSpec.Args, "--downsample-concurrency="+mco.Spec.AdvancedConfig.Compact.Debug.DownsampleConcurrency)
+	if mco.Spec.AdvancedConfig != nil && mco.Spec.AdvancedConfig.Compact != nil && mco.Spec.AdvancedConfig.Compact.Debug != nil && mco.Spec.AdvancedConfig.Compact.Debug.DownsampleConcurrency != nil {
+		compactSpec.Args = append(compactSpec.Args, fmt.Sprintf("--downsample-concurrency=%d", *mco.Spec.AdvancedConfig.Compact.Debug.DownsampleConcurrency))
 	}
 
 	compactSpec.VolumeClaimTemplate = newVolumeClaimTemplate(

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
@@ -1088,10 +1088,10 @@ func TestNewCompactSpec(t *testing.T) {
 				DownsampleConcurrency:     ptr.To(int32(4)),
 			},
 			expectedArgs: []string{
-				"--log.level=debug",
 				"--wait-interval=5m",
 				"--compact.cleanup-interval=5m",
 				"--compact.progress-interval=5m",
+				"--log.level=debug",
 				"--block-meta-fetch-concurrency=64",
 				"--downsample.concurrency=4",
 			},

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
@@ -1093,7 +1093,7 @@ func TestNewCompactSpec(t *testing.T) {
 				"--compact.cleanup-interval=5m",
 				"--compact.progress-interval=5m",
 				"--block-meta-fetch-concurrency=64",
-				"--downsample-concurrency=4",
+				"--downsample.concurrency=4",
 			},
 		},
 		{

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
@@ -1057,6 +1057,7 @@ func TestNewCompactSpec(t *testing.T) {
 		name         string
 		mcoaEnabled  bool
 		hasContainer bool
+		debug        *mcov1beta2.CompactDebugSpec
 		expectedArgs []string
 	}{
 		{
@@ -1076,6 +1077,48 @@ func TestNewCompactSpec(t *testing.T) {
 			mcoaEnabled:  true,
 			hasContainer: true,
 			expectedArgs: nil,
+		},
+		{
+			name: "compact debug with all fields at default wait interval",
+			debug: &mcov1beta2.CompactDebugSpec{
+				LogLevel:                  "debug",
+				WaitInterval:              "5m",
+				BlockMetaFetchConcurrency: "64",
+				DownsampleConcurrency:     "4",
+			},
+			expectedArgs: []string{
+				"--log.level=debug",
+				"--wait-interval=5m",
+				"--compact.cleanup-interval=5m",
+				"--compact.progress-interval=5m",
+				"--block-meta-fetch-concurrency=64",
+				"--downsample-concurrency=4",
+			},
+		},
+		{
+			name: "compact debug with wait interval above 5m adds web disable",
+			debug: &mcov1beta2.CompactDebugSpec{
+				WaitInterval:              "10m",
+				BlockMetaFetchConcurrency: "32",
+			},
+			expectedArgs: []string{
+				"--wait-interval=10m",
+				"--compact.cleanup-interval=10m",
+				"--compact.progress-interval=10m",
+				"--web.disable",
+				"--block-meta-fetch-concurrency=32",
+			},
+		},
+		{
+			name:        "MCOA enabled with compact debug",
+			mcoaEnabled: true,
+			debug: &mcov1beta2.CompactDebugSpec{
+				LogLevel: "info",
+			},
+			expectedArgs: []string{
+				"--compact.enable-vertical-compaction",
+				"--log.level=info",
+			},
 		},
 	}
 
@@ -1102,18 +1145,22 @@ func TestNewCompactSpec(t *testing.T) {
 				}
 			}
 
-			if tt.hasContainer {
+			if tt.hasContainer || tt.debug != nil {
 				mco.Spec.AdvancedConfig = &mcov1beta2.AdvancedConfig{
-					Compact: &mcov1beta2.CompactSpec{
-						Containers: []corev1.Container{{Name: "test"}},
-					},
+					Compact: &mcov1beta2.CompactSpec{},
+				}
+				if tt.hasContainer {
+					mco.Spec.AdvancedConfig.Compact.Containers = []corev1.Container{{Name: "test"}}
+				}
+				if tt.debug != nil {
+					mco.Spec.AdvancedConfig.Compact.Debug = tt.debug
 				}
 			}
 
 			compactSpec := newCompactSpec(mco, "test-sc")
 
 			if len(compactSpec.Args) != len(tt.expectedArgs) {
-				t.Fatalf("expected %d args, got %d", len(tt.expectedArgs), len(compactSpec.Args))
+				t.Fatalf("expected %d args, got %d: %v", len(tt.expectedArgs), len(compactSpec.Args), compactSpec.Args)
 			}
 
 			for i, expectedArg := range tt.expectedArgs {

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -1083,8 +1084,8 @@ func TestNewCompactSpec(t *testing.T) {
 			debug: &mcov1beta2.CompactDebugSpec{
 				LogLevel:                  "debug",
 				WaitInterval:              "5m",
-				BlockMetaFetchConcurrency: "64",
-				DownsampleConcurrency:     "4",
+				BlockMetaFetchConcurrency: ptr.To(int32(64)),
+				DownsampleConcurrency:     ptr.To(int32(4)),
 			},
 			expectedArgs: []string{
 				"--log.level=debug",
@@ -1099,7 +1100,7 @@ func TestNewCompactSpec(t *testing.T) {
 			name: "compact debug with wait interval above 5m adds web disable",
 			debug: &mcov1beta2.CompactDebugSpec{
 				WaitInterval:              "10m",
-				BlockMetaFetchConcurrency: "32",
+				BlockMetaFetchConcurrency: ptr.To(int32(32)),
 			},
 			expectedArgs: []string{
 				"--wait-interval=10m",

--- a/tests/pkg/tests/observability_config_test.go
+++ b/tests/pkg/tests/observability_config_test.go
@@ -479,26 +479,6 @@ var _ = Describe("", func() {
 	It(
 		"ACM-34594: Observability: Verify Thanos Compact debug tuning in MCO CR - [P2][Sev2][Observability][Integration]@ocpInterop @non-ui-post-restore @non-ui-post-release @non-ui-pre-upgrade @non-ui-post-upgrade @post-upgrade @post-restore @e2e @post-release (config/g0)",
 		func() {
-			By("Applying initial MCO config without custom compact containers")
-			mcoPath := ""
-			if os.Getenv("IS_CANARY_ENV") != trueStr {
-				mcoPath = "../../../examples/updatemcocr/initialmcoconfig/custom-certs"
-			} else {
-				mcoPath = "../../../examples/updatemcocr/initialmcoconfig"
-			}
-
-			yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: mcoPath})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(
-				utils.ApplyRetryOnConflict(
-					testOptions.HubCluster.ClusterServerURL,
-					testOptions.KubeConfig,
-					testOptions.HubCluster.KubeContext,
-					yamlB,
-				)).NotTo(HaveOccurred())
-
-			time.Sleep(60 * time.Second)
-
 			By("Updating MCO CR with compact debug settings")
 			mcoRes, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).
 				Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
@@ -594,19 +574,6 @@ var _ = Describe("", func() {
 				}
 				return nil
 			}, EventuallyTimeoutMinute*2, EventuallyIntervalSecond*10).Should(Succeed())
-
-			By("Revert MCO back to initial config")
-			yamlB, err = kustomize.Render(kustomize.Options{KustomizationPath: mcoPath})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(
-				utils.ApplyRetryOnConflict(
-					testOptions.HubCluster.ClusterServerURL,
-					testOptions.KubeConfig,
-					testOptions.HubCluster.KubeContext,
-					yamlB,
-				)).NotTo(HaveOccurred())
-
-			time.Sleep(60 * time.Second)
 		},
 	)
 

--- a/tests/pkg/tests/observability_config_test.go
+++ b/tests/pkg/tests/observability_config_test.go
@@ -476,6 +476,140 @@ var _ = Describe("", func() {
 		},
 	)
 
+	It(
+		"ACM-34594: Observability: Verify Thanos Compact debug tuning in MCO CR - [P2][Sev2][Observability][Integration]@ocpInterop @non-ui-post-restore @non-ui-post-release @non-ui-pre-upgrade @non-ui-post-upgrade @post-upgrade @post-restore @e2e @post-release (config/g0)",
+		func() {
+			By("Applying initial MCO config without custom compact containers")
+			mcoPath := ""
+			if os.Getenv("IS_CANARY_ENV") != trueStr {
+				mcoPath = "../../../examples/updatemcocr/initialmcoconfig/custom-certs"
+			} else {
+				mcoPath = "../../../examples/updatemcocr/initialmcoconfig"
+			}
+
+			yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: mcoPath})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(
+				utils.ApplyRetryOnConflict(
+					testOptions.HubCluster.ClusterServerURL,
+					testOptions.KubeConfig,
+					testOptions.HubCluster.KubeContext,
+					yamlB,
+				)).NotTo(HaveOccurred())
+
+			time.Sleep(60 * time.Second)
+
+			By("Updating MCO CR with compact debug settings")
+			mcoRes, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+				Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			spec := mcoRes.Object["spec"].(map[string]any)
+			advancedSpec, ok := spec["advanced"].(map[string]any)
+			if !ok {
+				Skip("Skip the case since the MCO CR did not have advanced spec configured")
+			}
+			compactSpec, ok := advancedSpec["compact"].(map[string]any)
+			if !ok {
+				compactSpec = map[string]any{}
+				advancedSpec["compact"] = compactSpec
+			}
+			compactSpec["debug"] = map[string]any{
+				"logLevel":                  "debug",
+				"waitInterval":              "5m",
+				"blockMetaFetchConcurrency": int64(64),
+				"downsampleConcurrency":     int64(4),
+			}
+
+			_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+				Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedCompactDebugArgs := []string{
+				"--log.level=debug",
+				"--wait-interval=5m",
+				"--compact.cleanup-interval=5m",
+				"--compact.progress-interval=5m",
+				"--block-meta-fetch-concurrency=64",
+				"--downsample.concurrency=4",
+			}
+
+			By("Checking compact debug args are applied to observability-thanos-compact")
+			Eventually(func() error {
+				sts, err := utils.GetStatefulSetWithLabel(testOptions, true, THANOS_COMPACT_LABEL, MCO_NAMESPACE)
+				if err != nil {
+					return err
+				}
+				if len(sts.Items) == 0 {
+					return fmt.Errorf("no thanos-compact statefulset found")
+				}
+				args := sts.Items[0].Spec.Template.Spec.Containers[0].Args
+				for _, expectedArg := range expectedCompactDebugArgs {
+					if !slices.Contains(args, expectedArg) {
+						return fmt.Errorf("expected arg %q not found in thanos-compact args: %v", expectedArg, args)
+					}
+				}
+				if slices.Contains(args, "--web.disable") {
+					return fmt.Errorf("did not expect --web.disable for 5m wait interval, args: %v", args)
+				}
+				return nil
+			}, EventuallyTimeoutMinute*2, EventuallyIntervalSecond*10).Should(Succeed())
+
+			By("Updating wait interval above 5m adds web disable flag")
+			mcoRes, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+				Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			spec = mcoRes.Object["spec"].(map[string]any)
+			advancedSpec = spec["advanced"].(map[string]any)
+			compactSpec = advancedSpec["compact"].(map[string]any)
+			compactSpec["debug"] = map[string]any{
+				"waitInterval":              "10m",
+				"blockMetaFetchConcurrency": int64(32),
+			}
+
+			_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+				Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() error {
+				sts, err := utils.GetStatefulSetWithLabel(testOptions, true, THANOS_COMPACT_LABEL, MCO_NAMESPACE)
+				if err != nil {
+					return err
+				}
+				if len(sts.Items) == 0 {
+					return fmt.Errorf("no thanos-compact statefulset found")
+				}
+				args := sts.Items[0].Spec.Template.Spec.Containers[0].Args
+				for _, expectedArg := range []string{
+					"--wait-interval=10m",
+					"--compact.cleanup-interval=10m",
+					"--compact.progress-interval=10m",
+					"--web.disable",
+					"--block-meta-fetch-concurrency=32",
+				} {
+					if !slices.Contains(args, expectedArg) {
+						return fmt.Errorf("expected arg %q not found in thanos-compact args: %v", expectedArg, args)
+					}
+				}
+				return nil
+			}, EventuallyTimeoutMinute*2, EventuallyIntervalSecond*10).Should(Succeed())
+
+			By("Revert MCO back to initial config")
+			yamlB, err = kustomize.Render(kustomize.Options{KustomizationPath: mcoPath})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(
+				utils.ApplyRetryOnConflict(
+					testOptions.HubCluster.ClusterServerURL,
+					testOptions.KubeConfig,
+					testOptions.HubCluster.KubeContext,
+					yamlB,
+				)).NotTo(HaveOccurred())
+
+			time.Sleep(60 * time.Second)
+		},
+	)
+
 	JustAfterEach(func() {
 		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 	})


### PR DESCRIPTION
Summary:

Fixes [ACM-34594](https://redhat.atlassian.net/browse/ACM-34594)
When a Thanos Compactor becomes unhealthy or lags behind, it accumulates a backlog of blocks. In large environments, this can result in tens of thousands of blocks waiting for compaction and downsampling. 

The default --wait-interval=5m (which also acts as a synchronization timeout) is often insufficient for metadata sync to complete under such load, causing the compactor to crash or hang in a loop. Furthermore, users currently lack the ability to tune the concurrency of metadata fetching or downsampling to speed up the recovery of a lagging compactor without manually overriding the entire container spec.

Problem: 

Users of MCO currently lack easy ability to tweak Thanos Compact

Root Cause:

The options were not easily available through the API. 

Fix:

Add a CompactDebugSpec to CompactSpec with LogLevel, WaitInterval, BlockMetaFetchConcurrency and Downsample Concurrency fields. Also  change logic controller must automatically append --web.disable if WaitInterval is longer than 5 minutes. This is required to bypass the 5-minute timeout enforced by the Thanos web interface on the common execution context

Files Changed:

Modified: 
```
operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
tests/pkg/tests/observability_config_test.go
```

Test Plan:
Tested end to end locally on the collective cluster and verified that the PrometheusRules and ScrapeConfigs deployed in the manifests/base/grafana on the hub by the MCOA no longer appear when the MCOA is switched to the MCO. 
Created Unit tests and verified that unit tests run successfully. An end to end test was also created that checks that the Thanos Compact Stateful state has the intended flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional compactor debug/tuning config in the CRD (log level, wait interval, block-meta-fetch concurrency, downsample concurrency). If wait interval > 5 minutes, the web UI is disabled automatically.
* **Tests**
  * Expanded unit tests to cover new debug scenarios and improved failure output for argument mismatches.
* **Chores**
  * Updated release manifest timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ACM-34594]: https://redhat.atlassian.net/browse/ACM-34594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ