### PR TITLE
[ACM-30183] fix: do not tear controller managers down when tls adherence is not strict

### DIFF
--- a/operators/endpointmetrics/main.go
+++ b/operators/endpointmetrics/main.go
@@ -23,6 +23,7 @@ import (
 	ocinfrav1 "github.com/openshift/api/config/v1"
 	tlsutil "github.com/openshift/controller-runtime-common/pkg/tls"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	prometheusv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/mcoa"
@@ -386,13 +387,31 @@ func runMCOA(args []string) {
 		if err != nil {
 			setupLog.Info("unable to get TLS profile spec, skipping SecurityProfileWatcher", "error", err)
 		} else {
+			adherencePolicy, err := operatorsutil.FetchTLSAdherencePolicy(ctx)
+			if err != nil {
+				setupLog.Info("unable to get TLS adherence policy, defaulting to NoOpinion", "error", err)
+			}
 			if err = (&tlsutil.SecurityProfileWatcher{
-				Client:                mgr.GetClient(),
-				InitialTLSProfileSpec: *tlsProfileSpec,
+				Client:                    mgr.GetClient(),
+				InitialTLSProfileSpec:     *tlsProfileSpec,
+				InitialTLSAdherencePolicy: adherencePolicy,
 				OnProfileChange: func(ctx context.Context, oldTLSProfileSpec, newTLSProfileSpec ocinfrav1.TLSProfileSpec) {
+					if !libgocrypto.ShouldHonorClusterTLSProfile(adherencePolicy) {
+						setupLog.Info("TLS profile changed but adherence policy does not require honoring it, skipping restart",
+							"adherencePolicy", adherencePolicy,
+						)
+						return
+					}
 					setupLog.Info("TLS profile changed, shutting the manager down to reload",
 						"oldProfile", oldTLSProfileSpec,
 						"newProfile", newTLSProfileSpec,
+					)
+					cancel()
+				},
+				OnAdherencePolicyChange: func(ctx context.Context, oldPolicy, newPolicy ocinfrav1.TLSAdherencePolicy) {
+					setupLog.Info("TLS adherence policy changed, shutting the manager down to reload",
+						"oldPolicy", oldPolicy,
+						"newPolicy", newPolicy,
 					)
 					cancel()
 				},
@@ -562,13 +581,31 @@ func runStandard(args []string) {
 		if err != nil {
 			setupLog.Info("unable get TLS profile spec, skipping SecurityProfileWatcher", "error", err)
 		} else {
+			adherencePolicy, err := operatorsutil.FetchTLSAdherencePolicy(ctx)
+			if err != nil {
+				setupLog.Info("unable to get TLS adherence policy, defaulting to NoOpinion", "error", err)
+			}
 			if err = (&tlsutil.SecurityProfileWatcher{
-				Client:                mgr.GetClient(),
-				InitialTLSProfileSpec: *tlsProfileSpec,
+				Client:                    mgr.GetClient(),
+				InitialTLSProfileSpec:     *tlsProfileSpec,
+				InitialTLSAdherencePolicy: adherencePolicy,
 				OnProfileChange: func(ctx context.Context, oldTLSProfileSpec, newTLSProfileSpec ocinfrav1.TLSProfileSpec) {
+					if !libgocrypto.ShouldHonorClusterTLSProfile(adherencePolicy) {
+						setupLog.Info("TLS profile changed but adherence policy does not require honoring it, skipping restart",
+							"adherencePolicy", adherencePolicy,
+						)
+						return
+					}
 					setupLog.Info("TLS profile changed, shutting the manager down to reload",
 						"oldProfile", oldTLSProfileSpec,
 						"newProfile", newTLSProfileSpec,
+					)
+					cancel()
+				},
+				OnAdherencePolicyChange: func(ctx context.Context, oldPolicy, newPolicy ocinfrav1.TLSAdherencePolicy) {
+					setupLog.Info("TLS adherence policy changed, shutting the manager down to reload",
+						"oldPolicy", oldPolicy,
+						"newPolicy", newPolicy,
 					)
 					cancel()
 				},

--- a/operators/multiclusterobservability/main.go
+++ b/operators/multiclusterobservability/main.go
@@ -19,6 +19,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	imagev1client "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	tlsutil "github.com/openshift/controller-runtime-common/pkg/tls"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	observabilityv1beta1 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta1"
@@ -379,13 +380,31 @@ func main() {
 		if err != nil {
 			setupLog.Info("unable to get TLS profile spec, skipping SecurityProfileWatcher", "error", err)
 		} else {
+			adherencePolicy, err := operatorsutil.FetchTLSAdherencePolicy(ctx)
+			if err != nil {
+				setupLog.Info("unable to get TLS adherence policy, defaulting to NoOpinion", "error", err)
+			}
 			if err = (&tlsutil.SecurityProfileWatcher{
-				Client:                mgr.GetClient(),
-				InitialTLSProfileSpec: *tlsProfileSpec,
+				Client:                    mgr.GetClient(),
+				InitialTLSProfileSpec:     *tlsProfileSpec,
+				InitialTLSAdherencePolicy: adherencePolicy,
 				OnProfileChange: func(ctx context.Context, oldTLSProfileSpec, newTLSProfileSpec ocinfrav1.TLSProfileSpec) {
+					if !libgocrypto.ShouldHonorClusterTLSProfile(adherencePolicy) {
+						setupLog.Info("TLS profile changed but adherence policy does not require honoring it, skipping restart",
+							"adherencePolicy", adherencePolicy,
+						)
+						return
+					}
 					setupLog.Info("TLS profile changed, shutting the manager down to reload",
 						"oldProfile", oldTLSProfileSpec,
 						"newProfile", newTLSProfileSpec,
+					)
+					cancel()
+				},
+				OnAdherencePolicyChange: func(ctx context.Context, oldPolicy, newPolicy ocinfrav1.TLSAdherencePolicy) {
+					setupLog.Info("TLS adherence policy changed, shutting the manager down to reload",
+						"oldPolicy", oldPolicy,
+						"newPolicy", newPolicy,
 					)
 					cancel()
 				},

--- a/operators/pkg/util/tls.go
+++ b/operators/pkg/util/tls.go
@@ -104,6 +104,24 @@ func SetTLSSecurityConfiguration(ctx context.Context, args []string, tlsCipherSu
 	return args, nil
 }
 
+// FetchTLSAdherencePolicy retrieves the current TLS adherence policy from the
+// OCP APIServer resource. Unlike GetOrCreateTLSProfileSpec, the result is NOT
+// cached because the policy can change at runtime and the SecurityProfileWatcher
+// callback needs the live value.
+func FetchTLSAdherencePolicy(ctx context.Context) (ocinfrav1.TLSAdherencePolicy, error) {
+	c, err := tlsClientFunc()
+	if err != nil {
+		return "", fmt.Errorf("unable to create client for API server: %w", err)
+	}
+
+	tap, err := tlsutil.FetchAPIServerTLSAdherencePolicy(ctx, c)
+	if err != nil {
+		return "", fmt.Errorf("unable to get TLS adherence policy: %w", err)
+	}
+
+	return tap, nil
+}
+
 func SetTLSClientFunc(fn func() (client.Client, error)) {
 	tlsClientFunc = fn
 }

--- a/operators/pkg/util/tls_test.go
+++ b/operators/pkg/util/tls_test.go
@@ -127,6 +127,47 @@ func TestGetOrCreateTLSProfileSpec(t *testing.T) {
 	}
 }
 
+func TestFetchTLSAdherencePolicy(t *testing.T) {
+	tests := []struct {
+		name       string
+		adherence  configv1.TLSAdherencePolicy
+		wantPolicy configv1.TLSAdherencePolicy
+	}{
+		{
+			name:       "returns StrictAllComponents",
+			adherence:  configv1.TLSAdherencePolicyStrictAllComponents,
+			wantPolicy: configv1.TLSAdherencePolicyStrictAllComponents,
+		},
+		{
+			name:       "returns NoOpinion when empty",
+			adherence:  configv1.TLSAdherencePolicyNoOpinion,
+			wantPolicy: configv1.TLSAdherencePolicyNoOpinion,
+		},
+		{
+			name:       "returns LegacyAdheringComponentsOnly",
+			adherence:  configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly,
+			wantPolicy: configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer ResetTLSState()
+			setFakeClient(newAPIServerWithProfile(nil, tt.adherence))
+			policy, err := FetchTLSAdherencePolicy(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPolicy, policy)
+		})
+	}
+}
+
+func TestFetchTLSAdherencePolicy_NotFound(t *testing.T) {
+	defer ResetTLSState()
+	setFakeClient()
+
+	_, err := FetchTLSAdherencePolicy(context.Background())
+	require.Error(t, err, "should return error when APIServer is not found")
+}
+
 func TestGetOrCreateTLSProfileSpec_NotFound(t *testing.T) {
 	defer ResetTLSState()
 	setFakeClient()


### PR DESCRIPTION
# Detected Bug

The endpoint-manager controller manager was ending up in a crash loop when the tls profile was set to "Modern", but the tlsAdherence field was not strict. This is because a change with respect the current tls profile setup was detected (causing the manager termination), but no action was taken.

# Solution
Do not terminate the operator when ShouldHonorClusterTLSProfile is false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TLS configuration reloads now follow the cluster’s TLS adherence policy.
  * Changes to the TLS adherence policy automatically trigger a configuration reload.

* **Bug Fixes**
  * Avoided unnecessary restarts when TLS profile changes are not required.
  * Applied a safe default when the adherence policy cannot be retrieved.

* **Tests**
  * Added coverage for adherence policy retrieval, supported policy values, and missing API configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->