### PR TITLE
[ACM-34653] restart alertmanager pods on client CA changes via hash annotation

### DIFF
--- a/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
@@ -6,6 +6,8 @@ package rendering
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 
@@ -143,6 +145,18 @@ func (r *MCORenderer) renderAlertManagerStatefulSet(ctx context.Context, res *re
 	}
 	kubeRbacProxyContainer.ImagePullPolicy = imagePullPolicy
 
+	// Compute hash of the client CA to trigger a rolling restart when the CA rotates.
+	// kube-rbac-proxy reads --client-ca-file only at startup; without this, a CA
+	// rotation leaves the pod using a stale CA until manually restarted (ACM-34653).
+	caHash, err := r.getClientCAHash(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute client CA hash: %w", err)
+	}
+	if dep.Spec.Template.Annotations == nil {
+		dep.Spec.Template.Annotations = map[string]string{}
+	}
+	dep.Spec.Template.Annotations["observability.open-cluster-management.io/client-ca-hash"] = caHash
+
 	// replace the volumeClaimTemplate
 	dep.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = &r.cr.Spec.StorageConfig.StorageClass
 	dep.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = apiresource.MustParse(r.cr.Spec.StorageConfig.AlertmanagerStorageSize)
@@ -153,6 +167,25 @@ func (r *MCORenderer) renderAlertManagerStatefulSet(ctx context.Context, res *re
 	}
 
 	return &unstructured.Unstructured{Object: unstructuredObj}, nil
+}
+
+func (r *MCORenderer) getClientCAHash(ctx context.Context) (string, error) {
+	namespacedName := types.NamespacedName{
+		Name:      "extension-apiserver-authentication",
+		Namespace: "kube-system",
+	}
+	sourceConfigMap := &corev1.ConfigMap{}
+	if err := r.kubeClient.Get(ctx, namespacedName, sourceConfigMap); err != nil {
+		return "", fmt.Errorf("error fetching extension-apiserver-authentication ConfigMap: %w", err)
+	}
+
+	caData, exists := sourceConfigMap.Data["client-ca-file"]
+	if !exists || len(caData) == 0 {
+		return "", fmt.Errorf("client-ca-file not found or empty in extension-apiserver-authentication ConfigMap")
+	}
+
+	hash := sha256.Sum256([]byte(caData))
+	return hex.EncodeToString(hash[:]), nil
 }
 
 func (r *MCORenderer) renderAlertManagerSecret(ctx context.Context, res *resource.Resource,

--- a/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager_test.go
@@ -5,6 +5,8 @@
 package rendering
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -70,6 +72,12 @@ func TestAlertManagerRenderer(t *testing.T) {
 	// clientCa configmap must be filled with the client-ca-file data
 	clientCaData := getResource[*corev1.ConfigMap](alertResources, "alertmanager-clientca-metric")
 	assert.Equal(t, clientCa.Data["client-ca-file"], clientCaData.Data["client-ca-file"])
+
+	// StatefulSet pod template must have the client CA hash annotation
+	sts := getResource[*appsv1.StatefulSet](alertResources, "")
+	caHashAnnotation := sts.Spec.Template.Annotations["observability.open-cluster-management.io/client-ca-hash"]
+	expectedHash := sha256.Sum256([]byte(clientCa.Data["client-ca-file"]))
+	assert.Equal(t, hex.EncodeToString(expectedHash[:]), caHashAnnotation)
 
 	// container images must be replaced with the ones from the mch-image-manifest configmap
 	for _, obj := range alertResources {
@@ -282,6 +290,36 @@ func TestAlertManagerRendererMCOConfig(t *testing.T) {
 			tc.expect(t, sts)
 		})
 	}
+}
+
+func TestAlertManagerClientCAHashRotation(t *testing.T) {
+	makeCA := func(data string) *corev1.ConfigMap {
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "extension-apiserver-authentication",
+				Namespace: "kube-system",
+			},
+			Data: map[string]string{
+				"client-ca-file": data,
+			},
+		}
+	}
+
+	client1 := fake.NewClientBuilder().WithObjects(makeCA("old-ca-bundle")).Build()
+	client2 := fake.NewClientBuilder().WithObjects(makeCA("new-ca-bundle")).Build()
+
+	resources1 := renderTemplates(t, client1, makeBaseMco())
+	resources2 := renderTemplates(t, client2, makeBaseMco())
+
+	sts1 := getResource[*appsv1.StatefulSet](resources1, "")
+	sts2 := getResource[*appsv1.StatefulSet](resources2, "")
+
+	hash1 := sts1.Spec.Template.Annotations["observability.open-cluster-management.io/client-ca-hash"]
+	hash2 := sts2.Spec.Template.Annotations["observability.open-cluster-management.io/client-ca-hash"]
+
+	assert.NotEmpty(t, hash1)
+	assert.NotEmpty(t, hash2)
+	assert.NotEqual(t, hash1, hash2, "hash must change when CA data changes")
 }
 
 func makeBaseMco() *mcov1beta2.MultiClusterObservability {


### PR DESCRIPTION
Related [ACM-34653](https://redhat.atlassian.net/browse/ACM-34653) 

Problem: After client CA rotation, kube-rbac-proxy in the alertmanager pod rejects all Prometheus scrapes with x509: certificate signed by unknown authority because it reads --client-ca-file only at startup. The operator updates the config map (ACM-20743 fix) but never restarts the pod.

Fix: Add SHA256 hash of the client CA data as a pod template annotation on the alertmanager StatefulSet. When CA rotates → hash changes → pod template changes → Kubernetes triggers rolling restart → kube-rbac-proxy loads new CA.


[ACM-34653]: https://redhat.atlassian.net/browse/ACM-34653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AlertManager pods now include a deterministic client-CA hash annotation so changes to the cluster CA trigger an automated rolling update, ensuring pods use the current certificate without manual intervention.

* **Tests**
  * Added tests that verify the client-CA hash is produced deterministically and changes when CA content changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->