### PR TITLE
[release-2.16] [ACM-34653] restart alertmanager pods on client CA changes via hash annotation

### DIFF
--- a/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager.go
@@ -6,6 +6,8 @@ package rendering
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 
@@ -143,6 +145,18 @@ func (r *MCORenderer) renderAlertManagerStatefulSet(res *resource.Resource, name
 	}
 	kubeRbacProxyContainer.ImagePullPolicy = imagePullPolicy
 
+	// Compute hash of the client CA to trigger a rolling restart when the CA rotates.
+	// kube-rbac-proxy reads --client-ca-file only at startup; without this, a CA
+	// rotation leaves the pod using a stale CA until manually restarted (ACM-34653).
+	caHash, err := r.getClientCAHash()
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute client CA hash: %w", err)
+	}
+	if dep.Spec.Template.Annotations == nil {
+		dep.Spec.Template.Annotations = map[string]string{}
+	}
+	dep.Spec.Template.Annotations["observability.open-cluster-management.io/client-ca-hash"] = caHash
+
 	// replace the volumeClaimTemplate
 	dep.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = &r.cr.Spec.StorageConfig.StorageClass
 	dep.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = apiresource.MustParse(r.cr.Spec.StorageConfig.AlertmanagerStorageSize)
@@ -153,6 +167,25 @@ func (r *MCORenderer) renderAlertManagerStatefulSet(res *resource.Resource, name
 	}
 
 	return &unstructured.Unstructured{Object: unstructuredObj}, nil
+}
+
+func (r *MCORenderer) getClientCAHash() (string, error) {
+	namespacedName := types.NamespacedName{
+		Name:      "extension-apiserver-authentication",
+		Namespace: "kube-system",
+	}
+	sourceConfigMap := &corev1.ConfigMap{}
+	if err := r.kubeClient.Get(context.Background(), namespacedName, sourceConfigMap); err != nil {
+		return "", fmt.Errorf("error fetching extension-apiserver-authentication ConfigMap: %w", err)
+	}
+
+	caData, exists := sourceConfigMap.Data["client-ca-file"]
+	if !exists || len(caData) == 0 {
+		return "", fmt.Errorf("client-ca-file not found or empty in extension-apiserver-authentication ConfigMap")
+	}
+
+	hash := sha256.Sum256([]byte(caData))
+	return hex.EncodeToString(hash[:]), nil
 }
 
 func (r *MCORenderer) renderAlertManagerSecret(res *resource.Resource,

--- a/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_alertmanager_test.go
@@ -6,6 +6,8 @@ package rendering
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -71,6 +73,12 @@ func TestAlertManagerRenderer(t *testing.T) {
 	// clientCa configmap must be filled with the client-ca-file data
 	clientCaData := getResource[*corev1.ConfigMap](alertResources, "alertmanager-clientca-metric")
 	assert.Equal(t, clientCa.Data["client-ca-file"], clientCaData.Data["client-ca-file"])
+
+	// StatefulSet pod template must have the client CA hash annotation
+	sts := getResource[*appsv1.StatefulSet](alertResources, "")
+	caHashAnnotation := sts.Spec.Template.Annotations["observability.open-cluster-management.io/client-ca-hash"]
+	expectedHash := sha256.Sum256([]byte(clientCa.Data["client-ca-file"]))
+	assert.Equal(t, hex.EncodeToString(expectedHash[:]), caHashAnnotation)
 
 	// container images must be replaced with the ones from the mch-image-manifest configmap
 	for _, obj := range alertResources {
@@ -283,6 +291,36 @@ func TestAlertManagerRendererMCOConfig(t *testing.T) {
 			tc.expect(t, sts)
 		})
 	}
+}
+
+func TestAlertManagerClientCAHashRotation(t *testing.T) {
+	makeCA := func(data string) *corev1.ConfigMap {
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "extension-apiserver-authentication",
+				Namespace: "kube-system",
+			},
+			Data: map[string]string{
+				"client-ca-file": data,
+			},
+		}
+	}
+
+	client1 := fake.NewClientBuilder().WithObjects(makeCA("old-ca-bundle")).Build()
+	client2 := fake.NewClientBuilder().WithObjects(makeCA("new-ca-bundle")).Build()
+
+	resources1 := renderTemplates(t, client1, makeBaseMco())
+	resources2 := renderTemplates(t, client2, makeBaseMco())
+
+	sts1 := getResource[*appsv1.StatefulSet](resources1, "")
+	sts2 := getResource[*appsv1.StatefulSet](resources2, "")
+
+	hash1 := sts1.Spec.Template.Annotations["observability.open-cluster-management.io/client-ca-hash"]
+	hash2 := sts2.Spec.Template.Annotations["observability.open-cluster-management.io/client-ca-hash"]
+
+	assert.NotEmpty(t, hash1)
+	assert.NotEmpty(t, hash2)
+	assert.NotEqual(t, hash1, hash2, "hash must change when CA data changes")
 }
 
 func makeBaseMco() *mcov1beta2.MultiClusterObservability {


### PR DESCRIPTION
## Summary

Backport of #2500 to `release-2.16`.

- kube-rbac-proxy reads `--client-ca-file` only at startup — CA rotation leaves pods using stale CA until manually restarted
- Adds sha256 hash of client CA bundle as pod template annotation on alertmanager StatefulSet
- When CA rotates, hash changes → rolling restart triggered automatically

## Test plan

- [x] Unit tests pass (`TestAlertManagerRenderer`, `TestAlertManagerRendererMCOConfig`, `TestAlertManagerClientCAHashRotation`)
- [x] `go vet` clean
- [ ] CI e2e tests