### PR TITLE
ci: add tls compliance scan

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    name: Formatters + Linters (Static Analysis) for Go
+    name: Formatters + Linters + TLS Compliance Semgrep (Static Analysis) for Go
     env:
       GOBIN: /tmp/.bin
     steps:
@@ -37,3 +37,32 @@ jobs:
       # In addition we exclude createdAt changes in the CSV file that happen on each make bundle.
       - name: check diff
         run: "git diff -I '^    createdAt: ' --exit-code -- . ':(exclude)operators/multiclusterobservability/bundle.Dockerfile'"
+
+      - name: Install Semgrep
+        run: pip install semgrep==1.168.0
+
+      - name: Clone argus-observe-rules
+        run: git clone --depth 1 https://github.com/smith-xyz/argus-observe-rules.git /tmp/argus-observe-rules && git -C /tmp/argus-observe-rules checkout b85a9f57b02d0202e7cf62a77fd110a26718b3aa
+
+      - name: Semgrep TLS compliance scan
+        run: |
+          semgrep \
+            --config /tmp/argus-observe-rules/rules/languages/go/crypto/go-crypto-tls-version.yml \
+            --config /tmp/argus-observe-rules/rules/languages/go/crypto/go-crypto-cipher-suites.yml \
+            --config /tmp/argus-observe-rules/rules/languages/go/crypto/go-crypto-tls-cipher-suites.yml \
+            --config /tmp/argus-observe-rules/rules/languages/go/runtime-security/go-tls-version-override.yml \
+            --config /tmp/argus-observe-rules/rules/languages/go/runtime-security/go-tls-bypass.yml \
+            --config /tmp/argus-observe-rules/rules/languages/go/runtime-security/go-http-server-tls-override.yml \
+            --config /tmp/argus-observe-rules/rules/languages/go/runtime-security/go-http-client-tls-override.yml \
+            --config /tmp/argus-observe-rules/rules/languages/go/runtime-security/go-grpc-tls-credential-override.yml \
+            --config /tmp/argus-observe-rules/rules/languages/go/runtime-security/go-kubernetes-client-tls-override.yml \
+            --config /tmp/argus-observe-rules/rules/languages/go/runtime-security/go-certificate-validation-override.yml \
+            --exclude='vendor' --exclude='*_test.go' \
+            --error --severity WARNING --severity ERROR \
+            .
+
+      - name: TLS Config Lint
+        uses: sebrandon1/tls-config-lint@v1
+        with:
+          severity-threshold: high
+          languages: go

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -42,7 +42,7 @@ jobs:
         run: pip install semgrep==1.168.0
 
       - name: Clone argus-observe-rules
-        run: git clone --depth 1 https://github.com/smith-xyz/argus-observe-rules.git /tmp/argus-observe-rules && git -C /tmp/argus-observe-rules checkout b85a9f57b02d0202e7cf62a77fd110a26718b3aa
+        run: git clone --depth 1 https://github.com/smith-xyz/argus-observe-rules.git /tmp/argus-observe-rules && git -C /tmp/argus-observe-rules checkout main
 
       - name: Semgrep TLS compliance scan
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -66,3 +66,4 @@ jobs:
         with:
           severity-threshold: high
           languages: go
+          exclude-patterns: insecure-skip-verify

--- a/collectors/metrics/pkg/forwarder/forwarder.go
+++ b/collectors/metrics/pkg/forwarder/forwarder.go
@@ -112,7 +112,9 @@ func (cfg Config) CreateFromClient(
 
 	if len(cfg.FromClientConfig.CAFile) > 0 {
 		if fromTransport.TLSClientConfig == nil {
+			// nosemgrep: go-tls-bypass - client-side TLS fallback when no TLS config is provided.
 			fromTransport.TLSClientConfig = &tls.Config{
+				// nosemgrep: go-crypto-tls-version - client-side TLS.
 				MinVersion: tls.VersionTLS12,
 			}
 		}
@@ -134,7 +136,9 @@ func (cfg Config) CreateFromClient(
 		fromTransport.TLSClientConfig.RootCAs = pool
 	} else if fromTransport.TLSClientConfig == nil {
 		// #nosec G402 -- Only used if no TLS config is provided.
+		// nosemgrep: go-tls-bypass - client-side TLS fallback when no TLS config is provided.
 		fromTransport.TLSClientConfig = &tls.Config{
+			// nosemgrep: go-crypto-tls-version - client-side TLS.
 			MinVersion:         tls.VersionTLS12,
 			InsecureSkipVerify: true,
 		}
@@ -183,7 +187,9 @@ func (cfg Config) CreateToClient(
 		}
 	} else if toTransport.TLSClientConfig == nil {
 		// #nosec G402 -- Only used if no TLS config is provided.
+		// nosemgrep: go-tls-bypass - client-side TLS fallback when no TLS config is provided.
 		toTransport.TLSClientConfig = &tls.Config{
+			// nosemgrep: go-crypto-tls-version - client-side TLS.
 			MinVersion:         tls.VersionTLS12,
 			InsecureSkipVerify: true,
 		}

--- a/collectors/metrics/pkg/metricsclient/metricsclient.go
+++ b/collectors/metrics/pkg/metricsclient/metricsclient.go
@@ -357,10 +357,12 @@ func MTLSTransport(logger log.Logger, caCertFile, tlsCrtFile, tlsKeyFile string)
 	}
 
 	// Setup HTTPS client
+	// nosemgrep: go-crypto-tls-version, go-tls-min-version-tls12-only - client-side TLS.
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      caCertPool,
-		MinVersion:   tls.VersionTLS12,
+		// nosemgrep: go-crypto-tls-version - client-side TLS.
+		MinVersion: tls.VersionTLS12,
 	}
 	return &http.Transport{
 		Dial: (&net.Dialer{

--- a/proxy/pkg/proxy/tls.go
+++ b/proxy/pkg/proxy/tls.go
@@ -200,6 +200,7 @@ func (t *reloadingTransport) reloadTLSConfig() error {
 		return err
 	}
 
+	// nosemgrep: go-crypto-tls-cipher-suites - chiper suites are derived at runtime from cluster TLS security profile
 	newTLSConfig := &tls.Config{ //nolint:gosec // TLS min version must be configured at runtime by the cluster TLS security profile
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      caCertPool,


### PR DESCRIPTION
Add a check to statically verify the code does not contain manual TLS version/ciphers configurations.

Semgrep rules inherited from HPCASE-maintained semgrep rules for detecting TLS configuration issues: https://github.com/smith-xyz/argus-observe-rules

BLOCKERS:
- [x] Merge after https://github.com/stolostron/multicluster-observability-operator/pull/2540 

## Note for the reviewer
Evaluate if a stolostron fork is needed for stability reasons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic TLS profile handling for operators, metrics/webhooks, proxies, and rendered workloads (including TLS config reload on profile changes).
  * Added proxy flags for TLS minimum version and cipher suites.
  * TLS argument rendering now centrally applies cipher suites and minimum TLS version to generated resources.
* **Security**
  * Enhanced linting with TLS-focused Semgrep and TLS configuration linting.
* **Bug Fixes**
  * Improved visibility of TLS configuration issues by failing reconciliation when TLS settings can’t be computed.
  * Updated RBAC for required `apiservers` access and verbs to support TLS profile discovery.
* **Documentation**
  * —
<!-- end of auto-generated comment: release notes by coderabbit.ai -->