### PR TITLE
[ACM-34806] add configurable write timeout for observatorium-api gateway

### DIFF
--- a/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
+++ b/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
@@ -387,7 +387,7 @@ type AdvancedConfig struct {
 	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$`
 	// +kubebuilder:default="300s"
 	QueryTimeout string `json:"queryTimeout,omitempty"`
-	// WriteTimeout is the timeout for signal ingestion (metrics, logs, traces)
+	// WriteTimeout is the timeout for metrics ingestion
 	// through the observatorium-api gateway. Controls the server write timeout
 	// for the response path. Increase for large payloads over high-latency networks.
 	// Default is 720s.

--- a/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
+++ b/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_types.go
@@ -379,13 +379,22 @@ type AdvancedConfig struct {
 	// For the alertmanager that runs in the hub this setting has no effect.
 	// +optional
 	CustomAlertmanagerHubURL observabilityshared.URL `json:"customAlertmanagerHubURL,omitempty"`
-	// QueryTimeout is the timeout for queries executed in Grafana.
-	// It is applied to the read path components from Grafana.
+	// QueryTimeout is the timeout for queries and reads through the observability gateway.
+	// It is applied to Grafana datasources, HAProxy route, rbac-query-proxy,
+	// and the observatorium-api server read timeout.
 	// Default is 300s.
 	// +optional
 	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$`
 	// +kubebuilder:default="300s"
 	QueryTimeout string `json:"queryTimeout,omitempty"`
+	// WriteTimeout is the timeout for signal ingestion (metrics, logs, traces)
+	// through the observatorium-api gateway. Controls the server write timeout
+	// for the response path. Increase for large payloads over high-latency networks.
+	// Default is 720s.
+	// +optional
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$`
+	// +kubebuilder:default="720s"
+	WriteTimeout string `json:"writeTimeout,omitempty"`
 	// The spec of the data retention configurations
 	// +optional
 	RetentionConfig *RetentionConfig `json:"retentionConfig,omitempty"`

--- a/operators/multiclusterobservability/bundle.Dockerfile
+++ b/operators/multiclusterobservability/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=multicluster-observability-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-unknown
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/operators/multiclusterobservability/bundle.Dockerfile
+++ b/operators/multiclusterobservability/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=multicluster-observability-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-unknown
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -10691,7 +10691,7 @@ spec:
                   writeTimeout:
                     default: 720s
                     description: |-
-                      WriteTimeout is the timeout for signal ingestion (metrics, logs, traces)
+                      WriteTimeout is the timeout for metrics ingestion
                       through the observatorium-api gateway. Controls the server write timeout
                       for the response path. Increase for large payloads over high-latency networks.
                       Default is 720s.

--- a/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -5646,8 +5646,9 @@ spec:
                   queryTimeout:
                     default: 300s
                     description: |-
-                      QueryTimeout is the timeout for queries executed in Grafana.
-                      It is applied to the read path components from Grafana.
+                      QueryTimeout is the timeout for queries and reads through the observability gateway.
+                      It is applied to Grafana datasources, HAProxy route, rbac-query-proxy,
+                      and the observatorium-api server read timeout.
                       Default is 300s.
                     pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                     type: string
@@ -10687,6 +10688,15 @@ spec:
                             type: object
                         type: object
                     type: object
+                  writeTimeout:
+                    default: 720s
+                    description: |-
+                      WriteTimeout is the timeout for signal ingestion (metrics, logs, traces)
+                      through the observatorium-api gateway. Controls the server write timeout
+                      for the response path. Increase for large payloads over high-latency networks.
+                      Default is 720s.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
                 type: object
               capabilities:
                 description: |-

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -10676,7 +10676,7 @@ spec:
                   writeTimeout:
                     default: 720s
                     description: |-
-                      WriteTimeout is the timeout for signal ingestion (metrics, logs, traces)
+                      WriteTimeout is the timeout for metrics ingestion
                       through the observatorium-api gateway. Controls the server write timeout
                       for the response path. Increase for large payloads over high-latency networks.
                       Default is 720s.

--- a/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
+++ b/operators/multiclusterobservability/config/crd/bases/observability.open-cluster-management.io_multiclusterobservabilities.yaml
@@ -5631,8 +5631,9 @@ spec:
                   queryTimeout:
                     default: 300s
                     description: |-
-                      QueryTimeout is the timeout for queries executed in Grafana.
-                      It is applied to the read path components from Grafana.
+                      QueryTimeout is the timeout for queries and reads through the observability gateway.
+                      It is applied to Grafana datasources, HAProxy route, rbac-query-proxy,
+                      and the observatorium-api server read timeout.
                       Default is 300s.
                     pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                     type: string
@@ -10672,6 +10673,15 @@ spec:
                             type: object
                         type: object
                     type: object
+                  writeTimeout:
+                    default: 720s
+                    description: |-
+                      WriteTimeout is the timeout for signal ingestion (metrics, logs, traces)
+                      through the observatorium-api gateway. Controls the server write timeout
+                      for the response path. Increase for large payloads over high-latency networks.
+                      Default is 720s.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
                 type: object
               capabilities:
                 description: |-

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium.go
@@ -553,6 +553,22 @@ func newAPISpec(c client.Client, mco *mcov1beta2.MultiClusterObservability, tlsP
 	}
 	apiSpec.ImagePullPolicy = mcoconfig.GetImagePullPolicy(mco.Spec)
 	apiSpec.ServiceMonitor = true
+	if mco.Spec.AdvancedConfig != nil {
+		if mco.Spec.AdvancedConfig.QueryTimeout != "" {
+			if _, err := time.ParseDuration(mco.Spec.AdvancedConfig.QueryTimeout); err != nil {
+				log.Error(err, "Invalid queryTimeout, skipping", "value", mco.Spec.AdvancedConfig.QueryTimeout)
+			} else {
+				apiSpec.QueryTimeout = mco.Spec.AdvancedConfig.QueryTimeout
+			}
+		}
+		if mco.Spec.AdvancedConfig.WriteTimeout != "" {
+			if _, err := time.ParseDuration(mco.Spec.AdvancedConfig.WriteTimeout); err != nil {
+				log.Error(err, "Invalid writeTimeout, skipping", "value", mco.Spec.AdvancedConfig.WriteTimeout)
+			} else {
+				apiSpec.WriteTimeout = mco.Spec.AdvancedConfig.WriteTimeout
+			}
+		}
+	}
 	if mco.Spec.StorageConfig.WriteStorage != nil {
 		var eps []mcoutil.RemoteWriteEndpointWithSecret
 		var mountSecrets []string

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
@@ -1241,7 +1241,7 @@ func buildObsSpec(t *testing.T, mco *mcov1beta2.MultiClusterObservability) *obse
 	if err := mcoconfig.SetOperandNames(cl); err != nil {
 		t.Fatalf("SetOperandNames: %v", err)
 	}
-	obs, err := newDefaultObservatoriumSpec(cl, mco, storageClassName, "")
+	obs, err := newDefaultObservatoriumSpec(cl, mco, storageClassName, "", observatoriumv1alpha1.TLSProfileSpec{})
 	if err != nil {
 		t.Fatalf("newDefaultObservatoriumSpec: %v", err)
 	}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/observatorium_test.go
@@ -1220,73 +1220,73 @@ func TestNewCompactSpec(t *testing.T) {
 	}
 }
 
+func buildObsSpec(t *testing.T, mco *mcov1beta2.MultiClusterObservability) *observatoriumv1alpha1.ObservatoriumSpec {
+	t.Helper()
+	writeStorageS := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "write_name",
+			Namespace: mcoconfig.GetDefaultNamespace(),
+		},
+		Type: "Opaque",
+		Data: map[string][]byte{
+			"write_key": []byte(`url: http://remotewrite/endpoint`),
+		},
+	}
+	s := runtime.NewScheme()
+	scheme.AddToScheme(s)
+	mcov1beta2.SchemeBuilder.AddToScheme(s)
+	observatoriumv1alpha1.SchemeBuilder.AddToScheme(s)
+	objs := []runtime.Object{mco, writeStorageS, alertmanagerCABundleConfigMap()}
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
+	if err := mcoconfig.SetOperandNames(cl); err != nil {
+		t.Fatalf("SetOperandNames: %v", err)
+	}
+	obs, err := newDefaultObservatoriumSpec(cl, mco, storageClassName, "")
+	if err != nil {
+		t.Fatalf("newDefaultObservatoriumSpec: %v", err)
+	}
+	return obs
+}
+
+func newBaseMCO() *mcov1beta2.MultiClusterObservability {
+	return &mcov1beta2.MultiClusterObservability{
+		TypeMeta: metav1.TypeMeta{Kind: "MultiClusterObservability"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+			Annotations: map[string]string{
+				mcoconfig.AnnotationKeyImageRepository: "quay.io:443/acm-d",
+				mcoconfig.AnnotationKeyImageTagSuffix:  "tag",
+			},
+		},
+		Spec: mcov1beta2.MultiClusterObservabilitySpec{
+			StorageConfig: &mcov1beta2.StorageConfig{
+				MetricObjectStorage: &mcoshared.PreConfiguredStorage{
+					Key:           "key",
+					Name:          "name",
+					TLSSecretName: "secret",
+				},
+				WriteStorage: []*mcoshared.PreConfiguredStorage{
+					{Key: "write_key", Name: "write_name"},
+				},
+				StorageClass:            storageClassName,
+				AlertmanagerStorageSize: "1Gi",
+				CompactStorageSize:      "1Gi",
+				RuleStorageSize:         "1Gi",
+				ReceiveStorageSize:      "1Gi",
+				StoreStorageSize:        "1Gi",
+			},
+			ObservabilityAddonSpec: &mcoshared.ObservabilityAddonSpec{
+				EnableMetrics: true,
+				Interval:      300,
+			},
+		},
+	}
+}
+
 func TestNewObservatoriumSpecMetricsAlertmanagerEndpoints(t *testing.T) {
-	buildObs := func(t *testing.T, mco *mcov1beta2.MultiClusterObservability) *observatoriumv1alpha1.ObservatoriumSpec {
-		t.Helper()
-		writeStorageS := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "write_name",
-				Namespace: mcoconfig.GetDefaultNamespace(),
-			},
-			Type: "Opaque",
-			Data: map[string][]byte{
-				"write_key": []byte(`url: http://remotewrite/endpoint`),
-			},
-		}
-		s := runtime.NewScheme()
-		scheme.AddToScheme(s)
-		mcov1beta2.SchemeBuilder.AddToScheme(s)
-		observatoriumv1alpha1.SchemeBuilder.AddToScheme(s)
-		objs := []runtime.Object{mco, writeStorageS, alertmanagerCABundleConfigMap()}
-		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
-		if err := mcoconfig.SetOperandNames(cl); err != nil {
-			t.Fatalf("SetOperandNames: %v", err)
-		}
-		obs, err := newDefaultObservatoriumSpec(cl, mco, storageClassName, "", observatoriumv1alpha1.TLSProfileSpec{})
-		if err != nil {
-			t.Fatalf("newDefaultObservatoriumSpec: %v", err)
-		}
-		return obs
-	}
-
-	baseMCO := func() *mcov1beta2.MultiClusterObservability {
-		return &mcov1beta2.MultiClusterObservability{
-			TypeMeta: metav1.TypeMeta{Kind: "MultiClusterObservability"},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test",
-				Annotations: map[string]string{
-					mcoconfig.AnnotationKeyImageRepository: "quay.io:443/acm-d",
-					mcoconfig.AnnotationKeyImageTagSuffix:  "tag",
-				},
-			},
-			Spec: mcov1beta2.MultiClusterObservabilitySpec{
-				StorageConfig: &mcov1beta2.StorageConfig{
-					MetricObjectStorage: &mcoshared.PreConfiguredStorage{
-						Key:           "key",
-						Name:          "name",
-						TLSSecretName: "secret",
-					},
-					WriteStorage: []*mcoshared.PreConfiguredStorage{
-						{Key: "write_key", Name: "write_name"},
-					},
-					StorageClass:            storageClassName,
-					AlertmanagerStorageSize: "1Gi",
-					CompactStorageSize:      "1Gi",
-					RuleStorageSize:         "1Gi",
-					ReceiveStorageSize:      "1Gi",
-					StoreStorageSize:        "1Gi",
-				},
-				ObservabilityAddonSpec: &mcoshared.ObservabilityAddonSpec{
-					EnableMetrics: true,
-					Interval:      300,
-				},
-			},
-		}
-	}
-
 	t.Run("default sizing produces DNS endpoints per alertmanager replica", func(t *testing.T) {
-		mco := baseMCO()
-		obs := buildObs(t, mco)
+		mco := newBaseMCO()
+		obs := buildObsSpec(t, mco)
 		want := []string{
 			"https://observability-alertmanager-0.alertmanager-operated.open-cluster-management-observability.svc:9095",
 			"https://observability-alertmanager-1.alertmanager-operated.open-cluster-management-observability.svc:9095",
@@ -1298,7 +1298,7 @@ func TestNewObservatoriumSpecMetricsAlertmanagerEndpoints(t *testing.T) {
 	})
 	var amReplicas int32 = 5
 	t.Run("advanced alertmanager replicas extends metrics endpoints", func(t *testing.T) {
-		mco := baseMCO()
+		mco := newBaseMCO()
 		mco.Spec.AdvancedConfig = &mcov1beta2.AdvancedConfig{
 			Alertmanager: &mcov1beta2.AlertmanagerSpec{
 				CommonSpec: mcov1beta2.CommonSpec{
@@ -1306,12 +1306,55 @@ func TestNewObservatoriumSpecMetricsAlertmanagerEndpoints(t *testing.T) {
 				},
 			},
 		}
-		obs := buildObs(t, mco)
+		obs := buildObsSpec(t, mco)
 		if got := len(obs.API.MetricsAlertmanagerEndpoints); got != int(amReplicas) {
 			t.Fatalf("len(MetricsAlertmanagerEndpoints) = %d, want %d", got, int(amReplicas))
 		}
 		if obs.API.MetricsAlertmanagerEndpoints[4] != "https://observability-alertmanager-4.alertmanager-operated.open-cluster-management-observability.svc:9095" {
 			t.Errorf("last endpoint = %q", obs.API.MetricsAlertmanagerEndpoints[4])
+		}
+	})
+}
+
+func TestNewObservatoriumSpecAPITimeouts(t *testing.T) {
+	t.Run("no advanced config leaves timeouts empty for jsonnet defaults", func(t *testing.T) {
+		mco := newBaseMCO()
+		obs := buildObsSpec(t, mco)
+		if obs.API.QueryTimeout != "" {
+			t.Errorf("QueryTimeout = %q, want empty", obs.API.QueryTimeout)
+		}
+		if obs.API.WriteTimeout != "" {
+			t.Errorf("WriteTimeout = %q, want empty", obs.API.WriteTimeout)
+		}
+	})
+
+	t.Run("both timeouts propagate from advanced config", func(t *testing.T) {
+		mco := newBaseMCO()
+		mco.Spec.AdvancedConfig = &mcov1beta2.AdvancedConfig{
+			QueryTimeout: "10m",
+			WriteTimeout: "15m",
+		}
+		obs := buildObsSpec(t, mco)
+		if obs.API.QueryTimeout != "10m" {
+			t.Errorf("QueryTimeout = %q, want %q", obs.API.QueryTimeout, "10m")
+		}
+		if obs.API.WriteTimeout != "15m" {
+			t.Errorf("WriteTimeout = %q, want %q", obs.API.WriteTimeout, "15m")
+		}
+	})
+
+	t.Run("invalid duration values are skipped", func(t *testing.T) {
+		mco := newBaseMCO()
+		mco.Spec.AdvancedConfig = &mcov1beta2.AdvancedConfig{
+			QueryTimeout: "invalid",
+			WriteTimeout: "5min",
+		}
+		obs := buildObsSpec(t, mco)
+		if obs.API.QueryTimeout != "" {
+			t.Errorf("QueryTimeout = %q, want empty for invalid input", obs.API.QueryTimeout)
+		}
+		if obs.API.WriteTimeout != "" {
+			t.Errorf("WriteTimeout = %q, want empty for invalid input", obs.API.WriteTimeout)
 		}
 	})
 }

--- a/tests/pkg/tests/observability_config_test.go
+++ b/tests/pkg/tests/observability_config_test.go
@@ -667,7 +667,7 @@ var _ = Describe("", func() {
 	It(
 		"ACM-34806: Observability: Verify configurable API gateway timeouts in MCO CR - [P2][Sev2][Observability][Integration] @e2e (config/g0)",
 		func() {
-			By("Verifying default state: Observatorium CR has no timeout fields")
+			By("Verifying default state: Observatorium CR has kubebuilder-defaulted timeout values")
 			Eventually(func() error {
 				cr, err := dynClient.Resource(utils.NewMCOMObservatoriumGVR()).
 					Namespace(MCO_NAMESPACE).
@@ -683,11 +683,11 @@ var _ = Describe("", func() {
 				if !ok {
 					return fmt.Errorf("spec.api not found or not a map")
 				}
-				if _, ok := apiSpec["queryTimeout"]; ok {
-					return fmt.Errorf("queryTimeout should not be set on Observatorium CR by default")
+				if qt, _ := apiSpec["queryTimeout"].(string); qt != "300s" {
+					return fmt.Errorf("Observatorium CR queryTimeout = %q, want %q", qt, "300s")
 				}
-				if _, ok := apiSpec["writeTimeout"]; ok {
-					return fmt.Errorf("writeTimeout should not be set on Observatorium CR by default")
+				if wt, _ := apiSpec["writeTimeout"].(string); wt != "720s" {
+					return fmt.Errorf("Observatorium CR writeTimeout = %q, want %q", wt, "720s")
 				}
 				return nil
 			}, EventuallyTimeoutMinute*1, EventuallyIntervalSecond*10).Should(Succeed())
@@ -702,11 +702,11 @@ var _ = Describe("", func() {
 					return fmt.Errorf("no observatorium-api deployment found")
 				}
 				args := deps.Items[0].Spec.Template.Spec.Containers[0].Args
-				if !slices.Contains(args, "--server.read-timeout=5m") {
-					return fmt.Errorf("expected default --server.read-timeout=5m not found in args: %v", args)
+				if !slices.Contains(args, "--server.read-timeout=300s") {
+					return fmt.Errorf("expected default --server.read-timeout=300s not found in args: %v", args)
 				}
-				if !slices.Contains(args, "--server.write-timeout=12m") {
-					return fmt.Errorf("expected default --server.write-timeout=12m not found in args: %v", args)
+				if !slices.Contains(args, "--server.write-timeout=720s") {
+					return fmt.Errorf("expected default --server.write-timeout=720s not found in args: %v", args)
 				}
 				return nil
 			}, EventuallyTimeoutMinute*1, EventuallyIntervalSecond*10).Should(Succeed())

--- a/tests/pkg/tests/observability_config_test.go
+++ b/tests/pkg/tests/observability_config_test.go
@@ -664,6 +664,130 @@ var _ = Describe("", func() {
 		},
 	)
 
+	It(
+		"ACM-34806: Observability: Verify configurable API gateway timeouts in MCO CR - [P2][Sev2][Observability][Integration] @e2e (config/g0)",
+		func() {
+			By("Verifying default state: Observatorium CR has no timeout fields")
+			Eventually(func() error {
+				cr, err := dynClient.Resource(utils.NewMCOMObservatoriumGVR()).
+					Namespace(MCO_NAMESPACE).
+					Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				specMap, ok := cr.Object["spec"].(map[string]any)
+				if !ok {
+					return fmt.Errorf("spec not found or not a map")
+				}
+				apiSpec, ok := specMap["api"].(map[string]any)
+				if !ok {
+					return fmt.Errorf("spec.api not found or not a map")
+				}
+				if _, ok := apiSpec["queryTimeout"]; ok {
+					return fmt.Errorf("queryTimeout should not be set on Observatorium CR by default")
+				}
+				if _, ok := apiSpec["writeTimeout"]; ok {
+					return fmt.Errorf("writeTimeout should not be set on Observatorium CR by default")
+				}
+				return nil
+			}, EventuallyTimeoutMinute*1, EventuallyIntervalSecond*10).Should(Succeed())
+
+			By("Verifying default state: observatorium-api deployment has default timeout args")
+			Eventually(func() error {
+				deps, err := utils.GetDeploymentWithLabel(testOptions, true, OBSERVATORIUM_API_LABEL, MCO_NAMESPACE)
+				if err != nil {
+					return err
+				}
+				if len(deps.Items) == 0 {
+					return fmt.Errorf("no observatorium-api deployment found")
+				}
+				args := deps.Items[0].Spec.Template.Spec.Containers[0].Args
+				if !slices.Contains(args, "--server.read-timeout=5m") {
+					return fmt.Errorf("expected default --server.read-timeout=5m not found in args: %v", args)
+				}
+				if !slices.Contains(args, "--server.write-timeout=12m") {
+					return fmt.Errorf("expected default --server.write-timeout=12m not found in args: %v", args)
+				}
+				return nil
+			}, EventuallyTimeoutMinute*1, EventuallyIntervalSecond*10).Should(Succeed())
+
+			By("Setting both queryTimeout and writeTimeout in MCO CR")
+			mcoRes, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+				Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			spec := mcoRes.Object["spec"].(map[string]any)
+			advancedSpec, ok := spec["advanced"].(map[string]any)
+			if !ok {
+				Skip("Skip the case since the MCO CR did not have advanced spec configured")
+			}
+			advancedSpec["queryTimeout"] = "10m"
+			advancedSpec["writeTimeout"] = "15m"
+
+			_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+				Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking Observatorium CR carries both timeout values")
+			Eventually(func() error {
+				cr, err := dynClient.Resource(utils.NewMCOMObservatoriumGVR()).
+					Namespace(MCO_NAMESPACE).
+					Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				specMap, ok := cr.Object["spec"].(map[string]any)
+				if !ok {
+					return fmt.Errorf("spec not found or not a map")
+				}
+				apiSpec, ok := specMap["api"].(map[string]any)
+				if !ok {
+					return fmt.Errorf("spec.api not found or not a map")
+				}
+				if qt, _ := apiSpec["queryTimeout"].(string); qt != "10m" {
+					return fmt.Errorf("Observatorium CR queryTimeout = %q, want %q", qt, "10m")
+				}
+				if wt, _ := apiSpec["writeTimeout"].(string); wt != "15m" {
+					return fmt.Errorf("Observatorium CR writeTimeout = %q, want %q", wt, "15m")
+				}
+				return nil
+			}, EventuallyTimeoutMinute*2, EventuallyIntervalSecond*10).Should(Succeed())
+
+			By("Checking observatorium-api deployment has updated timeout args")
+			Eventually(func() error {
+				deps, err := utils.GetDeploymentWithLabel(testOptions, true, OBSERVATORIUM_API_LABEL, MCO_NAMESPACE)
+				if err != nil {
+					return err
+				}
+				if len(deps.Items) == 0 {
+					return fmt.Errorf("no observatorium-api deployment found")
+				}
+				args := deps.Items[0].Spec.Template.Spec.Containers[0].Args
+				if !slices.Contains(args, "--server.read-timeout=10m") {
+					return fmt.Errorf("expected --server.read-timeout=10m not found in args: %v", args)
+				}
+				if !slices.Contains(args, "--server.write-timeout=15m") {
+					return fmt.Errorf("expected --server.write-timeout=15m not found in args: %v", args)
+				}
+				return nil
+			}, EventuallyTimeoutMinute*2, EventuallyIntervalSecond*10).Should(Succeed())
+
+			By("Reverting MCO CR timeouts to defaults")
+			mcoRes, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+				Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			spec = mcoRes.Object["spec"].(map[string]any)
+			advancedSpec = spec["advanced"].(map[string]any)
+			delete(advancedSpec, "queryTimeout")
+			delete(advancedSpec, "writeTimeout")
+
+			_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+				Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		},
+	)
+
 	JustAfterEach(func() {
 		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 	})


### PR DESCRIPTION
 **Summary**

  - Add writeTimeout field to AdvancedConfig in the MCO CR (default: 720s), controlling the observatorium-api server write timeout for signal ingestion (metrics, logs, traces).
  - Extend existing queryTimeout to also propagate to the observatorium-api server read timeout, ensuring consistency across the full read path from Grafana through to the API gateway.
  - Wire both values from MCO CR → Observatorium CR → observatorium-api deployment args
  (--server.read-timeout, --server.write-timeout).

  **Problem**

  Managed clusters sending large metric batches (>50K series) over WAN/VPN hit HTTP 502 errors. The upstream --server.read-timeout default of 5s is too short for large payloads over high-latency
  networks. This timeout was never explicitly set or exposed for configuration.

  **Depends on**

  - https://github.com/stolostron/observatorium-operator/pull/439 (must merge first)
  - After merge: update go.mod to pick up new observatorium-operator commit, run go mod vendor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable `writeTimeout` for signal ingestion/response-path behavior through the observability API gateway.
  * Expanded `queryTimeout` to cover gateway read timeouts beyond the Grafana query/read path.
* **Bug Fixes**
  * Timeout settings are applied only when valid; invalid duration values are ignored to avoid misconfiguration.
* **Documentation**
  * Updated CRD/schema descriptions for both `queryTimeout` and the new `writeTimeout`.
* **Tests**
  * Added unit and integration coverage to verify timeout propagation to `observatorium-api` (including reverting to defaults).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->