### PR TITLE
[ACM-39748] Fix Grafana 13.x dashboard folder assignment using folderUid

### DIFF
--- a/loaders/dashboards/pkg/controller/dashboard_controller.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -450,40 +449,40 @@ func (c *GrafanaDashboardController) cleanupOrphanDashboards(ctx context.Context
 	return nil
 }
 
-func (c *GrafanaDashboardController) findCustomFolderID(ctx context.Context, folderTitle string) int64 {
+func (c *GrafanaDashboardController) findCustomFolderUID(ctx context.Context, folderTitle string) string {
 	folders, err := c.grafana.ListFolders(ctx)
 	if err != nil {
 		klog.ErrorS(err, "failed to list folders")
-		return 0
+		return ""
 	}
 
 	for _, folder := range folders {
 		if folder.Title == folderTitle {
-			return folder.ID
+			return folder.UID
 		}
 	}
-	return 0
+	return ""
 }
 
-func (c *GrafanaDashboardController) createCustomFolder(ctx context.Context, folderTitle string) int64 {
-	folderID := c.findCustomFolderID(ctx, folderTitle)
-	if folderID != 0 {
-		return folderID
+func (c *GrafanaDashboardController) createCustomFolder(ctx context.Context, folderTitle string) string {
+	folderUID := c.findCustomFolderUID(ctx, folderTitle)
+	if folderUID != "" {
+		return folderUID
 	}
 
 	folder, err := c.grafana.CreateFolder(ctx, folderTitle)
 	if err != nil {
 		// Handle race condition
-		if retryID := c.findCustomFolderID(ctx, folderTitle); retryID != 0 {
-			return retryID
+		if retryUID := c.findCustomFolderUID(ctx, folderTitle); retryUID != "" {
+			return retryUID
 		}
 		klog.ErrorS(err, "failed to create custom folder", "folderTitle", folderTitle)
-		return 0
+		return ""
 	}
 
 	select {
 	case <-ctx.Done():
-		return 0
+		return ""
 	case <-time.After(folderCreationDelay):
 	}
 
@@ -491,40 +490,49 @@ func (c *GrafanaDashboardController) createCustomFolder(ctx context.Context, fol
 	hasPerm, err := c.grafana.HasPermissions(ctx, folder.UID)
 	if err != nil {
 		klog.ErrorS(err, "failed to check folder permissions", "folderTitle", folderTitle)
-		return 0
+		return ""
 	}
 	if !hasPerm {
 		klog.InfoS("failed to set permissions for folder. Deleting folder and retrying later.", "folderTitle", folderTitle)
 		select {
 		case <-ctx.Done():
-			return 0
+			return ""
 		case <-time.After(permissionsRetryDelay):
 		}
 
 		if err := c.grafana.DeleteFolder(ctx, folder.UID); err != nil {
 			klog.ErrorS(err, "failed to delete folder during retry", "folderUID", folder.UID)
 		}
-		return 0
+		return ""
 	}
 
-	return folder.ID
+	return folder.UID
 }
 
 func (c *GrafanaDashboardController) cleanupFolderIfEmpty(ctx context.Context, folderTitle string) error {
 	if folderTitle == "" {
 		return nil
 	}
-	folderID := c.findCustomFolderID(ctx, folderTitle)
-	if folderID == 0 {
+	folderUID := c.findCustomFolderUID(ctx, folderTitle)
+	if folderUID == "" {
 		return nil
 	}
-	folder, err := c.grafana.GetFolderByID(ctx, folderID)
+	// For Grafana 13+, we use UID-based lookup. If GetFolderByUID doesn't exist,
+	// we can list folders and find by UID
+	folders, err := c.grafana.ListFolders(ctx)
 	if err != nil {
-		var gErr *GrafanaError
-		if errors.As(err, &gErr) && gErr.Status == http.StatusNotFound {
-			return nil // Folder already gone, nothing to clean
+		return fmt.Errorf("failed to list folders for cleanup check: %w", err)
+	}
+
+	var folder *grafanaFolder
+	for _, f := range folders {
+		if f.UID == folderUID {
+			folder = &f
+			break
 		}
-		return fmt.Errorf("failed to check folder status in Grafana: %w", err)
+	}
+	if folder == nil {
+		return nil // Folder already gone, nothing to clean
 	}
 
 	// Check if the folder is empty. Grafana's search index is eventually consistent,
@@ -611,12 +619,12 @@ func (c *GrafanaDashboardController) updateDashboard(ctx context.Context, newObj
 	}
 	defer c.unlockReconcile()
 
-	var folderID int64
+	var folderUID string
 	folderTitle := getDashboardCustomFolderTitle(newObj)
 	if folderTitle != "" {
-		folderID = c.createCustomFolder(ctx, folderTitle)
-		if folderID == 0 {
-			return errors.New("failed to get folder id")
+		folderUID = c.createCustomFolder(ctx, folderTitle)
+		if folderUID == "" {
+			return errors.New("failed to get folder uid")
 		}
 	}
 
@@ -661,7 +669,7 @@ func (c *GrafanaDashboardController) updateDashboard(ctx context.Context, newObj
 		dashboard["uid"] = uid
 		delete(dashboard, "id")
 
-		id, err := c.grafana.CreateOrUpdateDashboard(ctx, dashboard, folderID)
+		id, err := c.grafana.CreateOrUpdateDashboard(ctx, dashboard, folderUID)
 		if err != nil {
 			var gErr *GrafanaError
 			if errors.As(err, &gErr) {

--- a/loaders/dashboards/pkg/controller/dashboard_controller_integration_test.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller_integration_test.go
@@ -143,7 +143,16 @@ func TestIntegrationGrafanaDashboardController(t *testing.T) {
 			json.NewDecoder(r.Body).Decode(&body)
 			dash, _ := body["dashboard"].(map[string]any)
 			uid := dash["uid"].(string)
-			folderID := int64(body["folderId"].(float64))
+
+			// Grafana 13+ uses folderUid instead of folderId
+			var folderID int64
+			if folderUidStr, ok := body["folderUid"].(string); ok && folderUidStr != "" {
+				// Parse UID like "uid-100" to get numeric ID
+				fmt.Sscanf(folderUidStr, "uid-%d", &folderID)
+			} else if fid, ok := body["folderId"].(float64); ok {
+				// Fallback for legacy folderId
+				folderID = int64(fid)
+			}
 			dash["folderId"] = folderID
 			dashboards[uid] = dash
 			json.NewEncoder(w).Encode(map[string]any{"id": 100, "uid": uid, "status": "success"})

--- a/loaders/dashboards/pkg/controller/dashboard_controller_integration_test.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller_integration_test.go
@@ -144,18 +144,28 @@ func TestIntegrationGrafanaDashboardController(t *testing.T) {
 			dash, _ := body["dashboard"].(map[string]any)
 			uid := dash["uid"].(string)
 
-			// Grafana 13+ uses folderUid instead of folderId
-			var folderID int64
+			// Grafana 13+ uses folderUid (opaque string) instead of folderId (int64)
+			// The mock needs to preserve the UID as-is and look up the corresponding folder
+			responsePayload := map[string]any{"id": 100, "uid": uid, "status": "success"}
 			if folderUidStr, ok := body["folderUid"].(string); ok && folderUidStr != "" {
-				// Parse UID like "uid-100" to get numeric ID
-				fmt.Sscanf(folderUidStr, "uid-%d", &folderID)
+				// Find the folder ID by UID for internal tracking
+				var folderID int64
+				for id := range folders {
+					expectedUID := fmt.Sprintf("uid-%d", id)
+					if expectedUID == folderUidStr {
+						folderID = id
+						break
+					}
+				}
+				dash["folderId"] = folderID
+				dash["folderUid"] = folderUidStr
+				responsePayload["folderUid"] = folderUidStr
 			} else if fid, ok := body["folderId"].(float64); ok {
-				// Fallback for legacy folderId
-				folderID = int64(fid)
+				// Legacy folderId fallback (should not be used by new code)
+				dash["folderId"] = int64(fid)
 			}
-			dash["folderId"] = folderID
 			dashboards[uid] = dash
-			json.NewEncoder(w).Encode(map[string]any{"id": 100, "uid": uid, "status": "success"})
+			json.NewEncoder(w).Encode(responsePayload)
 			return
 		}
 

--- a/loaders/dashboards/pkg/controller/dashboard_controller_test.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller_test.go
@@ -65,7 +65,7 @@ func (m *mockGrafanaClient) DeleteDashboard(ctx context.Context, uid string) err
 	return m.deleteDashErr
 }
 
-func (m *mockGrafanaClient) CreateOrUpdateDashboard(ctx context.Context, dashboard map[string]any, folderID int64) (int64, error) {
+func (m *mockGrafanaClient) CreateOrUpdateDashboard(ctx context.Context, dashboard map[string]any, folderUID string) (int64, error) {
 	m.createDashCalled++
 	m.lastDashboard = dashboard
 	if m.createErrFunc != nil {
@@ -360,15 +360,15 @@ func TestIsDesiredDashboardConfigmap(t *testing.T) {
 	}
 }
 
-func TestFindCustomFolderID(t *testing.T) {
+func TestFindCustomFolderUID(t *testing.T) {
 	c, mock := newTestController(t, "default")
-	mock.folders = []grafanaFolder{{ID: 1, Title: "Custom"}}
+	mock.folders = []grafanaFolder{{ID: 1, UID: "test-uid", Title: "Custom"}}
 
-	if c.findCustomFolderID(t.Context(), "Custom") != 1 {
-		t.Error("expected 1")
+	if c.findCustomFolderUID(t.Context(), "Custom") != "test-uid" {
+		t.Error("expected test-uid")
 	}
-	if c.findCustomFolderID(t.Context(), "Unknown") != 0 {
-		t.Error("expected 0")
+	if c.findCustomFolderUID(t.Context(), "Unknown") != "" {
+		t.Error("expected empty string")
 	}
 }
 
@@ -563,9 +563,9 @@ func TestCreateCustomFolder_PermissionsRetry(t *testing.T) {
 	c, mock := newTestController(t, "default")
 	mock.permResp = false // Force permission failure
 
-	id := c.createCustomFolder(ctx, "RetryFolder")
-	if id != 0 {
-		t.Errorf("expected 0 ID, got %v", id)
+	uid := c.createCustomFolder(ctx, "RetryFolder")
+	if uid != "" {
+		t.Errorf("expected empty UID, got %v", uid)
 	}
 	if mock.deleteFolderCalled["test"] != 1 {
 		t.Error("expected folder deletion on permission failure")

--- a/loaders/dashboards/pkg/controller/grafana_client.go
+++ b/loaders/dashboards/pkg/controller/grafana_client.go
@@ -85,7 +85,7 @@ type grafanaFolder struct {
 type GrafanaClient interface {
 	ListAllDashboards(ctx context.Context) ([]grafanaDashboard, error)
 	DeleteDashboard(ctx context.Context, uid string) error
-	CreateOrUpdateDashboard(ctx context.Context, dashboard map[string]any, folderID int64) (int64, error)
+	CreateOrUpdateDashboard(ctx context.Context, dashboard map[string]any, folderUID string) (int64, error)
 	SetHomeDashboard(ctx context.Context, id int64) error
 
 	ListFolders(ctx context.Context) ([]grafanaFolder, error)
@@ -124,14 +124,17 @@ func (g *grafanaClient) DeleteDashboard(ctx context.Context, uid string) error {
 	return nil
 }
 
-func (g *grafanaClient) CreateOrUpdateDashboard(ctx context.Context, dashboard map[string]any, folderID int64) (int64, error) {
+func (g *grafanaClient) CreateOrUpdateDashboard(ctx context.Context, dashboard map[string]any, folderUID string) (int64, error) {
 	data := map[string]any{
-		"folderId": folderID,
 		// We always overwrite to enforce the "Stateless Exclusive Ownership" model.
 		// Kubernetes is the absolute source of truth; any manual changes in the
 		// Grafana UI are intentionally disregarded and overwritten.
 		"overwrite": true,
 		"dashboard": dashboard,
+	}
+	// Only set folderUid if non-empty (Grafana 13+ uses folderUid instead of folderId)
+	if folderUID != "" {
+		data["folderUid"] = folderUID
 	}
 	b, err := json.Marshal(data)
 	if err != nil {

--- a/loaders/dashboards/pkg/controller/grafana_client_test.go
+++ b/loaders/dashboards/pkg/controller/grafana_client_test.go
@@ -81,7 +81,7 @@ func TestGrafanaClient(t *testing.T) {
 			defer ts.Close()
 
 			client := &grafanaClient{uri: ts.URL}
-			_, err := client.CreateOrUpdateDashboard(ctx, map[string]any{}, 0)
+			_, err := client.CreateOrUpdateDashboard(ctx, map[string]any{}, "")
 			if err == nil {
 				t.Fatal("expected error")
 			}
@@ -99,7 +99,7 @@ func TestGrafanaClient(t *testing.T) {
 			defer ts.Close()
 
 			client := &grafanaClient{uri: ts.URL}
-			_, err := client.CreateOrUpdateDashboard(ctx, map[string]any{}, 0)
+			_, err := client.CreateOrUpdateDashboard(ctx, map[string]any{}, "")
 			if err == nil {
 				t.Fatal("expected error")
 			}


### PR DESCRIPTION
## Summary
Fixes dashboard folder assignment after Grafana 13.1.0 upgrade by changing from `folderId` (int64) to `folderUid` (string) in the dashboard creation API.

Fixes: [ACM-39748](https://redhat.atlassian.net/browse/ACM-39748)

## Problem
After upgrading to Grafana 13.1.0, the e2e test **RHACM4K-1705** fails because dashboards are not being assigned to their configured folders:
- The "Alert Analysis" dashboard cannot be found in the "Alerts" folder
- All dashboards end up in the "General" folder instead
- Configured folders are detected as empty and deleted every 10 minutes

## Root Cause
Grafana 13.x changed the dashboard creation API to require `folderUid` (string) instead of `folderId` (int64). The dashboard loader was still sending `folderId`, which Grafana 13.x silently ignores, causing all dashboards to be created without folder assignment (defaults to folderId: 0 / "General" folder).

**Verified via API testing on Grafana 13.1.0:**
- Using `folderId`: Dashboard created in "General" folder ❌
- Using `folderUid`: Dashboard created in correct folder ✅

## Changes
- **grafana_client.go**: Changed `CreateOrUpdateDashboard` signature from `folderID int64` to `folderUID string`, updated API payload to use `folderUid`
- **dashboard_controller.go**: 
  - Renamed `findCustomFolderID` → `findCustomFolderUID` to return UIDs
  - Updated `createCustomFolder` to return `folder.UID` instead of `folder.ID`
  - Modified `cleanupFolderIfEmpty` to use UID-based folder lookup
- **Test files**: Updated mocks and integration tests to match new signatures

## Testing
- ✅ All unit tests pass
- ✅ Integration test mock updated to handle both `folderUid` (new) and `folderId` (legacy)
- ✅ Code compiles and linting passes
- ✅ Live API behavior verified on cluster with Grafana 13.1.0

This fix ensures dashboards are properly assigned to their folders in Grafana 13.x, which should make the RHACM4K-1705 e2e test pass.

[ACM-39748]: https://redhat.atlassian.net/browse/ACM-39748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard organization by using stable folder UIDs when creating, updating, locating, and removing dashboards.
  * Prevented failures when folders are already missing during cleanup.
  * Preserved compatibility with existing numeric folder references where supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->