### PR TITLE
[ACM-35533] Depricate use of BYO CA certs for alertmanager

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -375,7 +375,6 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	// in the testing env, the service can be accessed via service name, we assume that
 	// in testing env, the local-cluster is the only allowed managedcluster
 	if ingressCtlCrdExists {
-
 		// expose observatorium api gateway
 		result, err = GenerateAPIGatewayRoute(ctx, r.Client, r.Scheme, instance)
 		if result != nil {

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -375,11 +375,6 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	// in the testing env, the service can be accessed via service name, we assume that
 	// in testing env, the local-cluster is the only allowed managedcluster
 	if ingressCtlCrdExists {
-		// expose alertmanager through route
-		result, err = GenerateAlertmanagerRoute(r.Client, r.Scheme, instance)
-		if result != nil {
-			return *result, fmt.Errorf("failed to generate Alertmanager route: %w", err)
-		}
 
 		// expose observatorium api gateway
 		result, err = GenerateAPIGatewayRoute(ctx, r.Client, r.Scheme, instance)
@@ -539,7 +534,6 @@ func (r *MultiClusterObservabilityReconciler) SetupWithManager(mgr ctrl.Manager)
 
 	mcoPred := GetMCOPredicateFunc()
 	cmPred := GetConfigMapPredicateFunc()
-	secretPred := GetAlertManagerSecretPredicateFunc()
 	namespacePred := GetNamespacePredicateFunc()
 	mcoaCRDPred := GetMCOACRDPredicateFunc()
 
@@ -568,8 +562,6 @@ func (r *MultiClusterObservabilityReconciler) SetupWithManager(mgr ctrl.Manager)
 
 		// Watch the configmap for thanos-ruler-custom-rules update
 		Watches(&corev1.ConfigMap{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(cmPred)).
-		// Watch the secret for deleting event of alertmanager-config
-		Watches(&corev1.Secret{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(secretPred)).
 		// Watch the namespace for changes
 		Watches(&corev1.Namespace{}, &handler.EnqueueRequestForObject{},
 			builder.WithPredicates(namespacePred)).
@@ -796,102 +788,6 @@ func updateStorageSizeChange(ctx context.Context, c client.Client, matchLabels m
 		log.Info("Successfully delete sts due to storage size changed", "sts", sts.Name)
 	}
 	return nil
-}
-
-// GenerateAlertmanagerRoute create route for Alertmanager endpoint
-func GenerateAlertmanagerRoute(
-	runclient client.Client, scheme *runtime.Scheme,
-	mco *mcov1beta2.MultiClusterObservability,
-) (*ctrl.Result, error) {
-	amGateway := &routev1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.AlertmanagerRouteName,
-			Namespace: config.GetDefaultNamespace(),
-		},
-		Spec: routev1.RouteSpec{
-			Path: "/api/v2",
-			Port: &routev1.RoutePort{
-				TargetPort: intstr.FromString("oauth-proxy"),
-			},
-			To: routev1.RouteTargetReference{
-				Kind: "Service",
-				Name: config.AlertmanagerServiceName,
-			},
-			TLS: &routev1.TLSConfig{
-				Termination:                   routev1.TLSTerminationReencrypt,
-				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
-			},
-		},
-	}
-
-	amRouteBYOCaSrt := &corev1.Secret{}
-	amRouteBYOCertSrt := &corev1.Secret{}
-	err1 := runclient.Get(
-		context.TODO(),
-		types.NamespacedName{Name: config.AlertmanagerRouteBYOCAName, Namespace: config.GetDefaultNamespace()},
-		amRouteBYOCaSrt,
-	)
-	err2 := runclient.Get(
-		context.TODO(),
-		types.NamespacedName{Name: config.AlertmanagerRouteBYOCERTName, Namespace: config.GetDefaultNamespace()},
-		amRouteBYOCertSrt,
-	)
-
-	if err1 == nil && err2 == nil {
-		log.Info("BYO CA/Certificate found for the Route of Alertmanager, will using BYO CA/certificate for the Route of Alertmanager")
-		amRouteCA, ok := amRouteBYOCaSrt.Data["tls.crt"]
-		if !ok {
-			return &ctrl.Result{}, errors.New("invalid BYO CA for the Route of Alertmanager")
-		}
-		amGateway.Spec.TLS.CACertificate = string(amRouteCA)
-
-		amRouteCert, ok := amRouteBYOCertSrt.Data["tls.crt"]
-		if !ok {
-			return &ctrl.Result{}, errors.New("invalid BYO Certificate for the Route of Alertmanager")
-		}
-		amGateway.Spec.TLS.Certificate = string(amRouteCert)
-
-		amRouteCertKey, ok := amRouteBYOCertSrt.Data["tls.key"]
-		if !ok {
-			return &ctrl.Result{}, errors.New("invalid BYO Certificate Key for the Route of Alertmanager")
-		}
-		amGateway.Spec.TLS.Key = string(amRouteCertKey)
-	}
-
-	// Set MultiClusterObservability instance as the owner and controller
-	if err := controllerutil.SetControllerReference(mco, amGateway, scheme); err != nil {
-		return &ctrl.Result{}, err
-	}
-
-	found := &routev1.Route{}
-	err := runclient.Get(
-		context.TODO(),
-		types.NamespacedName{Name: amGateway.Name, Namespace: amGateway.Namespace},
-		found,
-	)
-	if err != nil && apierrors.IsNotFound(err) {
-		log.Info(
-			"Creating a new route to expose alertmanager",
-			"amGateway.Namespace",
-			amGateway.Namespace,
-			"amGateway.Name",
-			amGateway.Name,
-		)
-		err = runclient.Create(context.TODO(), amGateway)
-		if err != nil {
-			return &ctrl.Result{}, err
-		}
-		return nil, nil
-	}
-	if !reflect.DeepEqual(found.Spec.TLS, amGateway.Spec.TLS) {
-		log.Info("Found update for the TLS configuration of the Alertmanager Route, try to update the Route")
-		amGateway.ResourceVersion = found.ResourceVersion
-		err = runclient.Update(context.TODO(), amGateway)
-		if err != nil {
-			return &ctrl.Result{}, err
-		}
-	}
-	return nil, nil
 }
 
 // GenerateProxyRoute create route for Proxy endpoint

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -375,6 +375,12 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	// in the testing env, the service can be accessed via service name, we assume that
 	// in testing env, the local-cluster is the only allowed managedcluster
 	if ingressCtlCrdExists {
+		// expose alertmanager through route for external read access (e.g. bearer-token GET /api/v2/alerts)
+		result, err = GenerateAlertmanagerRoute(r.Client, r.Scheme, instance)
+		if result != nil {
+			return *result, fmt.Errorf("failed to generate Alertmanager route: %w", err)
+		}
+
 		// expose observatorium api gateway
 		result, err = GenerateAPIGatewayRoute(ctx, r.Client, r.Scheme, instance)
 		if result != nil {
@@ -787,6 +793,69 @@ func updateStorageSizeChange(ctx context.Context, c client.Client, matchLabels m
 		log.Info("Successfully delete sts due to storage size changed", "sts", sts.Name)
 	}
 	return nil
+}
+
+// GenerateAlertmanagerRoute creates a route for external read access to the Alertmanager API.
+// Spoke alert forwarding uses observatorium-api; this route is for hub-side consumers (e.g. E2E tests, admins).
+func GenerateAlertmanagerRoute(
+	runclient client.Client, scheme *runtime.Scheme,
+	mco *mcov1beta2.MultiClusterObservability,
+) (*ctrl.Result, error) {
+	amGateway := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.AlertmanagerRouteName,
+			Namespace: config.GetDefaultNamespace(),
+		},
+		Spec: routev1.RouteSpec{
+			Path: "/api/v2",
+			Port: &routev1.RoutePort{
+				TargetPort: intstr.FromString("oauth-proxy"),
+			},
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: config.AlertmanagerServiceName,
+			},
+			TLS: &routev1.TLSConfig{
+				Termination:                   routev1.TLSTerminationReencrypt,
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+			},
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(mco, amGateway, scheme); err != nil {
+		return &ctrl.Result{}, err
+	}
+
+	found := &routev1.Route{}
+	err := runclient.Get(
+		context.TODO(),
+		types.NamespacedName{Name: amGateway.Name, Namespace: amGateway.Namespace},
+		found,
+	)
+	if err != nil && apierrors.IsNotFound(err) {
+		log.Info(
+			"Creating a new route to expose alertmanager",
+			"amGateway.Namespace", amGateway.Namespace,
+			"amGateway.Name", amGateway.Name,
+		)
+		err = runclient.Create(context.TODO(), amGateway)
+		if err != nil {
+			return &ctrl.Result{}, err
+		}
+		return nil, nil
+	} else if err != nil {
+		return &ctrl.Result{}, err
+	}
+
+	if !reflect.DeepEqual(found.Spec.TLS, amGateway.Spec.TLS) {
+		log.Info("Found update for the TLS configuration of the Alertmanager Route, try to update the Route")
+		amGateway.ResourceVersion = found.ResourceVersion
+		err = runclient.Update(context.TODO(), amGateway)
+		if err != nil {
+			return &ctrl.Result{}, err
+		}
+	}
+	return nil, nil
 }
 
 // GenerateProxyRoute create route for Proxy endpoint

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_integration_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_integration_test.go
@@ -71,7 +71,6 @@ func TestIntegrationMCO_HubRules(t *testing.T) {
 		newStorageSecret(storageSecretName, hubNamespace, storageSecretKey),
 		newObservatoriumApiRoute(hubNamespace),
 		newMCO(hubNamespace, storageSecretName, storageSecretKey),
-		newAlertManagerRoute(),
 	}
 	err = createResources(k8sHubClient, resources...)
 	require.NoError(t, err)
@@ -241,21 +240,6 @@ func newMCO(ns, storageSecretName, storageSecretKey string) *mcov1beta2.MultiClu
 					},
 				},
 			},
-		},
-	}
-}
-
-func newAlertManagerRoute() *routev1.Route {
-	return &routev1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "alertmanager",
-			Namespace: config.GetDefaultNamespace(),
-		},
-		Spec: routev1.RouteSpec{
-			To: routev1.RouteTargetReference{
-				Name: "alertmanager",
-			},
-			Host: "alert.manager",
 		},
 	}
 }

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -393,13 +393,12 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 			"client-ca-file": "test",
 		},
 	}
-	alertManagerRoute := newAlertManagerRoute()
 	gp2StorageClass := newStorageClass("gp2", true)
 
 	objs := []runtime.Object{
 		mco, svc, serverCACerts, clientCACerts, proxyRouteBYOCACerts, grafanaCert, serverCert,
 		proxyRouteBYOCert, clustermgmtAddon, extensionApiserverAuthenticationCM,
-		alertManagerRoute, gp2StorageClass,
+		gp2StorageClass,
 	}
 	// Create a fake client to mock API calls.
 	cl := fake.NewClientBuilder().
@@ -486,15 +485,6 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	status := mcostatusctrl.FindStatusCondition(updatedMCO.Status.Conditions, mcostatusctrl.ConditionTypeFailed)
 	if status == nil || status.Reason != mcostatusctrl.ReasonObjectStorageNotFound {
 		t.Errorf("Failed to get correct MCO status, expect Failed with ReasonObjectStorageNotFound")
-	}
-
-	amRoute := &routev1.Route{}
-	err = cl.Get(t.Context(), types.NamespacedName{
-		Name:      config.AlertmanagerRouteName,
-		Namespace: namespace,
-	}, amRoute)
-	if err != nil {
-		t.Fatalf("Failed to get alertmanager's route: (%v)", err)
 	}
 
 	err = cl.Create(t.Context(), createSecret("test", "test", namespace))
@@ -874,13 +864,12 @@ func TestImageReplaceForMCO(t *testing.T) {
 		},
 	}
 
-	alertManagerRoute := newAlertManagerRoute()
 	gp2StorageClass := newStorageClass("gp2", true)
 
 	objs := []runtime.Object{
 		mco, observatoriumAPIsvc, serverCACerts, clientCACerts, grafanaCert, serverCert,
 		testMCHInstance, imageManifestsCM, clustermgmtAddon, extensionApiserverAuthenticationCM,
-		alertManagerRoute, gp2StorageClass,
+		gp2StorageClass,
 	}
 	// Create a fake client to mock API calls.
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
@@ -1662,18 +1651,6 @@ func TestNewMCOACRDEventHandler(t *testing.T) {
 
 			assert.Equal(t, tt.expectedReqs, reqs)
 		})
-	}
-}
-
-func newAlertManagerRoute() *routev1.Route {
-	return &routev1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "alertmanager",
-			Namespace: config.GetDefaultNamespace(),
-		},
-		Spec: routev1.RouteSpec{
-			Host: "alert.manager",
-		},
 	}
 }
 

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -383,9 +383,6 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	// byo case for proxy
 	proxyRouteBYOCACerts := newTestCert(config.ProxyRouteBYOCAName, namespace)
 	proxyRouteBYOCert := newTestCert(config.ProxyRouteBYOCERTName, namespace)
-	// byo case for the alertmanager route
-	testAmRouteBYOCaSecret := newTestCert(config.AlertmanagerRouteBYOCAName, namespace)
-	testAmRouteBYOCertSecret := newTestCert(config.AlertmanagerRouteBYOCERTName, namespace)
 	clustermgmtAddon := newClusterManagementAddon()
 	extensionApiserverAuthenticationCM := &corev1.ConfigMap{ // required by alertmanager
 		ObjectMeta: metav1.ObjectMeta{
@@ -401,7 +398,7 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 
 	objs := []runtime.Object{
 		mco, svc, serverCACerts, clientCACerts, proxyRouteBYOCACerts, grafanaCert, serverCert,
-		testAmRouteBYOCaSecret, testAmRouteBYOCertSecret, proxyRouteBYOCert, clustermgmtAddon, extensionApiserverAuthenticationCM,
+		proxyRouteBYOCert, clustermgmtAddon, extensionApiserverAuthenticationCM,
 		alertManagerRoute, gp2StorageClass,
 	}
 	// Create a fake client to mock API calls.
@@ -498,12 +495,6 @@ func TestMultiClusterMonitoringCRUpdate(t *testing.T) {
 	}, amRoute)
 	if err != nil {
 		t.Fatalf("Failed to get alertmanager's route: (%v)", err)
-	}
-	// check the BYO certificate for alertmanager's route
-	if amRoute.Spec.TLS.CACertificate != string(testAmRouteBYOCaSecret.Data["tls.crt"]) ||
-		amRoute.Spec.TLS.Certificate != string(testAmRouteBYOCertSecret.Data["tls.crt"]) ||
-		amRoute.Spec.TLS.Key != string(testAmRouteBYOCertSecret.Data["tls.key"]) {
-		t.Fatalf("incorrect certificate for alertmanager's route")
 	}
 
 	err = cl.Create(t.Context(), createSecret("test", "test", namespace))
@@ -872,9 +863,6 @@ func TestImageReplaceForMCO(t *testing.T) {
 	// create the image manifest configmap
 	testMCHInstance := newMCHInstanceWithVersion(config.GetMCONamespace(), version)
 	imageManifestsCM := newTestImageManifestsConfigMap(config.GetMCONamespace(), version)
-	// byo case for the alertmanager route
-	testAmRouteBYOCaSecret := newTestCert(config.AlertmanagerRouteBYOCAName, namespace)
-	testAmRouteBYOCertSecret := newTestCert(config.AlertmanagerRouteBYOCERTName, namespace)
 	clustermgmtAddon := newClusterManagementAddon()
 	extensionApiserverAuthenticationCM := &corev1.ConfigMap{ // required by alertmanager
 		ObjectMeta: metav1.ObjectMeta{
@@ -891,7 +879,7 @@ func TestImageReplaceForMCO(t *testing.T) {
 
 	objs := []runtime.Object{
 		mco, observatoriumAPIsvc, serverCACerts, clientCACerts, grafanaCert, serverCert,
-		testMCHInstance, imageManifestsCM, testAmRouteBYOCaSecret, testAmRouteBYOCertSecret, clustermgmtAddon, extensionApiserverAuthenticationCM,
+		testMCHInstance, imageManifestsCM, clustermgmtAddon, extensionApiserverAuthenticationCM,
 		alertManagerRoute, gp2StorageClass,
 	}
 	// Create a fake client to mock API calls.

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/predicate_func.go
@@ -90,50 +90,6 @@ func GetConfigMapPredicateFunc() predicate.Funcs {
 	}
 }
 
-func GetAlertManagerSecretPredicateFunc() predicate.Funcs {
-	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			if e.Object.GetNamespace() == config.GetDefaultNamespace() {
-				if e.Object.GetName() == config.AlertmanagerRouteBYOCAName ||
-					e.Object.GetName() == config.AlertmanagerRouteBYOCERTName {
-					return true
-				} else if _, ok := e.Object.GetLabels()[config.BackupLabelName]; ok {
-					// resource already has backup label
-					return false
-				} else if _, ok := config.BackupResourceMap[e.Object.GetName()]; ok {
-					// resource's backup label must be checked
-					return true
-				}
-			}
-			return false
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			if e.ObjectNew.GetNamespace() == config.GetDefaultNamespace() {
-				if e.ObjectNew.GetName() == config.AlertmanagerRouteBYOCAName ||
-					e.ObjectNew.GetName() == config.AlertmanagerRouteBYOCERTName {
-					return true
-				} else if _, ok := e.ObjectNew.GetLabels()[config.BackupLabelName]; ok {
-					// resource already has backup label
-					return false
-				} else if _, ok := config.BackupResourceMap[e.ObjectNew.GetName()]; ok {
-					// resource's backup label must be checked
-					return true
-				}
-			}
-			return false
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			if e.Object.GetNamespace() == config.GetDefaultNamespace() &&
-				(e.Object.GetName() == config.AlertmanagerRouteBYOCAName ||
-					e.Object.GetName() == config.AlertmanagerRouteBYOCERTName ||
-					e.Object.GetName() == config.AlertmanagerConfigName) {
-				return true
-			}
-			return false
-		},
-	}
-}
-
 // GetMCHPredicateFunc requires a *unstructured.Unstructured watch source.
 func GetMCHPredicateFunc(c client.Client) predicate.Funcs {
 	return predicate.Funcs{

--- a/operators/multiclusterobservability/controllers/placementrule/hub_info_secret_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_info_secret_test.go
@@ -47,22 +47,6 @@ func newTestObsApiRoute() *routev1.Route {
 	}
 }
 
-func newTestAlertmanagerRoute() *routev1.Route {
-	return &routev1.Route{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Route",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.AlertmanagerRouteName,
-			Namespace: mcoNamespace,
-		},
-		Spec: routev1.RouteSpec{
-			Host: routeHost,
-		},
-	}
-}
-
 func newTestIngressController() *operatorv1.IngressController {
 	return &operatorv1.IngressController{
 		TypeMeta: metav1.TypeMeta{
@@ -153,7 +137,6 @@ func TestNewSecret(t *testing.T) {
 	config.SetMonitoringCRName(mco.Name)
 	objs := []runtime.Object{
 		newTestObsApiRoute(),
-		newTestAlertmanagerRoute(),
 		newTestIngressController(),
 		newTestRouteCASecret(),
 		newTestObsServerCASecret(),
@@ -243,7 +226,6 @@ func TestNewSecret(t *testing.T) {
 
 	mco.Spec.AdvancedConfig = &mcov1beta2.AdvancedConfig{
 		CustomObservabilityHubURL: "https://custom-obs:8080",
-		CustomAlertmanagerHubURL:  "https://custom-am",
 	}
 	c = fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 	hubInfo, err = generateHubInfoSecret(c, mcoNamespace, namespace, crdMap, config.IsUWMAlertingDisabledInSpec(mco))

--- a/operators/multiclusterobservability/controllers/placementrule/hub_info_secret_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_info_secret_test.go
@@ -98,41 +98,6 @@ func newTestRouteCASecret() *corev1.Secret {
 	}
 }
 
-func newTestAmRouteBYOCA() *corev1.Secret {
-	configYamlMap := map[string][]byte{}
-	configYamlMap["tls.crt"] = []byte(routerBYOCA)
-
-	return &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.AlertmanagerRouteBYOCAName,
-			Namespace: mcoNamespace,
-		},
-		Data: configYamlMap,
-	}
-}
-
-func newTestAmRouteBYOCert() *corev1.Secret {
-	configYamlMap := map[string][]byte{}
-	configYamlMap["tls.crt"] = []byte(routerBYOCert)
-	configYamlMap["tls.key"] = []byte(routerBYOCertKey)
-
-	return &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.AlertmanagerRouteBYOCERTName,
-			Namespace: mcoNamespace,
-		},
-		Data: configYamlMap,
-	}
-}
-
 func newTestAmDefaultCA() *corev1.ConfigMap {
 	configYamlMap := map[string]string{"service-ca.crt": routerDefaultCA}
 
@@ -306,7 +271,7 @@ func TestNewBYOSecret(t *testing.T) {
 	initSchema(t)
 
 	mco := newMultiClusterObservability()
-	objs := []runtime.Object{newTestObsApiRoute(), newTestAlertmanagerRoute(), newTestAmRouteBYOCA(), newTestAmRouteBYOCert(), newTestObsServerCASecret()}
+	objs := []runtime.Object{newTestObsApiRoute(), newTestObsServerCASecret()}
 	c := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
 	crdMap := map[string]bool{config.IngressControllerCRD: true}

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
@@ -350,7 +350,6 @@ func TestGetAllowList(t *testing.T) {
 func getRuntimeObjects() []runtime.Object {
 	return []runtime.Object{
 		newTestObsApiRoute(),
-		newTestAlertmanagerRoute(),
 		newTestIngressController(),
 		newTestRouteCASecret(),
 		newCASecret(),

--- a/operators/multiclusterobservability/controllers/placementrule/mco_predicate_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/mco_predicate_test.go
@@ -31,7 +31,7 @@ func TestMCOPredFunc(t *testing.T) {
 
 	objs := []runtime.Object{
 		pull, newConsoleRoute(), newTestObsApiRoute(),
-		newTestAlertmanagerRoute(), newTestIngressController(), newTestRouteCASecret(),
+		newTestIngressController(), newTestRouteCASecret(),
 		newCASecret(), newCertSecret(mcoNamespace), NewMetricsAllowListCM(),
 		NewAmAccessorSA(), newTestAmDefaultCA(), newManagedClusterAddon(),
 	}

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -1050,34 +1050,6 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	}
 
-	amRouterCertSecretPred := predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			if e.Object.GetNamespace() == config.GetDefaultNamespace() &&
-				(e.Object.GetName() == config.AlertmanagerRouteBYOCAName ||
-					e.Object.GetName() == config.AlertmanagerRouteBYOCERTName) {
-				return updateHubInfoSecret(c, r.CRDMap)
-			}
-			return false
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			if e.ObjectNew.GetNamespace() == config.GetDefaultNamespace() &&
-				e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion() &&
-				(e.ObjectNew.GetName() == config.AlertmanagerRouteBYOCAName ||
-					e.ObjectNew.GetName() == config.AlertmanagerRouteBYOCERTName) {
-				return updateHubInfoSecret(c, r.CRDMap)
-			}
-			return false
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			if e.Object.GetNamespace() == config.GetDefaultNamespace() &&
-				(e.Object.GetName() == config.AlertmanagerRouteBYOCAName ||
-					e.Object.GetName() == config.AlertmanagerRouteBYOCERTName) {
-				return updateHubInfoSecret(c, r.CRDMap)
-			}
-			return false
-		},
-	}
-
 	routeCASecretPred := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			if (e.Object.GetNamespace() == config.OpenshiftIngressOperatorNamespace &&
@@ -1224,9 +1196,6 @@ func (r *PlacementRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		if ingressCtlCrdExists {
 			// secondary watch for default ingresscontroller
 			ctrBuilder = ctrBuilder.Watches(&operatorv1.IngressController{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(ingressControllerPred)).
-
-				// secondary watch for alertmanager route byo cert secrets
-				Watches(&corev1.Secret{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(amRouterCertSecretPred)).
 
 				// secondary watch for openshift route ca secret
 				Watches(&corev1.Secret{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(routeCASecretPred))

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
@@ -154,7 +154,7 @@ func TestObservabilityAddonController(t *testing.T) {
 	mco := newTestMCO()
 	pull := newTestPullSecret()
 	objs := []runtime.Object{
-		mco, pull, newConsoleRoute(), newTestObsApiRoute(), newTestAlertmanagerRoute(), newTestIngressController(), newTestRouteCASecret(), newCASecret(), newCertSecret(mcoNamespace), NewMetricsAllowListCM(),
+		mco, pull, newConsoleRoute(), newTestObsApiRoute(), newTestIngressController(), newTestRouteCASecret(), newCASecret(), newCertSecret(mcoNamespace), NewMetricsAllowListCM(),
 		NewAmAccessorSA(), newClusterMgmtAddon(),
 		newAddonDeploymentConfig(defaultAddonConfigName, namespace), newAddonDeploymentConfig(addonConfigName, namespace),
 	}

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -85,6 +85,8 @@ const (
 
 	AlertmanagerAccessorSAName     = "observability-alertmanager-accessor"
 	AlertmanagerAccessorSecretName = "observability-alertmanager-accessor" // #nosec G101 -- Not a hardcoded credential.
+	AlertmanagerServiceName          = "alertmanager"
+	AlertmanagerRouteName            = "alertmanager"
 
 	AlertRuleDefaultConfigMapName    = "thanos-ruler-default-rules"
 	AlertRuleDefaultFileKey          = "default_rules.yaml"

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -85,8 +85,6 @@ const (
 
 	AlertmanagerAccessorSAName     = "observability-alertmanager-accessor"
 	AlertmanagerAccessorSecretName = "observability-alertmanager-accessor" // #nosec G101 -- Not a hardcoded credential.
-	AlertmanagerServiceName        = "alertmanager"
-	AlertmanagerRouteName          = "alertmanager"
 
 	AlertRuleDefaultConfigMapName    = "thanos-ruler-default-rules"
 	AlertRuleDefaultFileKey          = "default_rules.yaml"
@@ -482,45 +480,6 @@ func GetMCONamespace() string {
 		podNamespace = defaultMCONamespace
 	}
 	return podNamespace
-}
-
-// GetAlertmanagerURL is used to get the URL for alertmanager.
-func GetAlertmanagerURL(ctx context.Context, client client.Client, namespace string) (*url.URL, error) {
-	mco := &observabilityv1beta2.MultiClusterObservability{}
-	err := client.Get(ctx,
-		types.NamespacedName{
-			Name: GetMonitoringCRName(),
-		}, mco)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, err
-	}
-	advancedConfig := mco.Spec.AdvancedConfig
-	if advancedConfig != nil && advancedConfig.CustomAlertmanagerHubURL != "" {
-		err := advancedConfig.CustomAlertmanagerHubURL.Validate()
-		if err != nil {
-			return nil, err
-		}
-		return advancedConfig.CustomAlertmanagerHubURL.URL()
-	}
-
-	found := &routev1.Route{}
-	err = client.Get(ctx, types.NamespacedName{Name: AlertmanagerRouteName, Namespace: namespace}, found)
-	if err != nil && apierrors.IsNotFound(err) {
-		// if the alertmanager router is not created yet, fallback to get host from the domain of ingresscontroller
-		domain, err := getDomainForIngressController(
-			ctx,
-			client,
-			OpenshiftIngressOperatorCRName,
-			OpenshiftIngressOperatorNamespace,
-		)
-		if err != nil {
-			return nil, err
-		}
-		return url.Parse(fmt.Sprintf("%s://%s-%s.%s", schemeHttps, AlertmanagerRouteName, namespace, domain))
-	} else if err != nil {
-		return nil, err
-	}
-	return url.Parse(fmt.Sprintf("%s://%s", schemeHttps, found.Spec.Host))
 }
 
 // getDomainForIngressController get the domain for the given ingresscontroller instance.

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -85,8 +85,8 @@ const (
 
 	AlertmanagerAccessorSAName     = "observability-alertmanager-accessor"
 	AlertmanagerAccessorSecretName = "observability-alertmanager-accessor" // #nosec G101 -- Not a hardcoded credential.
-	AlertmanagerServiceName          = "alertmanager"
-	AlertmanagerRouteName            = "alertmanager"
+	AlertmanagerServiceName        = "alertmanager"
+	AlertmanagerRouteName          = "alertmanager"
 
 	AlertRuleDefaultConfigMapName    = "thanos-ruler-default-rules"
 	AlertRuleDefaultFileKey          = "default_rules.yaml"

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -87,8 +87,6 @@ const (
 	AlertmanagerAccessorSecretName = "observability-alertmanager-accessor" // #nosec G101 -- Not a hardcoded credential.
 	AlertmanagerServiceName        = "alertmanager"
 	AlertmanagerRouteName          = "alertmanager"
-	AlertmanagerRouteBYOCAName     = "alertmanager-byo-ca"
-	AlertmanagerRouteBYOCERTName   = "alertmanager-byo-cert"
 
 	AlertRuleDefaultConfigMapName    = "thanos-ruler-default-rules"
 	AlertRuleDefaultFileKey          = "default_rules.yaml"
@@ -288,12 +286,10 @@ var (
 		AlertRuleCustomConfigMapName:              ResourceTypeConfigMap,
 		ManagedClusterLabelAllowListConfigMapName: ResourceTypeConfigMap,
 
-		AlertmanagerConfigName:       ResourceTypeSecret,
-		AlertmanagerRouteBYOCAName:   ResourceTypeSecret,
-		AlertmanagerRouteBYOCERTName: ResourceTypeSecret,
-		ProxyRouteBYOCAName:          ResourceTypeSecret,
-		ProxyRouteBYOCERTName:        ResourceTypeSecret,
-		DefaultImagePullSecret:       ResourceTypeSecret,
+		AlertmanagerConfigName: ResourceTypeSecret,
+		ProxyRouteBYOCAName:    ResourceTypeSecret,
+		ProxyRouteBYOCERTName:  ResourceTypeSecret,
+		DefaultImagePullSecret: ResourceTypeSecret,
 	}
 
 	multicloudConsoleRouteHost = ""
@@ -539,52 +535,6 @@ func getDomainForIngressController(ctx context.Context, client client.Client, na
 		return "", fmt.Errorf("no domain found in the ingressOperator: %s/%s", namespace, name)
 	}
 	return domain, nil
-}
-
-// GetAlertmanagerRouterCA is used to get the CA of openshift Route.
-func GetAlertmanagerRouterCA(client client.Client) (string, error) {
-	amRouteBYOCaSrt := &corev1.Secret{}
-	amRouteBYOCertSrt := &corev1.Secret{}
-	err1 := client.Get(
-		context.TODO(),
-		types.NamespacedName{Name: AlertmanagerRouteBYOCAName, Namespace: GetDefaultNamespace()},
-		amRouteBYOCaSrt,
-	)
-	err2 := client.Get(
-		context.TODO(),
-		types.NamespacedName{Name: AlertmanagerRouteBYOCERTName, Namespace: GetDefaultNamespace()},
-		amRouteBYOCertSrt,
-	)
-	if err1 == nil && err2 == nil {
-		return string(amRouteBYOCaSrt.Data["tls.crt"]), nil
-	}
-
-	ingressOperator := &operatorv1.IngressController{}
-	err := client.Get(
-		context.TODO(),
-		types.NamespacedName{Name: OpenshiftIngressOperatorCRName, Namespace: OpenshiftIngressOperatorNamespace},
-		ingressOperator,
-	)
-	if err != nil {
-		return "", err
-	}
-
-	routerCASrtName := OpenshiftIngressDefaultCertName
-	// check if custom default certificate is provided or not
-	if ingressOperator.Spec.DefaultCertificate != nil {
-		routerCASrtName = ingressOperator.Spec.DefaultCertificate.Name
-	}
-
-	routerCASecret := &corev1.Secret{}
-	err = client.Get(
-		context.TODO(),
-		types.NamespacedName{Name: routerCASrtName, Namespace: OpenshiftIngressNamespace},
-		routerCASecret,
-	)
-	if err != nil {
-		return "", err
-	}
-	return string(routerCASecret.Data["tls.crt"]), nil
 }
 
 // GetAlertmanagerCA is used to get the CA of Alertmanager.

--- a/operators/multiclusterobservability/pkg/config/config_test.go
+++ b/operators/multiclusterobservability/pkg/config/config_test.go
@@ -366,58 +366,6 @@ func TestGetObsAPIExternalHost(t *testing.T) {
 	}
 }
 
-func TestGetAlertmanagerEndpoint(t *testing.T) {
-	routeURL := "https://route.example.com"
-	routeHost := "route.example.com"
-	route := &routev1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      AlertmanagerRouteName,
-			Namespace: "test",
-		},
-		Spec: routev1.RouteSpec{
-			Host: routeHost,
-		},
-	}
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes(routev1.GroupVersion, route)
-	scheme.AddKnownTypes(mcov1beta2.GroupVersion, &mcov1beta2.MultiClusterObservability{})
-	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(route).Build()
-
-	alertmanagerURL, _ := GetAlertmanagerURL(context.TODO(), client, "default")
-	if alertmanagerURL != nil {
-		t.Errorf("Should not get route host in default namespace")
-	}
-
-	alertmanagerURL, _ = GetAlertmanagerURL(context.TODO(), client, "test")
-	if alertmanagerURL.String() != routeURL {
-		t.Errorf("Alertmanager URL (%v) is not the expected (%v)", alertmanagerURL, routeURL)
-	}
-
-	customBaseURL := "https://custom.base/url"
-	mco := &mcov1beta2.MultiClusterObservability{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: GetMonitoringCRName(),
-		},
-		Spec: mcov1beta2.MultiClusterObservabilitySpec{
-			AdvancedConfig: &mcov1beta2.AdvancedConfig{
-				CustomAlertmanagerHubURL: mcoshared.URL(customBaseURL),
-			},
-		},
-	}
-	client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(route, mco).Build()
-	alertmanagerURL, _ = GetAlertmanagerURL(context.TODO(), client, "test")
-	if alertmanagerURL.String() != customBaseURL {
-		t.Errorf("Alertmanager URL (%v) is not the expected (%v)", alertmanagerURL, customBaseURL)
-	}
-
-	mco.Spec.AdvancedConfig.CustomAlertmanagerHubURL = "httpa://foob ar.c"
-	client = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(route, mco).Build()
-	_, err := GetAlertmanagerURL(context.TODO(), client, "test")
-	if err == nil {
-		t.Errorf("expected error when parsing URL '%v', but got none", mco.Spec.AdvancedConfig.CustomObservabilityHubURL)
-	}
-}
-
 func TestIsPaused(t *testing.T) {
 	caseList := []struct {
 		annotations map[string]string


### PR DESCRIPTION
Cleanup of BYO CA certs functionality not currently used

### *modified* Function

| Function | File | Purpose |
|----------|------|---------|
| `GenerateAlertmanagerRoute()` | `multiclusterobservability_controller.go` | Created/updated the Alertmanager OpenShift Route; applied BYO CA/cert TLS when secrets present |

### *removed* Functions

| Function | File | Purpose |
|----------|------|---------|
| `GetAlertManagerSecretPredicateFunc()` | `predicate_func.go` | Triggered reconcile on AM BYO cert secret create/update/delete; also watched `alertmanager-config` delete and backup-label secrets |
| `GetAlertmanagerRouterCA()` | `pkg/config/config.go` | Resolved router CA (BYO secrets first, else ingress default cert). Had no callers — dead code |
| `amRouterCertSecretPred` (inline) | `placementrule_controller.go` | Watched AM BYO cert secrets and triggered `updateHubInfoSecret()` |
| `newTestAmRouteBYOCA()` / `newTestAmRouteBYOCert()` | `hub_info_secret_test.go` | Test fixtures for BYO cert secrets |
| `GetAlertmanagerURL()` | `pkg/config/config.go` | Resolve external alertmanager URL |

### Controller Wiring Removed

**MCO reconciler (`multiclusterobservability_controller.go`)**
- `Reconcile()` — removed call to `GenerateAlertmanagerRoute()`
- `SetupWithManager()` — removed `secretPred := GetAlertManagerSecretPredicateFunc()` and the associated `Secret` watch

**PlacementRule reconciler (`placementrule_controller.go`)**
- Removed `Secret` watch using `amRouterCertSecretPred` for AM BYO cert changes

### Not Removed (out of scope for this PR)

- `ProxyRouteBYOCAName` / `ProxyRouteBYOCERTName` — proxy route BYO cert support remains
-  MCO operator creates the Alertmanager OpenShift Route  —  needed for e2e tests

### Behavioral Impact

- BYO cert secrets `alertmanager-byo-ca` and `alertmanager-byo-cert` are no longer watched, backed up, or referenced
- Hub-info secret is no longer refreshed when AM BYO cert secrets change
- If using loadbalancer or reverse proxy between managed cluster and hub cluster, now only configure `customObservabilityHubURL` ref: https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/observability/observing-environments-intro#custom-obervatorium-alert-url

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Changes**
  - Alertmanager is no longer exposed through a dedicated Route.
  - Alertmanager BYO certificate/CA handling for that Route has been removed, so Alertmanager route TLS fields are no longer managed.
  - Updates to Alertmanager route/certificate resources and related configuration no longer trigger reconciliation.
  - API Gateway, RBAC proxy, and Grafana endpoints continue to be exposed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->