### PR TITLE
[release-2.15] e2e: Improve robustness of observability alert and addon tests (#2324)

### DIFF
--- a/tests/pkg/tests/observability_addon_test.go
+++ b/tests/pkg/tests/observability_addon_test.go
@@ -156,9 +156,21 @@ var _ = Describe("", func() {
 		}, EventuallyTimeoutMinute*1, EventuallyIntervalSecond*1).Should(BeTrue())
 	})
 
-	It("RHACM4K-1259: Observability: Verify imported cluster is observed [P3][Sev3][Observability][Stable]@ocpInterop @non-ui-post-restore @non-ui-post-release @non-ui-pre-upgrade @non-ui-post-upgrade @post-upgrade @post-restore (deploy/g1)", func() {
-		klog.V(1).Infof("managedcluster number is <%d>", len(testOptions.ManagedClusters))
-		if len(testOptions.ManagedClusters) >= 1 {
+	It(
+		"RHACM4K-1259: Observability: Verify imported cluster is observed [P3][Sev3][Observability][Stable]@ocpInterop @non-ui-post-restore @non-ui-post-release @non-ui-pre-upgrade @non-ui-post-upgrade @post-upgrade @post-restore (deploy/g1)",
+		func() {
+			klog.V(1).Infof("managedcluster number is <%d>", len(testOptions.ManagedClusters))
+
+			clusters, err := utils.ListManagedClusters(testOptions)
+			if err != nil {
+				klog.Errorf("Failed to list managed clusters: %v", err)
+				Skip("Skipping test: no available managed clusters found")
+			}
+
+			if len(clusters) < 2 {
+				Skip("Skipping test: no managed cluster beyond the hub found")
+			}
+
 			By("Waiting for ObservabilityAddon to be enabled and ready")
 			Eventually(func() error {
 				return utils.CheckAllOBAsEnabled(testOptions)
@@ -166,31 +178,55 @@ var _ = Describe("", func() {
 
 			By("Waiting for MCO addon components to be running")
 			Eventually(func() bool {
-				err, podList := utils.GetPodList(
-					testOptions,
-					false,
-					MCO_ADDON_NAMESPACE,
-					"component=metrics-collector",
-				)
+				// Re-list clusters inside Eventually in case the status changes
+				currentClusters, err := utils.ListManagedClusters(testOptions)
 				if err != nil {
-					klog.V(1).Infof("Failed to get pod list: %v", err)
+					klog.V(1).Infof("Failed to get managed clusters: %v", err)
 					return false
 				}
-				if len(podList.Items) < 1 {
-					klog.V(1).Infof("No metrics-collector pods found yet")
-					return false
-				}
-				// Verify all pods are in Running state
-				for _, pod := range podList.Items {
-					if pod.Status.Phase != "Running" {
-						klog.V(1).Infof("Pod %s is not running yet: %s", pod.Name, pod.Status.Phase)
+
+				for _, clusterInfo := range currentClusters {
+					if clusterInfo.IsLocalCluster {
+						continue
+					}
+
+					var clusterObj *utils.Cluster
+					for _, c := range testOptions.ManagedClusters {
+						if c.Name == clusterInfo.Name {
+							clusterObj = &c
+							break
+						}
+					}
+
+					if clusterObj == nil {
+						klog.V(1).Infof("Cluster %s not found in testOptions", clusterInfo.Name)
+						continue
+					}
+
+					client := utils.GetKubeClientWithCluster(*clusterObj)
+					podList, err := client.CoreV1().Pods(MCO_ADDON_NAMESPACE).List(context.TODO(), metav1.ListOptions{
+						LabelSelector: "component=metrics-collector",
+					})
+					if err != nil {
+						klog.V(1).Infof("Failed to get pod list for cluster %s: %v", clusterInfo.Name, err)
 						return false
+					}
+					if len(podList.Items) < 1 {
+						klog.V(1).Infof("No metrics-collector pods found yet for cluster %s", clusterInfo.Name)
+						return false
+					}
+					// Verify all pods are in Running state
+					for _, pod := range podList.Items {
+						if pod.Status.Phase != "Running" {
+							klog.V(1).Infof("Pod %s on cluster %s is not running yet: %s", pod.Name, clusterInfo.Name, pod.Status.Phase)
+							return false
+						}
 					}
 				}
 				return true
 			}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(BeTrue())
-		}
-	})
+		},
+	)
 
 	// This test is flaky because when the label is added to the managed cluster, the placement controller reconcile is triggered but
 	// the managed cluster still appears on this first reconcile. Then if we're lucky, or not, the addon is effectively removed from the managed cluster.

--- a/tests/pkg/tests/observability_alert_test.go
+++ b/tests/pkg/tests/observability_alert_test.go
@@ -419,15 +419,16 @@ var _ = Describe("", func() {
 			promRuleAdded := false
 			for idx, mc := range testOptions.ManagedClusters {
 				if mc.Name == ks {
-					err = utils.ApplyRetryOnConflict(
-						testOptions.ManagedClusters[idx].ClusterServerURL,
-						testOptions.ManagedClusters[idx].KubeConfig,
-						testOptions.ManagedClusters[idx].KubeContext,
-						yamlB,
-					)
+					Eventually(func() error {
+						return utils.ApplyRetryOnConflict(
+							testOptions.ManagedClusters[idx].ClusterServerURL,
+							testOptions.ManagedClusters[idx].KubeConfig,
+							testOptions.ManagedClusters[idx].KubeContext,
+							yamlB,
+						)
+					}, EventuallyTimeoutMinute*1, EventuallyIntervalSecond*5).Should(Succeed())
 					promRuleAdded = true
 					expectClusterIdentifiers = append(expectClusterIdentifiers, ks)
-					Expect(err).NotTo(HaveOccurred())
 				}
 			}
 			// If we couldn't find the credentials for the cluster and therefore
@@ -550,7 +551,7 @@ var _ = Describe("", func() {
 			alertGetReq.Header.Set("Authorization", "Bearer "+BearerToken)
 		}
 
-		expectedKSClusterNames, err := utils.GetManagedClusters(testOptions)
+		expectedKSClusterNames, err := utils.ListAvailableKSManagedClusterNames(testOptions)
 		Expect(err).NotTo(HaveOccurred())
 
 		watchDogRuleKustomizationPath := "../../../examples/alerts/watchdog_rule"
@@ -558,14 +559,15 @@ var _ = Describe("", func() {
 		Expect(err).NotTo(HaveOccurred())
 		for _, ks := range expectedKSClusterNames {
 			for idx, mc := range testOptions.ManagedClusters {
-				if mc.Name == ks.Name {
-					err = utils.ApplyRetryOnConflict(
-						testOptions.ManagedClusters[idx].ClusterServerURL,
-						testOptions.ManagedClusters[idx].KubeConfig,
-						testOptions.ManagedClusters[idx].KubeContext,
-						yamlB,
-					)
-					Expect(err).NotTo(HaveOccurred())
+				if mc.Name == ks {
+					Eventually(func() error {
+						return utils.ApplyRetryOnConflict(
+							testOptions.ManagedClusters[idx].ClusterServerURL,
+							testOptions.ManagedClusters[idx].KubeConfig,
+							testOptions.ManagedClusters[idx].KubeContext,
+							yamlB,
+						)
+					}, EventuallyTimeoutMinute*1, EventuallyIntervalSecond*5).Should(Succeed())
 				}
 			}
 		}

--- a/tests/pkg/utils/mco_managedcluster.go
+++ b/tests/pkg/utils/mco_managedcluster.go
@@ -16,6 +16,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 
@@ -31,7 +32,7 @@ var openshiftLabelSelector = labels.SelectorFromValidatedSet(map[string]string{
 
 type ClustersInfo struct {
 	Name           string
-	isLocalCluster bool
+	IsLocalCluster bool
 }
 
 func UpdateObservabilityFromManagedCluster(opt TestOptions, enableObservability bool) error {
@@ -76,13 +77,13 @@ func ListManagedClusters(opt TestOptions) ([]ClustersInfo, error) {
 
 		status, ok := obj.Object["status"].(map[string]any)
 		if !ok {
-			// No status found, skip this cluster
+			klog.Infof("Skip cluster %s: no status found", name)
 			continue
 		}
 
 		conditions, ok := status["conditions"].([]any)
 		if !ok {
-			// No conditions found, skip this cluster
+			klog.Infof("Skip cluster %s: no conditions found", name)
 			continue
 		}
 
@@ -100,10 +101,13 @@ func ListManagedClusters(opt TestOptions) ([]ClustersInfo, error) {
 
 		// Only add clusters with ManagedClusterConditionAvailable status == True
 		if available {
+			klog.Infof("Add cluster %s to the list", name)
 			clusters = append(clusters, ClustersInfo{
 				Name:           name,
-				isLocalCluster: metadata["labels"].(map[string]any)["local-cluster"] == "true",
+				IsLocalCluster: metadata["labels"].(map[string]any)["local-cluster"] == "true",
 			})
+		} else {
+			klog.Infof("Skip cluster %s: ManagedClusterConditionAvailable is not True", name)
 		}
 	}
 

--- a/tests/pkg/utils/mco_oba.go
+++ b/tests/pkg/utils/mco_oba.go
@@ -121,7 +121,7 @@ func CheckAllOBAsEnabled(opt TestOptions) error {
 
 	for _, cluster := range clusters {
 		// skip the check for local-cluster
-		if cluster.isLocalCluster {
+		if cluster.IsLocalCluster {
 			klog.V(1).Infof("Skip OBA status for managedcluster: %v", cluster.Name)
 			continue
 		}


### PR DESCRIPTION
Back port to release-2.15 for https://github.com/stolostron/multicluster-observability-operator/pull/2324

* fix RHACM4K-3457



* test: improve RHACM4K-1259 robustness and managed cluster discovery



* add logs for kind



* add logs for kind



* add logs for kind



* pick ocm commit



* fix lint



---------