### PR TITLE
Fix false positives in ManagedClusterMetricsMissing alert

### DIFF
--- a/operators/multiclusterobservability/manifests/base/alertmanager/hub_alert_rules.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/hub_alert_rules.yaml
@@ -61,6 +61,8 @@ data:
             )
             unless on(cluster, clusterID) (
               cluster:metrics_received:heartbeat
+              or
+              label_replace(cluster:metrics_received:heartbeat, "clusterID", "$1", "cluster", "(.*)")
             )
           for: 15m
           labels:


### PR DESCRIPTION
**Context / Problem**
The `ManagedClusterMetricsMissing` alert is currently firing false positives for certain managed clusters. This occurs because the `acm_managed_cluster_labels` metric sometimes incorrectly populates the `managed_cluster_id` label with the cluster's *name* instead of its UUID.

Since the alert requires a strict join (`unless on(cluster, clusterID)`) against the `cluster:metrics_received:heartbeat` metric (which always contains the correct UUID), the mismatch causes the join to fail and the alert to fire inappropriately.

**Solution**
Updated the right-hand side of the `unless` clause to include a fallback. By using `or label_replace(...)` on the heartbeat metric, the alert now successfully matches against either the true UUID or the cluster name masquerading as the UUID.

**Impact**

* Resolves false positive alerts for clusters affected by the label drift.
* Maintains strict label matching (`on(cluster, clusterID)`) to ensure alert routing and logic remain intact for correctly functioning clusters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alert handling so the `ManagedClusterMetricsMissing` alert no longer triggers when a valid heartbeat is present with alternate cluster label naming.
  * Reduced false positives in multicluster observability by making heartbeat matching more resilient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->