### PR TITLE
[release-2.17] [ACM-37993] fix: remove rename collision sources from metrics allowlist

### DIFF
--- a/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
+++ b/operators/multiclusterobservability/manifests/base/config/metrics_allowlist.yaml
@@ -201,7 +201,6 @@ data:
       - namespace:kube_pod_container_resource_requests_cpu_cores:sum
       - node_accelerator_card_info
       - node_cpu_seconds_total
-      - node_cpu_seconds_total
       - node_filesystem_avail_bytes
       - node_filesystem_free_bytes
       - node_filesystem_size_bytes
@@ -209,7 +208,6 @@ data:
       - node_memory_MemTotal_bytes
       - node_memory_SwapFree_bytes
       - node_memory_SwapTotal_bytes
-      - node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
       - node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m
       - node_netstat_Tcp_OutSegs
       - node_netstat_Tcp_RetransSegs
@@ -326,7 +324,6 @@ data:
       - apiserver_request_duration_seconds_bucket
       - apiserver_request_total
       - apiserver_storage_objects
-      - etcd_debugging_mvcc_db_total_size_in_bytes
       - etcd_mvcc_db_total_size_in_bytes
       - etcd_debugging_snap_save_total_duration_seconds_sum
       - etcd_disk_backend_commit_duration_seconds_bucket


### PR DESCRIPTION
Backport https://github.com/stolostron/multicluster-observability-operator/pull/2590