### PR TITLE
Experiment: Test Red Hat Hardened core-runtime Image (release-acm-212)

### DIFF
--- a/operators/endpointmetrics/Containerfile.operator
+++ b/operators/endpointmetrics/Containerfile.operator
@@ -11,7 +11,7 @@ COPY ./operators/pkg ./operators/pkg
 RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -o build/_output/bin/endpoint-monitoring-operator operators/endpointmetrics/main.go
 RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -o build/_output/bin/cmo-config-revert operators/endpointmetrics/cmd/cmo-config-revert/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/hi/core-runtime:latest-openssl-fips
 
 ARG VCS_REF
 ARG VCS_URL


### PR DESCRIPTION
## Purpose
This is an **experimental PR** against the inactive **release-acm-212** application to test Red Hat's hardened images.

## Changes
- Switch runtime base image from `ubi9/ubi-minimal`
- To: `registry.access.redhat.com/hi/core-runtime:latest-openssl-fips`
- Modified file: `operators/endpointmetrics/Containerfile.operator`

## Details
**Component:** endpoint-monitoring-operator
**Target Release:** release-2.12 (inactive)
**Hardened Image:** core-runtime with FIPS-enabled OpenSSL

### Why This Component?
- Clean Dockerfile - only copies binaries
- No package manager usage detected
- Good candidate for hardened image compatibility testing

## Testing
- Target: Inactive release-acm-212 Konflux application
- Goal: Validate Konflux build success with hardened images
- Focus: FIPS compliance, runtime compatibility
- Reference: https://images.redhat.com/

## Notes
- This is for experimentation only
- Not intended for merge to active releases
- Monitoring Konflux build pipeline for compatibility
- Part of systematic testing across ACM 2.12 components

/hold
/cc @gparvin