### PR TITLE
[release-2.17] [ACM-27932] Remove offset 6h from ACMThanosCompactHasNotRun alert

### DIFF
--- a/operators/multiclusterobservability/manifests/base/alertmanager/prometheusrule.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/prometheusrule.yaml
@@ -24,7 +24,7 @@ spec:
         annotations:
           description: Thanos Compact {{$labels.job}} in {{$labels.namespace}} has failed to run and now is halted.
           message: ACM Thanos Compact {{$labels.job}} in {{$labels.namespace}} has failed to run and now is halted.
-          summary: ACM Thanos Compact has failed to run and is now halted.
+          summary: ACM Thanos Compact has failed to run and now is halted.
           runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/advanced-cluster-management-operator/ACMThanosCompactHalted.md
         expr: acm_thanos_compact_halted{job="observability-thanos-compact"} == 1
         for: 5m
@@ -52,8 +52,8 @@ spec:
         annotations:
           description: Thanos Compact {{$labels.job}} in {{$labels.namespace}} Bucket is failing to execute {{$value | humanize}}% of operations.
           #TODO: add link to ACM documentation link to description
-          message: ACM Thanos Compact {{$labels.job}} in {{$labels.namespace}} Bucket is failing to execute {{$value | humanize}}% of operations.
-          summary: ACM Thanos Compact Bucket is having a high number of operation failures.
+          message: Thanos Compact {{$labels.job}} in {{$labels.namespace}} Bucket is failing to execute {{$value | humanize}}% of operations.
+          summary: Thanos Compact Bucket is having a high number of operation failures.
         expr: |
           (
             sum by (namespace, job) (rate(acm_thanos_objstore_bucket_operation_failures_total{job="observability-thanos-compact"}[5m]))
@@ -71,7 +71,7 @@ spec:
           #TODO: add link to ACM documentation link to description
           message: ACM Thanos Compact {{$labels.job}} in {{$labels.namespace}} has not uploaded anything for 24 hours.
           summary: ACM Thanos Compact has not uploaded anything for last 24 hours.
-        expr: (time() - max by (namespace, job) (max_over_time(acm_thanos_objstore_bucket_last_successful_upload_time{job="observability-thanos-compact"}[24h] offset 6h))) / 60 / 60 > 24
+        expr: (time() - max by (namespace, job) (max_over_time(acm_thanos_objstore_bucket_last_successful_upload_time{job="observability-thanos-compact"}[24h]))) / 60 / 60 > 24
         labels:
           namespace: open-cluster-management-observability
           severity: warning


### PR DESCRIPTION
Cherry-pick of #2413 to release-2.17.

Removes `offset 6h` from `ACMThanosCompactHasNotRun` to align with the upstream Thanos alert definition and eliminate false positives after compactor recovery.

See [ACM-27932](https://issues.redhat.com/browse/ACM-27932).

[ACM-27932]: https://redhat.atlassian.net/browse/ACM-27932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ