### PR TITLE
feat(ci): add Konflux integration test pipeline for MCO e2e tests

### DIFF
--- a/.tekton/integration-tests/mco-e2e-test-pipeline.yaml
+++ b/.tekton/integration-tests/mco-e2e-test-pipeline.yaml
@@ -1,0 +1,645 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelinesascode.tekton.dev/task: "[mco-install, mco-e2e-tests]"
+  name: mco-e2e-tests-pipeline
+spec:
+  description: |
+    This pipeline automates the process of running end-to-end tests for MCO
+    using HyperShift-based ephemeral clusters. The pipeline provisions a hub and
+    a managed cluster, installs OCM hub/spoke core and the MCO operator via the
+    existing setup scripts, imports the managed cluster, then runs the Ginkgo e2e
+    test suite via the existing run-e2e-tests.sh script.
+  params:
+    - name: SNAPSHOT
+      description: 'The JSON string representing the snapshot of the application under test.'
+      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
+      type: string
+    - name: test-name
+      description: 'The name of the test corresponding to a defined Konflux integration test.'
+      default: 'mco-e2e-tests'
+    - name: namespace
+      description: 'Namespace for MCO observability components'
+      default: 'open-cluster-management-observability'
+    - name: ACM_VERSION
+      description: 'ACM release version for downstream dev catalog channel'
+      default: '5.0'
+    - name: MCE_VERSION
+      description: 'MCE release version for downstream dev catalog channel'
+      default: '5.0'
+    - name: DEBUG_DUMP_CREDENTIALS
+      description: 'When "true", print hub/managed cluster kubeconfigs and admin passwords to the pipeline logs for manual debugging. Clusters are destroyed when the run ends (or after 2h), so this is the only window to grab them.'
+      default: 'false'
+  tasks:
+    - name: eaas-provision-space
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerKind
+          value: PipelineRun
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: provision-hub
+      runAfter:
+        - eaas-provision-space
+      taskSpec:
+        results:
+          - name: clusterName
+            value: "$(steps.create-cluster.results.clusterName)"
+        steps:
+          - name: get-supported-versions
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+          - name: pick-version
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+            params:
+              - name: prefix
+                value: "4.21."
+          - name: create-cluster
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: version
+                value: "$(steps.pick-version.results.version)"
+              - name: instanceType
+                value: "m5.2xlarge"
+              - name: timeout
+                value: "40m"
+              - name: imageContentSources
+                value: |
+                  - source: registry.redhat.io/rhacm2
+                    mirrors:
+                      - quay.io:443/acm-d
+                      - quay.io/redhat-user-workloads/crt-redhat-acm-tenant
+                  - source: registry.redhat.io/multicluster-engine
+                    mirrors:
+                      - quay.io:443/acm-d
+                  - source: registry.access.redhat.com/openshift4/ose-oauth-proxy
+                    mirrors:
+                      - registry.redhat.io/openshift4/ose-oauth-proxy
+    - name: provision-managed
+      runAfter:
+        - eaas-provision-space
+      taskSpec:
+        results:
+          - name: clusterName
+            value: "$(steps.create-cluster.results.clusterName)"
+        steps:
+          - name: get-supported-versions
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+          - name: pick-version
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+            params:
+              - name: prefix
+                value: "4.21."
+          - name: create-cluster
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: version
+                value: "$(steps.pick-version.results.version)"
+              - name: instanceType
+                value: "m5.xlarge"
+              - name: timeout
+                value: "40m"
+              - name: imageContentSources
+                value: |
+                  - source: registry.redhat.io/rhacm2
+                    mirrors:
+                      - quay.io:443/acm-d
+                      - quay.io/redhat-user-workloads/crt-redhat-acm-tenant
+                  - source: registry.redhat.io/multicluster-engine
+                    mirrors:
+                      - quay.io:443/acm-d
+                  - source: registry.access.redhat.com/openshift4/ose-oauth-proxy
+                    mirrors:
+                      - registry.redhat.io/openshift4/ose-oauth-proxy
+    - name: mco-install
+      description: Install ACM via downstream dev catalog, MCO operator, and import managed cluster
+      runAfter:
+        - provision-hub
+        - provision-managed
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: namespace
+          value: "$(params.namespace)"
+        - name: ACM_VERSION
+          value: "$(params.ACM_VERSION)"
+        - name: MCE_VERSION
+          value: "$(params.MCE_VERSION)"
+        - name: DEBUG_DUMP_CREDENTIALS
+          value: "$(params.DEBUG_DUMP_CREDENTIALS)"
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+          - name: namespace
+            type: string
+          - name: ACM_VERSION
+            type: string
+          - name: MCE_VERSION
+            type: string
+          - name: DEBUG_DUMP_CREDENTIALS
+            type: string
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-hub-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-hub.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: copy-pull-secret
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-copy-secrets-to-ephemeral-cluster/0.1/eaas-copy-secrets-to-ephemeral-cluster.yaml
+            params:
+              - name: credentials
+                value: credentials
+              - name: kubeconfig
+                value: "$(steps.get-hub-kubeconfig.results.kubeconfig)"
+              - name: namespace
+                value: openshift-marketplace
+              - name: labelSelector
+                value: "konflux-copy=acm-d-pull-secret"
+          - name: get-managed-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-managed.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: copy-pull-secret-to-managed
+            env:
+              - name: HUB_KUBECONFIG
+                value: "/credentials/$(steps.get-hub-kubeconfig.results.kubeconfig)"
+              - name: MANAGED_KUBECONFIG
+                value: "/credentials/$(steps.get-managed-kubeconfig.results.kubeconfig)"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            image: registry.redhat.io/openshift4/ose-cli:latest
+            script: |
+              #!/usr/bin/env bash
+              set -exo pipefail
+
+              echo "=== Setting up pull secret for managed cluster using HyperShift Global Pull Secret ==="
+
+              # Install jq
+              dnf -y install jq
+
+              # Extract quay.io credentials from hub cluster's acm-mco-konflux-e2e secret
+              QUAY_AUTH=$(oc --kubeconfig="${HUB_KUBECONFIG}" get secret acm-mco-konflux-e2e \
+                -n openshift-marketplace -o jsonpath='{.data.\.dockerconfigjson}' | \
+                base64 -d | jq -r '.auths["quay.io:443"].auth // .auths["quay.io"].auth // empty')
+
+              if [[ -z "$QUAY_AUTH" ]]; then
+                echo "ERROR: No quay.io auth found in acm-mco-konflux-e2e secret"
+                exit 1
+              fi
+
+              # Create pull secret with only quay.io credentials
+              jq -n --arg auth "${QUAY_AUTH}" \
+                '{"auths": {"quay.io:443": {"auth": $auth, "email": ""}}}' \
+                > /tmp/pull-secret.json
+
+              # Create additional-pull-secret in kube-system (HyperShift Global Pull Secret feature)
+              echo "Creating additional-pull-secret in kube-system..."
+              oc --kubeconfig="${MANAGED_KUBECONFIG}" create secret generic additional-pull-secret \
+                -n kube-system \
+                --from-file=.dockerconfigjson=/tmp/pull-secret.json \
+                --type=kubernetes.io/dockerconfigjson \
+                --dry-run=client -o yaml | \
+                oc --kubeconfig="${MANAGED_KUBECONFIG}" apply -f -
+
+              # Label nodes to enable global-pull-secret sync
+              echo "Labeling nodes for global-pull-secret sync..."
+              oc --kubeconfig="${MANAGED_KUBECONFIG}" label nodes --all \
+                hypershift.openshift.io/nodepool-globalps-enabled=true --overwrite 2>/dev/null || true
+
+              # Wait for HCCO to create global-pull-secret
+              echo "Waiting for global-pull-secret to be created by HCCO..."
+              for i in $(seq 1 30); do
+                if oc --kubeconfig="${MANAGED_KUBECONFIG}" get secret global-pull-secret -n kube-system &>/dev/null; then
+                  echo "global-pull-secret created successfully"
+                  break
+                fi
+                if [[ $i -eq 30 ]]; then
+                  echo "WARNING: global-pull-secret did not appear after 5 minutes"
+                fi
+                sleep 10
+              done
+
+              echo "Done. global-pull-secret-syncer will sync credentials to nodes."
+          - name: dump-credentials
+            env:
+              - name: DEBUG_DUMP_CREDENTIALS
+                value: "$(params.DEBUG_DUMP_CREDENTIALS)"
+              - name: HUB_API_SERVER_URL
+                value: "$(steps.get-hub-kubeconfig.results.apiServerURL)"
+              - name: HUB_CONSOLE_URL
+                value: "$(steps.get-hub-kubeconfig.results.consoleURL)"
+              - name: HUB_USERNAME
+                value: "$(steps.get-hub-kubeconfig.results.username)"
+              - name: HUB_PASSWORD_PATH
+                value: "$(steps.get-hub-kubeconfig.results.passwordPath)"
+              - name: HUB_KUBECONFIG_PATH
+                value: "$(steps.get-hub-kubeconfig.results.kubeconfig)"
+              - name: MANAGED_API_SERVER_URL
+                value: "$(steps.get-managed-kubeconfig.results.apiServerURL)"
+              - name: MANAGED_CONSOLE_URL
+                value: "$(steps.get-managed-kubeconfig.results.consoleURL)"
+              - name: MANAGED_USERNAME
+                value: "$(steps.get-managed-kubeconfig.results.username)"
+              - name: MANAGED_PASSWORD_PATH
+                value: "$(steps.get-managed-kubeconfig.results.passwordPath)"
+              - name: MANAGED_KUBECONFIG_PATH
+                value: "$(steps.get-managed-kubeconfig.results.kubeconfig)"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            image: registry.redhat.io/openshift4/ose-cli:latest
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              if [[ "${DEBUG_DUMP_CREDENTIALS}" != "true" ]]; then
+                echo "DEBUG_DUMP_CREDENTIALS is not 'true' — skipping credential dump."
+                exit 0
+              fi
+
+              echo "############################################################"
+              echo "# WARNING: cluster admin credentials follow. Ephemeral      #"
+              echo "# clusters are destroyed when this run ends (or after 2h)   #"
+              echo "# — copy what you need now.                                 #"
+              echo "############################################################"
+
+              echo "=== HUB CLUSTER ==="
+              echo "API Server:  ${HUB_API_SERVER_URL}"
+              echo "Console:     ${HUB_CONSOLE_URL}"
+              echo "Username:    ${HUB_USERNAME}"
+              echo "--- HUB password ---"
+              cat "/credentials/${HUB_PASSWORD_PATH}"; echo
+              echo "--- HUB kubeconfig (base64 — decode with: base64 -d) ---"
+              base64 -w0 "/credentials/${HUB_KUBECONFIG_PATH}"; echo
+
+              echo "=== MANAGED CLUSTER ==="
+              echo "API Server:  ${MANAGED_API_SERVER_URL}"
+              echo "Console:     ${MANAGED_CONSOLE_URL}"
+              echo "Username:    ${MANAGED_USERNAME}"
+              echo "--- MANAGED password ---"
+              cat "/credentials/${MANAGED_PASSWORD_PATH}"; echo
+              echo "--- MANAGED kubeconfig (base64 — decode with: base64 -d) ---"
+              base64 -w0 "/credentials/${MANAGED_KUBECONFIG_PATH}"; echo
+          - name: install
+            env:
+              - name: SNAPSHOT
+                value: $(params.SNAPSHOT)
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-hub-kubeconfig.results.kubeconfig)"
+              - name: MANAGED_KUBECONFIG
+                value: "/credentials/$(steps.get-managed-kubeconfig.results.kubeconfig)"
+              - name: ACM_VERSION
+                value: $(params.ACM_VERSION)
+              - name: MCE_VERSION
+                value: $(params.MCE_VERSION)
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            image: registry.redhat.io/openshift4/ose-cli:latest
+            script: |
+              #!/usr/bin/env bash
+              set -exo pipefail
+
+              echo "=== Installing dependencies ==="
+              dnf -y install jq git gettext
+
+              echo "=== Cloning MCO repository at PR revision ==="
+              GIT_URL=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^multicluster-observability-operator-acm-"))] | .[0].source.git.url')
+              GIT_REVISION=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^multicluster-observability-operator-acm-"))] | .[0].source.git.revision')
+              echo "Source: ${GIT_URL} @ ${GIT_REVISION}"
+              git clone "${GIT_URL}" /tmp/mco
+              cd /tmp/mco
+              git checkout "${GIT_REVISION}"
+
+              echo "=== Extracting component images from SNAPSHOT ==="
+              snapshot_image() {
+                echo "${SNAPSHOT}" | jq -r "[.components[] | select(.name | test(\"^${1}-acm-\"))] | .[0].containerImage"
+              }
+
+              export MCO_IMAGE=$(snapshot_image "multicluster-observability-operator")
+              export ENDPOINT_IMAGE=$(snapshot_image "endpoint-monitoring-operator")
+              export METRICS_COLLECTOR_IMAGE=$(snapshot_image "metrics-collector")
+              export RBAC_QUERY_PROXY_IMAGE=$(snapshot_image "rbac-query-proxy")
+              export GRAFANA_DASHBOARD_LOADER_IMAGE=$(snapshot_image "grafana-dashboard-loader")
+
+              echo "MCO operator image: ${MCO_IMAGE}"
+              echo "Endpoint monitoring image: ${ENDPOINT_IMAGE}"
+              echo "Metrics collector image: ${METRICS_COLLECTOR_IMAGE}"
+              echo "RBAC query proxy image: ${RBAC_QUERY_PROXY_IMAGE}"
+              echo "Grafana dashboard loader image: ${GRAFANA_DASHBOARD_LOADER_IMAGE}"
+
+              echo "=== Injecting quay.io:443 pull credentials ==="
+              ./dev-scripts/add-pull-secret.sh
+
+              echo "=== Installing ACM via downstream dev catalog ==="
+              ./dev-scripts/setup-downstream-catalog.sh
+
+              echo "=== Applying Konflux image overrides ==="
+              ./dev-scripts/image-override.sh
+
+              echo "=== Waiting for MCO operator rollout ==="
+              TIMEOUT=600
+              ELAPSED=0
+              echo "Waiting for deployment image to update to: ${MCO_IMAGE}"
+              while true; do
+                CURRENT_IMAGE=$(oc get deploy multicluster-observability-operator \
+                  -n open-cluster-management \
+                  -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || echo "")
+                if [[ "$CURRENT_IMAGE" == "$MCO_IMAGE" ]]; then
+                  echo "Deployment image updated, waiting for rollout..."
+                  oc rollout status deploy/multicluster-observability-operator \
+                    -n open-cluster-management --timeout=300s || true
+                  break
+                fi
+                if [[ "$ELAPSED" -ge "$TIMEOUT" ]]; then
+                  echo "WARNING: Timed out waiting for deployment image update"
+                  echo "Expected: ${MCO_IMAGE}"
+                  echo "Current:  ${CURRENT_IMAGE}"
+                  oc get pods -n open-cluster-management -l name=multicluster-observability-operator -o wide
+                  break
+                fi
+                echo "Waiting for MCH to process image override... (${ELAPSED}s elapsed)"
+                sleep 15
+                ELAPSED=$((ELAPSED + 15))
+              done
+              echo "MCO pods after rollout:"
+              oc get pods -n open-cluster-management -l name=multicluster-observability-operator -o wide
+
+              echo "=== Importing managed cluster into hub ==="
+              oc create namespace managed --dry-run=client -o yaml | oc apply -f -
+
+              cat <<MCEOF | oc apply -f -
+              apiVersion: cluster.open-cluster-management.io/v1
+              kind: ManagedCluster
+              metadata:
+                name: managed
+                labels:
+                  cloud: auto-detect
+                  vendor: auto-detect
+              spec:
+                hubAcceptsClient: true
+              MCEOF
+
+              oc create secret generic auto-import-secret \
+                -n managed \
+                --from-file=kubeconfig="${MANAGED_KUBECONFIG}" \
+                --dry-run=client -o yaml | oc apply -f -
+
+              oc wait managedcluster managed \
+                --for=condition=ManagedClusterConditionAvailable=True \
+                --timeout=300s || {
+                echo "=== managedcluster did not become Available — dumping debug info ==="
+                echo "--- ManagedCluster status (hub) ---"
+                oc get managedcluster managed -o yaml
+                echo "--- Pods in managed namespace (hub) ---"
+                oc get pods -n managed -o wide
+                echo "--- Import controller logs (hub) ---"
+                oc logs -n multicluster-engine -l app=managedcluster-import-controller-v2 --tail=200 || true
+                echo "--- Events in managed namespace (hub) ---"
+                oc get events -n managed --sort-by='.lastTimestamp' | tail -40
+                echo "--- Klusterlet agent pods on the managed cluster itself ---"
+                oc --kubeconfig="${MANAGED_KUBECONFIG}" get pods -n open-cluster-management-agent -o wide || true
+                oc --kubeconfig="${MANAGED_KUBECONFIG}" get pods -n open-cluster-management-agent-addon -o wide || true
+                echo "--- Klusterlet resource on the managed cluster itself ---"
+                oc --kubeconfig="${MANAGED_KUBECONFIG}" get klusterlet -o yaml || true
+                exit 1
+              }
+
+              echo "=== Verifying managed cluster registration ==="
+              oc get managedcluster
+
+              echo "=== Deploying observability ==="
+              ./dev-scripts/setup-observability.sh || {
+                echo "=== MCO deployment failed — debugging ==="
+                oc get pods -n open-cluster-management -o wide
+                oc get pods -n open-cluster-management-observability -o wide
+                oc describe pods -n open-cluster-management -l name=multicluster-observability-operator
+                oc get multiclusterobservability observability -o yaml
+                exit 1
+              }
+
+              echo "=== Verifying MCO is using Konflux images ==="
+              oc get deploy multicluster-observability-operator -n open-cluster-management -o jsonpath='{.spec.template.spec.containers[*].image}' && echo
+
+              echo "=== MCO installation complete ==="
+    - name: mco-e2e-tests
+      description: Run MCO Ginkgo e2e test suite using existing run-e2e-tests.sh
+      runAfter:
+        - mco-install
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: namespace
+          value: "$(params.namespace)"
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+          - name: namespace
+            type: string
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-hub-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-hub.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: get-managed-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-managed.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: run-e2e-tests
+            resources:
+              requests:
+                memory: 4Gi
+                cpu: "4"
+              limits:
+                memory: 8Gi
+                cpu: "8"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            env:
+              - name: SNAPSHOT
+                value: $(params.SNAPSHOT)
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-hub-kubeconfig.results.kubeconfig)"
+              - name: MANAGED_KUBECONFIG
+                value: "/credentials/$(steps.get-managed-kubeconfig.results.kubeconfig)"
+            image: registry.redhat.io/openshift4/ose-cli:latest
+            script: |
+              #!/usr/bin/env bash
+              set -exo pipefail
+
+              echo "=== Installing dependencies ==="
+              dnf -y install jq vim unzip git make wget
+
+              echo "=== Installing Go ==="
+              curl -Lo /go.tar.gz https://go.dev/dl/go1.24.9.linux-amd64.tar.gz
+              tar -C /usr/local -xzf /go.tar.gz
+              export PATH=$PATH:/usr/local/go/bin
+              export GOPATH=/tmp/go
+              export GOBIN=/tmp/go/bin
+              export GOCACHE=/tmp/.cache/go-build
+              export PATH=$PATH:/tmp/go/bin
+              mkdir -p /tmp/go/bin $GOCACHE
+              chmod -R 777 /tmp/go/bin $GOPATH $GOCACHE
+              go version
+
+              echo "=== Cloning MCO repository at PR revision ==="
+              GIT_URL=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^multicluster-observability-operator-acm-"))] | .[0].source.git.url')
+              GIT_REVISION=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^multicluster-observability-operator-acm-"))] | .[0].source.git.revision')
+              echo "Source: ${GIT_URL} @ ${GIT_REVISION}"
+              git clone "${GIT_URL}" /tmp/mco
+              cd /tmp/mco
+              git checkout "${GIT_REVISION}"
+
+              echo "=== Extracting component images from SNAPSHOT ==="
+              export MULTICLUSTER_OBSERVABILITY_OPERATOR_IMAGE_REF=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^multicluster-observability-operator-acm-"))] | .[0].containerImage')
+              export ENDPOINT_MONITORING_OPERATOR_IMAGE_REF=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^endpoint-monitoring-operator-acm-"))] | .[0].containerImage')
+              export METRICS_COLLECTOR_IMAGE_REF=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^metrics-collector-acm-"))] | .[0].containerImage')
+              export RBAC_QUERY_PROXY_IMAGE_REF=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^rbac-query-proxy-acm-"))] | .[0].containerImage')
+              export GRAFANA_DASHBOARD_LOADER_IMAGE_REF=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^grafana-dashboard-loader-acm-"))] | .[0].containerImage')
+
+              echo "=== Setting up SHARED_DIR with cluster kubeconfigs ==="
+              export SHARED_DIR=/tmp/shared
+              mkdir -p "${SHARED_DIR}"
+              cp "${KUBECONFIG}" "${SHARED_DIR}/hub-1.kc"
+              cp "${MANAGED_KUBECONFIG}" "${SHARED_DIR}/managed-1.kc"
+
+              echo "=== Running run-e2e-tests.sh ==="
+              ./cicd-scripts/run-e2e-tests.sh
+
+              echo "=== All e2e tests passed ==="

--- a/.tekton/integration-tests/mco-e2e-test-pipeline.yaml
+++ b/.tekton/integration-tests/mco-e2e-test-pipeline.yaml
@@ -276,12 +276,12 @@ spec:
             image: registry.redhat.io/openshift4/ose-cli:latest
             script: |
               #!/usr/bin/env bash
-              set -exo pipefail
+              set -euo pipefail
 
-              echo "=== Setting up pull secret for managed cluster using HyperShift Global Pull Secret ==="
+              echo "Setting up pull secret for managed cluster..."
 
               # Install jq
-              dnf -y install jq
+              dnf -y install jq >/dev/null 2>&1
 
               # Extract quay.io credentials from hub cluster's acm-mco-konflux-e2e secret
               QUAY_AUTH=$(oc --kubeconfig="${HUB_KUBECONFIG}" get secret acm-mco-konflux-e2e \
@@ -299,24 +299,21 @@ spec:
                 > /tmp/pull-secret.json
 
               # Create additional-pull-secret in kube-system (HyperShift Global Pull Secret feature)
-              echo "Creating additional-pull-secret in kube-system..."
               oc --kubeconfig="${MANAGED_KUBECONFIG}" create secret generic additional-pull-secret \
                 -n kube-system \
                 --from-file=.dockerconfigjson=/tmp/pull-secret.json \
                 --type=kubernetes.io/dockerconfigjson \
                 --dry-run=client -o yaml | \
-                oc --kubeconfig="${MANAGED_KUBECONFIG}" apply -f -
+                oc --kubeconfig="${MANAGED_KUBECONFIG}" apply -f - >/dev/null
 
               # Label nodes to enable global-pull-secret sync
-              echo "Labeling nodes for global-pull-secret sync..."
               oc --kubeconfig="${MANAGED_KUBECONFIG}" label nodes --all \
                 hypershift.openshift.io/nodepool-globalps-enabled=true --overwrite 2>/dev/null || true
 
               # Wait for HCCO to create global-pull-secret
-              echo "Waiting for global-pull-secret to be created by HCCO..."
               for i in $(seq 1 30); do
                 if oc --kubeconfig="${MANAGED_KUBECONFIG}" get secret global-pull-secret -n kube-system &>/dev/null; then
-                  echo "global-pull-secret created successfully"
+                  echo "Pull secret configured successfully"
                   break
                 fi
                 if [[ $i -eq 30 ]]; then
@@ -324,8 +321,6 @@ spec:
                 fi
                 sleep 10
               done
-
-              echo "Done. global-pull-secret-syncer will sync credentials to nodes."
           - name: dump-credentials
             env:
               - name: DEBUG_DUMP_CREDENTIALS
@@ -404,20 +399,20 @@ spec:
             image: registry.redhat.io/openshift4/ose-cli:latest
             script: |
               #!/usr/bin/env bash
-              set -exo pipefail
+              set -euo pipefail
 
-              echo "=== Installing dependencies ==="
-              dnf -y install jq git gettext
+              echo "Installing dependencies..."
+              dnf -y install jq git gettext >/dev/null 2>&1
 
-              echo "=== Cloning MCO repository at PR revision ==="
+              echo "Cloning MCO repository..."
               GIT_URL=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^multicluster-observability-operator-acm-"))] | .[0].source.git.url')
               GIT_REVISION=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^multicluster-observability-operator-acm-"))] | .[0].source.git.revision')
               echo "Source: ${GIT_URL} @ ${GIT_REVISION}"
-              git clone "${GIT_URL}" /tmp/mco
+              git clone -q "${GIT_URL}" /tmp/mco
               cd /tmp/mco
-              git checkout "${GIT_REVISION}"
+              git checkout -q "${GIT_REVISION}"
 
-              echo "=== Extracting component images from SNAPSHOT ==="
+              echo "Extracting component images from SNAPSHOT..."
               snapshot_image() {
                 echo "${SNAPSHOT}" | jq -r "[.components[] | select(.name | test(\"^${1}-acm-\"))] | .[0].containerImage"
               }
@@ -434,44 +429,39 @@ spec:
               echo "RBAC query proxy image: ${RBAC_QUERY_PROXY_IMAGE}"
               echo "Grafana dashboard loader image: ${GRAFANA_DASHBOARD_LOADER_IMAGE}"
 
-              echo "=== Injecting quay.io:443 pull credentials ==="
+              echo "Setting up pull secrets..."
               ./dev-scripts/add-pull-secret.sh
 
-              echo "=== Installing ACM via downstream dev catalog ==="
+              echo "Installing ACM via downstream catalog..."
               ./dev-scripts/setup-downstream-catalog.sh
 
-              echo "=== Applying Konflux image overrides ==="
+              echo "Applying Konflux image overrides..."
               ./dev-scripts/image-override.sh
 
-              echo "=== Waiting for MCO operator rollout ==="
+              echo "Waiting for MCO operator rollout..."
               TIMEOUT=600
               ELAPSED=0
-              echo "Waiting for deployment image to update to: ${MCO_IMAGE}"
               while true; do
                 CURRENT_IMAGE=$(oc get deploy multicluster-observability-operator \
                   -n open-cluster-management \
                   -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || echo "")
                 if [[ "$CURRENT_IMAGE" == "$MCO_IMAGE" ]]; then
-                  echo "Deployment image updated, waiting for rollout..."
                   oc rollout status deploy/multicluster-observability-operator \
-                    -n open-cluster-management --timeout=300s || true
+                    -n open-cluster-management --timeout=300s >/dev/null 2>&1 || true
                   break
                 fi
                 if [[ "$ELAPSED" -ge "$TIMEOUT" ]]; then
-                  echo "WARNING: Timed out waiting for deployment image update"
+                  echo "ERROR: Timed out waiting for deployment image update"
                   echo "Expected: ${MCO_IMAGE}"
                   echo "Current:  ${CURRENT_IMAGE}"
                   oc get pods -n open-cluster-management -l name=multicluster-observability-operator -o wide
-                  break
+                  exit 1
                 fi
-                echo "Waiting for MCH to process image override... (${ELAPSED}s elapsed)"
                 sleep 15
                 ELAPSED=$((ELAPSED + 15))
               done
-              echo "MCO pods after rollout:"
-              oc get pods -n open-cluster-management -l name=multicluster-observability-operator -o wide
 
-              echo "=== Importing managed cluster into hub ==="
+              echo "Importing managed cluster..."
               oc create namespace managed --dry-run=client -o yaml | oc apply -f -
 
               cat <<MCEOF | oc apply -f -
@@ -494,40 +484,23 @@ spec:
               oc wait managedcluster managed \
                 --for=condition=ManagedClusterConditionAvailable=True \
                 --timeout=300s || {
-                echo "=== managedcluster did not become Available — dumping debug info ==="
-                echo "--- ManagedCluster status (hub) ---"
+                echo "ERROR: Managed cluster did not become Available"
+                echo "ManagedCluster status:"
                 oc get managedcluster managed -o yaml
-                echo "--- Pods in managed namespace (hub) ---"
-                oc get pods -n managed -o wide
-                echo "--- Import controller logs (hub) ---"
-                oc logs -n multicluster-engine -l app=managedcluster-import-controller-v2 --tail=200 || true
-                echo "--- Events in managed namespace (hub) ---"
-                oc get events -n managed --sort-by='.lastTimestamp' | tail -40
-                echo "--- Klusterlet agent pods on the managed cluster itself ---"
+                echo "Klusterlet pods on managed cluster:"
                 oc --kubeconfig="${MANAGED_KUBECONFIG}" get pods -n open-cluster-management-agent -o wide || true
-                oc --kubeconfig="${MANAGED_KUBECONFIG}" get pods -n open-cluster-management-agent-addon -o wide || true
-                echo "--- Klusterlet resource on the managed cluster itself ---"
-                oc --kubeconfig="${MANAGED_KUBECONFIG}" get klusterlet -o yaml || true
                 exit 1
               }
 
-              echo "=== Verifying managed cluster registration ==="
-              oc get managedcluster
-
-              echo "=== Deploying observability ==="
+              echo "Deploying observability..."
               ./dev-scripts/setup-observability.sh || {
-                echo "=== MCO deployment failed — debugging ==="
-                oc get pods -n open-cluster-management -o wide
+                echo "ERROR: MCO deployment failed"
                 oc get pods -n open-cluster-management-observability -o wide
-                oc describe pods -n open-cluster-management -l name=multicluster-observability-operator
                 oc get multiclusterobservability observability -o yaml
                 exit 1
               }
 
-              echo "=== Verifying MCO is using Konflux images ==="
-              oc get deploy multicluster-observability-operator -n open-cluster-management -o jsonpath='{.spec.template.spec.containers[*].image}' && echo
-
-              echo "=== MCO installation complete ==="
+              echo "MCO installation complete"
     - name: mco-e2e-tests
       description: Run MCO Ginkgo e2e test suite using existing run-e2e-tests.sh
       runAfter:
@@ -601,13 +574,13 @@ spec:
             image: registry.redhat.io/openshift4/ose-cli:latest
             script: |
               #!/usr/bin/env bash
-              set -exo pipefail
+              set -euo pipefail
 
-              echo "=== Installing dependencies ==="
-              dnf -y install jq vim unzip git make wget
+              echo "Installing dependencies..."
+              dnf -y install jq vim unzip git make wget >/dev/null 2>&1
 
-              echo "=== Installing Go ==="
-              curl -Lo /go.tar.gz https://go.dev/dl/go1.24.9.linux-amd64.tar.gz
+              echo "Installing Go..."
+              curl -sLo /go.tar.gz https://go.dev/dl/go1.24.9.linux-amd64.tar.gz
               tar -C /usr/local -xzf /go.tar.gz
               export PATH=$PATH:/usr/local/go/bin
               export GOPATH=/tmp/go
@@ -616,30 +589,28 @@ spec:
               export PATH=$PATH:/tmp/go/bin
               mkdir -p /tmp/go/bin $GOCACHE
               chmod -R 777 /tmp/go/bin $GOPATH $GOCACHE
-              go version
 
-              echo "=== Cloning MCO repository at PR revision ==="
+              echo "Cloning MCO repository..."
               GIT_URL=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^multicluster-observability-operator-acm-"))] | .[0].source.git.url')
               GIT_REVISION=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^multicluster-observability-operator-acm-"))] | .[0].source.git.revision')
               echo "Source: ${GIT_URL} @ ${GIT_REVISION}"
-              git clone "${GIT_URL}" /tmp/mco
+              git clone -q "${GIT_URL}" /tmp/mco
               cd /tmp/mco
-              git checkout "${GIT_REVISION}"
+              git checkout -q "${GIT_REVISION}"
 
-              echo "=== Extracting component images from SNAPSHOT ==="
+              echo "Setting up test environment..."
               export MULTICLUSTER_OBSERVABILITY_OPERATOR_IMAGE_REF=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^multicluster-observability-operator-acm-"))] | .[0].containerImage')
               export ENDPOINT_MONITORING_OPERATOR_IMAGE_REF=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^endpoint-monitoring-operator-acm-"))] | .[0].containerImage')
               export METRICS_COLLECTOR_IMAGE_REF=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^metrics-collector-acm-"))] | .[0].containerImage')
               export RBAC_QUERY_PROXY_IMAGE_REF=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^rbac-query-proxy-acm-"))] | .[0].containerImage')
               export GRAFANA_DASHBOARD_LOADER_IMAGE_REF=$(echo "${SNAPSHOT}" | jq -r '[.components[] | select(.name | test("^grafana-dashboard-loader-acm-"))] | .[0].containerImage')
 
-              echo "=== Setting up SHARED_DIR with cluster kubeconfigs ==="
               export SHARED_DIR=/tmp/shared
               mkdir -p "${SHARED_DIR}"
               cp "${KUBECONFIG}" "${SHARED_DIR}/hub-1.kc"
               cp "${MANAGED_KUBECONFIG}" "${SHARED_DIR}/managed-1.kc"
 
-              echo "=== Running run-e2e-tests.sh ==="
+              echo "Running e2e tests..."
               ./cicd-scripts/run-e2e-tests.sh
 
-              echo "=== All e2e tests passed ==="
+              echo "E2e tests completed"

--- a/dev-scripts/add-pull-secret.sh
+++ b/dev-scripts/add-pull-secret.sh
@@ -1,33 +1,120 @@
 #!/usr/bin/env bash
-# Injects quay.io credentials into the cluster pull secret so that nodes can
-# pull images from quay.io:443/acm-d (downstream dev builds).
+# Makes quay.io:443/acm-d pull credentials available to the cluster.
 #
-# Usage:
+# Local usage (standard OCP cluster — patches the global node pull secret
+# directly; this persists normally on non-HyperShift clusters):
 #   QUAY_USER=rh-ee-you QUAY_TOKEN=<token> ./add-pull-secret.sh
+#
+# Konflux CI usage: these are HyperShift-hosted ephemeral clusters, whose
+# openshift-config/pull-secret is continuously reconciled from the
+# HostedCluster's spec on the management cluster — direct edits get
+# silently reverted within seconds. Per-pod/SA/Deployment-level secrets
+# don't help either: mirror-redirected pulls (e.g. registry.redhat.io ->
+# quay.io:443/acm-d via imageContentSources) are resolved by CRI-O at the
+# node level and only ever consult the node's own credential file,
+# regardless of what's attached to the pod. Proven empirically — a pod
+# with acm-d-pull-secret correctly set in its own imagePullSecrets still
+# got "unauthorized" pulling a mirrored image.
+#
+# Instead, use HyperShift's "Global Pull Secret" feature: creating
+# additional-pull-secret in kube-system is a dedicated, sanctioned
+# extension point (unlike openshift-config/pull-secret) that the Hosted
+# Cluster Config Operator merges into global-pull-secret and syncs to
+# every eligible node's kubelet config via the global-pull-secret-syncer
+# DaemonSet — no management-cluster access needed.
+# https://hypershift.pages.dev/how-to/aws/global-pull-secret/
+#
+# The pipeline's eaas-copy-secrets-to-ephemeral-cluster step already copies
+# acm-mco-konflux-e2e from the Konflux tenant namespace into
+# openshift-marketplace on this cluster before this script runs.
+#   ./add-pull-secret.sh   # no args needed in Konflux CI
 
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/common.sh"
 
-require_env QUAY_USER QUAY_TOKEN
-
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "$WORK_DIR"' EXIT
 
-log_info "Fetching existing cluster pull secret..."
-oc get secret pull-secret -n openshift-config \
-  -o jsonpath='{.data.\.dockerconfigjson}' |
-  base64 -d >"${WORK_DIR}/pull-secret.json"
+log_info "Checking for acm-mco-konflux-e2e in openshift-marketplace (Konflux CI)..."
+COPIED_SECRET_FOUND=0
+for _ in $(seq 1 10); do
+  if oc get secret acm-mco-konflux-e2e -n openshift-marketplace &>/dev/null; then
+    COPIED_SECRET_FOUND=1
+    break
+  fi
+  sleep 10
+done
 
-log_info "Merging quay.io credentials for user ${QUAY_USER}..."
-oc registry login \
-  --registry="quay.io:443" \
-  --auth-basic="${QUAY_USER}:${QUAY_TOKEN}" \
-  --to="${WORK_DIR}/pull-secret.json"
+if [[ $COPIED_SECRET_FOUND -eq 1 ]]; then
+  require_tool jq
+  log_info "Found acm-mco-konflux-e2e in openshift-marketplace."
+  oc get secret acm-mco-konflux-e2e -n openshift-marketplace \
+    -o jsonpath='{.data.\.dockerconfigjson}' |
+    base64 -d >"${WORK_DIR}/copied-secret.json"
+  QUAY_AUTH=$(jq -r '.auths["quay.io:443"].auth // .auths["quay.io"].auth // empty' "${WORK_DIR}/copied-secret.json")
+  if [[ -z $QUAY_AUTH ]]; then
+    log_error "No quay.io auth entry found in acm-mco-konflux-e2e"
+    exit 1
+  fi
+  jq -n --arg auth "${QUAY_AUTH}" '{"auths": {"quay.io:443": {"auth": $auth, "email": ""}}}' \
+    >"${WORK_DIR}/pull-secret.json"
+else
+  log_warn "acm-mco-konflux-e2e not found in openshift-marketplace after waiting; falling back to QUAY_USER/QUAY_TOKEN."
+  require_env QUAY_USER QUAY_TOKEN
 
-log_info "Updating cluster pull secret..."
-oc set data secret/pull-secret \
-  -n openshift-config \
-  --from-file=.dockerconfigjson="${WORK_DIR}/pull-secret.json"
+  log_info "Fetching existing cluster pull secret..."
+  oc get secret pull-secret -n openshift-config \
+    -o jsonpath='{.data.\.dockerconfigjson}' |
+    base64 -d >"${WORK_DIR}/pull-secret.json"
 
-log_info "Done. Nodes will restart rolling to apply the new credentials — this may take several minutes."
+  log_info "Merging quay.io credentials for user ${QUAY_USER}..."
+  oc registry login \
+    --registry="quay.io:443" \
+    --auth-basic="${QUAY_USER}:${QUAY_TOKEN}" \
+    --to="${WORK_DIR}/pull-secret.json"
+
+  log_info "Updating cluster pull secret..."
+  oc set data secret/pull-secret \
+    -n openshift-config \
+    --from-file=.dockerconfigjson="${WORK_DIR}/pull-secret.json"
+  log_info "Nodes will restart rolling to apply the new credentials — this may take several minutes."
+fi
+
+log_info "Creating acm-d-pull-secret in openshift-marketplace for CatalogSource.spec.secrets..."
+oc create secret generic acm-d-pull-secret -n openshift-marketplace \
+  --from-file=.dockerconfigjson="${WORK_DIR}/pull-secret.json" \
+  --type=kubernetes.io/dockerconfigjson \
+  --dry-run=client -o yaml | oc apply -f -
+
+if [[ $COPIED_SECRET_FOUND -eq 1 ]]; then
+  log_info "Creating additional-pull-secret in kube-system (HyperShift Global Pull Secret feature)..."
+  oc create secret generic additional-pull-secret -n kube-system \
+    --from-file=.dockerconfigjson="${WORK_DIR}/pull-secret.json" \
+    --type=kubernetes.io/dockerconfigjson \
+    --dry-run=client -o yaml | oc apply -f -
+
+  # The sync DaemonSet's node label is only auto-applied for AWS/Azure
+  # "Replace" NodePools, not "InPlace" ones. Label nodes ourselves in case
+  # this cluster's NodePool doesn't get it automatically — best-effort,
+  # since forcing this on an InPlace NodePool isn't an officially
+  # documented combination.
+  oc label nodes --all hypershift.openshift.io/nodepool-globalps-enabled=true --overwrite 2>/dev/null || true
+
+  log_info "Waiting for HCCO to merge additional-pull-secret into global-pull-secret..."
+  GLOBAL_SECRET_FOUND=0
+  for _ in $(seq 1 30); do
+    if oc get secret global-pull-secret -n kube-system &>/dev/null; then
+      GLOBAL_SECRET_FOUND=1
+      break
+    fi
+    sleep 10
+  done
+  if [[ $GLOBAL_SECRET_FOUND -eq 1 ]]; then
+    log_info "global-pull-secret created; global-pull-secret-syncer will sync it to eligible nodes."
+  else
+    log_warn "global-pull-secret did not appear after 5 minutes — HCCO may not have processed additional-pull-secret yet."
+  fi
+fi
+
+log_info "Done."

--- a/dev-scripts/image-override.sh
+++ b/dev-scripts/image-override.sh
@@ -46,10 +46,25 @@ resolve_tag() { echo "${1:-${REPO_TAG}}"; }
 # Returns the component registry if set, else falls back to global REGISTRY.
 resolve_registry() { echo "${1:-${REGISTRY}}"; }
 
-# parse_image_ref <full-ref>  →  prints "<remote> <tag>"
-# Callers must supply a ref with an explicit tag (name:tag). A bare ref without
-# a tag (e.g. registry:5000/image) will split on the port instead of the tag.
-parse_image_ref() { echo "${1%:*}" "${1##*:}"; }
+# parse_image_ref <full-ref>  →  prints "<remote> <name> <tag>"
+# Handles tag refs (registry/path/name:tag) and digest refs (registry/path/name@sha256:hash).
+# For digest refs, the algorithm (e.g. "sha256") is appended to name with "@" so that
+# MCH's "image-remote/image-name:image-tag" reconstruction produces a valid digest ref.
+parse_image_ref() {
+  local ref="$1" repo tag name remote
+  if [[ $ref == *"@"* ]]; then
+    repo="${ref%%@*}"
+    local digest="${ref#*@}"
+    name="${repo##*/}@${digest%%:*}"
+    tag="${digest#*:}"
+  else
+    repo="${ref%:*}"
+    tag="${ref##*:}"
+    name="${repo##*/}"
+  fi
+  remote="${repo%/*}"
+  echo "$remote" "$name" "$tag"
+}
 
 # format_entry <image-name> <key> <remote> <tag>  →  prints JSON object
 format_entry() {
@@ -60,13 +75,13 @@ format_entry() {
 # Prints a JSON entry using the global REGISTRY and REPO_TAG fallback, or nothing.
 add_repo_component() {
   local image_name="$1" key="$2" image_var="$3" tag_var="$4"
-  local image_val="${!image_var:-}" tag_val tag_resolved r t
+  local image_val="${!image_var:-}" tag_val tag_resolved r n t
   tag_val="${!tag_var:-}"
   tag_resolved="$(resolve_tag "$tag_val")"
 
   if [[ -n $image_val ]]; then
-    read -r r t <<<"$(parse_image_ref "$image_val")"
-    format_entry "$image_name" "$key" "$r" "$t"
+    read -r r n t <<<"$(parse_image_ref "$image_val")"
+    format_entry "$n" "$key" "$r" "$t"
   elif [[ -n $tag_resolved ]]; then
     format_entry "$image_name" "$key" "$REGISTRY" "$tag_resolved"
   fi
@@ -76,11 +91,11 @@ add_repo_component() {
 # Prints a JSON entry using per-component registry (falls back to global), or nothing.
 add_external_component() {
   local image_name="$1" key="$2" image_var="$3" tag_var="$4" registry_var="$5"
-  local image_val="${!image_var:-}" tag_val="${!tag_var:-}" registry_val="${!registry_var:-}" r t
+  local image_val="${!image_var:-}" tag_val="${!tag_var:-}" registry_val="${!registry_var:-}" r n t
 
   if [[ -n $image_val ]]; then
-    read -r r t <<<"$(parse_image_ref "$image_val")"
-    format_entry "$image_name" "$key" "$r" "$t"
+    read -r r n t <<<"$(parse_image_ref "$image_val")"
+    format_entry "$n" "$key" "$r" "$t"
   elif [[ -n $tag_val ]]; then
     format_entry "$image_name" "$key" "$(resolve_registry "$registry_val")" "$tag_val"
   fi

--- a/dev-scripts/setup-downstream-catalog.sh
+++ b/dev-scripts/setup-downstream-catalog.sh
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
 # Sets up downstream dev build catalog sources and installs ACM via OLM.
-# Requires the cluster pull secret to already include quay.io:443/acm-d credentials
-# (run add-pull-secret.sh first if needed — many dev clusters already have them).
+# Requires an acm-d-pull-secret in openshift-marketplace (run add-pull-secret.sh
+# first if needed) — CatalogSource.spec.secrets references it directly for
+# the catalog images. Operand image pulls (mirrored via imageContentSources)
+# rely on add-pull-secret.sh's additional-pull-secret in kube-system, which
+# HyperShift's Global Pull Secret feature syncs to every node's kubelet
+# config: https://hypershift.pages.dev/how-to/aws/global-pull-secret/
 #
 # Usage — rolling latest build for a given version:
-#   ACM_VERSION=2.16 MCE_VERSION=2.11 ./setup-downstream-catalog.sh
+#   ACM_VERSION=5.0 MCE_VERSION=5.0 ./setup-downstream-catalog.sh
 #
 # Usage — pin to a specific downstream build or release:
-#   ACM_VERSION=2.16 MCE_VERSION=2.11 \
-#   ACM_CATALOG_TAG=2.16.1-DOWNSTREAM-2026-03-30-06-49-38 \
-#   MCE_CATALOG_TAG=2.11.1-DOWNSTREAM-2026-03-30-06-49-38 \
+#   ACM_VERSION=5.0 MCE_VERSION=5.0 \
+#   ACM_CATALOG_TAG=5.0.1-DOWNSTREAM-2026-03-30-06-49-38 \
+#   MCE_CATALOG_TAG=5.0.1-DOWNSTREAM-2026-03-30-06-49-38 \
 #     ./setup-downstream-catalog.sh
 #
-#   ACM_VERSION=2.16 MCE_VERSION=2.11 \
-#   ACM_CATALOG_TAG=v2.16.1 MCE_CATALOG_TAG=v2.11.1 \
+#   ACM_VERSION=5.0 MCE_VERSION=5.0 \
+#   ACM_CATALOG_TAG=v5.0.1 MCE_CATALOG_TAG=v5.0.1 \
 #     ./setup-downstream-catalog.sh
 #
 # After this script completes, run setup-observability.sh to deploy the MCO stack.
@@ -23,6 +27,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/common.sh"
 
 require_env ACM_VERSION MCE_VERSION
+
+log_info "Checking for acm-d-pull-secret in openshift-marketplace..."
+if oc get secret acm-d-pull-secret -n openshift-marketplace &>/dev/null; then
+  log_info "acm-d-pull-secret found."
+else
+  log_error "acm-d-pull-secret not found in openshift-marketplace."
+  log_error "Run: QUAY_USER=<user> QUAY_TOKEN=<token> ./add-pull-secret.sh"
+  log_error "(or, in Konflux CI: ./add-pull-secret.sh — no args needed)"
+  exit 1
+fi
 
 # Default catalog tags to the rolling latest build for the given version.
 # Override with ACM_CATALOG_TAG / MCE_CATALOG_TAG to pin to a release candidate.
@@ -34,7 +48,14 @@ require_tool envsubst "Install gettext: brew install gettext (macOS) / dnf insta
 MANIFESTS="${SCRIPT_DIR}/manifests/catalog/downstream"
 
 log_info "Applying ImageDigestMirrorSet (applied without node reboots)..."
-oc apply -f "${MANIFESTS}/image-digest-mirror-set.yaml"
+if ! APPLY_ERR=$(oc apply -f "${MANIFESTS}/image-digest-mirror-set.yaml" 2>&1); then
+  if echo "${APPLY_ERR}" | grep -q "ValidatingAdmissionPolicy 'mirror'"; then
+    log_warn "ImageDigestMirrorSet is managed by the HostedCluster on HyperShift-hosted clusters (rejected here) — relying on imageContentSources passed at cluster creation instead."
+  else
+    log_error "${APPLY_ERR}"
+    exit 1
+  fi
+fi
 
 log_info "Applying CatalogSources and Subscriptions for ACM ${ACM_VERSION} / MCE ${MCE_VERSION}..."
 export ACM_VERSION MCE_VERSION
@@ -42,16 +63,65 @@ envsubst <"${MANIFESTS}/catalogsource.yaml" | oc apply -f -
 
 log_info "Waiting for ACM CSV to appear in ${ACM_NS}..."
 # The subscription triggers an InstallPlan; wait for the CRD that signals ACM is installed.
-wait_for_resource crd multiclusterhubs.operator.open-cluster-management.io "" 600
+wait_for_resource crd multiclusterhubs.operator.open-cluster-management.io "" 600 || {
+  log_error "=== ACM CSV did not appear — dumping catalog/subscription debug info ==="
+  echo "--- CatalogSource status ---"
+  oc get catalogsource -n openshift-marketplace -o wide
+  oc describe catalogsource acm-custom-registry multiclusterengine-catalog -n openshift-marketplace
+  echo "--- Catalog/registry pods ---"
+  oc get pods -n openshift-marketplace -o wide
+  oc describe pods -n openshift-marketplace -l olm.catalogSource=acm-custom-registry
+  oc describe pods -n openshift-marketplace -l olm.catalogSource=multiclusterengine-catalog
+  echo "--- Subscriptions and InstallPlans ---"
+  oc get subscription,installplan -n "${ACM_NS}" -o wide
+  oc describe subscription acm-sub -n "${ACM_NS}"
+  echo "--- Recent events in openshift-marketplace and ${ACM_NS} ---"
+  oc get events -n openshift-marketplace --sort-by='.lastTimestamp' | tail -30
+  oc get events -n "${ACM_NS}" --sort-by='.lastTimestamp' | tail -30
+  exit 1
+}
 
 log_info "Waiting for MultiClusterHub operator webhook to be ready..."
 until oc get pod -n "${ACM_NS}" -l name=multiclusterhub-operator --no-headers 2>/dev/null | grep -q .; do sleep 5; done
 oc wait pod -n "${ACM_NS}" -l name=multiclusterhub-operator \
-  --for=condition=Ready --timeout=300s
+  --for=condition=Ready --timeout=300s || {
+  log_error "=== multiclusterhub-operator did not become Ready — dumping debug info ==="
+  echo "--- Pod status ---"
+  oc get pods -n "${ACM_NS}" -l name=multiclusterhub-operator -o wide
+  echo "--- global-pull-secret / syncer state (HyperShift Global Pull Secret feature) ---"
+  oc get secret global-pull-secret -n kube-system 2>&1 | head -1
+  oc get daemonset global-pull-secret-syncer -n kube-system -o wide 2>&1
+  oc get pods -n kube-system -l name=global-pull-secret-syncer -o wide 2>&1
+  echo "--- Pod description (image, container statuses, events) ---"
+  oc describe pods -n "${ACM_NS}" -l name=multiclusterhub-operator
+  echo "--- Container logs (current) ---"
+  oc logs -n "${ACM_NS}" -l name=multiclusterhub-operator --all-containers --tail=100 || true
+  echo "--- Container logs (previous, if crash-looping) ---"
+  oc logs -n "${ACM_NS}" -l name=multiclusterhub-operator --all-containers --tail=100 --previous || true
+  echo "--- Recent events in ${ACM_NS} ---"
+  oc get events -n "${ACM_NS}" --sort-by='.lastTimestamp' | tail -30
+  exit 1
+}
 
 log_info "Creating MultiClusterHub CR..."
 oc apply -f "${SCRIPT_DIR}/manifests/acm/multiclusterhub-cr.yaml"
 
-wait_for_mch_running 900
+wait_for_mch_running 900 || {
+  log_error "=== MultiClusterHub did not reach Running — dumping debug info ==="
+  echo "--- MultiClusterHub component status ---"
+  oc get multiclusterhub multiclusterhub -n "${ACM_NS}" -o json |
+    jq '.status.components // {} | to_entries[] | select(.value.type != "Available" or .value.status != "True")' \
+    2>/dev/null || oc describe multiclusterhub multiclusterhub -n "${ACM_NS}"
+  echo "--- All pods in ${ACM_NS} and multicluster-engine not Running/Completed ---"
+  oc get pods -n "${ACM_NS}" -o wide | awk 'NR==1 || $3!="Running"'
+  oc get pods -n multicluster-engine -o wide | awk 'NR==1 || $3!="Running"'
+  echo "--- Deployments not fully available in ${ACM_NS} and multicluster-engine ---"
+  oc get deployments -n "${ACM_NS}" -o wide
+  oc get deployments -n multicluster-engine -o wide
+  echo "--- Recent events in ${ACM_NS} and multicluster-engine ---"
+  oc get events -n "${ACM_NS}" --sort-by='.lastTimestamp' | tail -40
+  oc get events -n multicluster-engine --sort-by='.lastTimestamp' | tail -40
+  exit 1
+}
 
 log_info "ACM is installed and running. Next step: run setup-observability.sh"


### PR DESCRIPTION
## Summary

Adds a Tekton pipeline that provisions HyperShift ephemeral clusters and runs the full MCO e2e test suite through Konflux CI.

## Changes

### Pipeline (`.tekton/integration-tests/mco-e2e-test-pipeline.yaml`)
- Provisions HyperShift hub + managed clusters (OCP 4.21) via Konflux EaaS
- Installs ACM 5.0 via downstream dev catalog
- Overrides MCO component images with PR build artifacts
- Runs full e2e test suite
- Uses HyperShift Global Pull Secret for `quay.io/acm-d` access

### Dev Scripts Updates (Backwards Compatible)

All dev-scripts changes are **backwards compatible enhancements** that work on both HyperShift and standard OCP clusters:

#### `add-pull-secret.sh`
- **Auto-detects Konflux CI** by checking for `acm-mco-konflux-e2e` secret
- If found: Uses HyperShift Global Pull Secret feature (`additional-pull-secret` in `kube-system`)
- If not found: **Falls back to original behavior** (requires `QUAY_USER`/`QUAY_TOKEN`, updates `openshift-config/pull-secret`)
- **Local dev benefit**: Now works on HyperShift clusters too

#### `setup-downstream-catalog.sh`
- Validates `acm-d-pull-secret` exists before proceeding (fail-fast)
- **Gracefully handles HyperShift**: Catches IDMS rejection (HyperShift uses `imageContentSources` instead), warns and continues
- **Standard OCP**: IDMS still applies normally; any real error still fails
- Updated version examples to 5.0 (documentation only)
- **Local dev benefit**: Works on both cluster types

#### `image-override.sh`  
- Enhanced `parse_image_ref` to handle **both** tag refs (`name:tag`) and digest refs (`name@sha256:hash`)
- Preserves algorithm in name for proper MCH reconstruction (`name@sha256` → `name@sha256:hash`)
- **Backwards compatible**: Still handles tag refs correctly
- **Local dev benefit**: Can now work with Konflux digest-based snapshot images

## Test Results

Pipeline successfully provisions clusters, installs ACM/MCO, and runs e2e tests. 4 test failures identified (unrelated to pipeline infrastructure):
- Route access test
- 2× Right-sizing PrometheusRule missing  
- MCOA addon deployment

## Dev Scripts Philosophy

The dev-scripts updates follow the pattern of **auto-detection with graceful fallback**:
- Detect Konflux/HyperShift environment automatically
- If detected, use the appropriate mechanism
- If not, fall back to original behavior  
- Never break existing local dev workflows

This makes the scripts useful for both:
- ✅ **Konflux CI** - Automated testing in ephemeral HyperShift clusters
- ✅ **Local development** - Developers using either standard OCP or HyperShift clusters

Closes #2490 (supersedes the original working branch with a clean commit history)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end test pipeline that provisions temporary hub and managed clusters, installs required components, and runs the MCO test suite.
  * Added support for configurable snapshots, software versions, namespaces, and optional debugging credentials.
  * Enhanced image handling for both tagged and digest-based image references.

* **Bug Fixes**
  * Improved pull-secret setup for standard and ephemeral clusters.
  * Added prerequisite validation and clearer diagnostics for catalog and operator installation failures.
  * Improved handling of supported image mirroring policy conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->