### PR TITLE
Add HCP Monitoring Support CLI Tool for monitoring HCPs on managed clusters

### DIFF
--- a/operators/endpointmetrics/cmd/hcp-monitoring-support/README.md
+++ b/operators/endpointmetrics/cmd/hcp-monitoring-support/README.md
@@ -1,0 +1,49 @@
+# HCP Monitoring Support Tool
+
+This tool provides a support exception for monitoring Hosted Control Planes (HCP) on managed clusters. It creates specific `ServiceMonitors` with the correct cluster identification labels required by ACM.
+
+## Important: Support Scope
+
+- **Architecture Compatibility**: This tool is **only supported** when using the legacy **metrics-collector** architecture. It is NOT compatible with the new **MCOA** (Multi-Cluster Observability Addon) architecture.
+- **Native Support Versions**: 
+  - **metrics-collector**: This feature (automatic monitoring of Hosted Clusters on managed clusters) is natively supported starting from version **2.17**.
+  - **MCOA**: Native support for this feature is planned for version **5.0**.
+
+## Prerequisites
+
+To build and run this tool, the following must be installed on your system:
+- **Go**: Version 1.23 or higher (as specified in the project's `go.mod`).
+- **Git**: To clone the repository and manage dependencies.
+- **Access**: A user with `cluster-admin` permissions on the managed cluster.
+
+## Authentication
+
+The tool uses the standard Kubernetes client-go authentication logic. It will look for cluster credentials in the following order:
+1. The `KUBECONFIG` environment variable pointing to a valid kubeconfig file.
+2. The default `~/.kube/config` file.
+
+**Important**: Ensure your current context is set to the managed cluster where the Hosted Control Planes are running.
+
+## Usage
+
+### Run directly
+You can run the tool directly using the Go toolchain:
+```bash
+export KUBECONFIG=/path/to/managed-cluster-kubeconfig
+go run -mod=mod operators/endpointmetrics/cmd/hcp-monitoring-support/main.go --setup
+```
+
+### Build and run binary
+Alternatively, you can build a standalone binary:
+```bash
+go build -mod=mod -o hcp-monitoring-support operators/endpointmetrics/cmd/hcp-monitoring-support/main.go
+./hcp-monitoring-support --setup
+```
+
+### Commands
+- `--setup`: Create or update the required `ServiceMonitors` for all `HostedClusters` found on the cluster.
+- `--cleanup`: Delete the ACM-specific `ServiceMonitors`.
+
+### Options
+- `--auto-approve`: Automatically approve write actions (skips the confirmation prompt).
+- `--dry-run`: Display what actions would be taken without executing any changes on the cluster.

--- a/operators/endpointmetrics/cmd/hcp-monitoring-support/main.go
+++ b/operators/endpointmetrics/cmd/hcp-monitoring-support/main.go
@@ -1,0 +1,135 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/hypershift"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+func main() {
+	setup := flag.Bool("setup", false, "Create/Update ServiceMonitors for Hosted Clusters")
+	cleanup := flag.Bool("cleanup", false, "Delete ServiceMonitors for Hosted Clusters")
+	autoApprove := flag.Bool("auto-approve", false, "Automatically approve all actions")
+	dryRun := flag.Bool("dry-run", false, "Display actions without executing them")
+	flag.Parse()
+
+	if !*setup && !*cleanup {
+		fmt.Fprintln(os.Stderr, "Error: Either --setup or --cleanup must be specified.")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	if *setup && *cleanup {
+		fmt.Fprintln(os.Stderr, "Error: --setup and --cleanup cannot be used together.")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(promv1.AddToScheme(scheme))
+	utilruntime.Must(hyperv1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+
+	ctx := context.Background()
+	cfg, err := config.GetConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get kubeconfig: %v\n", err)
+		os.Exit(1)
+	}
+
+	c, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create client: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Check for HyperShift CRD
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	err = c.Get(ctx, client.ObjectKey{Name: hypershift.HostedClusterCRDName}, crd)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			fmt.Fprintln(os.Stderr, "Error: This cluster does not appear to be a HyperShift cluster (HostedCluster CRD not found).")
+		} else {
+			fmt.Fprintf(os.Stderr, "Failed to check for HyperShift CRD: %v\n", err)
+		}
+		os.Exit(1)
+	}
+
+	if *dryRun {
+		c = client.NewDryRunClient(c)
+		fmt.Println("--- DRY RUN MODE ENABLED ---")
+	}
+
+	if *setup {
+		if !confirmAction("This will create/update ACM ServiceMonitors for all HostedClusters. Proceed?", *autoApprove, *dryRun) {
+			return
+		}
+		fmt.Println("Scanning for HostedClusters...")
+		count, err := hypershift.ReconcileHostedClustersServiceMonitors(ctx, c)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Setup failed: %v\n", err)
+			os.Exit(1)
+		}
+		if *dryRun {
+			fmt.Printf("[Dry-run] Would have reconciled ServiceMonitors for %d HostedClusters.\n", count)
+		} else {
+			fmt.Printf("Successfully reconciled ServiceMonitors for %d HostedClusters.\n", count)
+		}
+	}
+
+	if *cleanup {
+		if !confirmAction("This will delete ACM ServiceMonitors for all HostedClusters. Proceed?", *autoApprove, *dryRun) {
+			return
+		}
+		err := hypershift.DeleteServiceMonitors(ctx, c)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Cleanup failed: %v\n", err)
+			os.Exit(1)
+		}
+		if *dryRun {
+			fmt.Println("[Dry-run] Would have deleted ACM ServiceMonitors.")
+		} else {
+			fmt.Println("Successfully deleted ACM ServiceMonitors.")
+		}
+	}
+}
+
+func confirmAction(message string, autoApprove, dryRun bool) bool {
+	if autoApprove || dryRun {
+		return true
+	}
+
+	fmt.Printf("%s (y/n): ", message)
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+	if response == "y" || response == "yes" {
+		return true
+	}
+
+	fmt.Println("Aborted.")
+	return false
+}

--- a/operators/endpointmetrics/pkg/hypershift/hypershift.go
+++ b/operators/endpointmetrics/pkg/hypershift/hypershift.go
@@ -25,6 +25,8 @@ const (
 	AcmApiServerSmName = "acm-kube-apiserver"
 	EtcdSmName         = "etcd"
 	ApiServerSmName    = "kube-apiserver"
+
+	HostedClusterCRDName = "hostedclusters.hypershift.openshift.io"
 )
 
 // ReconcileHostedClustersServiceMonitors reconciles ServiceMonitors for hypershift hosted clusters
@@ -102,7 +104,7 @@ func IsHypershiftCluster() (bool, error) {
 		return false, fmt.Errorf("failed to get/create CRD client: %w", err)
 	}
 
-	isHypershift, err = operatorutil.CheckCRDExist(crdClient, "hostedclusters.hypershift.openshift.io")
+	isHypershift, err = operatorutil.CheckCRDExist(crdClient, HostedClusterCRDName)
 	if err != nil {
 		return false, fmt.Errorf("failed to check if the CRD hostedclusters.hypershift.openshift.io exists: %w", err)
 	}


### PR DESCRIPTION
#### Overview
This PR introduces a standalone CLI tool to provide a support exception for customers who need to monitor Hosted Control Planes (HCP) running on managed clusters (spokes). Currently, native reconciliation of these ServiceMonitors is restricted to the Hub or requires newer versions of the metrics-collector.

This tool allows administrators to manually bridge this gap until they can migrate to natively supported versions.

#### Key Features
- **Idempotent Setup**: Uses the same logic as the operator to create/update `acm-etcd` and `acm-kube-apiserver` ServiceMonitors with the required `_id` and cluster identification labels.
- **Cleanup Mode**: Easily remove the ACM-specific monitoring resources when they are no longer needed.
- **Safety First**: Includes a `--dry-run` mode to simulate API calls and an interactive confirmation prompt (bypassable with `--auto-approve`).
- **Robust Detection**: Automatically verifies the presence of the `HostedCluster` CRD before execution.

#### Compatibility & Roadmap
- **Architecture**: This tool is designed **specifically for the legacy `metrics-collector`** architecture. It is not compatible with MCOA.
- **Native Support**:
  - `metrics-collector`: Native support is available in version **2.17+**.
  - `MCOA`: Native support is planned for version **5.0**.

#### Location
- Code: `operators/endpointmetrics/cmd/hcp-monitoring-support/main.go`
- Documentation: `operators/endpointmetrics/cmd/hcp-monitoring-support/README.md`

#### How to use
```bash
# Preview changes
go run -mod=mod operators/endpointmetrics/cmd/hcp-monitoring-support/main.go --setup --dry-run

# Apply monitoring
go run -mod=mod operators/endpointmetrics/cmd/hcp-monitoring-support/main.go --setup --auto-approve
```
