### PR TITLE
Add identifier labels to ACM Observability PrometheusRules

### DIFF
--- a/operators/endpointmetrics/manifests/prometheus/prometheusrules/k8s.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/prometheusrules/k8s.yaml
@@ -5,6 +5,9 @@ kind: PrometheusRule
 metadata:
   name: k8s-rules
   namespace: open-cluster-management-addon-observability
+  labels:
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/managed-by: multicluster-observability-operator
 spec:
   groups:
   - name: k8s.rules

--- a/operators/endpointmetrics/manifests/prometheus/prometheusrules/kube-apiserver-availability.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/prometheusrules/kube-apiserver-availability.yaml
@@ -4,6 +4,9 @@ kind: PrometheusRule
 metadata:
   name: kube-apiserver-availability-rules
   namespace: open-cluster-management-addon-observability
+  labels:
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/managed-by: multicluster-observability-operator
 spec:
   groups:
   - interval: 3m

--- a/operators/endpointmetrics/manifests/prometheus/prometheusrules/kube-apiserver-histogram.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/prometheusrules/kube-apiserver-histogram.yaml
@@ -5,6 +5,9 @@ kind: PrometheusRule
 metadata:
   name: kube-apiserver-histogram-rules
   namespace: open-cluster-management-addon-observability
+  labels:
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/managed-by: multicluster-observability-operator
 spec:
   groups:
   - name: kube-apiserver-histogram.rules

--- a/operators/endpointmetrics/manifests/prometheus/prometheusrules/kube-apiserver.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/prometheusrules/kube-apiserver.yaml
@@ -5,6 +5,9 @@ kind: PrometheusRule
 metadata:
   name: kube-apiserver-rules
   namespace: open-cluster-management-addon-observability
+  labels:
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/managed-by: multicluster-observability-operator
 spec:
   groups:
   - name: kube-apiserver-burnrate.rules

--- a/operators/endpointmetrics/manifests/prometheus/prometheusrules/kube-prometheus-general.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/prometheusrules/kube-prometheus-general.yaml
@@ -5,6 +5,9 @@ kind: PrometheusRule
 metadata:
   name: kube-prometheus-general
   namespace: open-cluster-management-addon-observability
+  labels:
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/managed-by: multicluster-observability-operator
 spec:
   groups:
   - name: kube-prometheus-general.rules

--- a/operators/endpointmetrics/manifests/prometheus/prometheusrules/kube-prometheus-node-recording.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/prometheusrules/kube-prometheus-node-recording.yaml
@@ -5,6 +5,9 @@ kind: PrometheusRule
 metadata:
   name: kube-prometheus-node-recording-rules
   namespace: open-cluster-management-addon-observability
+  labels:
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/managed-by: multicluster-observability-operator
 spec:
   groups:
   - name: kube-prometheus-node-recording.rules

--- a/operators/endpointmetrics/manifests/prometheus/prometheusrules/kube-scheduler.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/prometheusrules/kube-scheduler.yaml
@@ -5,6 +5,9 @@ kind: PrometheusRule
 metadata:
   name: kube-scheduler-rules
   namespace: open-cluster-management-addon-observability
+  labels:
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/managed-by: multicluster-observability-operator
 spec:
   groups:
   - name: kube-scheduler.rules

--- a/operators/endpointmetrics/manifests/prometheus/prometheusrules/kubelet.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/prometheusrules/kubelet.yaml
@@ -5,6 +5,9 @@ kind: PrometheusRule
 metadata:
   name: kubelet-rules
   namespace: open-cluster-management-addon-observability
+  labels:
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/managed-by: multicluster-observability-operator
 spec:
   groups:
   - name: kubelet.rules

--- a/operators/endpointmetrics/manifests/prometheus/prometheusrules/kubernetes-monitoring-alertingrules.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/prometheusrules/kubernetes-monitoring-alertingrules.yaml
@@ -3,6 +3,9 @@ kind: PrometheusRule
 metadata:
   name: kubernetes-monitoring-alertingrules
   namespace: open-cluster-management-addon-observability
+  labels:
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/managed-by: multicluster-observability-operator
 spec:
   groups:
   - name: kube-state-metrics

--- a/operators/endpointmetrics/manifests/prometheus/prometheusrules/node-exporter.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/prometheusrules/node-exporter.yaml
@@ -6,6 +6,9 @@ kind: PrometheusRule
 metadata:
   name: node-exporter-rules
   namespace: open-cluster-management-addon-observability
+  labels:
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/managed-by: multicluster-observability-operator
 spec:
   groups:
   - name: node-exporter.rules

--- a/operators/endpointmetrics/manifests/prometheus/prometheusrules/node.yaml
+++ b/operators/endpointmetrics/manifests/prometheus/prometheusrules/node.yaml
@@ -5,6 +5,9 @@ kind: PrometheusRule
 metadata:
   name: node-rules
   namespace: open-cluster-management-addon-observability
+  labels:
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/managed-by: multicluster-observability-operator
 spec:
   groups:
   - name: node.rules

--- a/operators/endpointmetrics/pkg/collector/metrics_collector.go
+++ b/operators/endpointmetrics/pkg/collector/metrics_collector.go
@@ -529,7 +529,12 @@ func (m *MetricsCollector) ensureAlertingRule(ctx context.Context, isUWL bool) e
 			m.Log.Info("Updating PrometheusRule", "name", name, "namespace", m.Namespace)
 
 			foundPromRule.Spec = desiredPromRule.Spec
-			foundPromRule.Labels = desiredPromRule.Labels
+			mergedLabels := maps.Clone(foundPromRule.Labels)
+			if mergedLabels == nil {
+				mergedLabels = make(map[string]string)
+			}
+			maps.Copy(mergedLabels, desiredPromRule.Labels)
+			foundPromRule.Labels = mergedLabels
 			foundPromRule.OwnerReferences = desiredPromRule.OwnerReferences
 			if err := m.Client.Update(ctx, foundPromRule); err != nil {
 				return fmt.Errorf("failed to update PrometheusRule %s/%s: %w", m.Namespace, name, err)

--- a/operators/endpointmetrics/pkg/collector/metrics_collector.go
+++ b/operators/endpointmetrics/pkg/collector/metrics_collector.go
@@ -7,6 +7,7 @@ package collector
 import (
 	"context"
 	"fmt"
+	"maps"
 	"regexp"
 	"sort"
 	"strconv"
@@ -462,6 +463,7 @@ func (m *MetricsCollector) ensureAlertingRule(ctx context.Context, isUWL bool) e
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: m.Namespace,
+			Labels:    operatorconfig.GetACMPrometheusRuleLabels(),
 		},
 		Spec: monitoringv1.PrometheusRuleSpec{
 			Groups: []monitoringv1.RuleGroup{
@@ -521,10 +523,13 @@ func (m *MetricsCollector) ensureAlertingRule(ctx context.Context, isUWL bool) e
 			return fmt.Errorf("failed to get PrometheusRule %s/%s: %w", m.Namespace, name, err)
 		}
 
-		if !equality.Semantic.DeepDerivative(desiredPromRule.Spec, foundPromRule.Spec) || !metav1.IsControlledBy(foundPromRule, m.Owner) {
+		if !equality.Semantic.DeepDerivative(desiredPromRule.Spec, foundPromRule.Spec) ||
+			!metav1.IsControlledBy(foundPromRule, m.Owner) ||
+			!maps.Equal(desiredPromRule.Labels, foundPromRule.Labels) {
 			m.Log.Info("Updating PrometheusRule", "name", name, "namespace", m.Namespace)
 
 			foundPromRule.Spec = desiredPromRule.Spec
+			foundPromRule.Labels = desiredPromRule.Labels
 			foundPromRule.OwnerReferences = desiredPromRule.OwnerReferences
 			if err := m.Client.Update(ctx, foundPromRule); err != nil {
 				return fmt.Errorf("failed to update PrometheusRule %s/%s: %w", m.Namespace, name, err)

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-namespace/prometheusrule.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-namespace/prometheusrule.go
@@ -9,6 +9,7 @@ import (
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	rsutility "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility"
+	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -56,6 +57,7 @@ func GeneratePrometheusRule(configData rsutility.RSNamespaceConfigMapData) (moni
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      PrometheusRuleName,
 			Namespace: rsutility.MonitoringNamespace,
+			Labels:    operatorconfig.GetACMPrometheusRuleLabels(),
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PrometheusRule",

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-namespace/prometheusrule_test.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-namespace/prometheusrule_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	rsutility "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility"
+	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,6 +34,7 @@ func TestGeneratePrometheusRule_InclusionOnly(t *testing.T) {
 	rule, err := GeneratePrometheusRule(config)
 	assert.NoError(t, err)
 	assert.Equal(t, PrometheusRuleName, rule.Name)
+	assert.Equal(t, operatorconfig.GetACMPrometheusRuleLabels(), rule.Labels)
 	assert.Len(t, rule.Spec.Groups, 4)
 	assert.Contains(t, rule.Spec.Groups[0].Rules[0].Expr.String(), `namespace=~"ns-a|ns-b"`)
 	assert.Contains(t, rule.Spec.Groups[0].Rules[0].Expr.String(), `label_env=~"prod"`)

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-virtualization/prometheusrule.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-virtualization/prometheusrule.go
@@ -9,6 +9,7 @@ import (
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	rsutility "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility"
+	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -56,6 +57,7 @@ func GeneratePrometheusRule(configData rsutility.RSNamespaceConfigMapData) (moni
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      PrometheusRuleName,
 			Namespace: rsutility.MonitoringNamespace,
+			Labels:    operatorconfig.GetACMPrometheusRuleLabels(),
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PrometheusRule",

--- a/operators/multiclusterobservability/manifests/base/alertmanager/prometheusrule.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/prometheusrule.yaml
@@ -3,6 +3,9 @@ kind: PrometheusRule
 metadata:
   annotations:
     update-namespace: 'false'
+  labels:
+    app.kubernetes.io/part-of: multicluster-observability-addon
+    app.kubernetes.io/managed-by: multicluster-observability-operator
   name: acm-observability-alert-rules
   namespace: open-cluster-management-observability
 spec:

--- a/operators/pkg/config/config.go
+++ b/operators/pkg/config/config.go
@@ -66,3 +66,18 @@ const (
 	DefaultClusterType = ""
 	SnoClusterType     = "SNO"
 )
+
+const (
+	ACMPrometheusRulePartOfLabelKey      = "app.kubernetes.io/part-of"
+	ACMPrometheusRuleManagedByLabelKey   = "app.kubernetes.io/managed-by"
+	ACMPrometheusRulePartOfLabelValue    = "multicluster-observability-addon"
+	ACMPrometheusRuleManagedByLabelValue = "multicluster-observability-operator"
+)
+
+// GetACMPrometheusRuleLabels returns metadata labels applied to PrometheusRules shipped by ACM observability.
+func GetACMPrometheusRuleLabels() map[string]string {
+	return map[string]string{
+		ACMPrometheusRulePartOfLabelKey:    ACMPrometheusRulePartOfLabelValue,
+		ACMPrometheusRuleManagedByLabelKey: ACMPrometheusRuleManagedByLabelValue,
+	}
+}

--- a/operators/pkg/deploying/deployer.go
+++ b/operators/pkg/deploying/deployer.go
@@ -349,25 +349,28 @@ func (d *Deployer) updatePrometheusRule(ctx context.Context, desiredObj, runtime
 		return err
 	}
 
-	// Use ssa if MCOA
-	if mcoconfig.MultiClusterObservabilityAddon == desiredPrometheusRule.Labels["app.kubernetes.io/part-of"] {
-		// Merge labels
-		desiredLabels := maps.Clone(runtimePrometheusRule.GetLabels())
-		maps.Copy(desiredLabels, desiredPrometheusRule.Labels)
-		desiredPrometheusRule.Labels = desiredLabels
+	useSSA := mcoconfig.MultiClusterObservabilityAddon == desiredPrometheusRule.Labels["app.kubernetes.io/part-of"]
+	desiredPrometheusRule.Labels, _ = mergeMetadata(
+		runtimePrometheusRule.Labels, nil,
+		desiredPrometheusRule.Labels, nil,
+	)
 
-		if !equality.Semantic.DeepDerivative(desiredPrometheusRule.Spec, runtimePrometheusRule.Spec) || !maps.Equal(desiredPrometheusRule.Labels, runtimePrometheusRule.Labels) {
-			logUpdateInfo(runtimeObj)
-			return d.client.Patch(ctx, desiredPrometheusRule, client.Apply, client.ForceOwnership, client.FieldOwner(mcoconfig.GetMonitoringCRName()))
-		}
-	} else if !equality.Semantic.DeepDerivative(desiredPrometheusRule.Spec, runtimePrometheusRule.Spec) {
-		logUpdateInfo(runtimeObj)
-		if desiredPrometheusRule.ResourceVersion != runtimePrometheusRule.ResourceVersion {
-			desiredPrometheusRule.ResourceVersion = runtimePrometheusRule.ResourceVersion
-		}
-
-		return d.client.Update(ctx, desiredPrometheusRule)
+	specChanged := !equality.Semantic.DeepDerivative(desiredPrometheusRule.Spec, runtimePrometheusRule.Spec)
+	labelsChanged := !maps.Equal(desiredPrometheusRule.Labels, runtimePrometheusRule.Labels)
+	if !specChanged && !labelsChanged {
+		return nil
 	}
+
+	logUpdateInfo(runtimeObj)
+	if useSSA {
+		return d.client.Patch(ctx, desiredPrometheusRule, client.Apply, client.ForceOwnership, client.FieldOwner(mcoconfig.GetMonitoringCRName()))
+	}
+
+	if desiredPrometheusRule.ResourceVersion != runtimePrometheusRule.ResourceVersion {
+		desiredPrometheusRule.ResourceVersion = runtimePrometheusRule.ResourceVersion
+	}
+
+	return d.client.Update(ctx, desiredPrometheusRule)
 
 	return nil
 }

--- a/operators/pkg/deploying/deployer.go
+++ b/operators/pkg/deploying/deployer.go
@@ -371,8 +371,6 @@ func (d *Deployer) updatePrometheusRule(ctx context.Context, desiredObj, runtime
 	}
 
 	return d.client.Update(ctx, desiredPrometheusRule)
-
-	return nil
 }
 
 func (d *Deployer) updateIngress(ctx context.Context, desiredObj, runtimeObj *unstructured.Unstructured) error {


### PR DESCRIPTION
## Summary

Customers need a way to identify alerts and rules that ACM Observability puts in place, and to filter out ACM-specific config on hub and managed clusters. This PR adds standard identifier labels to PrometheusRules shipped by ACM Observability so they can be found with `kubectl` / `oc`.

## Why

Some customers have asked to filter out config that is specific to ACM on the hub and on managed clusters. Today, ACM-owned PrometheusRules are not consistently labeled, so there is no reliable way to select only ACM observability rules (or exclude them) using label selectors.

## How

We add labels to the PrometheusRules that ACM ships so they are clearly ACM-owned and searchable with kubectl:

| Label | Value | Purpose |
|-------|--------|---------|
| `app.kubernetes.io/part-of` | `multicluster-observability-addon` | Groups rules as part of the ACM observability addon |
| `app.kubernetes.io/managed-by` | `multicluster-observability-operator` | Identifies the operator that reconciles the rule |

We use **two** labels on purpose:
- **`part-of`** — answers *“does this rule belong to ACM observability?”* (what customers filter on)
- **`managed-by`** — answers *“which controller owns this rule?”* (useful for support and automation)

Both names follow the [Kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) (`app.kubernetes.io/part-of`, `app.kubernetes.io/managed-by`).

Example:

```bash
oc get prometheusrule -n <namespace> \
  -l 'app.kubernetes.io/part-of=multicluster-observability-addon' --show-labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized metadata labels added to PrometheusRule resources across monitoring components, ensuring consistent ownership and association for alerting/recording rules.
  * Operator now synchronizes and preserves runtime labels when managing PrometheusRule resources to improve update consistency.
* **Tests**
  * Unit tests updated to assert generated PrometheusRule labels match the standardized labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->