### PR TITLE
[release-2.17] fix(grafana): update namespace rightsizing panel titles to reflect ratio metric

### DIFF
--- a/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-namespace.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-namespace.yaml
@@ -245,7 +245,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "CPU Utilization of Top Namespaces",
+          "title": "CPU Usage to Request Ratio of Top Namespaces",
           "type": "timeseries"
         },
         {
@@ -1180,7 +1180,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Memory Utilization of Top Namespaces",
+          "title": "Memory Usage to Request Ratio of Top Namespaces",
           "type": "timeseries"
         },
         {


### PR DESCRIPTION
Cherry-pick of #2580 to release-2.17.

Original PR: https://github.com/stolostron/multicluster-observability-operator/pull/2580

Automated cherrypick failed due to empty commit in original PR. This is a manual cherrypick of the fix commit only.