### PR TITLE
[release-2.17] e2e: use latest konflux build of MCOA/obo

### DIFF
--- a/cicd-scripts/customize-mco.sh
+++ b/cicd-scripts/customize-mco.sh
@@ -16,6 +16,10 @@ SED_COMMAND=(sed -i -e)
 source ./scripts/test-utils.sh
 LATEST_SNAPSHOT=${LATEST_SNAPSHOT:-$(get_latest_acm_snapshot)}
 
+# customize the images for testing
+export MULTICLUSTER_OBSERVABILITY_ADDON_IMAGE_REF="quay.io:443/acm-d/acm-multicluster-observability-addon-rhel9:$VERSION-dev"
+export OBO_PROMETHEUS_OPERATOR_IMAGE_REF="quay.io:443/acm-d/obo-prometheus-rhel9-operator:$VERSION-dev"
+
 if [[ -n ${IS_KIND_ENV} ]]; then
   source ./tests/run-in-kind/env.sh
 fi

--- a/cicd-scripts/run-e2e-tests.sh
+++ b/cicd-scripts/run-e2e-tests.sh
@@ -12,9 +12,6 @@ ROOTDIR="$(
 
 SED_COMMAND=(sed -i -e)
 
-# customize the images for testing
-export MULTICLUSTER_OBSERVABILITY_ADDON_IMAGE_REF="quay.io/rhobs/multicluster-observability-addon:latest"
-export OBO_PROMETHEUS_OPERATOR_IMAGE_REF="quay.io/rhobs/obo-prometheus-operator:v0.82.1-rhobs1"
 ${ROOTDIR}/cicd-scripts/customize-mco.sh
 GINKGO_FOCUS="$(cat /tmp/ginkgo_focus)"
 


### PR DESCRIPTION
For the relevant release. This ensures we are getting the right image for the specific stream instead of hardcoding the latest version.