### PR TITLE
[release-2.16] fix(grafana): update namespace rightsizing panel titles to reflect ratio metric

### DIFF
--- a/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-namespace.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-namespace.yaml
@@ -244,7 +244,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "CPU Utilization of Top Namespaces",
+          "title": "CPU Usage to Request Ratio of Top Namespaces",
           "type": "timeseries"
         },
         {
@@ -1175,7 +1175,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Memory Utilization of Top Namespaces",
+          "title": "Memory Usage to Request Ratio of Top Namespaces",
           "type": "timeseries"
         },
         {


### PR DESCRIPTION
Cherry-pick of #2580 to release-2.16.

Original PR: https://github.com/stolostron/multicluster-observability-operator/pull/2580

Manual cherrypick of the fix commit only (skipped empty commit that caused automated cherrypick failure).