### PR TITLE
fix(grafana): update namespace rightsizing panel titles to reflect ratio metric

### DIFF
--- a/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-namespace.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-namespace.yaml
@@ -245,7 +245,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "CPU Utilization of Top Namespaces",
+          "title": "CPU Usage to Request Ratio of Top Namespaces",
           "type": "timeseries"
         },
         {
@@ -1180,7 +1180,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Memory Utilization of Top Namespaces",
+          "title": "Memory Usage to Request Ratio of Top Namespaces",
           "type": "timeseries"
         },
         {


### PR DESCRIPTION
<!-- issue-fix-agent:jira=OBSINTA-1519 session=implement -->

## Summary
Updates Grafana namespace right-sizing dashboard panel titles from "Utilization" to "Usage to Request Ratio" to accurately describe the underlying PromQL metric (usage / request ratio).

## Root Cause
The panel titles said "CPU Utilization of Top Namespaces" and "Memory Utilization of Top Namespaces" but the PromQL queries compute a usage-to-request ratio, not utilization. MCO team requested the labels be corrected.

## Changes
- `operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-namespace.yaml`: Changed "CPU Utilization of Top Namespaces" → "CPU Usage to Request Ratio of Top Namespaces"
- `operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-namespace.yaml`: Changed "Memory Utilization of Top Namespaces" → "Memory Usage to Request Ratio of Top Namespaces"

## Testing
- [x] No code logic changed (YAML text-only)
- [ ] Regression test not applicable (static dashboard label text)

## Jira
[OBSINTA-1519](https://redhat.atlassian.net/browse/OBSINTA-1519)

---
Assisted-by: OpenCode / claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dashboard Updates**
  * Renamed the CPU and memory namespace panels to clarify that they show usage-to-request ratios.
  * No changes were made to the displayed data, queries, or dashboard configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[OBSINTA-1519]: https://redhat.atlassian.net/browse/OBSINTA-1519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ