### PR TITLE
Test: Ensure MCH pullsecret is created in right ns

### DIFF
--- a/tests/pkg/utils/utils.go
+++ b/tests/pkg/utils/utils.go
@@ -606,16 +606,16 @@ func GetPullSecret(opt TestOptions) (string, error) {
 		newSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "multiclusterhub-operator-pull-secret",
-				Namespace: "open-cluster-management",
+				Namespace: mchNs,
 			},
 			Type: corev1.SecretTypeDockerConfigJson,
 			Data: map[string][]byte{
 				".dockerconfigjson": secret.Data[".dockerconfigjson"],
 			},
 		}
-		_, err = clientKube.CoreV1().Secrets("open-cluster-management").Create(context.TODO(), newSecret, metav1.CreateOptions{})
+		_, err = clientKube.CoreV1().Secrets(mchNs).Create(context.TODO(), newSecret, metav1.CreateOptions{})
 		if err != nil && !k8sErrors.IsAlreadyExists(err) {
-			return "", fmt.Errorf("failed to create pull-secret in open-cluster-management %v", err)
+			return "", fmt.Errorf("failed to create pull-secret in ns: %s. %w", mchNs, err)
 		}
 		return newSecret.Name, nil
 	}


### PR DESCRIPTION
Sometimes MCH might be installed in a different namespace (commonly `ocm`) in regression tests. This caused issues creating the pull secret, since the namespace was hardcoded.

This correctly detects which namespace MCH is installed, and uses that one on the secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Corrected pull secret creation to use the MultiClusterHub instance’s own namespace instead of a hardcoded default, improving resource isolation and multi-instance compatibility. The secret name is unchanged for backward compatibility, and failure messages now include the target namespace to simplify troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->