### PR TITLE
Fix: Add a refresh with the time range picker for vm right-sizing grafana dashboard

### DIFF
--- a/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization.yaml
@@ -2804,9 +2804,7 @@ data:
         "from": "now-7d",
         "to": "now"
       },
-      "timepicker": {
-        "hidden": true
-      },
+      "timepicker": {},
       "timezone": "",
       "title": "ACM Right-Sizing OpenShift Virtualization",
       "uid": "bnqQIPySEProdkhgafkOpenshiftVirt",


### PR DESCRIPTION
This makes the toolbar visible again, giving users access to the refresh button and auto-refresh intervals. The time range picker will also appear, but since the queries use $days for their max_over_time windows, changing the Grafana time range won't affect the table data — it's harmless but does surface the refresh controls.

Unfortunately, this is a known Grafana limitation — there's no way to hide the time range picker while keeping only the refresh button visible in the standard dashboard JSON. The refresh button is part of the same timepicker toolbar component.

This has been a long-standing feature request (grafana/grafana#11782, #83691) with a proposed fix (PR #83697) that was never merged. Even in Grafana 12.x, hiding the timepicker hides the refresh button and disables auto-refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the Grafana time picker controls on the dashboard, making the time range selector visible again (it previously appeared hidden).
  * The dashboard’s refresh behavior remains unchanged, so update timing will not differ from before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->