### PR TITLE
[release-2.17] [ACM-34481] <MCO>: <Cleanup ScrapeConfigs and PrometheusRules deployed on Hub During MCOA -> MCO Transition>

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -340,6 +340,11 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 			return ctrl.Result{}, fmt.Errorf("failed to deploy %s %s/%s: %w", res.GetKind(), resNS, res.GetName(), err)
 		}
 	}
+	if !rendering.MCOAPlatformMetricsEnabled(instance) {
+		if err := r.undeployMCOAGrafanaResources(ctx, instance, renderer, deployer); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
 
 	if !rendering.MCOAEnabled(instance) && !rightSizingDelegated {
 		namespace, labels := renderer.NamespaceAndLabels()
@@ -1081,6 +1086,35 @@ func (r *MultiClusterObservabilityReconciler) deleteSpecificPrometheusRule(ctx c
 	} else if !apierrors.IsNotFound(err) {
 		log.Error(err, "Failed to fetch PrometheusRule")
 		return err
+	}
+
+	return nil
+}
+
+// undeployMCOAGrafanaResources removes MCOA Grafana resources when platform metrics collection is disabled.
+func (r *MultiClusterObservabilityReconciler) undeployMCOAGrafanaResources(
+	ctx context.Context,
+	instance *mcov1beta2.MultiClusterObservability,
+	renderer *rendering.MCORenderer,
+	deployer *deploying.Deployer,
+) error {
+	namespace, labels := renderer.NamespaceAndLabels()
+	toDelete, err := renderer.MCOAGrafanaResourcesForRemoval(ctx, namespace, labels)
+	if err != nil {
+		return fmt.Errorf("failed to list MCOA Grafana resources for deletion in namespace %s: %w", namespace, err)
+	}
+	for _, res := range toDelete {
+		resNS := res.GetNamespace()
+		if err := deployer.Undeploy(ctx, res, instance); err != nil {
+			if meta.IsNoMatchError(err) {
+				kind := res.GetKind()
+				if kind == monitoringv1.PrometheusRuleKind || kind == monitoringv1alpha1.ScrapeConfigsKind {
+					log.Info("CRD not available on MCO, skipping cleanup", "Kind", kind)
+					continue
+				}
+			}
+			return fmt.Errorf("failed to undeploy %s %s/%s: %w", res.GetKind(), resNS, res.GetName(), err)
+		}
 	}
 
 	return nil

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -30,10 +30,13 @@ import (
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
 	mcostatusctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/status"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/rendering"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/rendering/templates"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/util"
+	"github.com/stolostron/multicluster-observability-operator/operators/pkg/deploying"
 	observatoriumv1alpha1 "github.com/stolostron/observatorium-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -41,10 +44,12 @@ import (
 	storev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -54,6 +59,7 @@ import (
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -1471,6 +1477,164 @@ func TestServiceMonitorRemovedFromOpenshiftMonitoringNamespace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to delete ServiceMonitor: (%v)", err)
 	}
+}
+
+func TestUndeployMCOAGrafanaResources(t *testing.T) {
+	defer setupTest(t)()
+
+	namespace := config.GetDefaultNamespace()
+	mcoName := "monitoring"
+	mcoUID := types.UID("mco-uid-test")
+
+	mco := &mcov1beta2.MultiClusterObservability{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: mcov1beta2.GroupVersion.String(),
+			Kind:       "MultiClusterObservability",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mcoName,
+			UID:  mcoUID,
+		},
+	}
+	mcoWithPlatformMetrics := &mcov1beta2.MultiClusterObservability{
+		TypeMeta:   mco.TypeMeta,
+		ObjectMeta: mco.ObjectMeta,
+		Spec: mcov1beta2.MultiClusterObservabilitySpec{
+			Capabilities: &mcov1beta2.CapabilitiesSpec{
+				Platform: &mcov1beta2.PlatformCapabilitiesSpec{
+					Metrics: mcov1beta2.PlatformMetricsSpec{
+						Default: mcov1beta2.PlatformMetricsDefaultSpec{
+							Enabled: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s := runtime.NewScheme()
+	scheme.AddToScheme(s)
+	mcov1beta2.AddToScheme(s)
+	monitoringv1.AddToScheme(s)
+
+	controllerRef := metav1.NewControllerRef(mco, mcov1beta2.GroupVersion.WithKind("MultiClusterObservability"))
+	scrapeConfig := &unstructured.Unstructured{}
+	scrapeConfig.SetAPIVersion("monitoring.rhobs/v1alpha1")
+	scrapeConfig.SetKind("ScrapeConfig")
+	scrapeConfig.SetName("platform-metrics")
+	scrapeConfig.SetNamespace(namespace)
+	scrapeConfig.SetOwnerReferences([]metav1.OwnerReference{*controllerRef})
+	promRule := &monitoringv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "platform-rules-default",
+			Namespace:       namespace,
+			OwnerReferences: []metav1.OwnerReference{*controllerRef},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		mco            *mcov1beta2.MultiClusterObservability
+		existingObjs   []runtime.Object
+		expectDeletion bool
+	}{
+		{
+			name:           "undeploys MCOA Grafana resources when platform metrics disabled",
+			mco:            mco,
+			existingObjs:   []runtime.Object{mco, scrapeConfig, promRule},
+			expectDeletion: true,
+		},
+		{
+			name:           "skips undeploy when platform metrics enabled",
+			mco:            mcoWithPlatformMetrics,
+			existingObjs:   []runtime.Object{mcoWithPlatformMetrics, scrapeConfig, promRule},
+			expectDeletion: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(tt.existingObjs...).Build()
+			r := &MultiClusterObservabilityReconciler{Client: c, Scheme: s}
+			renderer := rendering.NewMCORenderer(tt.mco, c, nil)
+			deployer := deploying.NewDeployer(c, tt.mco.Name)
+
+			err := r.undeployMCOAGrafanaResources(t.Context(), tt.mco, renderer, deployer)
+			require.NoError(t, err)
+
+			gotScrapeConfig := &unstructured.Unstructured{}
+			gotScrapeConfig.SetAPIVersion("monitoring.rhobs/v1alpha1")
+			gotScrapeConfig.SetKind("ScrapeConfig")
+			err = c.Get(t.Context(), types.NamespacedName{Name: "platform-metrics", Namespace: namespace}, gotScrapeConfig)
+			if tt.expectDeletion {
+				assert.True(t, errors.IsNotFound(err), "ScrapeConfig should have been deleted")
+			} else {
+				require.NoError(t, err, "ScrapeConfig should still exist")
+			}
+
+			gotPromRule := &monitoringv1.PrometheusRule{}
+			err = c.Get(t.Context(), types.NamespacedName{Name: "platform-rules-default", Namespace: namespace}, gotPromRule)
+			if tt.expectDeletion {
+				assert.True(t, errors.IsNotFound(err), "PrometheusRule should have been deleted")
+			} else {
+				require.NoError(t, err, "PrometheusRule should still exist")
+			}
+		})
+	}
+}
+
+// noMatchScrapeConfigClient simulates production apiserver behavior when the
+// scrapeconfigs.monitoring.rhobs CRD is not installed. This is not about the Go
+// scheme: monitoring/v1 is registered for PrometheusRule, but MCO ScrapeConfigs
+// use monitoring.rhobs/v1alpha1 (a separate API group). The fake client cannot
+// reproduce NoMatch on its own—it returns NotFound for missing unstructured
+// objects—so this wrapper injects the error the real cluster returns.
+type noMatchScrapeConfigClient struct {
+	client.Client
+}
+
+func (c *noMatchScrapeConfigClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		gvk := u.GroupVersionKind()
+		if gvk.Group == "monitoring.rhobs" && gvk.Kind == "ScrapeConfig" {
+			return &meta.NoKindMatchError{
+				GroupKind:        schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind},
+				SearchedVersions: []string{gvk.Version},
+			}
+		}
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+// TestUndeployMCOAGrafanaResourcesSkipsMissingScrapeConfigCRD verifies cleanup
+// continues when the ScrapeConfig CRD is absent (legacy install without MCOA).
+func TestUndeployMCOAGrafanaResourcesSkipsMissingScrapeConfigCRD(t *testing.T) {
+	defer setupTest(t)()
+
+	mco := &mcov1beta2.MultiClusterObservability{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: mcov1beta2.GroupVersion.String(),
+			Kind:       "MultiClusterObservability",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "monitoring",
+		},
+	}
+
+	s := runtime.NewScheme()
+	scheme.AddToScheme(s)
+	mcov1beta2.AddToScheme(s)
+	monitoringv1.AddToScheme(s)
+
+	baseClient := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mco).Build()
+	c := &noMatchScrapeConfigClient{Client: baseClient}
+
+	r := &MultiClusterObservabilityReconciler{Client: c, Scheme: s}
+	renderer := rendering.NewMCORenderer(mco, c, nil)
+	deployer := deploying.NewDeployer(c, mco.Name)
+
+	err := r.undeployMCOAGrafanaResources(t.Context(), mco, renderer, deployer)
+	require.NoError(t, err)
 }
 
 func TestNewMCOACRDEventHandler(t *testing.T) {

--- a/operators/multiclusterobservability/pkg/rendering/renderer.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer.go
@@ -199,6 +199,20 @@ func (r *MCORenderer) MCOAResources(ctx context.Context, namespace string, label
 	return mcoaResources, nil
 }
 
+// MCOAGrafanaResourcesForRemoval renders the MCOA addon grafana templates into unstructured resources for removal.
+func (r *MCORenderer) MCOAGrafanaResourcesForRemoval(ctx context.Context, namespace string, labels map[string]string) ([]*unstructured.Unstructured, error) {
+	grafanaTemplates, err := templates.GetOrLoadGrafanaTemplates(templatesutil.GetTemplateRenderer())
+	if err != nil {
+		return nil, err
+	}
+	mcoaGrafanaResources, err := r.RenderGrafanaMCOATemplatesForRemoval(ctx, grafanaTemplates, namespace, labels)
+	if err != nil {
+		return nil, err
+	}
+
+	return mcoaGrafanaResources, nil
+}
+
 // HasImagestream checks if the cluster supports OpenShift ImageStream resources.
 func (r *MCORenderer) HasImagestream() bool {
 	dcl := discovery.NewDiscoveryClient(r.imageClient.RESTClient())

--- a/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_grafana.go
@@ -168,6 +168,44 @@ func (r *MCORenderer) renderGrafanaTemplates(
 	return uobjs, nil
 }
 
+func (r *MCORenderer) RenderGrafanaMCOATemplatesForRemoval(
+	ctx context.Context,
+	templates []*resource.Resource,
+	namespace string, labels map[string]string,
+) ([]*unstructured.Unstructured, error) {
+	if MCOAPlatformMetricsEnabled(r.cr) {
+		return []*unstructured.Unstructured{}, nil
+	}
+	uobjs := []*unstructured.Unstructured{}
+
+	for _, template := range templates {
+		// Only render resource kinds that are specific to MCOA.
+		if !isMCOASpecificResourceKind(template) {
+			continue
+		}
+
+		render, ok := r.renderGrafanaFns[template.GetKind()]
+		if !ok {
+			m, err := template.Map()
+			if err != nil {
+				return []*unstructured.Unstructured{}, err
+			}
+			uobjs = append(uobjs, &unstructured.Unstructured{Object: m})
+			continue
+		}
+		uobj, err := render(ctx, template, namespace, labels)
+		if err != nil {
+			return []*unstructured.Unstructured{}, err
+		}
+		if uobj == nil {
+			continue
+		}
+		uobjs = append(uobjs, uobj)
+	}
+
+	return uobjs, nil
+}
+
 // isMCOASpecificResourceType returns true if the resource is a scrape config or a Prometheus rule
 func isMCOASpecificResourceKind(res *resource.Resource) bool {
 	kind := res.GetKind()

--- a/operators/multiclusterobservability/pkg/rendering/renderer_grafana_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_grafana_test.go
@@ -182,3 +182,75 @@ func TestRenderGrafana(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderGrafanaMCOATemplatesForRemoval(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	templatesPath := filepath.Join(wd, "..", "..", "manifests")
+	tmplRenderer := templatesutil.NewTemplateRenderer(templatesPath)
+	grafanaTemplates, err := templates.GetOrLoadGrafanaTemplates(tmplRenderer)
+	require.NoError(t, err)
+
+	testCases := map[string]struct {
+		mco    obv1beta2.MultiClusterObservability
+		expect func(*testing.T, []*unstructured.Unstructured)
+	}{
+		"MCOA for metrics is enabled": {
+			mco: obv1beta2.MultiClusterObservability{
+				Spec: obv1beta2.MultiClusterObservabilitySpec{
+					Capabilities: &obv1beta2.CapabilitiesSpec{
+						Platform: &obv1beta2.PlatformCapabilitiesSpec{
+							Metrics: obv1beta2.PlatformMetricsSpec{
+								Default: obv1beta2.PlatformMetricsDefaultSpec{
+									Enabled: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			expect: func(t *testing.T, resources []*unstructured.Unstructured) {
+				assert.Empty(t, resources)
+			},
+		},
+		"MCOA for metrics is disabled": {
+			mco: obv1beta2.MultiClusterObservability{},
+			expect: func(t *testing.T, resources []*unstructured.Unstructured) {
+				assert.NotEmpty(t, resources)
+
+				allowedKinds := []string{"ScrapeConfig", "PrometheusRule"}
+				kindCounts := map[string]int{}
+				for _, resource := range resources {
+					kind := resource.GetKind()
+					assert.Contains(t, allowedKinds, kind)
+					kindCounts[kind]++
+				}
+
+				assert.Equal(t, 7, kindCounts["ScrapeConfig"])
+				assert.Equal(t, 3, kindCounts["PrometheusRule"])
+			},
+		},
+	}
+
+	for tcName, tc := range testCases {
+		t.Run(tcName, func(t *testing.T) {
+			mcoRenderer := &MCORenderer{
+				renderer: rendererutil.NewRenderer(),
+				cr:       &tc.mco,
+			}
+			mcoRenderer.newGranfanaRenderer()
+
+			namespace := "myns"
+			resources, err := mcoRenderer.RenderGrafanaMCOATemplatesForRemoval(
+				t.Context(), grafanaTemplates, namespace, nil,
+			)
+			require.NoError(t, err)
+			for _, resource := range resources {
+				assert.Equal(t, namespace, resource.GetNamespace(),
+					fmt.Sprintf("resource %s/%s", resource.GetKind(), resource.GetName()))
+			}
+
+			tc.expect(t, resources)
+		})
+	}
+}

--- a/operators/multiclusterobservability/pkg/rendering/renderer_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_test.go
@@ -5,6 +5,7 @@
 package rendering
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -17,8 +18,10 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
 	templatesutil "github.com/stolostron/multicluster-observability-operator/operators/pkg/rendering/templates"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -121,4 +124,70 @@ func TestGetOauthProxyFromImageStreams(t *testing.T) {
 		t.Fatal("Failed to get oauth proxy image")
 	}
 	assert.Equal(t, "quay.io/openshift-release-dev/ocp-v4.0-art-dev", oauthProxyImage)
+}
+
+func TestMCOAGrafanaResourcesForRemoval(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	templatesPath := path.Join(path.Dir(path.Dir(wd)), "manifests")
+	t.Setenv(templatesutil.TemplatesPathEnvVar, templatesPath)
+
+	kubeClient := fake.NewClientBuilder().Build()
+
+	testCases := map[string]struct {
+		mco    mcov1beta2.MultiClusterObservability
+		expect func(*testing.T, []*unstructured.Unstructured)
+	}{
+		"MCOA for metrics is enabled": {
+			mco: mcov1beta2.MultiClusterObservability{
+				Spec: mcov1beta2.MultiClusterObservabilitySpec{
+					Capabilities: &mcov1beta2.CapabilitiesSpec{
+						Platform: &mcov1beta2.PlatformCapabilitiesSpec{
+							Metrics: mcov1beta2.PlatformMetricsSpec{
+								Default: mcov1beta2.PlatformMetricsDefaultSpec{
+									Enabled: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			expect: func(t *testing.T, resources []*unstructured.Unstructured) {
+				assert.Empty(t, resources)
+			},
+		},
+		"MCOA for metrics is disabled": {
+			mco: mcov1beta2.MultiClusterObservability{},
+			expect: func(t *testing.T, resources []*unstructured.Unstructured) {
+				assert.NotEmpty(t, resources)
+
+				allowedKinds := []string{"ScrapeConfig", "PrometheusRule"}
+				kindCounts := map[string]int{}
+				for _, resource := range resources {
+					kind := resource.GetKind()
+					assert.Contains(t, allowedKinds, kind)
+					kindCounts[kind]++
+				}
+
+				assert.Equal(t, 7, kindCounts["ScrapeConfig"])
+				assert.Equal(t, 3, kindCounts["PrometheusRule"])
+			},
+		},
+	}
+
+	for tcName, tc := range testCases {
+		t.Run(tcName, func(t *testing.T) {
+			renderer := NewMCORenderer(&tc.mco, kubeClient, nil)
+
+			namespace := "myns"
+			resources, err := renderer.MCOAGrafanaResourcesForRemoval(t.Context(), namespace, nil)
+			require.NoError(t, err)
+			for _, resource := range resources {
+				assert.Equal(t, namespace, resource.GetNamespace(),
+					fmt.Sprintf("resource %s/%s", resource.GetKind(), resource.GetName()))
+			}
+
+			tc.expect(t, resources)
+		})
+	}
 }


### PR DESCRIPTION
This is a cherry-pick of https://github.com/stolostron/multicluster-observability-operator/pull/2491to release-2.17. This fixes the issue where ScrapeConfigs and PrometheusRules that were deployed on the hub weren't being cleaned up during the MCOA -> MCO transition.

Previously approved by Thibault in https://github.com/stolostron/multicluster-observability-operator/pull/2538