### PR TITLE
[release-2.17] fix - duplicate Grafana links in ACM console when MCOA is enabled without platform metrics

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -244,6 +244,15 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	}
 	disableMCOACMAORender := !apierrors.IsNotFound(err)
 
+	// Sync Grafana link annotations on existing MCOA CMA independently of the render pipeline.
+	// DisableCMAORender prevents re-rendering the CMA, so annotation changes from toggling
+	// platform metrics would not propagate through Render()/Deploy().
+	if disableMCOACMAORender {
+		if err := syncMCOACMAGrafanaLink(ctx, r.Client, instance, mcoaCMAO); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to sync MCOA CMA Grafana link: %w", err)
+		}
+	}
+
 	// Check if right-sizing is delegated to MCOA via MCO CR annotation.
 	rightSizingDelegated := util.IsRightSizingDelegated(instance)
 
@@ -1153,4 +1162,50 @@ func newMCOACRDEventHandler(c client.Client) handler.EventHandler {
 			return reqs
 		},
 	)
+}
+
+// syncMCOACMAGrafanaLink ensures the MCOA ClusterManagementAddOn's Grafana launch-link
+// annotation is present only when platform metrics are enabled via MCOA. This runs
+// independently of the render pipeline because DisableCMAORender skips re-rendering
+// the CMA once it exists.
+func syncMCOACMAGrafanaLink(
+	ctx context.Context,
+	c client.Client,
+	mco *mcov1beta2.MultiClusterObservability,
+	cmao *addonv1alpha1.ClusterManagementAddOn,
+) error {
+	annotations := cmao.GetAnnotations()
+	_, hasLink := annotations[util.GrafanaLaunchLinkKey]
+	metricsEnabled := rendering.MCOAPlatformMetricsEnabled(mco)
+
+	if metricsEnabled && !hasLink {
+		host, err := config.GetRouteHost(ctx, c, config.GrafanaRouteName, config.GetDefaultNamespace())
+		if err != nil {
+			return fmt.Errorf("failed to get Grafana route host: %w", err)
+		}
+		if host == "" {
+			return fmt.Errorf("grafana route host is empty, cannot construct launch link")
+		}
+		grafanaURL := url.URL{
+			Scheme: "https",
+			Host:   host,
+			Path:   rendering.GrafanaMCOADashboardPath,
+		}
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[util.GrafanaLaunchLinkKey] = grafanaURL.String()
+		annotations[util.GrafanaLaunchLinkTextKey] = "Grafana"
+		cmao.SetAnnotations(annotations)
+		return c.Update(ctx, cmao)
+	}
+
+	if !metricsEnabled && hasLink {
+		delete(annotations, util.GrafanaLaunchLinkKey)
+		delete(annotations, util.GrafanaLaunchLinkTextKey)
+		cmao.SetAnnotations(annotations)
+		return c.Update(ctx, cmao)
+	}
+
+	return nil
 }

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -31,6 +31,7 @@ import (
 	mcostatusctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/status"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/rendering/templates"
+	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/util"
 	observatoriumv1alpha1 "github.com/stolostron/observatorium-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
@@ -1604,6 +1605,115 @@ func TestDeleteVestigialProxyIngress(t *testing.T) {
 				assert.True(t, errors.IsNotFound(err), "ingress should have been deleted")
 			} else {
 				assert.True(t, errors.IsNotFound(err), "ingress should not exist")
+			}
+		})
+	}
+}
+
+// TestSyncMCOACMAGrafanaLink verifies that syncMCOACMAGrafanaLink correctly adds,
+// removes, or leaves unchanged the Grafana launch-link annotation on the MCOA CMA
+// based on whether platform metrics collection is enabled.
+func TestSyncMCOACMAGrafanaLink(t *testing.T) {
+	s := runtime.NewScheme()
+	assert.NoError(t, routev1.AddToScheme(s))
+	addonv1alpha1.AddToScheme(s)
+
+	grafanaRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.GrafanaRouteName,
+			Namespace: config.GetDefaultNamespace(),
+		},
+		Spec: routev1.RouteSpec{
+			Host: "grafana.apps.test.example.com",
+		},
+	}
+
+	tests := []struct {
+		name            string
+		metricsEnabled  bool
+		existingLink    bool
+		expectUpdate    bool
+		expectLinkAfter bool
+	}{
+		{
+			name:            "Platform metrics ON, link absent - should add link",
+			metricsEnabled:  true,
+			existingLink:    false,
+			expectUpdate:    true,
+			expectLinkAfter: true,
+		},
+		{
+			name:            "Platform metrics OFF, link present - should remove link",
+			metricsEnabled:  false,
+			existingLink:    true,
+			expectUpdate:    true,
+			expectLinkAfter: false,
+		},
+		{
+			name:            "Platform metrics ON, link present - no-op",
+			metricsEnabled:  true,
+			existingLink:    true,
+			expectUpdate:    false,
+			expectLinkAfter: true,
+		},
+		{
+			name:            "Platform metrics OFF, link absent - no-op",
+			metricsEnabled:  false,
+			existingLink:    false,
+			expectUpdate:    false,
+			expectLinkAfter: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mco := &mcov1beta2.MultiClusterObservability{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mco"},
+			}
+			if tt.metricsEnabled {
+				mco.Spec.Capabilities = &mcov1beta2.CapabilitiesSpec{
+					Platform: &mcov1beta2.PlatformCapabilitiesSpec{
+						Metrics: mcov1beta2.PlatformMetricsSpec{
+							Default: mcov1beta2.PlatformMetricsDefaultSpec{
+								Enabled: true,
+							},
+						},
+					},
+				}
+			}
+
+			cmao := &addonv1alpha1.ClusterManagementAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: config.MultiClusterObservabilityAddon,
+				},
+			}
+			if tt.existingLink {
+				cmao.Annotations = map[string]string{
+					util.GrafanaLaunchLinkKey:     "https://grafana.old.example.com/d/old-dashboard/overview",
+					util.GrafanaLaunchLinkTextKey: "Grafana",
+				}
+			}
+
+			c := fake.NewClientBuilder().WithScheme(s).WithObjects(cmao, grafanaRoute).Build()
+
+			err := syncMCOACMAGrafanaLink(t.Context(), c, mco, cmao)
+			assert.NoError(t, err)
+
+			updated := &addonv1alpha1.ClusterManagementAddOn{}
+			err = c.Get(t.Context(), types.NamespacedName{Name: config.MultiClusterObservabilityAddon}, updated)
+			assert.NoError(t, err)
+
+			_, hasLink := updated.Annotations[util.GrafanaLaunchLinkKey]
+			assert.Equal(t, tt.expectLinkAfter, hasLink, "Grafana link presence mismatch")
+
+			if tt.expectLinkAfter && tt.expectUpdate {
+				assert.Contains(t, updated.Annotations[util.GrafanaLaunchLinkKey], "grafana.apps.test.example.com")
+				assert.Equal(t, "Grafana", updated.Annotations[util.GrafanaLaunchLinkTextKey])
+			}
+
+			if tt.expectLinkAfter && !tt.expectUpdate && tt.existingLink {
+				assert.Equal(t, "https://grafana.old.example.com/d/old-dashboard/overview",
+					updated.Annotations[util.GrafanaLaunchLinkKey])
 			}
 		})
 	}

--- a/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
@@ -42,6 +42,9 @@ const (
 
 	grafanaMCOAHomeDashboardID = "89eaec849a6e4837a619fb0540c22b13"
 	grafanaLink                = "/d/" + grafanaMCOAHomeDashboardID + "/acm-clusters-overview"
+
+	// GrafanaMCOADashboardPath is the MCOA Grafana dashboard URL path for the CMA launch-link annotation.
+	GrafanaMCOADashboardPath = grafanaLink
 )
 
 type MCOARendererOptions struct {
@@ -181,7 +184,8 @@ func (r *MCORenderer) renderMCOADeployment(
 	return &unstructured.Unstructured{Object: uObj}, nil
 }
 
-// renderClusterManagementAddOn renders the CMA resource with addon lifecycle annotations.
+// renderClusterManagementAddOn renders the MCOA ClusterManagementAddOn resource with labels
+// and conditionally adds the Grafana launch-link annotation when platform metrics are enabled.
 func (r *MCORenderer) renderClusterManagementAddOn(
 	ctx context.Context,
 	res *resource.Resource,
@@ -194,22 +198,30 @@ func (r *MCORenderer) renderClusterManagementAddOn(
 	}
 	u := &unstructured.Unstructured{Object: m}
 
-	// Add grafana link annotation
-	host, err := mcoconfig.GetRouteHost(ctx, r.kubeClient, mcoconfig.GrafanaRouteName, mcoconfig.GetDefaultNamespace())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get host route: %w", err)
-	}
-	grafanaUrl := url.URL{
-		Scheme: "https",
-		Host:   host,
-		Path:   grafanaLink,
-	}
 	annotations := maps.Clone(u.GetAnnotations())
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
-	annotations["console.open-cluster-management.io/launch-link"] = grafanaUrl.String()
-	annotations["console.open-cluster-management.io/launch-link-text"] = "Grafana"
+
+	// Only add the Grafana link when platform metrics are enabled via MCOA.
+	// When MCOA is activated only for right-sizing (without platform metrics),
+	// the legacy "observability-controller" CMA already provides the Grafana link.
+	if MCOAPlatformMetricsEnabled(r.cr) {
+		host, err := mcoconfig.GetRouteHost(ctx, r.kubeClient, mcoconfig.GrafanaRouteName, mcoconfig.GetDefaultNamespace())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get host route: %w", err)
+		}
+		if host == "" {
+			return nil, fmt.Errorf("grafana route host is empty, cannot construct launch link")
+		}
+		grafanaUrl := url.URL{
+			Scheme: "https",
+			Host:   host,
+			Path:   grafanaLink,
+		}
+		annotations[mcoutil.GrafanaLaunchLinkKey] = grafanaUrl.String()
+		annotations[mcoutil.GrafanaLaunchLinkTextKey] = "Grafana"
+	}
 	u.SetAnnotations(annotations)
 
 	cLabels := u.GetLabels()

--- a/operators/multiclusterobservability/pkg/rendering/renderer_mcoa_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_mcoa_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	routev1 "github.com/openshift/api/route/v1"
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/rendering/templates"
@@ -22,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	kustomizeres "sigs.k8s.io/kustomize/api/resource"
 )
 
@@ -478,4 +480,130 @@ func TestRenderMCOATemplates(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRenderClusterManagementAddOn verifies that the Grafana launch-link annotation
+// is set only when platform metrics are enabled via MCOA capabilities.
+func TestRenderClusterManagementAddOn(t *testing.T) {
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	templatesPath := filepath.Join(wd, "..", "..", "manifests")
+	t.Setenv(templatesutil.TemplatesPathEnvVar, templatesPath)
+
+	tmplRenderer := templatesutil.NewTemplateRenderer(templatesPath)
+	mcoaTemplates, err := templates.GetOrLoadMCOATemplates(tmplRenderer)
+	assert.NoError(t, err)
+
+	var cmaTemplate *kustomizeres.Resource
+	for _, template := range mcoaTemplates {
+		if template.GetKind() == "ClusterManagementAddOn" {
+			cmaTemplate = template.DeepCopy()
+			break
+		}
+	}
+	assert.NotNil(t, cmaTemplate, "ClusterManagementAddOn template not found")
+
+	grafanaRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mcoconfig.GrafanaRouteName,
+			Namespace: mcoconfig.GetDefaultNamespace(),
+		},
+		Spec: routev1.RouteSpec{
+			Host: "grafana.apps.test-cluster.example.com",
+		},
+	}
+
+	s := runtime.NewScheme()
+	assert.NoError(t, routev1.AddToScheme(s))
+
+	tests := []struct {
+		name           string
+		metricsEnabled bool
+		expectLink     bool
+	}{
+		{
+			name:           "Platform metrics enabled - should have Grafana link",
+			metricsEnabled: true,
+			expectLink:     true,
+		},
+		{
+			name:           "Platform metrics disabled - should not have Grafana link",
+			metricsEnabled: false,
+			expectLink:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mco := &mcov1beta2.MultiClusterObservability{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "multicluster-observability",
+				},
+			}
+			if tt.metricsEnabled {
+				mco.Spec.Capabilities = &mcov1beta2.CapabilitiesSpec{
+					Platform: &mcov1beta2.PlatformCapabilitiesSpec{
+						Metrics: mcov1beta2.PlatformMetricsSpec{
+							Default: mcov1beta2.PlatformMetricsDefaultSpec{
+								Enabled: true,
+							},
+						},
+					},
+				}
+			}
+
+			fakeClient := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(grafanaRoute).Build()
+			renderer := &MCORenderer{cr: mco, kubeClient: fakeClient}
+
+			uobj, err := renderer.renderClusterManagementAddOn(t.Context(), cmaTemplate.DeepCopy(), "test", map[string]string{"key": "value"})
+			assert.NoError(t, err)
+			assert.NotNil(t, uobj)
+
+			annotations := uobj.GetAnnotations()
+			if tt.expectLink {
+				assert.Contains(t, annotations, "console.open-cluster-management.io/launch-link")
+				assert.Equal(t, "Grafana", annotations["console.open-cluster-management.io/launch-link-text"])
+				assert.Contains(t, annotations["console.open-cluster-management.io/launch-link"], "grafana.apps.test-cluster.example.com")
+				assert.Contains(t, annotations["console.open-cluster-management.io/launch-link"], grafanaMCOAHomeDashboardID)
+			} else {
+				assert.NotContains(t, annotations, "console.open-cluster-management.io/launch-link")
+				assert.NotContains(t, annotations, "console.open-cluster-management.io/launch-link-text")
+			}
+
+			// Labels should always be set regardless of metrics
+			assert.Contains(t, uobj.GetLabels(), "key")
+		})
+	}
+}
+
+// TestRenderClusterManagementAddOnNilCapabilities verifies that a nil Capabilities
+// spec does not attempt a Grafana route lookup and produces no launch-link annotation.
+func TestRenderClusterManagementAddOnNilCapabilities(t *testing.T) {
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	templatesPath := filepath.Join(wd, "..", "..", "manifests")
+	t.Setenv(templatesutil.TemplatesPathEnvVar, templatesPath)
+
+	tmplRenderer := templatesutil.NewTemplateRenderer(templatesPath)
+	mcoaTemplates, err := templates.GetOrLoadMCOATemplates(tmplRenderer)
+	assert.NoError(t, err)
+
+	var cmaTemplate *kustomizeres.Resource
+	for _, template := range mcoaTemplates {
+		if template.GetKind() == "ClusterManagementAddOn" {
+			cmaTemplate = template.DeepCopy()
+			break
+		}
+	}
+
+	mco := &mcov1beta2.MultiClusterObservability{
+		ObjectMeta: metav1.ObjectMeta{Name: "multicluster-observability"},
+	}
+
+	// kubeClient intentionally nil: with nil Capabilities, no route fetch should occur
+	renderer := &MCORenderer{cr: mco}
+	uobj, err := renderer.renderClusterManagementAddOn(t.Context(), cmaTemplate.DeepCopy(), "test", map[string]string{"key": "value"})
+	assert.NoError(t, err)
+	assert.NotNil(t, uobj)
+	assert.NotContains(t, uobj.GetAnnotations(), "console.open-cluster-management.io/launch-link")
 }

--- a/operators/multiclusterobservability/pkg/util/clustermanagementaddon.go
+++ b/operators/multiclusterobservability/pkg/util/clustermanagementaddon.go
@@ -21,6 +21,8 @@ const (
 	ObservabilityController       = "observability-controller" // #nosec G101 -- Not a hardcoded credential.
 	AddonGroup                    = "addon.open-cluster-management.io"
 	AddonDeploymentConfigResource = "addondeploymentconfigs"
+	GrafanaLaunchLinkKey          = "console.open-cluster-management.io/launch-link"
+	GrafanaLaunchLinkTextKey      = "console.open-cluster-management.io/launch-link-text"
 	grafanaLink                   = "/d/2b679d600f3b9e7676a7c5ac3643d448/acm-clusters-overview"
 )
 
@@ -106,8 +108,8 @@ func newClusterManagementAddon(ctx context.Context, c client.Client) (*addonv1al
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ObservabilityController,
 			Annotations: map[string]string{
-				"console.open-cluster-management.io/launch-link":      grafanaUrl.String(),
-				"console.open-cluster-management.io/launch-link-text": "Grafana",
+				GrafanaLaunchLinkKey:     grafanaUrl.String(),
+				GrafanaLaunchLinkTextKey: "Grafana",
 			},
 		},
 		Spec: addonv1alpha1.ClusterManagementAddOnSpec{


### PR DESCRIPTION
## Summary
- Manual cherry-pick of #2464 (f722b83a) to `release-2.17`
- Automated cherry-pick failed due to addon API version differences (`addonv1alpha1` on release-2.17 vs `addonv1beta1` on main) and missing context imports from PR #2491

### Adaptations for release-2.17
- `addonv1beta1` → `addonv1alpha1` throughout (release-2.17 uses addon API v1alpha1)
- `addonv1beta1.Install(s)` → `addonv1alpha1.AddToScheme(s)` for scheme registration
- Import layout adjusted for release-2.17 branch differences
