### PR TITLE
ci: query latest-published snapshot tags to avoid race during publish

### DIFF
--- a/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_webhook.go
+++ b/operators/multiclusterobservability/api/v1beta2/multiclusterobservability_webhook.go
@@ -70,6 +70,12 @@ func (v *mcoValidator) ValidateCreate(ctx context.Context, obj *MultiClusterObse
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (v *mcoValidator) ValidateUpdate(ctx context.Context, oldObj, newObj *MultiClusterObservability) (admission.Warnings, error) {
 	multiclusterobservabilitylog.Info("validate update", "name", newObj.Name)
+
+	if newObj.GetDeletionTimestamp() != nil {
+		multiclusterobservabilitylog.Info("skip update validation during deletion", "name", newObj.Name)
+		return nil, nil
+	}
+
 	return nil, newObj.validateMultiClusterObservability(oldObj)
 }
 

--- a/scripts/test-utils.sh
+++ b/scripts/test-utils.sh
@@ -21,7 +21,7 @@ get_latest_acm_snapshot() {
   # z version 1-2 digits
   # -SNAPSHOT
   MATCH=$SNAPSHOT_RELEASE".\d{1,2}-SNAPSHOT"
-  LATEST_SNAPSHOT=$(curl -s "https://quay.io/api/v1/repository/stolostron/multicluster-observability-operator/tag/?filter_tag_name=like:$SNAPSHOT_RELEASE&limit=100" | jq --arg MATCH "$MATCH" '.tags[] | select(.name | match($MATCH; "i")  ).name' | sort -r --version-sort | head -n 1)
+  LATEST_SNAPSHOT=$(curl -s "https://quay.io/api/v1/repository/stolostron/acm-custom-registry/tag/?filter_tag_name=like:$SNAPSHOT_RELEASE&limit=100" | jq --arg MATCH "$MATCH" '.tags[] | select(.name | match($MATCH; "i")  ).name' | sort -r --version-sort | head -n 1)
 
   # trim the leading and tailing quotes
   LATEST_SNAPSHOT="${LATEST_SNAPSHOT#\"}"


### PR DESCRIPTION
The snapshot images take a ~7 minute publish window. `acm-custom-registry` is the last image published, so any tag found there is guaranteed to be available across all stolostron repositories.

In addition, validation webhooks verification are disabled during delete operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the ACM snapshot lookup to retrieve tags from the correct Quay registry source.
  * Improves reliability of selecting the latest matching ACM snapshot tags to reduce missed or incorrect matches.
  * Fixed the multicluster observability update admission webhook to skip update validation when the object is being deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->