### PR TITLE
[release-2.16] fix(rightsizing): eliminate ConfigMap predicate reconciliation storm

### DIFF
--- a/operators/multiclusterobservability/controllers/analytics/analytics_controller.go
+++ b/operators/multiclusterobservability/controllers/analytics/analytics_controller.go
@@ -87,7 +87,7 @@ func (r *AnalyticsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, fmt.Errorf("rs - failed to add analytics finalizer: %w", err)
 		}
 		reqLogger.Info("rs - Analytics finalizer added to MCO CR")
-		return ctrl.Result{}, nil // watch-triggered reconcile picks up updated finalizers
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// Do not reconcile objects if this instance of mch is labeled "paused"
@@ -169,13 +169,9 @@ func (r *AnalyticsReconciler) ensureRightSizingDefaults(ctx context.Context, ins
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AnalyticsReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	c := mgr.GetClient()
-	ctx := context.Background()
-
 	mcoPred := mcoctrl.GetMCOPredicateFunc()
-	cmNamespaceRSPred := rightsizingctrl.GetNamespaceRSConfigMapPredicateFunc(ctx, c)
-	cmVirtualizationRSPred := rightsizingctrl.GetVirtualizationRSConfigMapPredicateFunc(ctx, c)
-
+	cmNamespaceRSPred := rightsizingctrl.GetNamespaceRSConfigMapPredicateFunc()
+	cmVirtualizationRSPred := rightsizingctrl.GetVirtualizationRSConfigMapPredicateFunc()
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("rightsizing").
 		For(&mcov1beta2.MultiClusterObservability{}, builder.WithPredicates(mcoPred)).

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rightsizing_controller.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rightsizing_controller.go
@@ -86,11 +86,11 @@ func getNamespaceBinding(mco *mcov1beta2.MultiClusterObservability, componentTyp
 }
 
 // GetNamespaceRSConfigMapPredicateFunc returns predicate for namespace right-sizing ConfigMap
-func GetNamespaceRSConfigMapPredicateFunc(ctx context.Context, c client.Client) predicate.Funcs {
-	return rsnamespace.GetNamespaceRSConfigMapPredicateFunc(ctx, c)
+func GetNamespaceRSConfigMapPredicateFunc() predicate.Funcs {
+	return rsnamespace.GetNamespaceRSConfigMapPredicateFunc()
 }
 
 // GetVirtualizationRSConfigMapPredicateFunc returns predicate for virtualization right-sizing ConfigMap
-func GetVirtualizationRSConfigMapPredicateFunc(ctx context.Context, c client.Client) predicate.Funcs {
-	return rsvirtualization.GetVirtualizationRSConfigMapPredicateFunc(ctx, c)
+func GetVirtualizationRSConfigMapPredicateFunc() predicate.Funcs {
+	return rsvirtualization.GetVirtualizationRSConfigMapPredicateFunc()
 }

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-namespace/configmap.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-namespace/configmap.go
@@ -35,9 +35,9 @@ func GetRightSizingConfigData(cm *corev1.ConfigMap) (rsutility.RSNamespaceConfig
 	return rsutility.GetRSConfigData(cm)
 }
 
-// Gets the namesapce rightsizing predicate function
-func GetNamespaceRSConfigMapPredicateFunc(ctx context.Context, c client.Client) predicate.Funcs {
-	return rsutility.GetRSConfigMapPredicateFunc(ctx, c, ConfigMapName, ApplyRSNamespaceConfigMapChanges)
+// GetNamespaceRSConfigMapPredicateFunc returns the namespace right-sizing ConfigMap predicate.
+func GetNamespaceRSConfigMapPredicateFunc() predicate.Funcs {
+	return rsutility.GetRSConfigMapPredicateFunc(ConfigMapName)
 }
 
 // ApplyRSNamespaceConfigMapChanges updates PrometheusRule, Policy, Placement based on configmap changes

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component.go
@@ -128,23 +128,23 @@ func HandleComponentRightSizing(
 		if err := CleanupComponentResources(ctx, c, componentConfig, existingNamespace, true); err != nil {
 			return fmt.Errorf("rs - failed to cleanup %s resources after namespace binding update: %w", componentConfig.ComponentType, err)
 		}
+	}
 
-		// Get configmap
-		cm := &corev1.ConfigMap{}
-		if err := c.Get(ctx, client.ObjectKey{Name: componentConfig.ConfigMapName, Namespace: config.GetDefaultNamespace()}, cm); err != nil {
-			return fmt.Errorf("rs - failed to get existing configmap: %w", err)
-		}
+	// Get configmap
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(ctx, client.ObjectKey{Name: componentConfig.ConfigMapName, Namespace: config.GetDefaultNamespace()}, cm); err != nil {
+		return fmt.Errorf("rs - failed to get existing configmap: %w", err)
+	}
 
-		// Get configmap data into specified structure
-		configData, err := GetRSConfigData(cm)
-		if err != nil {
-			return fmt.Errorf("rs - failed to extract config data: %w", err)
-		}
+	// Get configmap data into specified structure
+	configData, err := GetRSConfigData(cm)
+	if err != nil {
+		return fmt.Errorf("rs - failed to extract config data: %w", err)
+	}
 
-		// If NamespaceBinding has been updated apply the Policy Placement Placementbinding again
-		if err := componentConfig.ApplyChangesFunc(ctx, c, configData); err != nil {
-			return fmt.Errorf("rs - failed to apply configmap changes: %w", err)
-		}
+	// Apply the Policy, Placement, PlacementBinding
+	if err := componentConfig.ApplyChangesFunc(ctx, c, configData); err != nil {
+		return fmt.Errorf("rs - failed to apply configmap changes: %w", err)
 	}
 
 	log.Info("rs - create component task completed", "component", componentConfig.ComponentType)

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component_test.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component_test.go
@@ -66,8 +66,8 @@ func mockApplyChangesFunc(ctx context.Context, c client.Client, configData RSNam
 
 func mockGetDefaultConfigFunc() map[string]string {
 	return map[string]string{
-		"prometheusRuleConfig":   "test-rule-config",
-		"placementConfiguration": "test-placement-config",
+		"prometheusRuleConfig":   "namespaceFilterCriteria:\n  inclusionCriteria: []\n  exclusionCriteria: []\nrecommendationPercentage: 20\n",
+		"placementConfiguration": "",
 	}
 }
 
@@ -188,6 +188,149 @@ func TestHandleComponentRightSizing_FeatureEnabled(t *testing.T) {
 	}, cm)
 	require.NoError(t, err)
 	assert.Contains(t, cm.Data, "prometheusRuleConfig")
+}
+
+func TestHandleComponentRightSizing_FreshEnableAfterDelegation(t *testing.T) {
+	scheme := setupComponentTestScheme(t)
+	mco := newTestMCOForComponent(ComponentTypeNamespace, "custom-ns", true)
+
+	applyChangesCalled := false
+	trackingApplyFunc := func(ctx context.Context, c client.Client, configData RSNamespaceConfigMapData) error {
+		applyChangesCalled = true
+		return nil
+	}
+
+	componentConfig := ComponentConfig{
+		ComponentType:            ComponentTypeNamespace,
+		ConfigMapName:            "test-config",
+		PlacementName:            "test-placement",
+		PlacementBindingName:     "test-binding",
+		PrometheusRulePolicyName: "test-policy",
+		DefaultNamespace:         "default-ns",
+		GetDefaultConfigFunc:     mockGetDefaultConfigFunc,
+		ApplyChangesFunc:         trackingApplyFunc,
+	}
+
+	// Simulate state after delegation cleanup reset (Change 1)
+	state := &ComponentState{
+		Namespace: "custom-ns",
+		Enabled:   false, // Reset by CleanupPolicyResourcesForDelegation
+	}
+
+	// Pre-create ConfigMap with valid data (as would exist from prior MCOA usage)
+	existingCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: "open-cluster-management-observability",
+		},
+		Data: mockGetDefaultConfigFunc(),
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mco, existingCM).
+		Build()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := HandleComponentRightSizing(ctx, client, mco, componentConfig, state)
+	require.NoError(t, err)
+
+	// Verify state
+	assert.True(t, state.Enabled)
+	assert.Equal(t, "custom-ns", state.Namespace)
+
+	// Verify ApplyChangesFunc was called
+	assert.True(t, applyChangesCalled, "ApplyChangesFunc should be called after delegation reset")
+}
+
+func TestHandleComponentRightSizing_NamespaceBindingChange(t *testing.T) {
+	scheme := setupComponentTestScheme(t)
+	mco := newTestMCOForComponent(ComponentTypeNamespace, "new-ns", true)
+
+	applyChangesCalled := false
+	trackingApplyFunc := func(ctx context.Context, c client.Client, configData RSNamespaceConfigMapData) error {
+		applyChangesCalled = true
+		return nil
+	}
+
+	componentConfig := ComponentConfig{
+		ComponentType:            ComponentTypeNamespace,
+		ConfigMapName:            "test-config",
+		PlacementName:            "test-placement",
+		PlacementBindingName:     "test-binding",
+		PrometheusRulePolicyName: "test-policy",
+		DefaultNamespace:         "default-ns",
+		GetDefaultConfigFunc:     mockGetDefaultConfigFunc,
+		ApplyChangesFunc:         trackingApplyFunc,
+	}
+
+	// Simulate already-enabled state with a different namespace
+	state := &ComponentState{
+		Namespace: "old-ns",
+		Enabled:   true,
+	}
+
+	// Pre-create resources in the old namespace that should be cleaned up
+	oldPlacement := &clusterv1beta1.Placement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-placement",
+			Namespace: "old-ns",
+		},
+	}
+	oldBinding := &policyv1.PlacementBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-binding",
+			Namespace: "old-ns",
+		},
+	}
+	oldPolicy := &policyv1.Policy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-policy",
+			Namespace: "old-ns",
+		},
+	}
+
+	existingCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: "open-cluster-management-observability",
+		},
+		Data: mockGetDefaultConfigFunc(),
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mco, existingCM, oldPlacement, oldBinding, oldPolicy).
+		Build()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := HandleComponentRightSizing(ctx, client, mco, componentConfig, state)
+	require.NoError(t, err)
+
+	// Verify state updated to new namespace
+	assert.True(t, state.Enabled)
+	assert.Equal(t, "new-ns", state.Namespace)
+
+	// Verify ApplyChangesFunc was called
+	assert.True(t, applyChangesCalled, "ApplyChangesFunc should be called after namespace binding change")
+
+	// Verify old namespace resources were cleaned up
+	err = client.Get(ctx, types.NamespacedName{Name: "test-placement", Namespace: "old-ns"}, &clusterv1beta1.Placement{})
+	assert.True(t, errors.IsNotFound(err), "old placement should be deleted")
+
+	err = client.Get(ctx, types.NamespacedName{Name: "test-binding", Namespace: "old-ns"}, &policyv1.PlacementBinding{})
+	assert.True(t, errors.IsNotFound(err), "old placement binding should be deleted")
+
+	err = client.Get(ctx, types.NamespacedName{Name: "test-policy", Namespace: "old-ns"}, &policyv1.Policy{})
+	assert.True(t, errors.IsNotFound(err), "old policy should be deleted")
+
+	// Verify ConfigMap was NOT deleted (bindingUpdated=true preserves it)
+	err = client.Get(ctx, types.NamespacedName{Name: "test-config", Namespace: "open-cluster-management-observability"}, &corev1.ConfigMap{})
+	assert.NoError(t, err, "ConfigMap should be preserved during namespace binding change")
 }
 
 func TestCleanupComponentResources_WithConfigMap(t *testing.T) {

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/configmap.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/configmap.go
@@ -79,50 +79,26 @@ func GetRSConfigData(cm *corev1.ConfigMap) (RSNamespaceConfigMapData, error) {
 	return configData, nil
 }
 
-// GetRSConfigMapPredicateFunc returns a predicate function for watching ConfigMap events
-func GetRSConfigMapPredicateFunc(ctx context.Context, c client.Client, configMapName string, applyChangesFunc func(context.Context, client.Client, RSNamespaceConfigMapData) error) predicate.Funcs {
-	log.Info("rs - watch for ConfigMap events set up started")
-
-	processConfigMap := func(cm *corev1.ConfigMap) bool {
-		configData, err := GetRSConfigData(cm)
-		if err != nil {
-			log.Error(err, "rs - failed to extract config data")
-			return false
-		}
-
-		// Apply changes based on the config map
-		if err := applyChangesFunc(ctx, c, configData); err != nil {
-			log.Error(err, "rs - failed to apply configmap changes")
-			return false
-		}
-		return true
-	}
-
+// GetRSConfigMapPredicateFunc returns a predicate that filters ConfigMap watch
+// events to only the named RS ConfigMap with actual data changes.
+func GetRSConfigMapPredicateFunc(configMapName string) predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			if e.Object.GetName() == configMapName && e.Object.GetNamespace() == config.GetDefaultNamespace() {
-				if cm, ok := e.Object.(*corev1.ConfigMap); ok {
-					return processConfigMap(cm)
-				}
-			}
-			return true
+			return e.Object.GetName() == configMapName && e.Object.GetNamespace() == config.GetDefaultNamespace()
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			if e.ObjectNew.GetName() != configMapName || e.ObjectNew.GetNamespace() != config.GetDefaultNamespace() {
-				return true
+				return false
 			}
 
-			// Check if the ConfigMap `Data` has changed before proceeding
 			oldCM, oldOK := e.ObjectOld.(*corev1.ConfigMap)
 			newCM, newOK := e.ObjectNew.(*corev1.ConfigMap)
-
 			if oldOK && newOK && reflect.DeepEqual(oldCM.Data, newCM.Data) {
-				log.V(1).Info("rs - no changes detected in configmap data, skipping update")
-				return true
+				return false
 			}
-
-			log.V(1).Info("rs - configmap data has changed, processing update")
-			return processConfigMap(newCM)
+			return true
 		},
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
 }

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-virtualization/configmap.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-virtualization/configmap.go
@@ -34,8 +34,8 @@ func GetRightSizingVirtualizationConfigData(cm *corev1.ConfigMap) (rsutility.RSN
 	return rsutility.GetRSConfigData(cm)
 }
 
-func GetVirtualizationRSConfigMapPredicateFunc(ctx context.Context, c client.Client) predicate.Funcs {
-	return rsutility.GetRSConfigMapPredicateFunc(ctx, c, ConfigMapName, ApplyRSVirtualizationConfigMapChanges)
+func GetVirtualizationRSConfigMapPredicateFunc() predicate.Funcs {
+	return rsutility.GetRSConfigMapPredicateFunc(ConfigMapName)
 }
 
 func ApplyRSVirtualizationConfigMapChanges(ctx context.Context, c client.Client, configData rsutility.RSNamespaceConfigMapData) error {


### PR DESCRIPTION
## Summary

Manual cherry-pick of #2476 (fc99ea8b) to release-2.16. Automated cherry-pick was not possible due to merge conflicts (4 files conflicted, all resolved manually).

- **Predicate is now a pure filter** — removed `processConfigMap` side-effect closure that ran Policy/Placement/PlacementBinding creation inside the informer goroutine
- **Apply runs unconditionally in reconcile loop** — `HandleComponentRightSizing` now always reads the ConfigMap and calls `ApplyChangesFunc`, not just on namespace binding change
- **Eliminates reconciliation storm** — predicate returns `false` for non-matching ConfigMaps (was `true`, causing ~80 spurious reconciles per restart)
- **Explicit requeue after finalizer** — `Requeue: true` instead of relying on watch-triggered reconcile

## Root Cause

The virt right-sizing e2e test (`RHACM4K-58751`) fails intermittently because:
1. `HandleComponentRightSizing` only called `ApplyChangesFunc` when `namespaceBindingUpdated == true`
2. Initial Policy/Placement creation relied on a predicate side-effect (race condition)
3. On operator restart or timing mismatch, the predicate didn't fire → PrometheusRule never deployed

## Conflict Resolution

4 files had merge conflicts during cherry-pick, all trivial:
- `analytics_controller.go` — predicate function signature `(ctx, c)` → `()`
- `component.go` — moved apply block out of `if namespaceBindingUpdated`
- `configmap.go` — removed `processConfigMap` closure
- `component_test.go` — inserted new test functions

Additionally, `mockGetDefaultConfigFunc` in tests was updated to return valid YAML since `ApplyChangesFunc` now runs unconditionally (previously unreachable code path).
