### PR TITLE
[release-2.14] Prevent downgrade of thanos receive PVC to 1Gi in e2e

### DIFF
--- a/examples/updatemcocr/advancedmcoconfig/custom-certs/v1beta2-observability-custom-mco.yaml
+++ b/examples/updatemcocr/advancedmcoconfig/custom-certs/v1beta2-observability-custom-mco.yaml
@@ -155,7 +155,7 @@ spec:
       name: thanos-object-storage
       tlsSecretMountPath: /etc/minio/certs
       tlsSecretName: minio-tls-secret
-    receiveStorageSize: 1Gi
+    receiveStorageSize: 10Gi
     ruleStorageSize: 1Gi
     storageClass: gp2
     storeStorageSize: 1Gi

--- a/examples/updatemcocr/advancedmcoconfig/v1beta2-observability-custom-mco.yaml
+++ b/examples/updatemcocr/advancedmcoconfig/v1beta2-observability-custom-mco.yaml
@@ -153,7 +153,7 @@ spec:
     metricObjectStorage:
       key: thanos.yaml
       name: thanos-object-storage
-    receiveStorageSize: 1Gi
+    receiveStorageSize: 10Gi
     ruleStorageSize: 1Gi
     storageClass: gp2
     storeStorageSize: 1Gi

--- a/examples/updatemcocr/initialmcoconfig/custom-certs/v1beta2-observability-initial-mco.yaml
+++ b/examples/updatemcocr/initialmcoconfig/custom-certs/v1beta2-observability-initial-mco.yaml
@@ -121,7 +121,7 @@ spec:
       name: thanos-object-storage
       tlsSecretMountPath: /etc/minio/certs
       tlsSecretName: minio-tls-secret
-    receiveStorageSize: 1Gi
+    receiveStorageSize: 10Gi
     ruleStorageSize: 1Gi
     storageClass: gp2
     storeStorageSize: 1Gi

--- a/examples/updatemcocr/initialmcoconfig/v1beta2-observability-initial-mco.yaml
+++ b/examples/updatemcocr/initialmcoconfig/v1beta2-observability-initial-mco.yaml
@@ -119,7 +119,7 @@ spec:
     metricObjectStorage:
       key: thanos.yaml
       name: thanos-object-storage
-    receiveStorageSize: 1Gi
+    receiveStorageSize: 10Gi
     ruleStorageSize: 1Gi
     storageClass: gp2
     storeStorageSize: 1Gi


### PR DESCRIPTION
In jenkins QE regression tests, RHACM4K-43019 will apply MCO CR that lowers thanos receive PVC from 10Gi to 1Gi. The observability-thanos-receive pods will then fail to start as no storage is left on the device. No observability-thanos-receive pods will start causing a cascading failure in CI