### PR TITLE
fix: preserve legacy observability-controller CMA when MCOA is enabled

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -146,10 +146,16 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Clean spokes addon resources (except the hub collector) if metrics are disabled.
 	metricsAreDisabled := mco.Spec.ObservabilityAddonSpec != nil && !mco.Spec.ObservabilityAddonSpec.EnableMetrics
-	if mcoIsNotFound || metricsAreDisabled || mcoaForMetricsIsEnabled(mco) {
+	mcoaMetricsEnabled := mcoaForMetricsIsEnabled(mco)
+	if mcoIsNotFound || metricsAreDisabled || mcoaMetricsEnabled {
 		reqLogger.Info("Cleaning all spokes resources", "mcoIsNotFound", mcoIsNotFound, "metricsAreDisabled",
-			metricsAreDisabled, "mcoaIsEnabled", mcoaForMetricsIsEnabled(mco))
-		if requeue, err := r.cleanSpokesAddonResources(ctx); err != nil {
+			metricsAreDisabled, "mcoaIsEnabled", mcoaMetricsEnabled)
+		// When MCOA takes over metrics collection, preserve the legacy
+		// "observability-controller" ClusterManagementAddOn so that external
+		// consumers (e.g. Fleet Virtualization) that look up this name to
+		// determine whether observability is installed continue to find it.
+		preserveLegacyCMA := mcoaMetricsEnabled
+		if requeue, err := r.cleanSpokesAddonResources(ctx, preserveLegacyCMA); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to clean all resources: %w", err)
 		} else if requeue {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
@@ -160,6 +166,14 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			}
 			// Also clear the amAccessorToken global var, to ensure it's not re-used on re-deploys
 			amAccessorTokenSecret = nil
+		}
+		// When MCOA is enabled, ensure the legacy CMA exists for backward
+		// compatibility. This covers fresh MCOA installs where the legacy
+		// path never ran.
+		if mcoaMetricsEnabled {
+			if _, err := util.CreateClusterManagementAddon(ctx, r.Client); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to ensure backward-compatible legacy ClusterManagementAddon for MCOA: %w", err)
+			}
 		}
 
 		// Don't return right away from here because the above cleanup is not complete and it requires
@@ -385,7 +399,7 @@ func (r *PlacementRuleReconciler) waitForImageList(reqLogger logr.Logger) bool {
 	return false
 }
 
-func (r *PlacementRuleReconciler) cleanSpokesAddonResources(ctx context.Context) (bool, error) {
+func (r *PlacementRuleReconciler) cleanSpokesAddonResources(ctx context.Context, preserveLegacyCMA bool) (bool, error) {
 	opts := &client.ListOptions{LabelSelector: labels.SelectorFromSet(map[string]string{ownerLabelKey: ownerLabelValue})}
 	obsAddonList := &mcov1beta1.ObservabilityAddonList{}
 	if err := r.Client.List(ctx, obsAddonList, opts); err != nil {
@@ -421,7 +435,7 @@ func (r *PlacementRuleReconciler) cleanSpokesAddonResources(ctx context.Context)
 	}
 
 	if len(workList.Items) == 0 {
-		if err := deleteGlobalResource(ctx, r.Client); err != nil {
+		if err := deleteGlobalResource(ctx, r.Client, preserveLegacyCMA); err != nil {
 			return false, fmt.Errorf("failed to delete global resources: %w", err)
 		}
 	}
@@ -713,7 +727,7 @@ func deleteAllObsAddons(
 	return requeue, nil
 }
 
-func deleteGlobalResource(ctx context.Context, c client.Client) error {
+func deleteGlobalResource(ctx context.Context, c client.Client, preserveLegacyCMA bool) error {
 	err := deleteClusterRole(ctx, c)
 	if err != nil {
 		return err
@@ -722,10 +736,10 @@ func deleteGlobalResource(ctx context.Context, c client.Client) error {
 	if err != nil {
 		return err
 	}
-	// delete ClusterManagementAddon
-	err = util.DeleteClusterManagementAddon(ctx, c)
-	if err != nil {
-		return err
+	if !preserveLegacyCMA {
+		if err := util.DeleteClusterManagementAddon(ctx, c); err != nil {
+			return fmt.Errorf("failed to delete legacy ClusterManagementAddon: %w", err)
+		}
 	}
 	return nil
 }

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
@@ -577,6 +577,81 @@ func TestObservabilityAddonController(t *testing.T) {
 	}
 }
 
+func TestDeleteGlobalResourcePreservesLegacyCMA(t *testing.T) {
+	initSchema(t)
+
+	cma := newClusterMgmtAddon()
+	c := fake.NewClientBuilder().WithRuntimeObjects(cma).Build()
+
+	err := deleteGlobalResource(context.TODO(), c, true)
+	assert.NoError(t, err)
+
+	found := &addonv1beta1.ClusterManagementAddOn{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: operatorutil.ObservabilityController}, found)
+	assert.NoError(t, err, "Legacy observability-controller CMA should be preserved when preserveLegacyCMA is true")
+}
+
+func TestDeleteGlobalResourceDeletesCMAWhenNotPreserved(t *testing.T) {
+	initSchema(t)
+
+	cma := newClusterMgmtAddon()
+	c := fake.NewClientBuilder().WithRuntimeObjects(cma).Build()
+
+	err := deleteGlobalResource(context.TODO(), c, false)
+	assert.NoError(t, err)
+
+	found := &addonv1beta1.ClusterManagementAddOn{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: operatorutil.ObservabilityController}, found)
+	assert.True(t, errors.IsNotFound(err), "Legacy observability-controller CMA should be deleted when preserveLegacyCMA is false")
+}
+
+func TestLegacyCMADeletedWhenMetricsDisabled(t *testing.T) {
+	initSchema(t)
+	config.SetMonitoringCRName(mcoName)
+	setupTest(t)
+
+	mco := newTestMCO()
+	mco.Spec.ObservabilityAddonSpec.EnableMetrics = false
+	objs := []runtime.Object{
+		mco, newTestPullSecret(), newConsoleRoute(), newTestObsApiRoute(),
+		newTestIngressController(), newTestRouteCASecret(),
+		newCASecret(), newCertSecret(mcoNamespace), NewMetricsAllowListCM(),
+		NewAmAccessorSA(), newClusterMgmtAddon(),
+		newAddonDeploymentConfig(defaultAddonConfigName, namespace),
+		newAddonDeploymentConfig(addonConfigName, namespace),
+	}
+	c := fake.
+		NewClientBuilder().
+		WithStatusSubresource(
+			&addonv1beta1.ManagedClusterAddOn{},
+			&mcov1beta2.MultiClusterObservability{},
+			&mcov1beta1.ObservabilityAddon{},
+		).
+		WithRuntimeObjects(objs...).
+		Build()
+	kubeClient := newMockKubeClient()
+	r := &PlacementRuleReconciler{
+		Client:     c,
+		Scheme:     scheme.Scheme,
+		CRDMap:     map[string]bool{config.IngressControllerCRD: true},
+		KubeClient: kubeClient,
+	}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      config.GetDefaultCRName(),
+			Namespace: mcoNamespace,
+		},
+	}
+
+	_, err := r.Reconcile(context.TODO(), req)
+	assert.NoError(t, err)
+
+	cma := &addonv1beta1.ClusterManagementAddOn{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: operatorutil.ObservabilityController}, cma)
+	assert.True(t, errors.IsNotFound(err), "Legacy observability-controller CMA should be deleted when metrics are disabled")
+}
+
 func newManagedClusterAddon() *addonv1beta1.ManagedClusterAddOn {
 	return &addonv1beta1.ManagedClusterAddOn{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
## Summary

- When MCOA takes over metrics collection, the legacy spoke cleanup path was deleting the `observability-controller` ClusterManagementAddOn. External consumers like Fleet Virtualization check for this CMA to determine whether observability is installed, causing a 404 and "Failed to load alerts" errors.
- This fix preserves the legacy CMA during MCOA spoke cleanup (`preserveLegacyCMA` flag in `deleteGlobalResource`) and ensures it exists for fresh MCOA installs where the legacy path never ran.

Fixes: [CNV-93086](https://redhat.atlassian.net/browse/CNV-93086)

## Changes

- `placementrule_controller.go`: Skip legacy CMA deletion when MCOA metrics is enabled; ensure CMA exists for fresh MCOA installs via `util.CreateClusterManagementAddon`
- `placementrule_controller_test.go`: Three new tests covering CMA preservation, CMA deletion, and full reconcile with metrics disabled

## Test plan

- [x] `TestDeleteGlobalResourcePreservesLegacyCMA` — verifies CMA is NOT deleted when `preserveLegacyCMA=true`
- [x] `TestDeleteGlobalResourceDeletesCMAWhenNotPreserved` — verifies CMA IS deleted when `preserveLegacyCMA=false`
- [x] `TestLegacyCMADeletedWhenMetricsDisabled` — integration test via full reconcile when metrics are disabled
- [x] All existing placement controller tests pass
- [ ] Manual verification: enable MCOA on a cluster, confirm `GET clustermanagementaddons/observability-controller` returns 200


Made with [Cursor](https://cursor.com)

[CNV-93086]: https://redhat.atlassian.net/browse/CNV-93086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of multicluster observability spoke and global resources when metrics collection is disabled or MCOA is not taking over.
  * Preserved the legacy observability ClusterManagementAddOn during metrics migration scenarios, while ensuring it is recreated when needed for backward compatibility.
* **Tests**
  * Added unit tests validating legacy add-on preservation vs deletion, and confirming legacy removal after reconciliation when metrics are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->