### PR TITLE
Fix for e2e kind tests following alert fanout

### DIFF
--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
@@ -147,7 +147,7 @@ func createHubAmAccessorTokenSecret(ctx context.Context, client client.Client, n
 		return fmt.Errorf("fail to get %s/%s secret: %w", namespace, hubAmAccessorSecretName, err)
 	}
 
-	hubAmAccessorSecret := appendHubClusterID(hubAmAccessorSecretName, hubInfo)
+	hubAmAccessorSecret := hubInfo.AppendHubClusterID(hubAmAccessorSecretName)
 	dataMap := map[string][]byte{hubAmAccessorSecretKey: []byte(amAccessorToken)}
 	hubAmAccessorTokenSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -242,7 +242,7 @@ func cleanUpOldAMSecrets(ctx context.Context, client client.Client, targetNamesp
 		deleteSecret(hubAmRouterCASecretName+"-"+clusterDomain, targetNamespace)
 	}
 	if hubInfo != nil && hubInfo.HubClusterID != "" {
-		deleteSecret(appendHubClusterID(hubAmRouterCASecretName, hubInfo), targetNamespace)
+		deleteSecret(hubInfo.AppendHubClusterID(hubAmRouterCASecretName), targetNamespace)
 	}
 
 	if uwlNsExists {
@@ -254,7 +254,7 @@ func cleanUpOldAMSecrets(ctx context.Context, client client.Client, targetNamesp
 			deleteSecret(hubAmRouterCASecretName+"-"+clusterDomain, ns)
 		}
 		if hubInfo != nil && hubInfo.HubClusterID != "" {
-			deleteSecret(appendHubClusterID(hubAmRouterCASecretName, hubInfo), ns)
+			deleteSecret(hubInfo.AppendHubClusterID(hubAmRouterCASecretName), ns)
 		}
 	}
 
@@ -264,16 +264,9 @@ func cleanUpOldAMSecrets(ctx context.Context, client client.Client, targetNamesp
 	return nil
 }
 
-func appendHubClusterID(secretName string, hubInfo *operatorconfig.HubInfo) string {
-	if hubInfo == nil || hubInfo.HubClusterID == "" {
-		return secretName
-	}
-	return secretName + "-" + hubInfo.HubClusterID
-}
-
 func newAdditionalAlertmanagerConfig(hubInfo *operatorconfig.HubInfo) cmomanifests.AdditionalAlertmanagerConfig {
-	amMtlsCARef := appendHubClusterID(amMtlsCaName, hubInfo)
-	amMtlsCertRef := appendHubClusterID(amMtlsCertName, hubInfo)
+	amMtlsCARef := hubInfo.AppendHubClusterID(amMtlsCaName)
+	amMtlsCertRef := hubInfo.AppendHubClusterID(amMtlsCertName)
 	config := cmomanifests.AdditionalAlertmanagerConfig{
 		Scheme:     "https",
 		PathPrefix: "/",
@@ -301,7 +294,7 @@ func newAdditionalAlertmanagerConfig(hubInfo *operatorconfig.HubInfo) cmomanifes
 		},
 		BearerToken: &corev1.SecretKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{
-				Name: appendHubClusterID(hubAmAccessorSecretName, hubInfo),
+				Name: hubInfo.AppendHubClusterID(hubAmAccessorSecretName),
 			},
 			Key: hubAmAccessorSecretKey,
 		},
@@ -962,7 +955,7 @@ func createMtlsSecretInNamespace(ctx context.Context, c client.Client, sourceNam
 		return fmt.Errorf("failed to get source secret %s/%s: %w", sourceNamespace, secretName, err)
 	}
 
-	targetName := appendHubClusterID(secretRename, hubInfo)
+	targetName := hubInfo.AppendHubClusterID(secretRename)
 	target := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      targetName,

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
@@ -420,8 +420,8 @@ func testCreateOrUpdateClusterMonitoringConfig(t *testing.T, hubInfo *operatorco
 	}
 
 	containsOCMAlertmanagerConfig := false
-	amMtlsCARef := appendHubClusterID(amMtlsCaName, hubInfo)
-	amMtlsCertRef := appendHubClusterID(amMtlsCertName, hubInfo)
+	amMtlsCARef := hubInfo.AppendHubClusterID(amMtlsCaName)
+	amMtlsCertRef := hubInfo.AppendHubClusterID(amMtlsCertName)
 	for _, v := range foundClusterMonitoringConfiguration.PrometheusK8sConfig.AlertmanagerConfigs {
 		if v.TLSConfig.CA != nil && v.TLSConfig.CA.Name == amMtlsCARef &&
 			v.TLSConfig.Cert != nil && v.TLSConfig.Cert.Name == amMtlsCertRef &&
@@ -636,8 +636,8 @@ func testCreateOrUpdateUserWorkloadMonitoringConfig(t *testing.T, hubInfo *opera
 	}
 
 	containsOCMAlertmanagerConfig := false
-	amMtlsCARef := appendHubClusterID(amMtlsCaName, hubInfo)
-	amMtlsCertRef := appendHubClusterID(amMtlsCertName, hubInfo)
+	amMtlsCARef := hubInfo.AppendHubClusterID(amMtlsCaName)
+	amMtlsCertRef := hubInfo.AppendHubClusterID(amMtlsCertName)
 	for _, v := range foundUserWorkloadConfiguration.Prometheus.AlertmanagerConfigs {
 		if v.TLSConfig.CA != nil && v.TLSConfig.CA.Name == amMtlsCARef &&
 			v.TLSConfig.Cert != nil && v.TLSConfig.Cert.Name == amMtlsCertRef &&
@@ -795,8 +795,8 @@ prometheus:
 	}
 
 	containsOCMAlertmanagerConfig := false
-	amMtlsCARef := appendHubClusterID(amMtlsCaName, hubInfo)
-	amMtlsCertRef := appendHubClusterID(amMtlsCertName, hubInfo)
+	amMtlsCARef := hubInfo.AppendHubClusterID(amMtlsCaName)
+	amMtlsCertRef := hubInfo.AppendHubClusterID(amMtlsCertName)
 	for _, v := range foundUserWorkloadConfiguration.Prometheus.AlertmanagerConfigs {
 		if v.TLSConfig.CA != nil && v.TLSConfig.CA.Name == amMtlsCARef &&
 			v.TLSConfig.Cert != nil && v.TLSConfig.Cert.Name == amMtlsCertRef &&
@@ -926,8 +926,8 @@ prometheus:
 	}
 
 	containsOCMAlertmanagerConfig := false
-	amMtlsCARef := appendHubClusterID(amMtlsCaName, hubInfo)
-	amMtlsCertRef := appendHubClusterID(amMtlsCertName, hubInfo)
+	amMtlsCARef := hubInfo.AppendHubClusterID(amMtlsCaName)
+	amMtlsCertRef := hubInfo.AppendHubClusterID(amMtlsCertName)
 	for _, v := range foundUserWorkloadConfiguration.Prometheus.AlertmanagerConfigs {
 		if v.TLSConfig.CA != nil && v.TLSConfig.CA.Name == amMtlsCARef &&
 			v.TLSConfig.Cert != nil && v.TLSConfig.Cert.Name == amMtlsCertRef &&
@@ -1048,7 +1048,7 @@ userWorkloadEnabled: false
 				for _, config := range parsed.Prometheus.AlertmanagerConfigs {
 					if config.TLSConfig.CA != nil &&
 						(config.TLSConfig.CA.Name == amMtlsCaName ||
-							config.TLSConfig.CA.Name == appendHubClusterID(amMtlsCaName, hubInfo)) {
+							config.TLSConfig.CA.Name == hubInfo.AppendHubClusterID(amMtlsCaName)) {
 						t.Fatalf("UWL configmap still contains ACM alertmanager configuration when it should be cleaned up")
 					}
 				}
@@ -1162,7 +1162,7 @@ enableUserWorkload: true
 	}
 
 	// Verify that the ACM alertmanager configuration is present by checking for the mTLS CA secret
-	if !strings.Contains(configYAML, appendHubClusterID(amMtlsCaName, hubInfo)) {
+	if !strings.Contains(configYAML, hubInfo.AppendHubClusterID(amMtlsCaName)) {
 		t.Fatalf("UWL configmap should contain ACM alertmanager configuration with mTLS CA secret reference")
 	}
 
@@ -1265,10 +1265,10 @@ prometheusK8s:
 	if len(amCfgs) != 1 {
 		t.Fatalf("expected exactly 1 additionalAlertmanagerConfig after dedupe, got %d", len(amCfgs))
 	}
-	if amCfgs[0].TLSConfig.CA == nil || amCfgs[0].TLSConfig.CA.Name != appendHubClusterID(amMtlsCaName, hubInfo) {
-		t.Fatalf("expected single mTLS ACM alertmanager config (CA %q), got %#v", appendHubClusterID(amMtlsCaName, hubInfo), amCfgs[0].TLSConfig.CA)
+	if amCfgs[0].TLSConfig.CA == nil || amCfgs[0].TLSConfig.CA.Name != hubInfo.AppendHubClusterID(amMtlsCaName) {
+		t.Fatalf("expected single mTLS ACM alertmanager config (CA %q), got %#v", hubInfo.AppendHubClusterID(amMtlsCaName), amCfgs[0].TLSConfig.CA)
 	}
-	if amCfgs[0].TLSConfig.Cert == nil || amCfgs[0].TLSConfig.Cert.Name != appendHubClusterID(amMtlsCertName, hubInfo) {
+	if amCfgs[0].TLSConfig.Cert == nil || amCfgs[0].TLSConfig.Cert.Name != hubInfo.AppendHubClusterID(amMtlsCertName) {
 		t.Fatalf("expected mTLS client cert on deduped config, got cert ref %#v", amCfgs[0].TLSConfig.Cert)
 	}
 }

--- a/operators/endpointmetrics/pkg/rendering/renderer.go
+++ b/operators/endpointmetrics/pkg/rendering/renderer.go
@@ -177,9 +177,9 @@ func Render(
 					Key: "alertmanager.yaml",
 				}
 				spec.Secrets = []string{
-					"obs-alertmanager-mtls-ca" + "-" + hubInfo.HubClusterID,
-					"obs-alertmanager-mtls-cert" + "-" + hubInfo.HubClusterID,
-					"observability-alertmanager-accessor" + "-" + hubInfo.HubClusterID,
+					hubInfo.AppendHubClusterID("obs-alertmanager-mtls-ca"),
+					hubInfo.AppendHubClusterID("obs-alertmanager-mtls-cert"),
+					hubInfo.AppendHubClusterID("observability-alertmanager-accessor"),
 				}
 			}
 

--- a/operators/pkg/config/types.go
+++ b/operators/pkg/config/types.go
@@ -21,6 +21,13 @@ type HubInfo struct {
 	HubClusterID             string `yaml:"hub-cluster-id"`
 }
 
+func (h *HubInfo) AppendHubClusterID(base string) string {
+	if h == nil || h.HubClusterID == "" {
+		return base
+	}
+	return base + "-" + h.HubClusterID
+}
+
 type RecordingRule struct {
 	Record string `yaml:"record"`
 	Expr   string `yaml:"expr"`


### PR DESCRIPTION
Added hubInfo.AppendHubClusterID for consistent naming of secrets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in how hub cluster identifiers are applied to secret naming throughout the monitoring configuration stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->