### PR TITLE
[ACM-37993] fix: remove rename collision sources from metrics allowlist

### DIFF
--- a/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
+++ b/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
@@ -201,7 +201,6 @@ data:
       - namespace:kube_pod_container_resource_requests_cpu_cores:sum
       - node_accelerator_card_info
       - node_cpu_seconds_total
-      - node_cpu_seconds_total
       - node_filesystem_avail_bytes
       - node_filesystem_free_bytes
       - node_filesystem_size_bytes
@@ -209,7 +208,6 @@ data:
       - node_memory_MemTotal_bytes
       - node_memory_SwapFree_bytes
       - node_memory_SwapTotal_bytes
-      - node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
       - node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m
       - node_netstat_Tcp_OutSegs
       - node_netstat_Tcp_RetransSegs
@@ -326,7 +324,6 @@ data:
       - apiserver_request_duration_seconds_bucket
       - apiserver_request_total
       - apiserver_storage_objects
-      - etcd_debugging_mvcc_db_total_size_in_bytes
       - etcd_mvcc_db_total_size_in_bytes
       - etcd_debugging_snap_save_total_duration_seconds_sum
       - etcd_disk_backend_commit_duration_seconds_bucket


### PR DESCRIPTION
## Summary

- Remove `node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate` from default `names` list to fix HTTP 409 "duplicate sample for timestamp" errors on managed clusters with >10k time series
- Remove `etcd_debugging_mvcc_db_total_size_in_bytes` from UWL `names` list to fix a latent rename collision in HCP (Hosted Control Planes) environments
- Remove duplicate `node_cpu_seconds_total` entry from default `names` list

## Root Cause

The metrics allowlist contains rename rules (e.g., `sum_irate → sum_rate5m`) where **both** the source and target metric appear in the `names` list. The metrics-collector fetches both via `/federate`, applies the rename, and produces duplicate time series. When these duplicates straddle the 10,000-sample batch boundary, Thanos receive rejects the second batch with HTTP 409.

**Default list collision (active):** `sum_irate` is renamed to `sum_rate5m`, but both are in the names list. OCP 4.20 PrometheusRules produce both recording rules for backward compatibility, so `/federate` returns ~450-630 duplicate series per cluster.

**UWL list collision (latent, HCP only):** `etcd_mvcc_db_total_size_in_bytes` is renamed to `etcd_debugging_mvcc_db_total_size_in_bytes`, but both are in the UWL names list. In HCP environments where `prometheus-user-workload` scrapes hosted control plane etcd pods (via ACM `acm-etcd` ServiceMonitors in non-openshift-* namespaces), this can produce duplicates on older OCP versions where etcd exposes both metric names. On OCP 4.20+ (etcd 3.5+), the deprecated `etcd_debugging_*` variant is no longer exposed, so this collision is dormant but should still be fixed.

## Approach

Remove the collision-causing metric names from the `names` lists while preserving the rename rules. This ensures:
- No duplicate series are fetched via `/federate`
- Backward-compatible dashboards continue to work (the rename still transforms collected source metrics to the expected target name)
- No impact to recording rules, matches, or Grafana dashboards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Expanded the observability metric allowlist to include additional node filesystem, memory, and swap metrics.
  - Updated node-level container CPU usage reporting to use a 5-minute rate for more consistent monitoring.
  - Enabled collection of the standard ETCD MVCC database size metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->