### PR TITLE
fix: patch CVE-2026-42151 in github.com/prometheus/prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
-	github.com/prometheus/prometheus v0.305.0
+	github.com/prometheus/prometheus v0.305.3
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stolostron/observatorium-operator v0.0.0-20260422075739-5b3b9e12c92f

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/digitalocean/godo v1.152.0 h1:WRgkPMogZSXEJK70IkZKTB/PsMn16hMQ+NI3wCI
 github.com/digitalocean/godo v1.152.0/go.mod h1:tYeiWY5ZXVpU48YaFv0M5irUFHXGorZpDNm7zzdWMzM=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/docker v28.2.2+incompatible h1:CjwRSksz8Yo4+RmQ339Dp/D2tGO5JxwYeqtMOEe0LDw=
-github.com/docker/docker v28.2.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
+github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
@@ -401,8 +401,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
-github.com/prometheus/prometheus v0.305.0 h1:UO/LsM32/E9yBDtvQj8tN+WwhbyWKR10lO35vmFLx0U=
-github.com/prometheus/prometheus v0.305.0/go.mod h1:JG+jKIDUJ9Bn97anZiCjwCxRyAx+lpcEQ0QnZlUlbwY=
+github.com/prometheus/prometheus v0.305.3 h1:LzXTBJasd61l8kD/RcpwoiJ95v2Txkb3vZJX74uEe2E=
+github.com/prometheus/prometheus v0.305.3/go.mod h1:Ys8JihI93h10WYlbLRBeU3WP4OhN0yHQUabGN886kfk=
 github.com/prometheus/sigv4 v0.2.0 h1:qDFKnHYFswJxdzGeRP63c4HlH3Vbn1Yf/Ao2zabtVXk=
 github.com/prometheus/sigv4 v0.2.0/go.mod h1:D04rqmAaPPEUkjRQxGqjoxdyJuyCh6E0M18fZr0zBiE=
 github.com/redis/go-redis/v9 v9.8.0 h1:q3nRvjrlge/6UD7eTu/DSg2uYiU2mCL0G/uzBWqhicI=


### PR DESCRIPTION
## Summary

- Bumps `github.com/prometheus/prometheus` from v0.305.0 to v0.305.3 to fix **CVE-2026-42151** (GHSA-wg65-39gg-5wfj)
- The `ClientSecret` field in `storage/remote/azuread` `OAuthConfig` was typed as `string` instead of `config_util.Secret`, causing the Azure AD remote write OAuth client secret to be exposed via the Prometheus config API (bypassing redaction)
- Upstream fix PRs: prometheus/prometheus#18587, prometheus/prometheus#18590
- Verified fix: `ClientSecret` field changed from `string` to `config_util.Secret` in v0.305.3

## Affected go.mod files

Only the root `go.mod` depends on `github.com/prometheus/prometheus`. The `.bingo/go.mod` does not.

## Verification

- **govulncheck (before):** GO-2026-5710 confirmed at v0.305.0
- **Source inspection:** v0.305.0 has `ClientSecret string` (vulnerable); v0.305.3 has `ClientSecret config_util.Secret` (fixed)
- **govulncheck (after):** Database lists v0.311.3 as fix (does not track v0.305.3 backport), but source-level verification confirms the fix is present
- **Build:** `go build ./...` passes
- **Tests:** All unit tests pass; E2E tests skipped (require live cluster)

## Jira

- ACM-36210
- ACM-36241
- ACM-36249
- ACM-36250

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `go test ./...` unit tests pass
- [x] `go mod verify` checksums valid
- [x] Source-level verification that `ClientSecret` field type changed from `string` to `config_util.Secret`
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)