### PR TITLE
Prevent downgrade of thanos receive PVC to 1Gi in jenkins e2e

### DIFF
--- a/examples/updatemcocr/advancedmcoconfig/custom-certs/v1beta2-observability-custom-mco.yaml
+++ b/examples/updatemcocr/advancedmcoconfig/custom-certs/v1beta2-observability-custom-mco.yaml
@@ -155,6 +155,6 @@ spec:
       name: thanos-object-storage
       tlsSecretMountPath: /etc/minio/certs
       tlsSecretName: minio-tls-secret
-    receiveStorageSize: 1Gi
+    receiveStorageSize: 10Gi
     ruleStorageSize: 1Gi
     storeStorageSize: 1Gi

--- a/examples/updatemcocr/advancedmcoconfig/v1beta2-observability-custom-mco.yaml
+++ b/examples/updatemcocr/advancedmcoconfig/v1beta2-observability-custom-mco.yaml
@@ -153,6 +153,6 @@ spec:
     metricObjectStorage:
       key: thanos.yaml
       name: thanos-object-storage
-    receiveStorageSize: 1Gi
+    receiveStorageSize: 10Gi
     ruleStorageSize: 1Gi
     storeStorageSize: 1Gi

--- a/examples/updatemcocr/initialmcoconfig/custom-certs/v1beta2-observability-initial-mco.yaml
+++ b/examples/updatemcocr/initialmcoconfig/custom-certs/v1beta2-observability-initial-mco.yaml
@@ -121,6 +121,6 @@ spec:
       name: thanos-object-storage
       tlsSecretMountPath: /etc/minio/certs
       tlsSecretName: minio-tls-secret
-    receiveStorageSize: 1Gi
+    receiveStorageSize: 10Gi
     ruleStorageSize: 1Gi
     storeStorageSize: 1Gi

--- a/examples/updatemcocr/initialmcoconfig/v1beta2-observability-initial-mco.yaml
+++ b/examples/updatemcocr/initialmcoconfig/v1beta2-observability-initial-mco.yaml
@@ -119,6 +119,6 @@ spec:
     metricObjectStorage:
       key: thanos.yaml
       name: thanos-object-storage
-    receiveStorageSize: 1Gi
+    receiveStorageSize: 10Gi
     ruleStorageSize: 1Gi
     storeStorageSize: 1Gi


### PR DESCRIPTION
e2e tests are deployed with thanos receive storage size at 10Gi. In jenkins QE regressions the test [RHACM4K-43019](https://github.com/stolostron/multicluster-observability-operator/blob/7f469b761faeb6cceeb188427c11a9490c1fef31/tests/pkg/tests/observability_config_test.go#L371) can run which downgrades the PVC size for thanos receive to 1Gi. If the test suite was running for an extended period of time this will push the thanos receive pods into an error state.

As mentioned in https://github.com/stolostron/multicluster-observability-operator/pull/2257 increasing the PV storage will delay the problem for now. There may come a need for another solution.

After these changes thanos receive storage size should stay at 10Gi through the duration of the e2e suite. receiveStorageSize is not changed for unit tests or for kind e2e tests i.e.
```
/examples/mco/e2e/v1beta2/custom-certs-kind/observability.yaml
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation / Examples**
  * Updated observability example configurations to increase receive storage capacity to `10Gi` (from `1Gi`).
  * Applied the update consistently across initial and advanced setup examples, including custom-certificate variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->