### PR TITLE
Fix Integration test cert mismatch

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_integration_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/observabilityaddon_controller_integration_test.go
@@ -103,6 +103,20 @@ alertmanager-router-ca: |
 			Data:       nil,
 			StringData: map[string]string{hubAmAccessorSecretKey: "lol"},
 		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      mtlsCertName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{"tls.crt": []byte("test-cert"), "tls.key": []byte("test-key")},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      mtlsCaName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{"ca.crt": []byte("test-ca")},
+		},
 		&oav1beta1.ObservabilityAddon{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "observability-addon",

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
@@ -959,6 +959,10 @@ func RevertUserWorkloadMonitoringConfig(ctx context.Context, client client.Clien
 func createMtlsSecretInNamespace(ctx context.Context, c client.Client, sourceNamespace, targetNamespace, secretName string, secretRename string, hubInfo *operatorconfig.HubInfo) error {
 	source := &corev1.Secret{}
 	if err := c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: sourceNamespace}, source); err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("mTLS secret not found", "name", secretName, "namespace", sourceNamespace)
+			return nil
+		}
 		return fmt.Errorf("failed to get source secret %s/%s: %w", sourceNamespace, secretName, err)
 	}
 


### PR DESCRIPTION
The TestIntegrationCMOConfigWatching test previously didn't run until recent changes made. With alert fanout changes from https://github.com/stolostron/multicluster-observability-operator/pull/2485 the mTLS secrets need to be added such that they can be copied into cmo. 

Avoid nil pointer error on missing mTLS secrets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mTLS certificate handling to gracefully manage unavailable certificates, allowing the system to continue operating with appropriate logging instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->