### PR TITLE
[release-2.15] [ACM-27932] Remove offset 6h from ACMThanosCompactHasNotRun alert

### DIFF
--- a/operators/multiclusterobservability/manifests/base/alertmanager/prometheusrule.yaml
+++ b/operators/multiclusterobservability/manifests/base/alertmanager/prometheusrule.yaml
@@ -70,7 +70,7 @@ spec:
           #TODO: add link to ACM documentation link to description
           message: ACM Thanos Compact {{$labels.job}} in {{$labels.namespace}} has not uploaded anything for 24 hours.
           summary: ACM Thanos Compact has not uploaded anything for last 24 hours.
-        expr: (time() - max by (namespace, job) (max_over_time(acm_thanos_objstore_bucket_last_successful_upload_time{job="observability-thanos-compact"}[24h] offset 6h))) / 60 / 60 > 24
+        expr: (time() - max by (namespace, job) (max_over_time(acm_thanos_objstore_bucket_last_successful_upload_time{job="observability-thanos-compact"}[24h]))) / 60 / 60 > 24
         labels:
           namespace: open-cluster-management-observability
           severity: warning


### PR DESCRIPTION
Cherry-pick of #2413 to release-2.15.

Removes `offset 6h` from `ACMThanosCompactHasNotRun` to align with the upstream Thanos alert definition and eliminate false positives after compactor recovery.

See [ACM-27932](https://issues.redhat.com/browse/ACM-27932).

[ACM-27932]: https://redhat.atlassian.net/browse/ACM-27932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ