### PR TITLE
tests: don't overwrite MCOA/obo images

### DIFF
--- a/cicd-scripts/run-e2e-tests.sh
+++ b/cicd-scripts/run-e2e-tests.sh
@@ -13,8 +13,6 @@ ROOTDIR="$(
 SED_COMMAND=(sed -i -e)
 
 # customize the images for testing
-export MULTICLUSTER_OBSERVABILITY_ADDON_IMAGE_REF="quay.io/rhobs/multicluster-observability-addon:latest"
-export OBO_PROMETHEUS_OPERATOR_IMAGE_REF="quay.io/rhobs/obo-prometheus-operator:v0.82.1-rhobs1"
 ${ROOTDIR}/cicd-scripts/customize-mco.sh
 GINKGO_FOCUS="$(cat /tmp/ginkgo_focus)"
 


### PR DESCRIPTION
Both of these now exists correctly in stolostron repos and snapshots are built. We can therefore remove the customizations for these images, and rely on the same logic as other images.