### PR TITLE
[release-2.17] [ACM-30479] <MCO>: <Fix Issue Where ViolatedPolicyGuidelines rule would break when additional labels are added to managed cluster that is violating policy guidelines>

### DIFF
--- a/operators/multiclusterobservability/manifests/base/alertmanager/alert_rules.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/alert_rules.yaml
@@ -37,7 +37,7 @@ data:
           annotations:
             summary: "There is a policy report violation with a {{ $labels.severity }} severity level detected."
             description: "The policy: {{ $labels.policy }} has a severity of {{ $labels.severity }} on cluster: {{ $labels.cluster }}"
-          expr: sum without (managed_cluster_id) (label_replace((sum without (clusterID) (label_replace((sum(policyreport_info * on (managed_cluster_id) group_left (cluster) label_replace(acm_managed_cluster_labels, "cluster", "$1", "name", "(.*)")) by (cluster, category, clusterID, managed_cluster_id, policy, severity) > 0),"hub_cluster_id", "$1", "clusterID", "(.*)"))),"clusterID", "$1", "managed_cluster_id", "(.*)"))
+          expr: sum without (managed_cluster_id) (label_replace((sum without (clusterID) (label_replace((sum(policyreport_info * on (managed_cluster_id) group_left (cluster) max by (managed_cluster_id, cluster) (label_replace(acm_managed_cluster_labels, "cluster", "$1", "name", "(.*)"))) by (cluster, category, clusterID, managed_cluster_id, policy, severity) > 0),"hub_cluster_id", "$1", "clusterID", "(.*)"))),"clusterID", "$1", "managed_cluster_id", "(.*)"))
           for: 1m
           labels:
             severity: "{{ $labels.severity }}"

--- a/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/prometheus-rule.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/platform-mcoa/prometheus-rule.yaml
@@ -217,7 +217,7 @@ spec:
         annotations:
           summary: "There is a policy report violation with a {{ $labels.severity }} severity level detected."
           description: "The policy: {{ $labels.policy }} has a severity of {{ $labels.severity }} on cluster: {{ $labels.cluster }}"
-        expr: sum without (managed_cluster_id) (label_replace((sum without (clusterID) (label_replace((sum(policyreport_info * on (managed_cluster_id) group_left (cluster) label_replace(acm_managed_cluster_labels, "cluster", "$1", "name", "(.*)")) by (cluster, category, clusterID, managed_cluster_id, policy, severity) > 0),"hub_cluster_id", "$1", "clusterID", "(.*)"))),"clusterID", "$1", "managed_cluster_id", "(.*)"))
+        expr: sum without (managed_cluster_id) (label_replace((sum without (clusterID) (label_replace((sum(policyreport_info * on (managed_cluster_id) group_left (cluster) max by (managed_cluster_id, cluster) (label_replace(acm_managed_cluster_labels, "cluster", "$1", "name", "(.*)"))) by (cluster, category, clusterID, managed_cluster_id, policy, severity) > 0),"hub_cluster_id", "$1", "clusterID", "(.*)"))),"clusterID", "$1", "managed_cluster_id", "(.*)"))
         for: 1m
         labels:
           severity: "{{ $labels.severity }}"


### PR DESCRIPTION
This is a cherry-pick of https://github.com/stolostron/multicluster-observability-operator/pull/2486 to release-2.17. This fixes the issue where ViolatedPolicyGuidelines rule would break when additional labels are added to managed cluster that is violating policy guidelines.