### PR TITLE
Add raw metrics collection support for mcoa - #2579 - CLONE

### DIFF
--- a/loaders/dashboards/pkg/controller/dashboard_controller.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -450,40 +449,40 @@ func (c *GrafanaDashboardController) cleanupOrphanDashboards(ctx context.Context
 	return nil
 }
 
-func (c *GrafanaDashboardController) findCustomFolderID(ctx context.Context, folderTitle string) int64 {
+func (c *GrafanaDashboardController) findCustomFolderUID(ctx context.Context, folderTitle string) string {
 	folders, err := c.grafana.ListFolders(ctx)
 	if err != nil {
 		klog.ErrorS(err, "failed to list folders")
-		return 0
+		return ""
 	}
 
 	for _, folder := range folders {
 		if folder.Title == folderTitle {
-			return folder.ID
+			return folder.UID
 		}
 	}
-	return 0
+	return ""
 }
 
-func (c *GrafanaDashboardController) createCustomFolder(ctx context.Context, folderTitle string) int64 {
-	folderID := c.findCustomFolderID(ctx, folderTitle)
-	if folderID != 0 {
-		return folderID
+func (c *GrafanaDashboardController) createCustomFolder(ctx context.Context, folderTitle string) string {
+	folderUID := c.findCustomFolderUID(ctx, folderTitle)
+	if folderUID != "" {
+		return folderUID
 	}
 
 	folder, err := c.grafana.CreateFolder(ctx, folderTitle)
 	if err != nil {
 		// Handle race condition
-		if retryID := c.findCustomFolderID(ctx, folderTitle); retryID != 0 {
-			return retryID
+		if retryUID := c.findCustomFolderUID(ctx, folderTitle); retryUID != "" {
+			return retryUID
 		}
 		klog.ErrorS(err, "failed to create custom folder", "folderTitle", folderTitle)
-		return 0
+		return ""
 	}
 
 	select {
 	case <-ctx.Done():
-		return 0
+		return ""
 	case <-time.After(folderCreationDelay):
 	}
 
@@ -491,40 +490,49 @@ func (c *GrafanaDashboardController) createCustomFolder(ctx context.Context, fol
 	hasPerm, err := c.grafana.HasPermissions(ctx, folder.UID)
 	if err != nil {
 		klog.ErrorS(err, "failed to check folder permissions", "folderTitle", folderTitle)
-		return 0
+		return ""
 	}
 	if !hasPerm {
 		klog.InfoS("failed to set permissions for folder. Deleting folder and retrying later.", "folderTitle", folderTitle)
 		select {
 		case <-ctx.Done():
-			return 0
+			return ""
 		case <-time.After(permissionsRetryDelay):
 		}
 
 		if err := c.grafana.DeleteFolder(ctx, folder.UID); err != nil {
 			klog.ErrorS(err, "failed to delete folder during retry", "folderUID", folder.UID)
 		}
-		return 0
+		return ""
 	}
 
-	return folder.ID
+	return folder.UID
 }
 
 func (c *GrafanaDashboardController) cleanupFolderIfEmpty(ctx context.Context, folderTitle string) error {
 	if folderTitle == "" {
 		return nil
 	}
-	folderID := c.findCustomFolderID(ctx, folderTitle)
-	if folderID == 0 {
+	folderUID := c.findCustomFolderUID(ctx, folderTitle)
+	if folderUID == "" {
 		return nil
 	}
-	folder, err := c.grafana.GetFolderByID(ctx, folderID)
+	// For Grafana 13+, we use UID-based lookup. If GetFolderByUID doesn't exist,
+	// we can list folders and find by UID
+	folders, err := c.grafana.ListFolders(ctx)
 	if err != nil {
-		var gErr *GrafanaError
-		if errors.As(err, &gErr) && gErr.Status == http.StatusNotFound {
-			return nil // Folder already gone, nothing to clean
+		return fmt.Errorf("failed to list folders for cleanup check: %w", err)
+	}
+
+	var folder *grafanaFolder
+	for _, f := range folders {
+		if f.UID == folderUID {
+			folder = &f
+			break
 		}
-		return fmt.Errorf("failed to check folder status in Grafana: %w", err)
+	}
+	if folder == nil {
+		return nil // Folder already gone, nothing to clean
 	}
 
 	// Check if the folder is empty. Grafana's search index is eventually consistent,
@@ -611,12 +619,12 @@ func (c *GrafanaDashboardController) updateDashboard(ctx context.Context, newObj
 	}
 	defer c.unlockReconcile()
 
-	var folderID int64
+	var folderUID string
 	folderTitle := getDashboardCustomFolderTitle(newObj)
 	if folderTitle != "" {
-		folderID = c.createCustomFolder(ctx, folderTitle)
-		if folderID == 0 {
-			return errors.New("failed to get folder id")
+		folderUID = c.createCustomFolder(ctx, folderTitle)
+		if folderUID == "" {
+			return errors.New("failed to get folder uid")
 		}
 	}
 
@@ -661,7 +669,7 @@ func (c *GrafanaDashboardController) updateDashboard(ctx context.Context, newObj
 		dashboard["uid"] = uid
 		delete(dashboard, "id")
 
-		id, err := c.grafana.CreateOrUpdateDashboard(ctx, dashboard, folderID)
+		id, err := c.grafana.CreateOrUpdateDashboard(ctx, dashboard, folderUID)
 		if err != nil {
 			var gErr *GrafanaError
 			if errors.As(err, &gErr) {

--- a/loaders/dashboards/pkg/controller/dashboard_controller_integration_test.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller_integration_test.go
@@ -143,7 +143,16 @@ func TestIntegrationGrafanaDashboardController(t *testing.T) {
 			json.NewDecoder(r.Body).Decode(&body)
 			dash, _ := body["dashboard"].(map[string]any)
 			uid := dash["uid"].(string)
-			folderID := int64(body["folderId"].(float64))
+
+			// Grafana 13+ uses folderUid instead of folderId
+			var folderID int64
+			if folderUidStr, ok := body["folderUid"].(string); ok && folderUidStr != "" {
+				// Parse UID like "uid-100" to get numeric ID
+				fmt.Sscanf(folderUidStr, "uid-%d", &folderID)
+			} else if fid, ok := body["folderId"].(float64); ok {
+				// Fallback for legacy folderId
+				folderID = int64(fid)
+			}
 			dash["folderId"] = folderID
 			dashboards[uid] = dash
 			json.NewEncoder(w).Encode(map[string]any{"id": 100, "uid": uid, "status": "success"})

--- a/loaders/dashboards/pkg/controller/dashboard_controller_integration_test.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller_integration_test.go
@@ -144,18 +144,28 @@ func TestIntegrationGrafanaDashboardController(t *testing.T) {
 			dash, _ := body["dashboard"].(map[string]any)
 			uid := dash["uid"].(string)
 
-			// Grafana 13+ uses folderUid instead of folderId
-			var folderID int64
+			// Grafana 13+ uses folderUid (opaque string) instead of folderId (int64)
+			// The mock needs to preserve the UID as-is and look up the corresponding folder
+			responsePayload := map[string]any{"id": 100, "uid": uid, "status": "success"}
 			if folderUidStr, ok := body["folderUid"].(string); ok && folderUidStr != "" {
-				// Parse UID like "uid-100" to get numeric ID
-				fmt.Sscanf(folderUidStr, "uid-%d", &folderID)
+				// Find the folder ID by UID for internal tracking
+				var folderID int64
+				for id := range folders {
+					expectedUID := fmt.Sprintf("uid-%d", id)
+					if expectedUID == folderUidStr {
+						folderID = id
+						break
+					}
+				}
+				dash["folderId"] = folderID
+				dash["folderUid"] = folderUidStr
+				responsePayload["folderUid"] = folderUidStr
 			} else if fid, ok := body["folderId"].(float64); ok {
-				// Fallback for legacy folderId
-				folderID = int64(fid)
+				// Legacy folderId fallback (should not be used by new code)
+				dash["folderId"] = int64(fid)
 			}
-			dash["folderId"] = folderID
 			dashboards[uid] = dash
-			json.NewEncoder(w).Encode(map[string]any{"id": 100, "uid": uid, "status": "success"})
+			json.NewEncoder(w).Encode(responsePayload)
 			return
 		}
 

--- a/loaders/dashboards/pkg/controller/dashboard_controller_test.go
+++ b/loaders/dashboards/pkg/controller/dashboard_controller_test.go
@@ -65,7 +65,7 @@ func (m *mockGrafanaClient) DeleteDashboard(ctx context.Context, uid string) err
 	return m.deleteDashErr
 }
 
-func (m *mockGrafanaClient) CreateOrUpdateDashboard(ctx context.Context, dashboard map[string]any, folderID int64) (int64, error) {
+func (m *mockGrafanaClient) CreateOrUpdateDashboard(ctx context.Context, dashboard map[string]any, folderUID string) (int64, error) {
 	m.createDashCalled++
 	m.lastDashboard = dashboard
 	if m.createErrFunc != nil {
@@ -360,15 +360,15 @@ func TestIsDesiredDashboardConfigmap(t *testing.T) {
 	}
 }
 
-func TestFindCustomFolderID(t *testing.T) {
+func TestFindCustomFolderUID(t *testing.T) {
 	c, mock := newTestController(t, "default")
-	mock.folders = []grafanaFolder{{ID: 1, Title: "Custom"}}
+	mock.folders = []grafanaFolder{{ID: 1, UID: "test-uid", Title: "Custom"}}
 
-	if c.findCustomFolderID(t.Context(), "Custom") != 1 {
-		t.Error("expected 1")
+	if c.findCustomFolderUID(t.Context(), "Custom") != "test-uid" {
+		t.Error("expected test-uid")
 	}
-	if c.findCustomFolderID(t.Context(), "Unknown") != 0 {
-		t.Error("expected 0")
+	if c.findCustomFolderUID(t.Context(), "Unknown") != "" {
+		t.Error("expected empty string")
 	}
 }
 
@@ -563,9 +563,9 @@ func TestCreateCustomFolder_PermissionsRetry(t *testing.T) {
 	c, mock := newTestController(t, "default")
 	mock.permResp = false // Force permission failure
 
-	id := c.createCustomFolder(ctx, "RetryFolder")
-	if id != 0 {
-		t.Errorf("expected 0 ID, got %v", id)
+	uid := c.createCustomFolder(ctx, "RetryFolder")
+	if uid != "" {
+		t.Errorf("expected empty UID, got %v", uid)
 	}
 	if mock.deleteFolderCalled["test"] != 1 {
 		t.Error("expected folder deletion on permission failure")

--- a/loaders/dashboards/pkg/controller/grafana_client.go
+++ b/loaders/dashboards/pkg/controller/grafana_client.go
@@ -85,7 +85,7 @@ type grafanaFolder struct {
 type GrafanaClient interface {
 	ListAllDashboards(ctx context.Context) ([]grafanaDashboard, error)
 	DeleteDashboard(ctx context.Context, uid string) error
-	CreateOrUpdateDashboard(ctx context.Context, dashboard map[string]any, folderID int64) (int64, error)
+	CreateOrUpdateDashboard(ctx context.Context, dashboard map[string]any, folderUID string) (int64, error)
 	SetHomeDashboard(ctx context.Context, id int64) error
 
 	ListFolders(ctx context.Context) ([]grafanaFolder, error)
@@ -124,14 +124,17 @@ func (g *grafanaClient) DeleteDashboard(ctx context.Context, uid string) error {
 	return nil
 }
 
-func (g *grafanaClient) CreateOrUpdateDashboard(ctx context.Context, dashboard map[string]any, folderID int64) (int64, error) {
+func (g *grafanaClient) CreateOrUpdateDashboard(ctx context.Context, dashboard map[string]any, folderUID string) (int64, error) {
 	data := map[string]any{
-		"folderId": folderID,
 		// We always overwrite to enforce the "Stateless Exclusive Ownership" model.
 		// Kubernetes is the absolute source of truth; any manual changes in the
 		// Grafana UI are intentionally disregarded and overwritten.
 		"overwrite": true,
 		"dashboard": dashboard,
+	}
+	// Only set folderUid if non-empty (Grafana 13+ uses folderUid instead of folderId)
+	if folderUID != "" {
+		data["folderUid"] = folderUID
 	}
 	b, err := json.Marshal(data)
 	if err != nil {

--- a/loaders/dashboards/pkg/controller/grafana_client_test.go
+++ b/loaders/dashboards/pkg/controller/grafana_client_test.go
@@ -81,7 +81,7 @@ func TestGrafanaClient(t *testing.T) {
 			defer ts.Close()
 
 			client := &grafanaClient{uri: ts.URL}
-			_, err := client.CreateOrUpdateDashboard(ctx, map[string]any{}, 0)
+			_, err := client.CreateOrUpdateDashboard(ctx, map[string]any{}, "")
 			if err == nil {
 				t.Fatal("expected error")
 			}
@@ -99,7 +99,7 @@ func TestGrafanaClient(t *testing.T) {
 			defer ts.Close()
 
 			client := &grafanaClient{uri: ts.URL}
-			_, err := client.CreateOrUpdateDashboard(ctx, map[string]any{}, 0)
+			_, err := client.CreateOrUpdateDashboard(ctx, map[string]any{}, "")
 			if err == nil {
 				t.Fatal("expected error")
 			}

--- a/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
+++ b/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
@@ -7,106 +7,643 @@ package mcoa
 import (
 	"context"
 	"fmt"
+	"maps"
+	"net/url"
+	"slices"
+	"strings"
 
 	cmomanifests "github.com/openshift/cluster-monitoring-operator/pkg/manifests"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	prometheusv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
+	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/remotewrite"
+	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/yaml"
 )
 
-var cmoConfigConflictsTotal = promauto.With(metrics.Registry).NewCounter(
+const (
+	// uwlMonitoringConfigDataKey is the data key mandated by the user-workload-monitoring ConfigMap schema
+	uwlMonitoringConfigDataKey = "config.yaml"
+
+	// labelKeyComponent is the standard metadata label key for Kubernetes component discovery
+	labelKeyComponent = "app.kubernetes.io/component"
+
+	// mcoaRawNamePrefix is the unique name prefix assigned to MCOA raw metrics RemoteWrites
+	mcoaRawNamePrefix = "mcoa-raw-"
+
+	// Package-level constants for load-bearing component labels
+	platformMetricsCollectorRawComponent     = "platform-metrics-collector-raw"
+	userWorkloadMetricsCollectorRawComponent = "user-workload-metrics-collector-raw"
+	platformMetricsCollectorComponent        = "platform-metrics-collector"
+	userWorkloadMetricsCollectorComponent    = "user-workload-metrics-collector"
+
+	// Default bootstrap YAML templates to avoid magic strings
+	defaultCMOConfigYAML = "prometheusK8s: {}"
+	defaultUWLConfigYAML = "prometheus: {}"
+)
+
+var cmoConfigReconcilesTotal = promauto.With(metrics.Registry).NewCounter(
 	prometheus.CounterOpts{
-		Name: "mcoa_cmo_config_conflicts_total",
-		Help: "Total number of conflicts detected in the cluster-monitoring-config ConfigMap.",
+		Name: "mcoa_cmo_config_reconciles_total",
+		Help: "Total number of reconciles/updates performed on the cluster-monitoring-config ConfigMap.",
 	},
 )
 
-func (r *MCOAAgentReconciler) reconcileCMO(ctx context.Context, req client.ObjectKey) error {
-	// If Alertmanager forwarding is disabled, we ensure our config is removed.
-	if r.AlertmanagerEndpoint == "" {
-		r.Log.Info("Alertmanager endpoint is empty, ensuring Hub configuration is removed")
-		return observabilityendpoint.RevertClusterMonitoringConfig(ctx, r.Client, r.CASecret, r.ClusterName)
-	}
+var uwlConfigReconcilesTotal = promauto.With(metrics.Registry).NewCounter(
+	prometheus.CounterOpts{
+		Name: "mcoa_uwl_config_reconciles_total",
+		Help: "Total number of reconciles/updates performed on the user-workload-monitoring-config ConfigMap.",
+	},
+)
 
-	cm := &corev1.ConfigMap{}
-	err := r.Get(ctx, req, cm)
+func (r *MCOAAgentReconciler) ReconcileCMOPlatformConfig(ctx context.Context) error {
+	alertmanagerURL := r.HubAlertmanagerURL
+
+	scrapeConfigs, err := r.listScrapeConfigsByComponent(ctx, platformMetricsCollectorRawComponent)
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
-		cm = nil
+		return err
 	}
 
-	// We trigger a repair if the config is missing or corrupted.
-	if cm != nil {
-		if r.detectConflict(cm) {
-			cmoConfigConflictsTotal.Inc()
-			r.Recorder.Eventf(
-				cm, nil, corev1.EventTypeWarning, "ConfigConflict", "ConfigReapply",
-				"Detected external mutation overwriting Alertmanager configuration. Re-applying Hub Alertmanager config.",
-			)
-			r.Log.Info("Detected conflict in CMO ConfigMap, re-applying configuration", "name", cm.Name, "namespace", cm.Namespace)
+	// Fetch PrometheusAgent dynamically to read remoteWrite config
+	agent, err := r.fetchPrometheusAgentByComponent(ctx, platformMetricsCollectorComponent)
+	if err != nil {
+		return err
+	}
+
+	cmoKey := client.ObjectKey{
+		Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+		Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+	}
+
+	cm, isCreate, err := r.fetchCMOConfigMap(ctx, cmoKey, agent, alertmanagerURL, len(scrapeConfigs), r.EnablePlatformAlertForwarding)
+	if err != nil || cm == nil {
+		return err
+	}
+
+	configYAML := cm.Data[observabilityendpoint.ClusterMonitoringConfigDataKey]
+	parsed := &cmomanifests.ClusterMonitoringConfiguration{}
+	if err := yaml.Unmarshal([]byte(configYAML), parsed); err != nil {
+		return fmt.Errorf("failed to unmarshal CMO config: %w", err)
+	}
+
+	modified := isCreate
+
+	// Ensure PrometheusK8sConfig is initialized if we are deploying configurations
+	if (agent != nil || alertmanagerURL != "") && parsed.PrometheusK8sConfig == nil {
+		parsed.PrometheusK8sConfig = &cmomanifests.PrometheusK8sConfig{}
+	}
+
+	if parsed.PrometheusK8sConfig != nil {
+		// 1. Reconcile External Labels (only when alert forwarding is enabled)
+		hasAlertForwarding := alertmanagerURL != "" && r.EnablePlatformAlertForwarding
+		if r.reconcileExternalLabels(parsed.PrometheusK8sConfig, hasAlertForwarding) {
+			modified = true
+		}
+
+		// 2. Reconcile Alertmanager Configurations
+		cleanAm, modifiedAm := r.reconcileAlertmanagerConfigs(parsed.PrometheusK8sConfig.AlertmanagerConfigs, alertmanagerURL, r.EnablePlatformAlertForwarding)
+		if modifiedAm {
+			parsed.PrometheusK8sConfig.AlertmanagerConfigs = cleanAm
+			modified = true
+
+			// Emit event if we had to update/overwrite Alertmanager configs in an existing ConfigMap
+			if !isCreate && alertmanagerURL != "" {
+				if r.Recorder != nil {
+					r.Recorder.Eventf(
+						cm, nil, corev1.EventTypeWarning, "ConfigConflict", "ConfigReapply",
+						"Detected external mutation overwriting Alertmanager configuration. Re-applying Hub Alertmanager config.",
+					)
+				}
+				r.Log.Info("Detected conflict in Alertmanager configuration, re-applying", "name", cm.Name, "namespace", cm.Namespace)
+			}
+		}
+
+		// 3. Reconcile Remote Writes
+		existingRemoteWrites := parsed.PrometheusK8sConfig.RemoteWrite
+		cleanRemoteWrite := r.reconcileRemoteWrites(existingRemoteWrites, scrapeConfigs, agent)
+		if !equality.Semantic.DeepEqual(cleanRemoteWrite, existingRemoteWrites) {
+			parsed.PrometheusK8sConfig.RemoteWrite = cleanRemoteWrite
+			modified = true
 		}
 	}
 
-	_, err = observabilityendpoint.CreateOrUpdateCMOConfig(
-		ctx,
-		r.Client,
-		r.ClusterID,
-		r.ClusterName,
-		r.AlertmanagerEndpoint,
-		r.CASecret,
-		r.CertSecret,
-		r.AccessorSecret,
-		"", // Pass empty namespace since MCOA handles cleanup dynamically in the reconciler and bypasses legacy persistent configmap markers.
-	)
+	if !modified {
+		return nil
+	}
 
+	updatedYAML, err := yaml.Marshal(parsed)
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated CMO config: %w", err)
+	}
+
+	if isCreate {
+		err := r.createConfigMap(ctx, cm, observabilityendpoint.ClusterMonitoringConfigDataKey, string(updatedYAML))
+		if err == nil {
+			cmoConfigReconcilesTotal.Inc()
+		}
+		return err
+	}
+	err = r.updateConfigMap(ctx, cm, observabilityendpoint.ClusterMonitoringConfigDataKey, string(updatedYAML))
+	if err == nil {
+		cmoConfigReconcilesTotal.Inc()
+	}
 	return err
 }
 
-func (r *MCOAAgentReconciler) reconcileUWLConfig(ctx context.Context) error {
-	if err := observabilityendpoint.CreateOrUpdateUserWorkloadMonitoringConfig(
-		ctx,
-		r.Client,
-		r.AlertmanagerEndpoint,
-		!r.EnableUWLAlertForwarding, // uwmAlertingDisabled
-		r.CASecret,
-		r.CertSecret,
-		r.AccessorSecret,
-	); err != nil {
-		return fmt.Errorf("failed to create or update user workload monitoring config: %w", err)
+func (r *MCOAAgentReconciler) ReconcileCMOUWLConfig(ctx context.Context) error {
+	alertmanagerURL := r.HubAlertmanagerURL
+
+	scrapeConfigs, err := r.listScrapeConfigsByComponent(ctx, userWorkloadMetricsCollectorRawComponent)
+	if err != nil {
+		return err
+	}
+
+	// Fetch PrometheusAgent dynamically
+	agent, err := r.fetchPrometheusAgentByComponent(ctx, userWorkloadMetricsCollectorComponent)
+	if err != nil {
+		return err
+	}
+
+	isCreate := false
+	cm := &corev1.ConfigMap{}
+	err = r.Get(ctx, client.ObjectKey{
+		Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+		Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+	}, cm)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to get UWL configmap: %w", err)
+		}
+		if (agent == nil && (alertmanagerURL == "" || !r.EnableUWLAlertForwarding)) && len(scrapeConfigs) == 0 {
+			return nil
+		}
+		isCreate = true
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+				Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+			},
+			Data: map[string]string{
+				uwlMonitoringConfigDataKey: defaultUWLConfigYAML,
+			},
+		}
+	}
+
+	configYAML := cm.Data[uwlMonitoringConfigDataKey]
+	parsed := &cmomanifests.UserWorkloadConfiguration{}
+	if err := yaml.Unmarshal([]byte(configYAML), parsed); err != nil {
+		return fmt.Errorf("failed to unmarshal UWL config: %w", err)
+	}
+
+	modified := isCreate
+
+	// Reconcile UWL Alertmanager forwarding
+	var existingAM []cmomanifests.AdditionalAlertmanagerConfig
+	if parsed.Prometheus != nil {
+		existingAM = parsed.Prometheus.AlertmanagerConfigs
+	}
+	cleanAm, modifiedAm := r.reconcileAlertmanagerConfigs(existingAM, alertmanagerURL, r.EnableUWLAlertForwarding)
+	if modifiedAm {
+		if parsed.Prometheus == nil {
+			parsed.Prometheus = &cmomanifests.PrometheusRestrictedConfig{}
+		}
+		parsed.Prometheus.AlertmanagerConfigs = cleanAm
+		modified = true
+	}
+
+	// Reconcile raw metrics RemoteWrite
+	var existingRemoteWrites []cmomanifests.RemoteWriteSpec
+	if parsed.Prometheus != nil {
+		existingRemoteWrites = parsed.Prometheus.RemoteWrite
+	}
+
+	cleanRemoteWrite := r.reconcileRemoteWrites(existingRemoteWrites, scrapeConfigs, agent)
+
+	if !equality.Semantic.DeepEqual(cleanRemoteWrite, existingRemoteWrites) {
+		if parsed.Prometheus == nil {
+			parsed.Prometheus = &cmomanifests.PrometheusRestrictedConfig{}
+		}
+		parsed.Prometheus.RemoteWrite = cleanRemoteWrite
+		modified = true
+	}
+
+	if !modified {
+		return nil
+	}
+
+	updatedYAML, err := yaml.Marshal(parsed)
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated UWL config: %w", err)
+	}
+
+	if isCreate {
+		err := r.createConfigMap(ctx, cm, uwlMonitoringConfigDataKey, string(updatedYAML))
+		if err == nil {
+			uwlConfigReconcilesTotal.Inc()
+		}
+		return err
+	}
+	err = r.updateConfigMap(ctx, cm, uwlMonitoringConfigDataKey, string(updatedYAML))
+	if err == nil {
+		uwlConfigReconcilesTotal.Inc()
+	}
+	return err
+}
+
+func (r *MCOAAgentReconciler) fetchCMOConfigMap(
+	ctx context.Context,
+	key client.ObjectKey,
+	agent *prometheusv1alpha1.PrometheusAgent,
+	alertmanagerURL string,
+	numScrapeConfigs int,
+	enablePlatformAlertForwarding bool,
+) (*corev1.ConfigMap, bool, error) {
+	cm := &corev1.ConfigMap{}
+	err := r.Get(ctx, key, cm)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, false, fmt.Errorf("failed to get CMO configmap %s/%s: %w", key.Namespace, key.Name, err)
+		}
+		if agent == nil && (alertmanagerURL == "" || !enablePlatformAlertForwarding) && numScrapeConfigs == 0 {
+			return nil, false, nil
+		}
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      key.Name,
+				Namespace: key.Namespace,
+			},
+			Data: map[string]string{
+				observabilityendpoint.ClusterMonitoringConfigDataKey: defaultCMOConfigYAML,
+			},
+		}, true, nil
+	}
+	return cm, false, nil
+}
+
+func (r *MCOAAgentReconciler) reconcileExternalLabels(cfg *cmomanifests.PrometheusK8sConfig, retainLabels bool) bool {
+	if cfg == nil {
+		return false
+	}
+	if !retainLabels {
+		if cfg.ExternalLabels == nil {
+			return false
+		}
+		modified := false
+		if _, exists := cfg.ExternalLabels[operatorconfig.ClusterLabelKeyForAlerts]; exists {
+			delete(cfg.ExternalLabels, operatorconfig.ClusterLabelKeyForAlerts)
+			modified = true
+		}
+		if _, exists := cfg.ExternalLabels[operatorconfig.ClusterNameLabelKeyForAlerts]; exists {
+			delete(cfg.ExternalLabels, operatorconfig.ClusterNameLabelKeyForAlerts)
+			modified = true
+		}
+		return modified
+	}
+
+	modified := false
+	if cfg.ExternalLabels == nil {
+		cfg.ExternalLabels = make(map[string]string)
+	}
+	if cfg.ExternalLabels[operatorconfig.ClusterLabelKeyForAlerts] != r.ClusterID {
+		cfg.ExternalLabels[operatorconfig.ClusterLabelKeyForAlerts] = r.ClusterID
+		modified = true
+	}
+	if r.ClusterName != "" {
+		if cfg.ExternalLabels[operatorconfig.ClusterNameLabelKeyForAlerts] != r.ClusterName {
+			cfg.ExternalLabels[operatorconfig.ClusterNameLabelKeyForAlerts] = r.ClusterName
+			modified = true
+		}
+	} else {
+		if _, exists := cfg.ExternalLabels[operatorconfig.ClusterNameLabelKeyForAlerts]; exists {
+			delete(cfg.ExternalLabels, operatorconfig.ClusterNameLabelKeyForAlerts)
+			modified = true
+		}
+	}
+	return modified
+}
+
+func (r *MCOAAgentReconciler) reconcileAlertmanagerConfigs(
+	existing []cmomanifests.AdditionalAlertmanagerConfig,
+	endpoint string,
+	enable bool,
+) ([]cmomanifests.AdditionalAlertmanagerConfig, bool) {
+	cleaned := slices.DeleteFunc(slices.Clone(existing), r.isOwnedAlertmanagerConfig)
+	if endpoint != "" && enable {
+		cleaned = append(cleaned, r.newAdditionalAlertmanagerConfig(endpoint))
+	}
+	sortAlertmanagerConfigs(cleaned)
+	sortedExisting := slices.Clone(existing)
+	sortAlertmanagerConfigs(sortedExisting)
+	return cleaned, !equality.Semantic.DeepEqual(cleaned, sortedExisting)
+}
+
+// sortAlertmanagerConfigs sorts in-place so that order differences introduced by other
+// controllers don't trigger spurious reconcile updates.
+func sortAlertmanagerConfigs(configs []cmomanifests.AdditionalAlertmanagerConfig) {
+	slices.SortFunc(configs, func(a, b cmomanifests.AdditionalAlertmanagerConfig) int {
+		if cmp := slices.Compare(a.StaticConfigs, b.StaticConfigs); cmp != 0 {
+			return cmp
+		}
+		if cmp := strings.Compare(a.Scheme, b.Scheme); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.PathPrefix, b.PathPrefix)
+	})
+}
+
+func (r *MCOAAgentReconciler) newAdditionalAlertmanagerConfig(endpoint string) cmomanifests.AdditionalAlertmanagerConfig {
+	config := cmomanifests.AdditionalAlertmanagerConfig{
+		Scheme:     "https",
+		PathPrefix: "/api/alertmanager/v2/default",
+		APIVersion: "v2",
+		TLSConfig: cmomanifests.TLSConfig{
+			CA: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: r.CASecret,
+				},
+				Key: "ca.crt",
+			},
+			Cert: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: r.CertSecret,
+				},
+				Key: "tls.crt",
+			},
+			Key: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: r.CertSecret,
+				},
+				Key: "tls.key",
+			},
+			InsecureSkipVerify: false,
+		},
+		BearerToken: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: r.AccessorSecret,
+			},
+			Key: "token",
+		},
+	}
+
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		r.Log.Info("failed to parse alertmanager endpoint, falling back to raw value", "endpoint", endpoint, "error", err)
+		config.StaticConfigs = []string{endpoint}
+		return config
+	}
+
+	if u.Host == "" {
+		config.StaticConfigs = []string{endpoint}
+		return config
+	}
+
+	if u.Path != "" {
+		config.PathPrefix = u.Path
+	}
+	config.StaticConfigs = []string{u.Host}
+	return config
+}
+
+func (r *MCOAAgentReconciler) isOwnedAlertmanagerConfig(am cmomanifests.AdditionalAlertmanagerConfig) bool {
+	if r.CASecret == "" || am.TLSConfig.CA == nil {
+		return false
+	}
+	if am.TLSConfig.CA.Name == r.CASecret {
+		return true
+	}
+	// Suffix-based fallback: the hub may rename the CA secret prefix across upgrades while
+	// keeping the hub-ID suffix (e.g. "-465e377c…") stable. The accessor secret has a stable
+	// base name, so stripping it from r.AccessorSecret yields the hub-ID suffix we can match on.
+	// This also makes MCOA e2e tests more resilient: if the legacy stack leaves behind an entry
+	// with a different CA prefix (e.g. obs-alertmanager-mtls-ca-<hubID>), MCOA can still
+	// identify and clean it up rather than leaving a stale forwarding config.
+	hubIDSuffix := strings.TrimPrefix(r.AccessorSecret, observabilityendpoint.HubAmAccessorSecretName)
+	if len(hubIDSuffix) <= 1 {
+		return false
+	}
+	return strings.HasSuffix(am.TLSConfig.CA.Name, hubIDSuffix)
+}
+
+func (r *MCOAAgentReconciler) listScrapeConfigsByComponent(ctx context.Context, component string) ([]prometheusv1alpha1.ScrapeConfig, error) {
+	if r.Namespace == "" {
+		return nil, nil
+	}
+	scrapeConfigs := &prometheusv1alpha1.ScrapeConfigList{}
+	err := r.List(ctx, scrapeConfigs, client.InNamespace(r.Namespace), client.MatchingLabels{
+		labelKeyComponent: component,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list raw scrape configs for component %s: %w", component, err)
+	}
+	return scrapeConfigs.Items, nil
+}
+
+func (r *MCOAAgentReconciler) reconcileRemoteWrites(
+	existing []cmomanifests.RemoteWriteSpec,
+	scrapeConfigs []prometheusv1alpha1.ScrapeConfig,
+	agent *prometheusv1alpha1.PrometheusAgent,
+) []cmomanifests.RemoteWriteSpec {
+	cleanRemoteWrite := r.filterRemoteWrites(existing)
+
+	if agent != nil && len(scrapeConfigs) > 0 {
+		slices.SortFunc(scrapeConfigs, func(a, b prometheusv1alpha1.ScrapeConfig) int {
+			return strings.Compare(a.Name, b.Name)
+		})
+		for _, sc := range scrapeConfigs {
+			rwSpecsTranspiled, err := remotewrite.Transpile(&sc, agent)
+			if err != nil {
+				// Log the error at Info level and skip to prevent a single malformed ScrapeConfig
+				// from blocking the deployment of other valid scrape configurations on the spoke.
+				r.Log.Info("Skipping malformed scrape config during remote write transpilation", "name", sc.Name, "error", err)
+				continue
+			}
+
+			for i, rwSpec := range rwSpecsTranspiled {
+				if rwSpec == nil {
+					continue
+				}
+				if rwSpec.URL == "" {
+					continue
+				}
+
+				suffix := fmt.Sprintf("%d", i)
+				if rwSpec.Name != nil {
+					suffix = *rwSpec.Name
+				}
+				name := mcoaRawNamePrefix + sc.Name + "-" + suffix
+				rwSpec.Name = &name
+
+				cleanRemoteWrite = append(cleanRemoteWrite, toCMORemoteWrite(rwSpec))
+			}
+		}
+	}
+	return cleanRemoteWrite
+}
+
+func (r *MCOAAgentReconciler) filterRemoteWrites(rws []cmomanifests.RemoteWriteSpec) []cmomanifests.RemoteWriteSpec {
+	clone := slices.Clone(rws)
+	return slices.DeleteFunc(clone, func(rw cmomanifests.RemoteWriteSpec) bool {
+		return strings.HasPrefix(rw.Name, mcoaRawNamePrefix)
+	})
+}
+
+func toCMORemoteWrite(rw *monitoringv1.RemoteWriteSpec) cmomanifests.RemoteWriteSpec {
+	if rw == nil {
+		return cmomanifests.RemoteWriteSpec{}
+	}
+	spec := cmomanifests.RemoteWriteSpec{
+		URL:                 rw.URL,
+		WriteRelabelConfigs: rw.WriteRelabelConfigs,
+		Headers:             maps.Clone(rw.Headers),
+	}
+
+	if rw.Name != nil {
+		spec.Name = *rw.Name
+	}
+
+	if rw.RemoteTimeout != nil {
+		spec.RemoteTimeout = string(*rw.RemoteTimeout)
+	}
+
+	if rw.BasicAuth != nil {
+		spec.BasicAuth = rw.BasicAuth.DeepCopy()
+	}
+
+	if rw.Authorization != nil {
+		spec.Authorization = &monitoringv1.SafeAuthorization{
+			Type: rw.Authorization.Type,
+		}
+		if rw.Authorization.Credentials != nil {
+			spec.Authorization.Credentials = rw.Authorization.Credentials.DeepCopy()
+		}
+	}
+
+	if rw.OAuth2 != nil {
+		spec.OAuth2 = rw.OAuth2.DeepCopy()
+	}
+
+	if rw.TLSConfig != nil {
+		// CAFile, CertFile, KeyFile from TLSConfig are intentionally omitted in standard Copy,
+		// but since cmomanifests.SafeTLSConfig supports only secret-reference TLS, we dynamically
+		// extract both the secret names (directories) and key names (filenames) from these path
+		// fields to reconstruct valid secret references dynamically.
+		spec.TLSConfig = rw.TLSConfig.SafeTLSConfig.DeepCopy()
+
+		caSecretName, caKeyName := extractSecretAndKey(rw.TLSConfig.CAFile)
+		if caSecretName != "" {
+			spec.TLSConfig.CA = monitoringv1.SecretOrConfigMap{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: caSecretName,
+					},
+					Key: caKeyName,
+				},
+			}
+		}
+
+		certSecretName, certKeyName := extractSecretAndKey(rw.TLSConfig.CertFile)
+		if certSecretName != "" {
+			spec.TLSConfig.Cert = monitoringv1.SecretOrConfigMap{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: certSecretName,
+					},
+					Key: certKeyName,
+				},
+			}
+		}
+
+		keySecretName, keyName := extractSecretAndKey(rw.TLSConfig.KeyFile)
+		if keySecretName != "" {
+			spec.TLSConfig.KeySecret = &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: keySecretName,
+				},
+				Key: keyName,
+			}
+		}
+	}
+
+	if rw.QueueConfig != nil {
+		spec.QueueConfig = rw.QueueConfig.DeepCopy()
+	}
+
+	if rw.ProxyURL != nil {
+		spec.ProxyURL = *rw.ProxyURL
+	}
+
+	return spec
+}
+
+func extractSecretAndKey(path string) (string, string) {
+	if path == "" {
+		return "", ""
+	}
+	parts := strings.Split(path, "/")
+	if len(parts) >= 2 {
+		secretName := parts[len(parts)-2]
+		keyName := parts[len(parts)-1]
+		return secretName, keyName
+	}
+	return "", ""
+}
+
+func (r *MCOAAgentReconciler) createConfigMap(ctx context.Context, cm *corev1.ConfigMap, dataKey, updatedYAML string) error {
+	cm = cm.DeepCopy()
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data[dataKey] = updatedYAML
+	if err := r.Create(ctx, cm); err != nil {
+		return fmt.Errorf("failed to create ConfigMap %s/%s: %w", cm.Namespace, cm.Name, err)
 	}
 	return nil
 }
 
-func (r *MCOAAgentReconciler) detectConflict(cm *corev1.ConfigMap) bool {
-	configYAML, ok := observabilityendpoint.HasClusterMonitoringConfigData(cm)
-	if !ok {
-		return true
+func (r *MCOAAgentReconciler) updateConfigMap(ctx context.Context, cm *corev1.ConfigMap, dataKey, updatedYAML string) error {
+	cm = cm.DeepCopy()
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
 	}
-
-	parsed := &cmomanifests.ClusterMonitoringConfiguration{}
-	if err := yaml.Unmarshal([]byte(configYAML), parsed); err != nil {
-		// Corrupted YAML is a conflict that needs repair.
-		return true
+	cm.Data[dataKey] = updatedYAML
+	if err := r.Update(ctx, cm); err != nil {
+		return fmt.Errorf("failed to update ConfigMap %s/%s: %w", cm.Namespace, cm.Name, err)
 	}
+	return nil
+}
 
-	if parsed.PrometheusK8sConfig == nil || parsed.PrometheusK8sConfig.AlertmanagerConfigs == nil {
-		return true
-	}
-
-	foundManaged := false
-	for _, amc := range parsed.PrometheusK8sConfig.AlertmanagerConfigs {
-		if observabilityendpoint.IsManaged(amc, r.CASecret) {
-			foundManaged = true
-			break
+// fetchPrometheusAgentByComponent lists PrometheusAgents by component label and returns
+// the first match. Returns (nil, nil) when zero agents exist or the CRD is not yet registered.
+func (r *MCOAAgentReconciler) fetchPrometheusAgentByComponent(
+	ctx context.Context, component string,
+) (*prometheusv1alpha1.PrometheusAgent, error) {
+	list := &prometheusv1alpha1.PrometheusAgentList{}
+	if err := r.List(ctx, list,
+		client.InNamespace(r.Namespace),
+		client.MatchingLabels{labelKeyComponent: component},
+	); err != nil {
+		if meta.IsNoMatchError(err) {
+			r.Log.V(1).Info("PrometheusAgent CRD not registered yet, skipping", "component", component, "error", err)
+			return nil, nil
 		}
+		return nil, fmt.Errorf("failed to list PrometheusAgents for component %s: %w", component, err)
 	}
-
-	return !foundManaged
+	if len(list.Items) == 0 {
+		r.Log.V(1).Info("No PrometheusAgent found matching component label", "component", component, "namespace", r.Namespace)
+		return nil, nil
+	}
+	if len(list.Items) > 1 {
+		r.Log.Info("Multiple PrometheusAgents found matching component label, using the first one",
+			"component", component, "count", len(list.Items), "namespace", r.Namespace)
+	}
+	return &list.Items[0], nil
 }

--- a/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler_test.go
@@ -5,28 +5,173 @@
 package mcoa
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	cmomanifests "github.com/openshift/cluster-monitoring-operator/pkg/manifests"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	prometheusv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
+	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 )
 
-func TestCMOConfigReconciler_detectConflict(t *testing.T) {
+func TestCMOConfigReconciler_reconcileAlertmanagerConfigs(t *testing.T) {
 	t.Parallel()
 
-	validCfg := cmomanifests.ClusterMonitoringConfiguration{
-		PrometheusK8sConfig: &cmomanifests.PrometheusK8sConfig{
-			AlertmanagerConfigs: []cmomanifests.AdditionalAlertmanagerConfig{
-				{
-					TLSConfig: cmomanifests.TLSConfig{
-						CA: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "hub-alertmanager-router-ca-hub-id",
+	r := &MCOAAgentReconciler{
+		Log:            ctrl.Log.WithName("test"),
+		CASecret:       "obs-alertmanager-mtls-ca-465e377c1ecd4cc29c7",
+		CertSecret:     "obs-alertmanager-mtls-cert-465e377c1ecd4cc29c7",
+		AccessorSecret: "observability-alertmanager-accessor-465e377c1ecd4cc29c7",
+	}
+
+	endpoint := "https://observatorium-api-open-cluster-management-observability.apps.sno-4xlarge-422-7wgdx.dev07.red-chesterfield.com"
+	configs, modified := r.reconcileAlertmanagerConfigs(nil, endpoint, true)
+	require.True(t, modified)
+	require.Len(t, configs, 1)
+
+	am := configs[0]
+	assert.Equal(t, "v2", am.APIVersion)
+	assert.Equal(t, "/api/alertmanager/v2/default", am.PathPrefix)
+	assert.Equal(t, "https", am.Scheme)
+	assert.Equal(t, []string{"observatorium-api-open-cluster-management-observability.apps.sno-4xlarge-422-7wgdx.dev07.red-chesterfield.com"}, am.StaticConfigs)
+
+	// Assert TLS Config
+	assert.False(t, am.TLSConfig.InsecureSkipVerify)
+	assert.Equal(t, "ca.crt", am.TLSConfig.CA.Key)
+	assert.Equal(t, "obs-alertmanager-mtls-ca-465e377c1ecd4cc29c7", am.TLSConfig.CA.Name)
+	assert.Equal(t, "tls.crt", am.TLSConfig.Cert.Key)
+	assert.Equal(t, "obs-alertmanager-mtls-cert-465e377c1ecd4cc29c7", am.TLSConfig.Cert.Name)
+	assert.Equal(t, "tls.key", am.TLSConfig.Key.Key)
+	assert.Equal(t, "obs-alertmanager-mtls-cert-465e377c1ecd4cc29c7", am.TLSConfig.Key.Name)
+
+	// Assert Bearer Token
+	assert.Equal(t, "token", am.BearerToken.Key)
+	assert.Equal(t, "observability-alertmanager-accessor-465e377c1ecd4cc29c7", am.BearerToken.Name)
+}
+
+// TestCMOConfigReconciler_reconcileAlertmanagerConfigs_RenamedCASecret tests that when the
+// hub renames the CA secret prefix across upgrades (e.g. obs-alertmanager-mtls-ca → hub-mtls-ca),
+// the old configmap entry is still recognized as owned and removed when forwarding is disabled.
+func TestCMOConfigReconciler_reconcileAlertmanagerConfigs_RenamedCASecret(t *testing.T) {
+	t.Parallel()
+
+	const hubID = "465e377c1ecd4cc29c7"
+	// Simulate a hub that renamed the CA secret from "obs-alertmanager-mtls-ca-<hubID>"
+	// to "hub-mtls-ca-<hubID>" across an upgrade.
+	r := &MCOAAgentReconciler{
+		Log:            ctrl.Log.WithName("test"),
+		CASecret:       "hub-mtls-ca-" + hubID,   // new prefix after hub rename
+		CertSecret:     "hub-mtls-cert-" + hubID, // new prefix after hub rename
+		AccessorSecret: "observability-alertmanager-accessor-" + hubID,
+	}
+
+	// Existing config was written with the old CA name (before the hub renamed it).
+	oldCfg := cmomanifests.AdditionalAlertmanagerConfig{
+		Scheme:     "https",
+		APIVersion: "v2",
+		TLSConfig: cmomanifests.TLSConfig{
+			CA: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "obs-alertmanager-mtls-ca-" + hubID,
+				},
+				Key: "ca.crt",
+			},
+		},
+	}
+
+	// With UWL alert forwarding disabled, the old entry must be removed even though
+	// its CA name doesn't exactly match r.CASecret.
+	endpoint := "https://observatorium-api.example.com"
+	configs, modified := r.reconcileAlertmanagerConfigs([]cmomanifests.AdditionalAlertmanagerConfig{oldCfg}, endpoint, false)
+	require.True(t, modified, "should be modified: old entry must be cleaned up")
+	assert.Empty(t, configs, "old alertmanager config with renamed CA should be removed")
+}
+
+// TestCMOConfigReconciler_reconcileAlertmanagerConfigs_OrderStable verifies that a reorder
+// of existing entries by another controller is not treated as a content change.
+func TestCMOConfigReconciler_reconcileAlertmanagerConfigs_OrderStable(t *testing.T) {
+	t.Parallel()
+
+	r := &MCOAAgentReconciler{
+		Log:            ctrl.Log.WithName("test"),
+		CASecret:       "obs-alertmanager-mtls-ca-hub1",
+		CertSecret:     "obs-alertmanager-mtls-cert-hub1",
+		AccessorSecret: "observability-alertmanager-accessor-hub1",
+	}
+
+	endpoint := "https://our-am.example.com"
+
+	// Produce the canonical entry for our hub so the test doesn't hard-code field values.
+	canonical, _ := r.reconcileAlertmanagerConfigs(nil, endpoint, true)
+	require.Len(t, canonical, 1)
+	ourEntry := canonical[0]
+
+	externalEntry := cmomanifests.AdditionalAlertmanagerConfig{
+		Scheme:        "http",
+		APIVersion:    "v2",
+		StaticConfigs: []string{"external-am.example.com"},
+	}
+
+	// Another controller stored them in reversed order.
+	existing := []cmomanifests.AdditionalAlertmanagerConfig{externalEntry, ourEntry}
+
+	// Forwarding still enabled: content is unchanged, only order differs.
+	_, modified := r.reconcileAlertmanagerConfigs(existing, endpoint, true)
+	assert.False(t, modified, "reorder by another controller must not trigger an update")
+}
+
+func TestCMOConfigReconciler_reconcileRemoteWrites(t *testing.T) {
+	t.Parallel()
+
+	r := &MCOAAgentReconciler{
+		Log:        ctrl.Log.WithName("test"),
+		CASecret:   "test-ca-secret",
+		CertSecret: "test-cert-secret",
+	}
+
+	agent := &prometheusv1alpha1.PrometheusAgent{
+		Spec: prometheusv1alpha1.PrometheusAgentSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				RemoteWrite: []monitoringv1.RemoteWriteSpec{
+					{
+						Name: ptr.To("acm-observability"),
+						URL:  "https://hub-am.example.com",
+						TLSConfig: &monitoringv1.TLSConfig{
+							SafeTLSConfig: monitoringv1.SafeTLSConfig{
+								CA: monitoringv1.SecretOrConfigMap{
+									Secret: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "test-ca-secret",
+										},
+										Key: "ca.crt",
+									},
+								},
+								Cert: monitoringv1.SecretOrConfigMap{
+									Secret: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "test-cert-secret",
+										},
+										Key: "tls.crt",
+									},
+								},
+								KeySecret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "test-cert-secret",
+									},
+									Key: "tls.key",
+								},
 							},
 						},
 					},
@@ -34,80 +179,497 @@ func TestCMOConfigReconciler_detectConflict(t *testing.T) {
 			},
 		},
 	}
-	validYAML, _ := yaml.Marshal(validCfg)
 
-	tests := []struct {
-		name     string
-		cm       *corev1.ConfigMap
-		expected bool
-	}{
+	// Case 1: Empty scrape configs returns empty/clean remote write list
+	configs := r.reconcileRemoteWrites(nil, nil, agent)
+	assert.Empty(t, configs)
+
+	// Case 2: Agent empty returns empty/clean remote write list even if scrape configs are present
+	sc := newRawScrapeConfig("test-sc", "test-ns", platformMetricsCollectorRawComponent)
+	configs = r.reconcileRemoteWrites(nil, []prometheusv1alpha1.ScrapeConfig{*sc}, nil)
+	assert.Empty(t, configs)
+
+	// Case 3: Endpoint and ScrapeConfigs present -> transpiles correctly
+	configs = r.reconcileRemoteWrites(nil, []prometheusv1alpha1.ScrapeConfig{*sc}, agent)
+	require.Len(t, configs, 1)
+
+	rw := configs[0]
+	assert.Equal(t, "https://hub-am.example.com", rw.URL)
+
+	// Assert TLS Config
+	require.NotNil(t, rw.TLSConfig)
+	assert.Equal(t, "ca.crt", rw.TLSConfig.CA.Secret.Key)
+	assert.Equal(t, "test-ca-secret", rw.TLSConfig.CA.Secret.Name)
+	assert.Equal(t, "tls.crt", rw.TLSConfig.Cert.Secret.Key)
+	assert.Equal(t, "test-cert-secret", rw.TLSConfig.Cert.Secret.Name)
+	assert.Equal(t, "tls.key", rw.TLSConfig.KeySecret.Key)
+	assert.Equal(t, "test-cert-secret", rw.TLSConfig.KeySecret.Name)
+
+	// Assert Relabel Configs
+	require.NotEmpty(t, rw.WriteRelabelConfigs)
+	assert.Equal(t, "__name__", string(rw.WriteRelabelConfigs[0].SourceLabels[0]))
+
+	// Case 4: Endpoint and ScrapeConfig with custom metricRelabelings (Job/Instance normalization) -> transpiles and appends correctly
+	scComplex := newRawScrapeConfig("test-sc-complex", "test-ns", platformMetricsCollectorRawComponent)
+	scComplex.Spec.MetricRelabelConfigs = []monitoringv1.RelabelConfig{
 		{
-			name:     "Empty ConfigMap (conflict)",
-			cm:       &corev1.ConfigMap{},
-			expected: true,
+			Action:       "replace",
+			SourceLabels: []monitoringv1.LabelName{"exported_job"},
+			TargetLabel:  "job",
 		},
 		{
-			name: "Missing data (conflict)",
-			cm: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					ManagedFields: []metav1.ManagedFieldsEntry{
-						{Manager: observabilityendpoint.EndpointMonitoringOperatorMgr},
-					},
-				},
-			},
-			expected: true,
+			Action:       "replace",
+			SourceLabels: []monitoringv1.LabelName{"exported_instance"},
+			TargetLabel:  "instance",
 		},
 		{
-			name: "Correct config",
-			cm: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					ManagedFields: []metav1.ManagedFieldsEntry{
-						{Manager: observabilityendpoint.EndpointMonitoringOperatorMgr},
-					},
-				},
-				Data: map[string]string{
-					observabilityendpoint.ClusterMonitoringConfigDataKey: string(validYAML),
-				},
-			},
-			expected: false,
-		},
-		{
-			name: "Incorrect config (conflict)",
-			cm: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					ManagedFields: []metav1.ManagedFieldsEntry{
-						{Manager: observabilityendpoint.EndpointMonitoringOperatorMgr},
-					},
-				},
-				Data: map[string]string{
-					observabilityendpoint.ClusterMonitoringConfigDataKey: "prometheusK8s: {}",
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "Corrupted YAML (conflict)",
-			cm: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					ManagedFields: []metav1.ManagedFieldsEntry{
-						{Manager: observabilityendpoint.EndpointMonitoringOperatorMgr},
-					},
-				},
-				Data: map[string]string{
-					observabilityendpoint.ClusterMonitoringConfigDataKey: "{invalid: yaml: :}",
-				},
-			},
-			expected: true,
+			Action: "labeldrop",
+			Regex:  "exported_job|exported_instance",
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r := &MCOAAgentReconciler{
-				Log:      ctrl.Log.WithName("test"),
-				CASecret: "hub-alertmanager-router-ca-hub-id", // Match the validCfg Name exactly
-			}
-			assert.Equal(t, tt.expected, r.detectConflict(tt.cm))
-		})
+	configs = r.reconcileRemoteWrites(nil, []prometheusv1alpha1.ScrapeConfig{*scComplex}, agent)
+	require.Len(t, configs, 1)
+
+	rwComplex := configs[0]
+	// Assert the transpiled relabel configs contain our custom ones appended at the end of standard ones
+	require.NotEmpty(t, rwComplex.WriteRelabelConfigs)
+
+	totalRelabels := len(rwComplex.WriteRelabelConfigs)
+	assert.Greater(t, totalRelabels, 3)
+
+	// Last 3 relabels should match the custom MetricRelabelConfigs exactly:
+	lastRelabel := rwComplex.WriteRelabelConfigs[totalRelabels-1]
+	assert.Equal(t, "labeldrop", strings.ToLower(lastRelabel.Action))
+	assert.Equal(t, "exported_job|exported_instance", lastRelabel.Regex)
+
+	prevRelabel := rwComplex.WriteRelabelConfigs[totalRelabels-2]
+	assert.Equal(t, "replace", strings.ToLower(prevRelabel.Action))
+	assert.Equal(t, "instance", prevRelabel.TargetLabel)
+	assert.Equal(t, "exported_instance", string(prevRelabel.SourceLabels[0]))
+
+	firstCustomRelabel := rwComplex.WriteRelabelConfigs[totalRelabels-3]
+	assert.Equal(t, "replace", strings.ToLower(firstCustomRelabel.Action))
+	assert.Equal(t, "job", firstCustomRelabel.TargetLabel)
+	assert.Equal(t, "exported_job", string(firstCustomRelabel.SourceLabels[0]))
+
+	// Case 5: Agent has a RemoteWrite with empty URL -> skips it
+	agentWithEmptyURL := &prometheusv1alpha1.PrometheusAgent{
+		Spec: prometheusv1alpha1.PrometheusAgentSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				RemoteWrite: []monitoringv1.RemoteWriteSpec{
+					{
+						Name: ptr.To("empty-url-write"),
+						URL:  "",
+					},
+					{
+						Name: ptr.To("valid-url-write"),
+						URL:  "https://valid-hub.com",
+					},
+				},
+			},
+		},
 	}
+	configsWithEmptyURL := r.reconcileRemoteWrites(nil, []prometheusv1alpha1.ScrapeConfig{*sc}, agentWithEmptyURL)
+	require.Len(t, configsWithEmptyURL, 1)
+	assert.Equal(t, "https://valid-hub.com", configsWithEmptyURL[0].URL)
+}
+
+func TestCMOConfigReconciler_reconcileRawMetrics(t *testing.T) {
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+
+	// Register ScrapeConfig for the custom monitoring.rhobs/v1alpha1 API Group
+	addRhobsToScheme(t, s)
+
+	ctx := context.Background()
+	namespace := "test-namespace"
+
+	agentPlatform := newTestPrometheusAgent("test-agent-platform", namespace, platformMetricsCollectorComponent, "https://hub-am.example.com", "", "")
+	agentUWL := newTestPrometheusAgent("test-agent-uwl", namespace, userWorkloadMetricsCollectorComponent, "https://hub-am.example.com", "", "")
+
+	// 1. Reconcile Platform (CMO) raw metrics RemoteWrite
+	scPlatform := newRawScrapeConfig("test-raw-scrape-platform", namespace, platformMetricsCollectorRawComponent)
+
+	cmPlatform := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+			Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+		},
+		Data: map[string]string{
+			observabilityendpoint.ClusterMonitoringConfigDataKey: defaultCMOConfigYAML,
+		},
+	}
+
+	clPlatform := fake.NewClientBuilder().WithScheme(s).WithObjects(scPlatform, cmPlatform, agentPlatform).Build()
+
+	rPlatform := &MCOAAgentReconciler{
+		Client:                        clPlatform,
+		Log:                           ctrl.Log.WithName("test-controller"),
+		Namespace:                     namespace,
+		HubAlertmanagerURL:            "https://hub-am.example.com",
+		CASecret:                      "test-ca-secret",
+		CertSecret:                    "test-cert-secret",
+		EnablePlatformAlertForwarding: true,
+	}
+
+	err := rPlatform.ReconcileCMOPlatformConfig(ctx)
+	require.NoError(t, err)
+
+	updatedCMPlatform := &corev1.ConfigMap{}
+	err = clPlatform.Get(ctx, client.ObjectKey{
+		Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+		Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+	}, updatedCMPlatform)
+	require.NoError(t, err)
+
+	platformYAML := updatedCMPlatform.Data[observabilityendpoint.ClusterMonitoringConfigDataKey]
+	assert.Contains(t, platformYAML, "https://hub-am.example.com")
+	assert.Contains(t, platformYAML, "test-ca-secret")
+	assert.Contains(t, platformYAML, "test-cert-secret")
+	assert.Contains(t, platformYAML, "up")
+
+	// 2. Reconcile User Workload (UWL) raw metrics RemoteWrite
+	scUWL := newRawScrapeConfig("test-raw-scrape-uwl", namespace, userWorkloadMetricsCollectorRawComponent)
+
+	cmUWL := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+			Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+		},
+		Data: map[string]string{
+			uwlMonitoringConfigDataKey: defaultUWLConfigYAML,
+		},
+	}
+
+	clUWL := fake.NewClientBuilder().WithScheme(s).WithObjects(scUWL, cmUWL, agentUWL).Build()
+
+	rUWL := &MCOAAgentReconciler{
+		Client:                   clUWL,
+		Log:                      ctrl.Log.WithName("test-controller"),
+		Namespace:                namespace,
+		HubAlertmanagerURL:       "https://hub-am.example.com",
+		CASecret:                 "test-ca-secret",
+		CertSecret:               "test-cert-secret",
+		EnableUWLAlertForwarding: true,
+	}
+
+	err = rUWL.ReconcileCMOUWLConfig(ctx)
+	require.NoError(t, err)
+
+	updatedCMUWL := &corev1.ConfigMap{}
+	err = clUWL.Get(ctx, client.ObjectKey{
+		Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+		Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+	}, updatedCMUWL)
+	require.NoError(t, err)
+
+	uwlYAML := updatedCMUWL.Data[uwlMonitoringConfigDataKey]
+	assert.Contains(t, uwlYAML, "https://hub-am.example.com")
+	assert.Contains(t, uwlYAML, "test-ca-secret")
+	assert.Contains(t, uwlYAML, "test-cert-secret")
+	assert.Contains(t, uwlYAML, "up")
+}
+
+func TestCMOConfigReconciler_reconcileConfigMutation(t *testing.T) {
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+
+	// Register ScrapeConfig for the custom monitoring.rhobs/v1alpha1 API Group
+	addRhobsToScheme(t, s)
+
+	ctx := context.Background()
+	namespace := "test-namespace"
+
+	// Outdated config map containing old alertmanager configs and old externalLabels
+	oldCfg := cmomanifests.ClusterMonitoringConfiguration{
+		PrometheusK8sConfig: &cmomanifests.PrometheusK8sConfig{
+			ExternalLabels: map[string]string{
+				operatorconfig.ClusterLabelKeyForAlerts:     "old-cluster-id",
+				operatorconfig.ClusterNameLabelKeyForAlerts: "old-cluster-name",
+			},
+			AlertmanagerConfigs: []cmomanifests.AdditionalAlertmanagerConfig{
+				{
+					Scheme:     "https",
+					PathPrefix: "/api/alerts/v1/default",
+					TLSConfig: cmomanifests.TLSConfig{
+						CA: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "test-ca-secret",
+							},
+							Key: "ca.crt",
+						},
+					},
+					StaticConfigs: []string{"old-hub.com"},
+				},
+			},
+		},
+	}
+	oldYAML, err := yaml.Marshal(oldCfg)
+	require.NoError(t, err)
+
+	cmPlatform := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+			Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+		},
+		Data: map[string]string{
+			observabilityendpoint.ClusterMonitoringConfigDataKey: string(oldYAML),
+		},
+	}
+
+	agent := newTestPrometheusAgent("test-agent", namespace, platformMetricsCollectorComponent, "https://new-hub.com", "", "")
+
+	clPlatform := fake.NewClientBuilder().WithScheme(s).WithObjects(cmPlatform, agent).Build()
+
+	rPlatform := &MCOAAgentReconciler{
+		Client:                        clPlatform,
+		Log:                           ctrl.Log.WithName("test-controller"),
+		Namespace:                     namespace,
+		ClusterID:                     "new-cluster-id",
+		ClusterName:                   "new-cluster-name",
+		HubAlertmanagerURL:            "https://new-hub.com",
+		CASecret:                      "test-ca-secret",
+		CertSecret:                    "test-cert-secret",
+		EnablePlatformAlertForwarding: true,
+	}
+
+	err = rPlatform.ReconcileCMOPlatformConfig(ctx)
+	require.NoError(t, err)
+
+	updatedCMPlatform := &corev1.ConfigMap{}
+	err = clPlatform.Get(ctx, client.ObjectKey{
+		Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+		Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+	}, updatedCMPlatform)
+	require.NoError(t, err)
+
+	platformYAML := updatedCMPlatform.Data[observabilityendpoint.ClusterMonitoringConfigDataKey]
+	// Assert the config was mutated and upgraded successfully!
+	assert.Contains(t, platformYAML, "new-cluster-id")
+	assert.Contains(t, platformYAML, "new-cluster-name")
+	assert.Contains(t, platformYAML, "new-hub.com")
+	assert.NotContains(t, platformYAML, "old-cluster-id")
+	assert.NotContains(t, platformYAML, "old-cluster-name")
+	assert.NotContains(t, platformYAML, "old-hub.com")
+}
+
+func TestToCMORemoteWrite_ReconstructsTLSSecrets(t *testing.T) {
+	rw := &monitoringv1.RemoteWriteSpec{
+		URL: "https://hub.example.com",
+		TLSConfig: &monitoringv1.TLSConfig{
+			SafeTLSConfig: monitoringv1.SafeTLSConfig{
+				CA:   monitoringv1.SecretOrConfigMap{},
+				Cert: monitoringv1.SecretOrConfigMap{},
+			},
+			CAFile:   "/etc/prometheus/secrets/obs-alertmanager-mtls-ca-465e377c1ecd4cc29c7/custom-ca.pem",
+			CertFile: "/etc/prometheus/secrets/obs-alertmanager-mtls-cert-465e377c1ecd4cc29c7/custom-cert.pem",
+			KeyFile:  "/etc/prometheus/secrets/obs-alertmanager-mtls-cert-465e377c1ecd4cc29c7/custom-key.pem",
+		},
+	}
+
+	cmoRW := toCMORemoteWrite(rw)
+
+	assert.NotNil(t, cmoRW.TLSConfig)
+	assert.NotNil(t, cmoRW.TLSConfig.CA.Secret)
+	assert.Equal(t, "obs-alertmanager-mtls-ca-465e377c1ecd4cc29c7", cmoRW.TLSConfig.CA.Secret.Name)
+	assert.Equal(t, "custom-ca.pem", cmoRW.TLSConfig.CA.Secret.Key)
+
+	assert.NotNil(t, cmoRW.TLSConfig.Cert.Secret)
+	assert.Equal(t, "obs-alertmanager-mtls-cert-465e377c1ecd4cc29c7", cmoRW.TLSConfig.Cert.Secret.Name)
+	assert.Equal(t, "custom-cert.pem", cmoRW.TLSConfig.Cert.Secret.Key)
+
+	assert.NotNil(t, cmoRW.TLSConfig.KeySecret)
+	assert.Equal(t, "obs-alertmanager-mtls-cert-465e377c1ecd4cc29c7", cmoRW.TLSConfig.KeySecret.Name)
+	assert.Equal(t, "custom-key.pem", cmoRW.TLSConfig.KeySecret.Key)
+}
+
+func TestCMOConfigReconciler_reconcileRemoteWrites_Sorting(t *testing.T) {
+	t.Parallel()
+
+	r := &MCOAAgentReconciler{
+		Log:        ctrl.Log.WithName("test"),
+		CASecret:   "test-ca-secret",
+		CertSecret: "test-cert-secret",
+	}
+
+	agent := &prometheusv1alpha1.PrometheusAgent{
+		Spec: prometheusv1alpha1.PrometheusAgentSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				RemoteWrite: []monitoringv1.RemoteWriteSpec{
+					{
+						Name: ptr.To("acm-observability"),
+						URL:  "https://hub-am.example.com",
+					},
+				},
+			},
+		},
+	}
+
+	// Create scrape configs in non-sorted name order: "z-sc", "a-sc", "m-sc"
+	scZ := newRawScrapeConfig("z-sc", "test-ns", platformMetricsCollectorRawComponent)
+	scA := newRawScrapeConfig("a-sc", "test-ns", platformMetricsCollectorRawComponent)
+	scM := newRawScrapeConfig("m-sc", "test-ns", platformMetricsCollectorRawComponent)
+
+	// Case 1: passing them as [scZ, scA, scM]
+	configs1 := r.reconcileRemoteWrites(nil, []prometheusv1alpha1.ScrapeConfig{*scZ, *scA, *scM}, agent)
+	require.Len(t, configs1, 3)
+
+	// Since they are sorted by Name ("a-sc", "m-sc", "z-sc"), the resulting RemoteWrites must be in that exact name order
+	assert.Contains(t, configs1[0].Name, "a-sc")
+	assert.Contains(t, configs1[1].Name, "m-sc")
+	assert.Contains(t, configs1[2].Name, "z-sc")
+
+	// Case 2: passing them in a different order [scA, scM, scZ] should produce the EXACT same ordered slice
+	configs2 := r.reconcileRemoteWrites(nil, []prometheusv1alpha1.ScrapeConfig{*scA, *scM, *scZ}, agent)
+	require.Len(t, configs2, 3)
+	assert.Equal(t, configs1, configs2)
+}
+
+func TestCMOConfigReconciler_reconcileExternalLabels(t *testing.T) {
+	t.Parallel()
+
+	r := &MCOAAgentReconciler{
+		Log:         ctrl.Log.WithName("test"),
+		ClusterID:   "my-cluster-id",
+		ClusterName: "my-cluster-name",
+	}
+
+	// Case 1: neither agent present nor forwarding enabled -> remove external labels
+	cfg1 := &cmomanifests.PrometheusK8sConfig{
+		ExternalLabels: map[string]string{
+			operatorconfig.ClusterLabelKeyForAlerts:     "old-id",
+			operatorconfig.ClusterNameLabelKeyForAlerts: "old-name",
+		},
+	}
+	modified := r.reconcileExternalLabels(cfg1, false)
+	assert.True(t, modified)
+	assert.Empty(t, cfg1.ExternalLabels)
+
+	// Case 2: forwarding enabled with NO agent (retainLabels = true) -> preserve and reconcile external labels
+	cfg2 := &cmomanifests.PrometheusK8sConfig{
+		ExternalLabels: map[string]string{
+			operatorconfig.ClusterLabelKeyForAlerts:     "old-id",
+			operatorconfig.ClusterNameLabelKeyForAlerts: "old-name",
+		},
+	}
+	modified = r.reconcileExternalLabels(cfg2, true)
+	assert.True(t, modified)
+	assert.Equal(t, "my-cluster-id", cfg2.ExternalLabels[operatorconfig.ClusterLabelKeyForAlerts])
+	assert.Equal(t, "my-cluster-name", cfg2.ExternalLabels[operatorconfig.ClusterNameLabelKeyForAlerts])
+
+	// Case 3: forwarding enabled with NO agent, labels already correct -> no modification
+	cfg3 := &cmomanifests.PrometheusK8sConfig{
+		ExternalLabels: map[string]string{
+			operatorconfig.ClusterLabelKeyForAlerts:     "my-cluster-id",
+			operatorconfig.ClusterNameLabelKeyForAlerts: "my-cluster-name",
+		},
+	}
+	modified = r.reconcileExternalLabels(cfg3, true)
+	assert.False(t, modified)
+}
+
+func TestCMOConfigReconciler_reconcileExternalLabels_DisabledForwarding(t *testing.T) {
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	addRhobsToScheme(t, s)
+
+	ctx := context.Background()
+	namespace := "test-namespace"
+
+	// Existing config map containing old externalLabels
+	oldCfg := cmomanifests.ClusterMonitoringConfiguration{
+		PrometheusK8sConfig: &cmomanifests.PrometheusK8sConfig{
+			ExternalLabels: map[string]string{
+				operatorconfig.ClusterLabelKeyForAlerts:     "my-cluster-id",
+				operatorconfig.ClusterNameLabelKeyForAlerts: "my-cluster-name",
+			},
+		},
+	}
+	oldYAML, err := yaml.Marshal(oldCfg)
+	require.NoError(t, err)
+
+	cmPlatform := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+			Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+		},
+		Data: map[string]string{
+			observabilityendpoint.ClusterMonitoringConfigDataKey: string(oldYAML),
+		},
+	}
+
+	clPlatform := fake.NewClientBuilder().WithScheme(s).WithObjects(cmPlatform).Build()
+
+	// Platform alert forwarding disabled (EnablePlatformAlertForwarding: false)
+	rPlatform := &MCOAAgentReconciler{
+		Client:                        clPlatform,
+		Log:                           ctrl.Log.WithName("test-controller"),
+		Namespace:                     namespace,
+		ClusterID:                     "my-cluster-id",
+		ClusterName:                   "my-cluster-name",
+		HubAlertmanagerURL:            "https://new-hub.com",
+		CASecret:                      "test-ca-secret",
+		CertSecret:                    "test-cert-secret",
+		EnablePlatformAlertForwarding: false,
+	}
+
+	err = rPlatform.ReconcileCMOPlatformConfig(ctx)
+	require.NoError(t, err)
+
+	updatedCMPlatform := &corev1.ConfigMap{}
+	err = clPlatform.Get(ctx, client.ObjectKey{
+		Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+		Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+	}, updatedCMPlatform)
+	require.NoError(t, err)
+
+	platformYAML := updatedCMPlatform.Data[observabilityendpoint.ClusterMonitoringConfigDataKey]
+	// Since alert forwarding was disabled, external labels must be removed!
+	assert.NotContains(t, platformYAML, "my-cluster-id")
+	assert.NotContains(t, platformYAML, "my-cluster-name")
+}
+
+func TestCMOConfigReconciler_fetchCMOConfigMap_Gating(t *testing.T) {
+	t.Parallel()
+
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	cl := fake.NewClientBuilder().WithScheme(s).Build()
+
+	r := &MCOAAgentReconciler{
+		Client: cl,
+		Log:    ctrl.Log.WithName("test"),
+	}
+
+	key := client.ObjectKey{
+		Name:      "test-cm",
+		Namespace: "test-ns",
+	}
+
+	// Case 1: missing CM, but agent, alertmanagerURL, numScrapeConfigs are all empty -> return nil (do not materialize)
+	cm, isCreate, err := r.fetchCMOConfigMap(context.TODO(), key, nil, "", 0, false)
+	require.NoError(t, err)
+	assert.False(t, isCreate)
+	assert.Nil(t, cm)
+
+	// Case 2: missing CM, agent is present -> return initialized CM
+	agent := &prometheusv1alpha1.PrometheusAgent{}
+	cm, isCreate, err = r.fetchCMOConfigMap(context.TODO(), key, agent, "", 0, false)
+	require.NoError(t, err)
+	assert.True(t, isCreate)
+	assert.NotNil(t, cm)
+	assert.Equal(t, "test-cm", cm.Name)
+
+	// Case 3: missing CM, alertmanagerURL is set but forwarding is disabled -> return nil (do not materialize)
+	cm, isCreate, err = r.fetchCMOConfigMap(context.TODO(), key, nil, "https://hub.com", 0, false)
+	require.NoError(t, err)
+	assert.False(t, isCreate)
+	assert.Nil(t, cm)
+
+	// Case 4: missing CM, alertmanagerURL is set and forwarding is enabled -> return initialized CM
+	cm, isCreate, err = r.fetchCMOConfigMap(context.TODO(), key, nil, "https://hub.com", 0, true)
+	require.NoError(t, err)
+	assert.True(t, isCreate)
+	assert.NotNil(t, cm)
 }

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	prometheusv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
 	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	corev1 "k8s.io/api/core/v1"
@@ -21,22 +22,24 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // MCOAAgentReconciler reconciles the MCOA components on the managed cluster.
 type MCOAAgentReconciler struct {
 	client.Client
-	Log                      logr.Logger
-	Scheme                   *runtime.Scheme
-	Recorder                 events.EventRecorder
-	Namespace                string
-	ClusterID                string
-	ClusterName              string
-	AlertmanagerEndpoint     string
-	CASecret                 string
-	CertSecret               string
-	AccessorSecret           string
-	EnableUWLAlertForwarding bool
+	Log                           logr.Logger
+	Scheme                        *runtime.Scheme
+	Recorder                      events.EventRecorder
+	Namespace                     string
+	ClusterID                     string
+	ClusterName                   string
+	HubAlertmanagerURL            string
+	CASecret                      string
+	CertSecret                    string
+	AccessorSecret                string
+	EnablePlatformAlertForwarding bool
+	EnableUWLAlertForwarding      bool
 }
 
 // NewMCOAAgentReconciler creates a new MCOAAgentReconciler.
@@ -48,25 +51,27 @@ func NewMCOAAgentReconciler(
 	namespace string,
 	clusterID string,
 	clusterName string,
-	alertmanagerEndpoint string,
+	hubAlertmanagerURL string,
 	caSecret string,
 	certSecret string,
 	accessorSecret string,
+	enablePlatformAlertForwarding bool,
 	enableUWLAlertForwarding bool,
 ) *MCOAAgentReconciler {
 	return &MCOAAgentReconciler{
-		Client:                   client,
-		Log:                      log,
-		Scheme:                   scheme,
-		Recorder:                 recorder,
-		Namespace:                namespace,
-		ClusterID:                clusterID,
-		ClusterName:              clusterName,
-		AlertmanagerEndpoint:     alertmanagerEndpoint,
-		CASecret:                 caSecret,
-		CertSecret:               certSecret,
-		AccessorSecret:           accessorSecret,
-		EnableUWLAlertForwarding: enableUWLAlertForwarding,
+		Client:                        client,
+		Log:                           log,
+		Scheme:                        scheme,
+		Recorder:                      recorder,
+		Namespace:                     namespace,
+		ClusterID:                     clusterID,
+		ClusterName:                   clusterName,
+		HubAlertmanagerURL:            hubAlertmanagerURL,
+		CASecret:                      caSecret,
+		CertSecret:                    certSecret,
+		AccessorSecret:                accessorSecret,
+		EnablePlatformAlertForwarding: enablePlatformAlertForwarding,
+		EnableUWLAlertForwarding:      enableUWLAlertForwarding,
 	}
 }
 
@@ -75,13 +80,12 @@ func (r *MCOAAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	switch {
 	case req.Name == operatorconfig.OCPClusterMonitoringConfigMapName && req.Namespace == operatorconfig.OCPClusterMonitoringNamespace:
-		if err := r.reconcileCMO(ctx, req.NamespacedName); err != nil {
+		if err := r.ReconcileCMOPlatformConfig(ctx); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile CMO config: %w", err)
 		}
 		return ctrl.Result{}, nil
-
 	case req.Name == operatorconfig.OCPUserWorkloadMonitoringConfigMap && req.Namespace == operatorconfig.OCPUserWorkloadMonitoringNamespace:
-		if err := r.reconcileUWLConfig(ctx); err != nil {
+		if err := r.ReconcileCMOUWLConfig(ctx); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile UWL config: %w", err)
 		}
 		return ctrl.Result{}, nil
@@ -127,5 +131,55 @@ func (r *MCOAAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				GenericFunc: func(_ event.GenericEvent) bool { return false },
 			}),
 		).
+		Watches(
+			&prometheusv1alpha1.ScrapeConfig{},
+			handler.EnqueueRequestsFromMapFunc(r.mapComponentLabelToRequests(
+				platformMetricsCollectorRawComponent,
+				userWorkloadMetricsCollectorRawComponent,
+			)),
+		).
+		Watches(
+			&prometheusv1alpha1.PrometheusAgent{},
+			handler.EnqueueRequestsFromMapFunc(r.mapComponentLabelToRequests(
+				platformMetricsCollectorComponent,
+				userWorkloadMetricsCollectorComponent,
+			)),
+		).
 		Complete(r)
+}
+
+func (r *MCOAAgentReconciler) mapComponentLabelToRequests(
+	platformComp, uwlComp string,
+) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		if obj.GetNamespace() != r.Namespace {
+			return nil
+		}
+		labels := obj.GetLabels()
+		if labels == nil {
+			return nil
+		}
+		comp := labels[labelKeyComponent]
+		switch comp {
+		case platformComp:
+			return []reconcile.Request{
+				{
+					NamespacedName: client.ObjectKey{
+						Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+						Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+					},
+				},
+			}
+		case uwlComp:
+			return []reconcile.Request{
+				{
+					NamespacedName: client.ObjectKey{
+						Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+						Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+					},
+				},
+			}
+		}
+		return nil
+	}
 }

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller_test.go
@@ -7,6 +7,7 @@ package mcoa
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	ocinfrav1 "github.com/openshift/api/config/v1"
@@ -19,9 +20,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,8 +33,12 @@ import (
 func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 	t.Parallel()
 
-	s := scheme.Scheme
-	_ = ocinfrav1.AddToScheme(s)
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, ocinfrav1.AddToScheme(s))
+
+	// Register ScrapeConfig for the custom monitoring.rhobs/v1alpha1 API Group
+	addRhobsToScheme(t, s)
 
 	namespace := "test-ns"
 	clusterID := "test-cluster-id"
@@ -128,17 +133,9 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
 						Namespace: operatorconfig.OCPClusterMonitoringNamespace,
-						ManagedFields: []metav1.ManagedFieldsEntry{
-							{
-								Manager:    observabilityendpoint.EndpointMonitoringOperatorMgr,
-								Operation:  metav1.ManagedFieldsOperationUpdate,
-								APIVersion: "v1",
-								FieldsType: "FieldsV1",
-							},
-						},
 					},
 					Data: map[string]string{
-						observabilityendpoint.ClusterMonitoringConfigDataKey: "prometheusK8s: {}",
+						observabilityendpoint.ClusterMonitoringConfigDataKey: "prometheusK8s:\n  additionalAlertmanagerConfigs:\n  - scheme: https\n    staticConfigs:\n    - old-hub.com",
 					},
 				},
 			},
@@ -178,7 +175,7 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 					Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
 				}, found)
 				require.NoError(t, err)
-				assert.Contains(t, found.Data["config.yaml"], "hub-am.example.com")
+				assert.Contains(t, found.Data[uwlMonitoringConfigDataKey], "hub-am.example.com")
 			},
 		},
 		{
@@ -216,14 +213,6 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
 						Namespace: operatorconfig.OCPClusterMonitoringNamespace,
-						ManagedFields: []metav1.ManagedFieldsEntry{
-							{
-								Manager:    observabilityendpoint.EndpointMonitoringOperatorMgr,
-								Operation:  metav1.ManagedFieldsOperationUpdate,
-								APIVersion: "v1",
-								FieldsType: "FieldsV1",
-							},
-						},
 					},
 					Data: map[string]string{
 						observabilityendpoint.ClusterMonitoringConfigDataKey: "prometheusK8s: { additionalAlertmanagerConfigs: [ { scheme: https, tlsConfig: { ca: { name: hub-alertmanager-router-ca-hub-id } }, staticConfigs: [ hub.com ] } ] }",
@@ -292,7 +281,7 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 					Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
 				}, found)
 				if err == nil {
-					assert.NotContains(t, found.Data["config.yaml"], "hub.com")
+					assert.NotContains(t, found.Data[uwlMonitoringConfigDataKey], "hub.com")
 				}
 			},
 		},
@@ -300,13 +289,20 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := fake.NewClientBuilder().WithScheme(s).WithObjects(tt.existingObjs...).WithReturnManagedFields().WithInterceptorFuncs(tt.clientInterceptors).Build()
+			caSecretName := observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmRouterCASecretName, tt.hubClusterID)
+
+			existingObjs := slices.Clone(tt.existingObjs)
+			if tt.alertmanagerEndpoint != "" {
+				agentPlatform := newTestPrometheusAgent("test-agent-platform", namespace, platformMetricsCollectorComponent, tt.alertmanagerEndpoint, "", "")
+				agentUWL := newTestPrometheusAgent("test-agent-uwl", namespace, userWorkloadMetricsCollectorComponent, tt.alertmanagerEndpoint, "", "")
+				existingObjs = append(existingObjs, agentPlatform, agentUWL)
+			}
+
+			c := fake.NewClientBuilder().WithScheme(s).WithObjects(existingObjs...).WithReturnManagedFields().WithInterceptorFuncs(tt.clientInterceptors).Build()
 			recorder := events.NewFakeRecorder(10)
 
 			// Capture initial metric value
-			initialMetric := testutil.ToFloat64(cmoConfigConflictsTotal)
-
-			caSecretName := observabilityendpoint.AppendHubClusterID(observabilityendpoint.HubAmRouterCASecretName, tt.hubClusterID)
+			initialMetric := testutil.ToFloat64(cmoConfigReconcilesTotal)
 
 			r := NewMCOAAgentReconciler(
 				c,
@@ -316,10 +312,11 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 				namespace,
 				clusterID,
 				clusterName,
-				tt.alertmanagerEndpoint,
+				tt.alertmanagerEndpoint, // HubAlertmanagerURL
 				caSecretName,
 				"obs-alertmanager-mtls-cert",
 				"observability-alertmanager-accessor",
+				tt.alertmanagerEndpoint != "", // enablePlatformAlertForwarding
 				!tt.disableUWLAlertForwarding,
 			)
 
@@ -333,7 +330,7 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 			assert.Zero(t, result.RequeueAfter, "reconciler must not schedule a periodic requeue — the CRD watch handles healing")
 
 			if tt.expectedMetric > 0 {
-				assert.Equal(t, initialMetric+tt.expectedMetric, testutil.ToFloat64(cmoConfigConflictsTotal))
+				assert.Equal(t, initialMetric+tt.expectedMetric, testutil.ToFloat64(cmoConfigReconcilesTotal))
 			}
 
 			if tt.expectedEvent {

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
@@ -16,6 +16,8 @@ import (
 	"time"
 
 	ocinfrav1 "github.com/openshift/api/config/v1"
+	cmomanifests "github.com/openshift/cluster-monitoring-operator/pkg/manifests"
+	prometheusv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
 	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	"github.com/stretchr/testify/require"
@@ -29,15 +31,21 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	yamltool "sigs.k8s.io/yaml"
 )
 
 var (
-	testEnv *envtest.Environment
-	cfg     *rest.Config
+	testEnv   *envtest.Environment
+	cfg       *rest.Config
+	s         = runtime.NewScheme()
+	namespace = "test-mcoa-agent-integration"
 )
 
 func TestMain(m *testing.M) {
@@ -48,6 +56,8 @@ func TestMain(m *testing.M) {
 
 	cvCRD := readCRDFiles(
 		filepath.Join("..", "observabilityendpoint", "testdata", "crd", "clusterversions-crd.yaml"),
+		filepath.Join("crds", "monitoring.rhobs_scrapeconfigs.yaml"),
+		filepath.Join("crds", "monitoring.rhobs_prometheusagents.yaml"),
 	)
 
 	testEnv = &envtest.Environment{
@@ -93,15 +103,16 @@ func readCRDFiles(crdPaths ...string) []*apiextensionsv1.CustomResourceDefinitio
 }
 
 func TestMCOAAgentIntegration(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	s := runtime.NewScheme()
 	require.NoError(t, kubescheme.AddToScheme(s))
 	require.NoError(t, ocinfrav1.AddToScheme(s))
 	require.NoError(t, apiextensionsv1.AddToScheme(s))
 
-	namespace := "test-mcoa-agent"
+	// Register ScrapeConfig for the custom monitoring.rhobs/v1alpha1 API Group
+	addRhobsToScheme(t, s)
+
 	hubInfo := &operatorconfig.HubInfo{
 		AlertmanagerEndpoint: "https://hub-am.example.com",
 		HubClusterID:         "hub-id",
@@ -119,6 +130,7 @@ func TestMCOAAgentIntegration(t *testing.T) {
 		caSecretName = "hub-alertmanager-router-ca-" + hubInfo.HubClusterID
 	}
 
+	// Default active production-like reconciler configuration
 	reconciler := NewMCOAAgentReconciler(
 		mgr.GetClient(),
 		mgr.GetLogger(),
@@ -127,27 +139,61 @@ func TestMCOAAgentIntegration(t *testing.T) {
 		namespace,
 		"test-cluster-id",
 		"test-cluster-name",
-		hubInfo.AlertmanagerEndpoint,
+		hubInfo.AlertmanagerEndpoint, // HubAlertmanagerURL
 		caSecretName,
 		"obs-alertmanager-mtls-cert",
 		"observability-alertmanager-accessor",
-		true,
+		true, // enablePlatformAlertForwarding
+		true, // enableUWLAlertForwarding
 	)
 	err = reconciler.SetupWithManager(mgr)
 	require.NoError(t, err)
 
+	directClient, err := client.New(cfg, client.Options{Scheme: s})
+	require.NoError(t, err)
+
+	// Deploy standard OBO CRDs first to ensure watched types exist before manager start
+	require.NoError(t, DeployCRDs(ctx, directClient))
+
+	// Wait for CRDs to be fully established on the API server
+	require.Eventually(t, func() bool {
+		for _, name := range []string{"scrapeconfigs.monitoring.rhobs", "prometheusagents.monitoring.rhobs"} {
+			crd := &apiextensionsv1.CustomResourceDefinition{}
+			err := directClient.Get(ctx, types.NamespacedName{Name: name}, crd)
+			if err != nil {
+				return false
+			}
+			established := false
+			for _, cond := range crd.Status.Conditions {
+				if cond.Type == apiextensionsv1.Established && cond.Status == apiextensionsv1.ConditionTrue {
+					established = true
+					break
+				}
+			}
+			if !established {
+				return false
+			}
+		}
+		return true
+	}, 10*time.Second, 100*time.Millisecond)
+
+	mgrCtx, mgrCancel := context.WithCancel(ctx)
+	mgrStopped := make(chan struct{})
 	go func() {
-		if err := mgr.Start(ctx); err != nil {
+		defer close(mgrStopped)
+		if err := mgr.Start(mgrCtx); err != nil && mgrCtx.Err() == nil {
 			fmt.Printf("Manager failed: %v\n", err)
 		}
 	}()
 
+	// Wait for cache to be fully synced and started before executing any cached client queries
+	require.True(t, mgr.GetCache().WaitForCacheSync(ctx), "Failed to sync cache before running tests")
+
 	k8sClient := mgr.GetClient()
-	directClient, err := client.New(cfg, client.Options{Scheme: s})
-	require.NoError(t, err)
 
 	// Setup required platform resources
 	setupResources := []client.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: operatorconfig.OCPClusterMonitoringNamespace}},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: operatorconfig.OCPUserWorkloadMonitoringNamespace}},
 		&ocinfrav1.ClusterVersion{
@@ -168,6 +214,8 @@ func TestMCOAAgentIntegration(t *testing.T) {
 			},
 			Data: map[string][]byte{"service-ca.crt": []byte("test-ca")},
 		},
+		newTestPrometheusAgent("test-agent-platform", namespace, platformMetricsCollectorComponent, "https://hub-am.example.com", caSecretName, "test-cert-secret"),
+		newTestPrometheusAgent("test-agent-uwl", namespace, userWorkloadMetricsCollectorComponent, "https://hub-am.example.com", caSecretName, "test-cert-secret"),
 	}
 	for _, obj := range setupResources {
 		err = directClient.Create(ctx, obj)
@@ -200,7 +248,20 @@ func TestMCOAAgentIntegration(t *testing.T) {
 				observabilityendpoint.ClusterMonitoringConfigDataKey: "prometheusK8s: {}",
 			},
 		}
-		require.NoError(t, directClient.Create(ctx, cmoCM, client.FieldOwner(observabilityendpoint.EndpointMonitoringOperatorMgr)))
+		err := directClient.Create(ctx, cmoCM, client.FieldOwner(observabilityendpoint.EndpointMonitoringOperatorMgr))
+		if apierrors.IsAlreadyExists(err) {
+			existing := &corev1.ConfigMap{}
+			require.NoError(t, directClient.Get(ctx, types.NamespacedName{
+				Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+			}, existing))
+			existing.Data = map[string]string{
+				observabilityendpoint.ClusterMonitoringConfigDataKey: "prometheusK8s: {}",
+			}
+			require.NoError(t, directClient.Update(ctx, existing))
+		} else {
+			require.NoError(t, err)
+		}
 
 		// Wait for the reconciler to populate our Alertmanager configs
 		require.Eventually(t, func() bool {
@@ -219,53 +280,30 @@ func TestMCOAAgentIntegration(t *testing.T) {
 		}, 5*time.Second, 100*time.Millisecond)
 	})
 
-	t.Run("Reconcile Revert path: Empty AlertmanagerEndpoint cleanly reverts the Alertmanager configuration", func(t *testing.T) {
-		// Disable alert forwarding on the active reconciler
-		reconciler.AlertmanagerEndpoint = ""
-
-		// Trigger reconcile by directly calling the Reconcile method on the reconciler, emulating the real flow.
-		_, err = reconciler.Reconcile(ctx, ctrl.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
-				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
-			},
-		})
-		require.NoError(t, err)
-
-		// Wait for the reconciler to clean up our Alertmanager configs (or cleanly delete the empty ConfigMap)
-		require.Eventually(t, func() bool {
-			foundCM := &corev1.ConfigMap{}
-			err := directClient.Get(ctx, types.NamespacedName{
-				Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
-				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
-			}, foundCM)
-			if apierrors.IsNotFound(err) {
-				return true
-			}
-			if err != nil {
-				fmt.Printf("Get ConfigMap error: %v\n", err)
-				return false
-			}
-			data := foundCM.Data[observabilityendpoint.ClusterMonitoringConfigDataKey]
-			return !strings.Contains(data, "hub-alertmanager-router-ca-hub-id") && !strings.Contains(data, "hub-am.example.com")
-		}, 5*time.Second, 100*time.Millisecond)
-	})
-
 	t.Run("Reconcile UWL Config: Managed ConfigMap is successfully populated with Alertmanager configuration", func(t *testing.T) {
-		// Set AlertmanagerEndpoint and EnableUWLAlertForwarding back to active state
-		reconciler.AlertmanagerEndpoint = "https://hub-am.example.com"
-		reconciler.EnableUWLAlertForwarding = true
-
 		uwlCM := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
 				Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
 			},
 			Data: map[string]string{
-				"config.yaml": "prometheus: {}",
+				uwlMonitoringConfigDataKey: defaultUWLConfigYAML,
 			},
 		}
-		require.NoError(t, directClient.Create(ctx, uwlCM, client.FieldOwner(observabilityendpoint.EndpointMonitoringOperatorMgr)))
+		err := directClient.Create(ctx, uwlCM, client.FieldOwner(observabilityendpoint.EndpointMonitoringOperatorMgr))
+		if apierrors.IsAlreadyExists(err) {
+			existing := &corev1.ConfigMap{}
+			require.NoError(t, directClient.Get(ctx, types.NamespacedName{
+				Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+				Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+			}, existing))
+			existing.Data = map[string]string{
+				uwlMonitoringConfigDataKey: defaultUWLConfigYAML,
+			}
+			require.NoError(t, directClient.Update(ctx, existing))
+		} else {
+			require.NoError(t, err)
+		}
 
 		// Wait for the reconciler to populate our Alertmanager configs in UWL ConfigMap
 		require.Eventually(t, func() bool {
@@ -277,8 +315,262 @@ func TestMCOAAgentIntegration(t *testing.T) {
 			if err != nil {
 				return false
 			}
-			data := found.Data["config.yaml"]
+			data := found.Data[uwlMonitoringConfigDataKey]
 			return strings.Contains(data, "hub-alertmanager-router-ca-hub-id") && strings.Contains(data, "hub-am.example.com")
+		}, 5*time.Second, 100*time.Millisecond)
+	})
+
+	// Stop the background manager before the revert tests so it cannot interfere
+	// with the direct Reconcile calls and the state assertions that follow.
+	mgrCancel()
+	<-mgrStopped
+
+	t.Run("Reconcile Revert path: Empty AlertmanagerEndpoint cleanly reverts the Alertmanager configuration", func(t *testing.T) {
+		// Instantiate a brand-new, private local reconciler with alert forwarding disabled (HubAlertmanagerURL = "") to simulate config update
+		revertReconciler := NewMCOAAgentReconciler(
+			directClient,
+			mgr.GetLogger(),
+			mgr.GetScheme(),
+			mgr.GetEventRecorder("mcoa-agent-test"),
+			namespace,
+			"test-cluster-id",
+			"test-cluster-name",
+			"", // empty HubAlertmanagerURL disables forwarding
+			caSecretName,
+			"obs-alertmanager-mtls-cert",
+			"observability-alertmanager-accessor",
+			false, // enablePlatformAlertForwarding
+			false, // enableUWLAlertForwarding
+		)
+
+		// Trigger reconcile by directly calling the Reconcile method on this private reconciler
+		_, err = revertReconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+			},
+		})
+		require.NoError(t, err)
+
+		foundCM := &corev1.ConfigMap{}
+		err = directClient.Get(ctx, types.NamespacedName{
+			Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+			Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+		}, foundCM)
+		if !apierrors.IsNotFound(err) {
+			require.NoError(t, err)
+			data := foundCM.Data[observabilityendpoint.ClusterMonitoringConfigDataKey]
+			require.False(t, strings.Contains(data, "hub-alertmanager-router-ca-hub-id"), "expected AM CA secret to be removed from CMO CM after revert")
+			require.False(t, strings.Contains(data, "hub-am.example.com"), "expected AM URL to be removed from CMO CM after revert")
+		}
+	})
+
+	t.Run("Reconcile UWL Revert path: Disabled EnableUWLAlertForwarding cleanly reverts the Alertmanager configuration", func(t *testing.T) {
+		// Pre-condition: the UWL CM must still carry the AM config at this point.
+		// This proves that the CMO revert above only touched cluster-monitoring-config
+		// and did not accidentally clean user-workload-monitoring-config as well.
+		preCM := &corev1.ConfigMap{}
+		require.NoError(t, directClient.Get(ctx, types.NamespacedName{
+			Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+			Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+		}, preCM))
+		preData := preCM.Data[uwlMonitoringConfigDataKey]
+		require.True(t, strings.Contains(preData, "hub-alertmanager-router-ca-hub-id"), "pre-condition: UWL CM should still have AM config before the revert")
+		require.True(t, strings.Contains(preData, "hub-am.example.com"), "pre-condition: UWL CM should still have AM config before the revert")
+
+		// Instantiate a brand-new, private local reconciler with UWL alert forwarding disabled to simulate config update
+		revertReconciler := NewMCOAAgentReconciler(
+			directClient,
+			mgr.GetLogger(),
+			mgr.GetScheme(),
+			mgr.GetEventRecorder("mcoa-agent-test"),
+			namespace,
+			"test-cluster-id",
+			"test-cluster-name",
+			"https://hub-am.example.com", // HubAlertmanagerURL
+			caSecretName,
+			"obs-alertmanager-mtls-cert",
+			"observability-alertmanager-accessor",
+			true,  // enablePlatformAlertForwarding
+			false, // disabled UWL alert forwarding
+		)
+
+		// Trigger reconcile by directly calling the Reconcile method on this private reconciler
+		_, err = revertReconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+				Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+			},
+		})
+		require.NoError(t, err)
+
+		foundCM := &corev1.ConfigMap{}
+		err = directClient.Get(ctx, types.NamespacedName{
+			Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+			Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+		}, foundCM)
+		if !apierrors.IsNotFound(err) {
+			require.NoError(t, err)
+			data := foundCM.Data[uwlMonitoringConfigDataKey]
+			require.False(t, strings.Contains(data, "hub-alertmanager-router-ca-hub-id"), "expected AM CA secret to be removed from UWL CM after revert")
+			require.False(t, strings.Contains(data, "hub-am.example.com"), "expected AM URL to be removed from UWL CM after revert")
+		}
+	})
+
+	// Restart with a fresh manager for the remaining tests. A controller-runtime manager
+	// cannot be restarted after it is stopped, so we create a new instance.
+	// Disable the metrics server to avoid a port conflict with the first manager.
+	mgr2, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:  s,
+		Cache:   GetCacheOptions(),
+		Metrics: metricsserver.Options{BindAddress: "0"},
+		// Controller name "configmap" is already registered in the process-global metrics
+		// registry by the first manager; skip re-registration validation.
+		Controller: config.Controller{SkipNameValidation: ptr.To(true)},
+	})
+	require.NoError(t, err)
+	require.NoError(t, NewMCOAAgentReconciler(
+		mgr2.GetClient(),
+		mgr2.GetLogger(),
+		mgr2.GetScheme(),
+		mgr2.GetEventRecorder("mcoa-agent-test"),
+		namespace,
+		"test-cluster-id",
+		"test-cluster-name",
+		hubInfo.AlertmanagerEndpoint,
+		caSecretName,
+		"obs-alertmanager-mtls-cert",
+		"observability-alertmanager-accessor",
+		true, // enablePlatformAlertForwarding
+		true, // enableUWLAlertForwarding
+	).SetupWithManager(mgr2))
+	go func() {
+		if err := mgr2.Start(ctx); err != nil && ctx.Err() == nil {
+			fmt.Printf("Manager2 failed: %v\n", err)
+		}
+	}()
+	require.True(t, mgr2.GetCache().WaitForCacheSync(ctx), "Failed to sync cache for manager2")
+
+	t.Run("Reconcile Raw Metrics ScrapeConfig: updates CMO and UWL with transpiled RemoteWrite", func(t *testing.T) {
+		// Re-create the mock PrometheusAgents if they were wiped out by the CRD deletion test
+		agentPlatform := newTestPrometheusAgent("test-agent-platform", namespace, platformMetricsCollectorComponent, "https://hub-am.example.com", caSecretName, "test-cert-secret")
+		err := directClient.Create(ctx, agentPlatform)
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			require.NoError(t, err)
+		}
+
+		agentUWL := newTestPrometheusAgent("test-agent-uwl", namespace, userWorkloadMetricsCollectorComponent, "https://hub-am.example.com", caSecretName, "test-cert-secret")
+		err = directClient.Create(ctx, agentUWL)
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			require.NoError(t, err)
+		}
+
+		// Create a platform-metrics-collector-raw ScrapeConfig
+		scPlatform := newRawScrapeConfig("test-raw-platform", namespace, platformMetricsCollectorRawComponent)
+		require.NoError(t, directClient.Create(ctx, scPlatform))
+
+		// Wait for raw platform metrics RemoteWrite injection in CMO ConfigMap and assert exactly one spec with correct name exists
+		require.Eventually(t, func() bool {
+			found := &corev1.ConfigMap{}
+			err := directClient.Get(ctx, types.NamespacedName{
+				Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+			}, found)
+			if err != nil {
+				return false
+			}
+			data := found.Data[observabilityendpoint.ClusterMonitoringConfigDataKey]
+			if !strings.Contains(data, "https://hub-am.example.com") {
+				return false
+			}
+
+			// Parse and assert exact length to prevent regression of duplication bugs
+			parsed := &cmomanifests.ClusterMonitoringConfiguration{}
+			if err := yamltool.Unmarshal([]byte(data), parsed); err != nil {
+				return false
+			}
+			if parsed.PrometheusK8sConfig == nil || len(parsed.PrometheusK8sConfig.RemoteWrite) != 1 {
+				return false
+			}
+			return strings.HasPrefix(parsed.PrometheusK8sConfig.RemoteWrite[0].Name, "mcoa-raw-test-raw-platform")
+		}, 5*time.Second, 100*time.Millisecond)
+
+		// Create a user-workload-metrics-collector-raw ScrapeConfig
+		scUWL := newRawScrapeConfig("test-raw-uwl", namespace, userWorkloadMetricsCollectorRawComponent)
+		require.NoError(t, directClient.Create(ctx, scUWL))
+
+		// Wait for raw UWL metrics RemoteWrite injection in UWL ConfigMap and assert exactly one spec with correct name exists
+		require.Eventually(t, func() bool {
+			found := &corev1.ConfigMap{}
+			err := directClient.Get(ctx, types.NamespacedName{
+				Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+				Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+			}, found)
+			if err != nil {
+				return false
+			}
+			data := found.Data[uwlMonitoringConfigDataKey]
+			if !strings.Contains(data, "https://hub-am.example.com") {
+				return false
+			}
+
+			// Parse and assert exact length to prevent regression of duplication bugs
+			parsed := &cmomanifests.UserWorkloadConfiguration{}
+			if err := yamltool.Unmarshal([]byte(data), parsed); err != nil {
+				return false
+			}
+			if parsed.Prometheus == nil || len(parsed.Prometheus.RemoteWrite) != 1 {
+				return false
+			}
+			return strings.HasPrefix(parsed.Prometheus.RemoteWrite[0].Name, "mcoa-raw-test-raw-uwl")
+		}, 5*time.Second, 100*time.Millisecond)
+	})
+
+	t.Run("Reconcile Raw Metrics ScrapeConfig Deletion: cleanly removes transpiled RemoteWrite from ConfigMap", func(t *testing.T) {
+		// Fetch the platform ScrapeConfig we created in the previous subtest
+		scPlatform := &prometheusv1alpha1.ScrapeConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-raw-platform",
+				Namespace: namespace,
+			},
+		}
+		require.NoError(t, directClient.Delete(ctx, scPlatform))
+
+		// Wait for raw platform metrics RemoteWrite to be cleanly removed from CMO ConfigMap
+		require.Eventually(t, func() bool {
+			found := &corev1.ConfigMap{}
+			err := directClient.Get(ctx, types.NamespacedName{
+				Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+			}, found)
+			if err != nil {
+				return false
+			}
+			data := found.Data[observabilityendpoint.ClusterMonitoringConfigDataKey]
+			return !strings.Contains(data, "test-cert-secret")
+		}, 5*time.Second, 100*time.Millisecond)
+
+		// Fetch the UWL ScrapeConfig we created in the previous subtest
+		scUWL := &prometheusv1alpha1.ScrapeConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-raw-uwl",
+				Namespace: namespace,
+			},
+		}
+		require.NoError(t, directClient.Delete(ctx, scUWL))
+
+		// Wait for raw UWL metrics RemoteWrite to be cleanly removed from UWL ConfigMap
+		require.Eventually(t, func() bool {
+			found := &corev1.ConfigMap{}
+			err := directClient.Get(ctx, types.NamespacedName{
+				Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+				Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+			}, found)
+			if err != nil {
+				return false
+			}
+			data := found.Data[uwlMonitoringConfigDataKey]
+			return !strings.Contains(data, "test-cert-secret")
 		}, 5*time.Second, 100*time.Millisecond)
 	})
 
@@ -301,37 +593,5 @@ func TestMCOAAgentIntegration(t *testing.T) {
 			}
 			return restored.Labels[ManagedByLabelKey] == ManagedByLabelValue
 		}, 10*time.Second, 100*time.Millisecond, "CRD %s was not restored after deletion", target)
-	})
-
-	t.Run("Reconcile UWL Revert path: Disabled EnableUWLAlertForwarding cleanly reverts the Alertmanager configuration", func(t *testing.T) {
-		// Disable UWL alert forwarding on the active reconciler
-		reconciler.EnableUWLAlertForwarding = false
-
-		// Trigger reconcile by directly calling the Reconcile method on the reconciler, emulating the real flow.
-		_, err = reconciler.Reconcile(ctx, ctrl.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
-				Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
-			},
-		})
-		require.NoError(t, err)
-
-		// Wait for the reconciler to clean up our Alertmanager configs from UWL ConfigMap
-		require.Eventually(t, func() bool {
-			foundCM := &corev1.ConfigMap{}
-			err := directClient.Get(ctx, types.NamespacedName{
-				Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
-				Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
-			}, foundCM)
-			if apierrors.IsNotFound(err) {
-				return true
-			}
-			if err != nil {
-				fmt.Printf("Get ConfigMap error: %v\n", err)
-				return false
-			}
-			data := foundCM.Data["config.yaml"]
-			return !strings.Contains(data, "hub-alertmanager-router-ca-hub-id") && !strings.Contains(data, "hub-am.example.com")
-		}, 5*time.Second, 100*time.Millisecond)
 	})
 }

--- a/operators/endpointmetrics/controllers/mcoa/testhelpers_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/testhelpers_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package mcoa
+
+import (
+	"testing"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	prometheusv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+)
+
+func addRhobsToScheme(t *testing.T, s *runtime.Scheme) {
+	t.Helper()
+	gv := schema.GroupVersion{Group: "monitoring.rhobs", Version: "v1alpha1"}
+	s.AddKnownTypes(gv,
+		&prometheusv1alpha1.ScrapeConfig{}, &prometheusv1alpha1.ScrapeConfigList{},
+		&prometheusv1alpha1.PrometheusAgent{}, &prometheusv1alpha1.PrometheusAgentList{},
+	)
+	metav1.AddToGroupVersion(s, gv)
+}
+
+func newRawScrapeConfig(name, namespace, component string) *prometheusv1alpha1.ScrapeConfig {
+	return &prometheusv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				labelKeyComponent: component,
+			},
+		},
+		Spec: prometheusv1alpha1.ScrapeConfigSpec{
+			Params: map[string][]string{
+				"match[]": {
+					`{__name__="up"}`,
+				},
+			},
+		},
+	}
+}
+
+func newTestPrometheusAgent(name, namespace, component, rwURL, caSecretName, certSecretName string) *prometheusv1alpha1.PrometheusAgent {
+	agent := &prometheusv1alpha1.PrometheusAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				labelKeyComponent: component,
+			},
+		},
+		Spec: prometheusv1alpha1.PrometheusAgentSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				RemoteWrite: []monitoringv1.RemoteWriteSpec{
+					{
+						Name: ptr.To("acm-observability"),
+						URL:  rwURL,
+					},
+				},
+			},
+		},
+	}
+
+	if caSecretName != "" || certSecretName != "" {
+		tlsConfig := &monitoringv1.TLSConfig{
+			SafeTLSConfig: monitoringv1.SafeTLSConfig{},
+		}
+		if caSecretName != "" {
+			tlsConfig.CA = monitoringv1.SecretOrConfigMap{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: caSecretName,
+					},
+					Key: "ca.crt",
+				},
+			}
+		}
+		if certSecretName != "" {
+			tlsConfig.Cert = monitoringv1.SecretOrConfigMap{
+				Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: certSecretName,
+					},
+					Key: "tls.crt",
+				},
+			}
+			tlsConfig.KeySecret = &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: certSecretName,
+				},
+				Key: "tls.key",
+			}
+		}
+		agent.Spec.RemoteWrite[0].TLSConfig = tlsConfig
+	}
+
+	return agent
+}

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config.go
@@ -29,6 +29,7 @@ const (
 	hubAmAccessorSecretKey         = "token"                               // #nosec G101 -- Not a hardcoded credential.
 	HubAmRouterCASecretName        = "hub-alertmanager-router-ca"
 	HubAmMtlsCASecretName          = "obs-alertmanager-mtls-ca"
+	HubMtlsCASecretName            = "hub-mtls-ca" // #nosec G101 -- Not a hardcoded credential.
 	clusterMonitoringConfigName    = "cluster-monitoring-config"
 	clusterMonitoringRevertedName  = "cluster-monitoring-reverted"
 	ClusterMonitoringConfigDataKey = "config.yaml"
@@ -816,15 +817,18 @@ func IsManaged(amc cmomanifests.AdditionalAlertmanagerConfig, caSecret string) b
 	// Suffix extraction and legacy upgrade matching:
 	// Extract the suffix (e.g. "-<hub-id>") from the expected caSecret.
 	var suffix string
-	if strings.HasPrefix(caSecret, amMtlsCaName+"-") {
+	switch {
+	case strings.HasPrefix(caSecret, amMtlsCaName+"-"):
 		suffix = strings.TrimPrefix(caSecret, amMtlsCaName)
-	} else if strings.HasPrefix(caSecret, HubAmRouterCASecretName+"-") {
+	case strings.HasPrefix(caSecret, HubAmRouterCASecretName+"-"):
 		suffix = strings.TrimPrefix(caSecret, HubAmRouterCASecretName)
+	case strings.HasPrefix(caSecret, HubMtlsCASecretName+"-"):
+		suffix = strings.TrimPrefix(caSecret, HubMtlsCASecretName)
 	}
 
 	// Ensure we found a valid, non-empty suffix (e.g. "-12345", meaning length > 1) before matching.
 	if len(suffix) > 1 {
-		isOurBase := strings.HasPrefix(caName, HubAmRouterCASecretName+"-") || strings.HasPrefix(caName, amMtlsCaName+"-")
+		isOurBase := strings.HasPrefix(caName, HubAmRouterCASecretName+"-") || strings.HasPrefix(caName, amMtlsCaName+"-") || strings.HasPrefix(caName, HubMtlsCASecretName+"-")
 		if isOurBase && strings.HasSuffix(caName, suffix) {
 			return true
 		}

--- a/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/ocp_monitoring_config_test.go
@@ -1350,6 +1350,24 @@ func TestIsManaged(t *testing.T) {
 			caSecret: "obs-alertmanager-mtls-ca-",
 			expected: false,
 		},
+		{
+			name:     "MCOA hub-mtls-ca entry recognized by standard mode (MCOA to standard transition)",
+			caName:   "hub-mtls-ca-AAAA",
+			caSecret: "obs-alertmanager-mtls-ca-AAAA",
+			expected: true,
+		},
+		{
+			name:     "Standard obs-alertmanager entry recognized by MCOA mode",
+			caName:   "obs-alertmanager-mtls-ca-AAAA",
+			caSecret: "hub-mtls-ca-AAAA",
+			expected: true,
+		},
+		{
+			name:     "MCOA hub-mtls-ca exact match",
+			caName:   "hub-mtls-ca-AAAA",
+			caSecret: "hub-mtls-ca-AAAA",
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/operators/endpointmetrics/main.go
+++ b/operators/endpointmetrics/main.go
@@ -24,6 +24,7 @@ import (
 	tlsutil "github.com/openshift/controller-runtime-common/pkg/tls"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	prometheusv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/mcoa"
 	obsepctl "github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
 	statusctl "github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/status"
@@ -38,6 +39,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -64,6 +66,14 @@ func init() {
 	utilruntime.Must(prometheusv1.AddToScheme(scheme))
 	utilruntime.Must(hyperv1.AddToScheme(scheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+
+	// Register ScrapeConfig and PrometheusAgent for the custom monitoring.rhobs/v1alpha1 API Group used by MCOA on spoke clusters
+	rhobsGroupVersion := schema.GroupVersion{Group: "monitoring.rhobs", Version: "v1alpha1"}
+	scheme.AddKnownTypes(rhobsGroupVersion,
+		&prometheusv1alpha1.ScrapeConfig{}, &prometheusv1alpha1.ScrapeConfigList{},
+		&prometheusv1alpha1.PrometheusAgent{}, &prometheusv1alpha1.PrometheusAgentList{},
+	)
+	metav1.AddToGroupVersion(scheme, rhobsGroupVersion)
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -145,6 +155,23 @@ func doCleanup(args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
 	defer cancel()
 
+	// Use the clean MCOA reconciler for single-pass revert
+	r := mcoa.NewMCOAAgentReconciler(
+		cl,
+		setupLog,
+		scheme,
+		noOpRecorder{},
+		"mcoa-cleanup-dummy-namespace", // non-empty dummy namespace ensures we find NO agents or scrapeConfigs, triggering unconditional label cleanup
+		"",
+		clusterName,
+		"", // empty hubAlertmanagerURL forces Alertmanager config removal
+		hubAmCASecret,
+		"",
+		"",
+		false, // false forces Platform Alertmanager config removal
+		false, // false forces UWL Alertmanager config removal
+	)
+
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var errs []error
@@ -160,7 +187,7 @@ func doCleanup(args []string) error {
 	go func() {
 		defer wg.Done()
 		setupLog.Info("Reverting Platform monitoring configuration", "caSecret", hubAmCASecret)
-		if err := obsepctl.RevertClusterMonitoringConfig(ctx, cl, hubAmCASecret, clusterName); err != nil {
+		if err := r.ReconcileCMOPlatformConfig(ctx); err != nil {
 			addErr(fmt.Errorf("failed to revert platform monitoring config: %w", err))
 		}
 	}()
@@ -168,7 +195,7 @@ func doCleanup(args []string) error {
 	go func() {
 		defer wg.Done()
 		setupLog.Info("Reverting User Workload monitoring configuration", "caSecret", hubAmCASecret)
-		if err := obsepctl.RevertUserWorkloadMonitoringConfig(ctx, cl, hubAmCASecret); err != nil {
+		if err := r.ReconcileCMOUWLConfig(ctx); err != nil {
 			addErr(fmt.Errorf("failed to revert user workload monitoring config: %w", err))
 		}
 	}()
@@ -203,6 +230,7 @@ func runMCOA(args []string) {
 	var hubAmCASecret string
 	var hubAmCertSecret string
 	var hubAmAccessorSecret string
+	var enablePlatformAlertForwarding bool
 	var enableUWLAlertForwarding bool
 
 	fs.StringVar(&metricsAddr, "metrics-bind-address", ":8383", "The address the metric endpoint binds to.")
@@ -222,7 +250,8 @@ func runMCOA(args []string) {
 	)
 	fs.StringVar(&hubAmCertSecret, "hub-alertmanager-cert-secret", "", "The name of the TLS cert/key secret for the Hub's Alertmanager.")
 	fs.StringVar(&hubAmAccessorSecret, "hub-alertmanager-accessor-secret", "", "The name of the accessor token secret for the Hub's Alertmanager.")
-	fs.BoolVar(&enableUWLAlertForwarding, "enable-uwl-alert-forwarding", true, "Enable or disable forwarding of user workload monitoring alerts.")
+	fs.BoolVar(&enablePlatformAlertForwarding, "enable-platform-alert-forwarding", false, "Enable or disable forwarding of platform monitoring alerts.")
+	fs.BoolVar(&enableUWLAlertForwarding, "enable-uwl-alert-forwarding", false, "Enable or disable forwarding of user workload monitoring alerts.")
 
 	klog.InitFlags(fs)
 	// Parse will exit on error due to flag.ExitOnError, so we can ignore the error return value.
@@ -241,37 +270,42 @@ func runMCOA(args []string) {
 		os.Exit(1)
 	}
 
+	if (enablePlatformAlertForwarding || enableUWLAlertForwarding) && hubAmURL == "" {
+		setupLog.Error(fmt.Errorf("hub-alertmanager-url flag must be set when platform or user workload alert forwarding is enabled"), "unable to start manager")
+		os.Exit(1)
+	}
+
 	if hubAmURL != "" {
-		parsedURL, err := url.Parse(hubAmURL)
-		if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		parsedAmURL, err := url.Parse(hubAmURL)
+		if err != nil || parsedAmURL.Scheme == "" || parsedAmURL.Host == "" {
 			setupLog.Error(fmt.Errorf("invalid hub-alertmanager-url %q: must be a valid absolute URL", hubAmURL), "unable to start manager")
 			os.Exit(1)
 		}
+	}
 
-		if clusterID == "" {
-			setupLog.Error(fmt.Errorf("cluster-id flag not set"), "unable to start manager")
-			os.Exit(1)
-		}
+	if clusterID == "" {
+		setupLog.Error(fmt.Errorf("cluster-id flag not set"), "unable to start manager")
+		os.Exit(1)
+	}
 
-		if clusterName == "" {
-			setupLog.Error(fmt.Errorf("cluster-name flag not set"), "unable to start manager")
-			os.Exit(1)
-		}
+	if clusterName == "" {
+		setupLog.Error(fmt.Errorf("cluster-name flag not set"), "unable to start manager")
+		os.Exit(1)
+	}
 
-		if hubAmCASecret == "" {
-			setupLog.Error(fmt.Errorf("hub-alertmanager-ca-secret flag not set"), "unable to start manager")
-			os.Exit(1)
-		}
+	if hubAmCASecret == "" {
+		setupLog.Error(fmt.Errorf("hub-alertmanager-ca-secret flag not set"), "unable to start manager")
+		os.Exit(1)
+	}
 
-		if hubAmCertSecret == "" {
-			setupLog.Error(fmt.Errorf("hub-alertmanager-cert-secret flag not set"), "unable to start manager")
-			os.Exit(1)
-		}
+	if hubAmCertSecret == "" {
+		setupLog.Error(fmt.Errorf("hub-alertmanager-cert-secret flag not set"), "unable to start manager")
+		os.Exit(1)
+	}
 
-		if hubAmAccessorSecret == "" {
-			setupLog.Error(fmt.Errorf("hub-alertmanager-accessor-secret flag not set"), "unable to start manager")
-			os.Exit(1)
-		}
+	if hubAmAccessorSecret == "" {
+		setupLog.Error(fmt.Errorf("hub-alertmanager-accessor-secret flag not set"), "unable to start manager")
+		os.Exit(1)
 	}
 
 	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
@@ -330,6 +364,7 @@ func runMCOA(args []string) {
 		hubAmCASecret,
 		hubAmCertSecret,
 		hubAmAccessorSecret,
+		enablePlatformAlertForwarding,
 		enableUWLAlertForwarding,
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "mcoa-endpoint-controller")
@@ -554,4 +589,9 @@ func runStandard(args []string) {
 		os.Exit(1)
 	}
 	cancel()
+}
+
+type noOpRecorder struct{}
+
+func (noOpRecorder) Eventf(regarding k8sruntime.Object, related k8sruntime.Object, eventtype, reason, action, note string, args ...any) {
 }

--- a/operators/endpointmetrics/pkg/remotewrite/transpiler.go
+++ b/operators/endpointmetrics/pkg/remotewrite/transpiler.go
@@ -1,0 +1,221 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package remotewrite
+
+import (
+	"cmp"
+	"fmt"
+	"maps"
+	"regexp"
+	"slices"
+	"strings"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"k8s.io/utils/ptr"
+)
+
+func Transpile(scrapeConfig *monitoringv1alpha1.ScrapeConfig, agent *monitoringv1alpha1.PrometheusAgent) ([]*monitoringv1.RemoteWriteSpec, error) {
+	if scrapeConfig == nil {
+		return nil, nil
+	}
+
+	matchersList, ok := scrapeConfig.Spec.Params["match[]"]
+	if !ok || len(matchersList) == 0 {
+		return nil, nil
+	}
+
+	var parsedSelectors [][]*labels.Matcher
+	for _, mStr := range matchersList {
+		matchers, err := parser.ParseMetricSelector(mStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse metric selector %q: %w", mStr, err)
+		}
+		if len(matchers) > 0 {
+			parsedSelectors = append(parsedSelectors, matchers)
+		}
+	}
+
+	if len(parsedSelectors) == 0 {
+		return nil, nil
+	}
+
+	var relabelConfigs []monitoringv1.RelabelConfig
+
+	// 1. Process each selector individually to handle negation (OR disjunction semantics)
+	for i, sel := range parsedSelectors {
+		type posMatcher struct {
+			name  string
+			value string
+		}
+
+		var posMatchers []posMatcher
+		for _, lm := range sel {
+			if lm.Type == labels.MatchEqual || lm.Type == labels.MatchRegexp {
+				var val string
+				if lm.Type == labels.MatchEqual {
+					val = regexp.QuoteMeta(lm.Value)
+				} else {
+					val = fmt.Sprintf("(?:%s)", lm.Value)
+				}
+				posMatchers = append(posMatchers, posMatcher{
+					name:  lm.Name,
+					value: val,
+				})
+			}
+		}
+
+		// Deterministically sort by label name, sub-sorting by regex value for stability
+		slices.SortFunc(posMatchers, func(a, b posMatcher) int {
+			if c := cmp.Compare(a.name, b.name); c != 0 {
+				return c
+			}
+			return cmp.Compare(a.value, b.value)
+		})
+
+		var sourceLabels []monitoringv1.LabelName
+		var posValues []string
+		for _, pm := range posMatchers {
+			sourceLabels = append(sourceLabels, monitoringv1.LabelName(pm.name))
+			posValues = append(posValues, pm.value)
+		}
+
+		// Positive Matchers Phase (Initialize __tmp_keep_i to "keep" if metric matches positive selectors)
+		tmpKeepLabel := fmt.Sprintf("__tmp_keep_%d", i)
+		if len(sourceLabels) > 0 {
+			relabelConfigs = append(relabelConfigs, monitoringv1.RelabelConfig{
+				Action:       "replace",
+				SourceLabels: sourceLabels,
+				Regex:        strings.Join(posValues, ";"),
+				TargetLabel:  tmpKeepLabel,
+				Replacement:  ptr.To("keep"),
+			})
+		} else {
+			relabelConfigs = append(relabelConfigs, monitoringv1.RelabelConfig{
+				Action:      "replace",
+				TargetLabel: tmpKeepLabel,
+				Replacement: ptr.To("keep"),
+			})
+		}
+
+		// Negative Matchers Phase (Clear __tmp_keep_i to "" if any negative matcher matches)
+		for _, lm := range sel {
+			if lm.Type == labels.MatchNotEqual || lm.Type == labels.MatchNotRegexp {
+				var regexVal string
+				if lm.Type == labels.MatchNotEqual {
+					regexVal = regexp.QuoteMeta(lm.Value)
+				} else {
+					regexVal = fmt.Sprintf("(?:%s)", lm.Value)
+				}
+
+				relabelConfigs = append(relabelConfigs, monitoringv1.RelabelConfig{
+					Action:       "replace",
+					SourceLabels: []monitoringv1.LabelName{monitoringv1.LabelName(tmpKeepLabel), monitoringv1.LabelName(lm.Name)},
+					Regex:        fmt.Sprintf("keep;%s", regexVal),
+					TargetLabel:  tmpKeepLabel,
+					Replacement:  ptr.To(""),
+				})
+			}
+		}
+	}
+
+	// 2. Initialize global __tmp_keep to "drop"
+	relabelConfigs = append(relabelConfigs, monitoringv1.RelabelConfig{
+		Action:      "replace",
+		TargetLabel: "__tmp_keep",
+		Replacement: ptr.To("drop"),
+	})
+
+	// 3. Combine selector decisions: set global __tmp_keep to "keep" if any __tmp_keep_i is "keep" (OR logic)
+	var combineSourceLabels []monitoringv1.LabelName
+	for i := range parsedSelectors {
+		combineSourceLabels = append(combineSourceLabels, monitoringv1.LabelName(fmt.Sprintf("__tmp_keep_%d", i)))
+	}
+
+	relabelConfigs = append(relabelConfigs, monitoringv1.RelabelConfig{
+		Action:       "replace",
+		SourceLabels: combineSourceLabels,
+		Regex:        ".*keep.*",
+		TargetLabel:  "__tmp_keep",
+		Replacement:  ptr.To("keep"),
+	})
+
+	// 4. Keep only metrics flagged with "keep"
+	relabelConfigs = append(relabelConfigs, monitoringv1.RelabelConfig{
+		Action:       "keep",
+		SourceLabels: []monitoringv1.LabelName{"__tmp_keep"},
+		Regex:        "keep",
+	})
+
+	// 5. Cleanup all temporary labels
+	relabelConfigs = append(relabelConfigs, monitoringv1.RelabelConfig{
+		Action: "labeldrop",
+		Regex:  "__tmp_keep.*",
+	})
+
+	// 6. Append custom metricRelabelings from scrapeConfig directly (safely deep-copied)
+	for _, cfg := range scrapeConfig.Spec.MetricRelabelConfigs {
+		relabelConfigs = append(relabelConfigs, *cfg.DeepCopy())
+	}
+
+	if agent == nil || len(agent.Spec.RemoteWrite) == 0 {
+		baseSpec := &monitoringv1.RemoteWriteSpec{
+			WriteRelabelConfigs: relabelConfigs,
+		}
+		return []*monitoringv1.RemoteWriteSpec{baseSpec}, nil
+	}
+
+	var specs []*monitoringv1.RemoteWriteSpec
+	for _, agentRw := range agent.Spec.RemoteWrite {
+		relabelConfigsCopy := make([]monitoringv1.RelabelConfig, len(relabelConfigs))
+		for i, cfg := range relabelConfigs {
+			cfg.DeepCopyInto(&relabelConfigsCopy[i])
+		}
+
+		spec := &monitoringv1.RemoteWriteSpec{
+			WriteRelabelConfigs: relabelConfigsCopy,
+		}
+
+		spec.URL = agentRw.URL
+
+		if agentRw.RemoteTimeout != nil {
+			spec.RemoteTimeout = ptr.To(*agentRw.RemoteTimeout)
+		}
+		if agentRw.BasicAuth != nil {
+			spec.BasicAuth = agentRw.BasicAuth.DeepCopy()
+		}
+		if agentRw.Authorization != nil {
+			spec.Authorization = agentRw.Authorization.DeepCopy()
+		}
+		if agentRw.OAuth2 != nil {
+			spec.OAuth2 = agentRw.OAuth2.DeepCopy()
+		}
+		if agentRw.QueueConfig != nil {
+			spec.QueueConfig = agentRw.QueueConfig.DeepCopy()
+		}
+		if agentRw.TLSConfig != nil {
+			spec.TLSConfig = agentRw.TLSConfig.DeepCopy()
+		}
+		if agentRw.ProxyURL != nil {
+			spec.ProxyURL = ptr.To(*agentRw.ProxyURL)
+		}
+		if agentRw.NoProxy != nil {
+			spec.NoProxy = ptr.To(*agentRw.NoProxy)
+		}
+		if agentRw.Headers != nil {
+			spec.Headers = make(map[string]string)
+			maps.Copy(spec.Headers, agentRw.Headers)
+		}
+		if agentRw.Name != nil {
+			spec.Name = ptr.To(*agentRw.Name)
+		}
+
+		specs = append(specs, spec)
+	}
+
+	return specs, nil
+}

--- a/operators/endpointmetrics/pkg/remotewrite/transpiler_test.go
+++ b/operators/endpointmetrics/pkg/remotewrite/transpiler_test.go
@@ -1,0 +1,452 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package remotewrite
+
+import (
+	"strings"
+	"testing"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/relabel"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+func convertToPromRelabel(cfgs []monitoringv1.RelabelConfig) []*relabel.Config {
+	var ret []*relabel.Config
+	for _, c := range cfgs {
+		var srcLabels model.LabelNames
+		for _, sl := range c.SourceLabels {
+			srcLabels = append(srcLabels, model.LabelName(sl))
+		}
+
+		re := relabel.MustNewRegexp(c.Regex)
+
+		replacement := "$1"
+		if c.Replacement != nil {
+			replacement = *c.Replacement
+		}
+
+		ret = append(ret, &relabel.Config{
+			SourceLabels: srcLabels,
+			Separator:    ";",
+			Regex:        re,
+			TargetLabel:  c.TargetLabel,
+			Replacement:  replacement,
+			Action:       relabel.Action(strings.ToLower(c.Action)),
+		})
+	}
+	return ret
+}
+
+func TestTranspile(t *testing.T) {
+	scrapeConfig := &monitoringv1alpha1.ScrapeConfig{
+		Spec: monitoringv1alpha1.ScrapeConfigSpec{
+			Params: map[string][]string{
+				"match[]": {
+					"up",
+					"workqueue_adds_total{job=\"apiserver\"}",
+					"container_memory_cache{container!=\"POD\",container!=\"\"}",
+					"process_resident_memory_bytes{job=~\"apiserver|etcd\"}",
+				},
+			},
+			MetricRelabelConfigs: []monitoringv1.RelabelConfig{
+				{
+					Action: "labeldrop",
+					Regex:  "foo",
+				},
+			},
+		},
+	}
+
+	agent := &monitoringv1alpha1.PrometheusAgent{
+		Spec: monitoringv1alpha1.PrometheusAgentSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				RemoteWrite: []monitoringv1.RemoteWriteSpec{
+					{
+						Name:          ptr.To("acm-observability"),
+						URL:           "https://example.com/write",
+						RemoteTimeout: ptr.To(monitoringv1.Duration("30s")),
+						QueueConfig: &monitoringv1.QueueConfig{
+							MaxShards: 10,
+						},
+						TLSConfig: &monitoringv1.TLSConfig{
+							SafeTLSConfig: monitoringv1.SafeTLSConfig{
+								CA: monitoringv1.SecretOrConfigMap{
+									Secret: &corev1.SecretKeySelector{
+										Key: "ca.crt",
+									},
+								},
+								InsecureSkipVerify: ptr.To(true),
+							},
+						},
+						Authorization: &monitoringv1.Authorization{
+							SafeAuthorization: monitoringv1.SafeAuthorization{
+								Type: "Bearer",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	gotList, err := Transpile(scrapeConfig, agent)
+	if err != nil {
+		t.Fatalf("Transpile returned error: %v", err)
+	}
+	if len(gotList) != 1 {
+		t.Fatalf("Expected exactly 1 transpiled spec, got %d", len(gotList))
+	}
+	got := gotList[0]
+	if got == nil {
+		t.Fatalf("Transpile returned nil spec")
+	}
+
+	// Verify QueueConfig and TLSConfig were copied
+	if got.URL != "https://example.com/write" {
+		t.Errorf("Expected URL to be copied, got %s", got.URL)
+	}
+	if got.RemoteTimeout == nil || *got.RemoteTimeout != "30s" {
+		t.Errorf("Expected RemoteTimeout to be copied, got %+v", got.RemoteTimeout)
+	}
+	if got.Authorization == nil || got.Authorization.Type != "Bearer" {
+		t.Errorf("Expected Authorization to be copied, got %+v", got.Authorization)
+	}
+	if got.QueueConfig == nil || got.QueueConfig.MaxShards != 10 {
+		t.Errorf("Expected QueueConfig MaxShards to be 10, got %+v", got.QueueConfig)
+	}
+	if got.TLSConfig == nil || !*got.TLSConfig.InsecureSkipVerify {
+		t.Errorf("Expected TLSConfig InsecureSkipVerify to be true, got %+v", got.TLSConfig)
+	}
+
+	// Deep behavior test executing the generated relabel configs using Prometheus's own relabeling engine!
+	promCfgs := convertToPromRelabel(got.WriteRelabelConfigs)
+
+	tests := []struct {
+		name         string
+		inputLabels  map[string]string
+		expectedKeep bool
+	}{
+		{
+			name:         "Keep standard up metric",
+			inputLabels:  map[string]string{"__name__": "up"},
+			expectedKeep: true,
+		},
+		{
+			name:         "Keep up metric with arbitrary labels",
+			inputLabels:  map[string]string{"__name__": "up", "job": "prometheus"},
+			expectedKeep: true,
+		},
+		{
+			name:         "Keep workqueue_adds_total with matching job",
+			inputLabels:  map[string]string{"__name__": "workqueue_adds_total", "job": "apiserver"},
+			expectedKeep: true,
+		},
+		{
+			name:         "Drop workqueue_adds_total with non-matching job",
+			inputLabels:  map[string]string{"__name__": "workqueue_adds_total", "job": "not-apiserver"},
+			expectedKeep: false,
+		},
+		{
+			name:         "Keep container_memory_cache with compliant container",
+			inputLabels:  map[string]string{"__name__": "container_memory_cache", "container": "main"},
+			expectedKeep: true,
+		},
+		{
+			name:         "Drop container_memory_cache with negative container matching POD",
+			inputLabels:  map[string]string{"__name__": "container_memory_cache", "container": "POD"},
+			expectedKeep: false,
+		},
+		{
+			name:         "Drop container_memory_cache with negative empty container",
+			inputLabels:  map[string]string{"__name__": "container_memory_cache", "container": ""},
+			expectedKeep: false,
+		},
+		{
+			name:         "Keep process_resident_memory_bytes with apiserver job",
+			inputLabels:  map[string]string{"__name__": "process_resident_memory_bytes", "job": "apiserver"},
+			expectedKeep: true,
+		},
+		{
+			name:         "Keep process_resident_memory_bytes with etcd job",
+			inputLabels:  map[string]string{"__name__": "process_resident_memory_bytes", "job": "etcd"},
+			expectedKeep: true,
+		},
+		{
+			name:         "Drop process_resident_memory_bytes with other job",
+			inputLabels:  map[string]string{"__name__": "process_resident_memory_bytes", "job": "other"},
+			expectedKeep: false,
+		},
+		{
+			name:         "Drop completely unrelated metric (whitelist behavior)",
+			inputLabels:  map[string]string{"__name__": "node_cpu_seconds_total"},
+			expectedKeep: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input := labels.FromMap(tc.inputLabels)
+			lb := labels.NewBuilder(input)
+			keep := relabel.ProcessBuilder(lb, promCfgs...)
+
+			if keep != tc.expectedKeep {
+				t.Fatalf("Expected keep to be %v, got %v for metric %v", tc.expectedKeep, keep, input)
+			}
+
+			if keep {
+				res := lb.Labels()
+				// Verify custom metricRelabelings (the custom labeldrop of label 'foo')
+				if res.Get("foo") != "" {
+					t.Errorf("Expected label 'foo' to be dropped, but got value '%s'", res.Get("foo"))
+				}
+			}
+		})
+	}
+}
+
+func TestNegationBugAndNoMetricNameSelectors(t *testing.T) {
+	scrapeConfig := &monitoringv1alpha1.ScrapeConfig{
+		Spec: monitoringv1alpha1.ScrapeConfigSpec{
+			Params: map[string][]string{
+				"match[]": {
+					// Selector 0 has negative container matcher on container_memory_cache
+					"container_memory_cache{container!=\"POD\"}",
+					// Selector 1 matches any metric (with or without metric name) having job="prometheus"
+					"{job=\"prometheus\"}",
+					// Selector 2 matches regex metric names up|down
+					"{__name__=~\"up|down\", job=\"apiserver\"}",
+					// Selector 3 has multiple positive matchers on the same label 'job'
+					"up{job=~\"api.*\", job=~\".*-secure\"}",
+				},
+			},
+		},
+	}
+
+	gotList, err := Transpile(scrapeConfig, nil)
+	if err != nil {
+		t.Fatalf("Transpile returned error: %v", err)
+	}
+	if len(gotList) != 1 {
+		t.Fatalf("Expected exactly 1 transpiled spec, got %d", len(gotList))
+	}
+	got := gotList[0]
+
+	promCfgs := convertToPromRelabel(got.WriteRelabelConfigs)
+
+	tests := []struct {
+		name         string
+		inputLabels  map[string]string
+		expectedKeep bool
+	}{
+		{
+			// Resolves high priority bug 1: The Negation Bug (cross-selector drops)
+			// Selector 0 would drop container="POD", but Selector 1 matches it due to job="prometheus".
+			// In standard Prometheus disjunction (OR) rules, this metric MUST be kept!
+			name:         "Negation Bug check: Keep metric matching Selector 1 despite matching Selector 0's negative filter",
+			inputLabels:  map[string]string{"__name__": "container_memory_cache", "container": "POD", "job": "prometheus"},
+			expectedKeep: true,
+		},
+		{
+			// Resolves high priority bug 2: Selectors without exact metric names
+			// Selector 1 matches any metric name (e.g., "my_custom_metric") as long as job="prometheus".
+			name:         "Keep custom metric without standard name matching Selector 1",
+			inputLabels:  map[string]string{"__name__": "my_custom_metric", "job": "prometheus"},
+			expectedKeep: true,
+		},
+		{
+			// Resolves high priority bug 2: Regex metric names
+			// Selector 2 matches up{job="apiserver"}
+			name:         "Keep up metric matching Selector 2",
+			inputLabels:  map[string]string{"__name__": "up", "job": "apiserver"},
+			expectedKeep: true,
+		},
+		{
+			// Selector 2 matches down{job="apiserver"}
+			name:         "Keep down metric matching Selector 2",
+			inputLabels:  map[string]string{"__name__": "down", "job": "apiserver"},
+			expectedKeep: true,
+		},
+		{
+			// Selector 2 does not match other{job="apiserver"}
+			name:         "Drop other metric not matching Selector 2",
+			inputLabels:  map[string]string{"__name__": "other", "job": "apiserver"},
+			expectedKeep: false,
+		},
+		{
+			// Selector 3 matches up{job="api-secure"} (both job=~"api.*" and job=~".*-secure" are satisfied)
+			name:         "Keep up metric matching multiple positive matchers on the same label",
+			inputLabels:  map[string]string{"__name__": "up", "job": "api-secure"},
+			expectedKeep: true,
+		},
+		{
+			// Selector 3 does not match up{job="api-insecure"} (job=~".*-secure" is not satisfied)
+			name:         "Drop up metric matching only one positive matcher on the same label",
+			inputLabels:  map[string]string{"__name__": "up", "job": "api-insecure"},
+			expectedKeep: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input := labels.FromMap(tc.inputLabels)
+			lb := labels.NewBuilder(input)
+			keep := relabel.ProcessBuilder(lb, promCfgs...)
+
+			if keep != tc.expectedKeep {
+				for _, c := range got.WriteRelabelConfigs {
+					repl := ""
+					if c.Replacement != nil {
+						repl = *c.Replacement
+					}
+					t.Logf("Config: Action=%s, SourceLabels=%v, Regex=%s, TargetLabel=%s, Replacement=%s", c.Action, c.SourceLabels, c.Regex, c.TargetLabel, repl)
+				}
+				t.Fatalf("Expected keep to be %v, got %v for metric %v", tc.expectedKeep, keep, input)
+			}
+		})
+	}
+}
+
+func TestSharedPointerCacheIsolation(t *testing.T) {
+	scrapeConfig := &monitoringv1alpha1.ScrapeConfig{
+		Spec: monitoringv1alpha1.ScrapeConfigSpec{
+			Params: map[string][]string{
+				"match[]": {"up"},
+			},
+		},
+	}
+
+	originalAgent := &monitoringv1alpha1.PrometheusAgent{
+		Spec: monitoringv1alpha1.PrometheusAgentSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				RemoteWrite: []monitoringv1.RemoteWriteSpec{
+					{
+						Name:          ptr.To("acm-observability"),
+						URL:           "https://example.com/write",
+						RemoteTimeout: ptr.To(monitoringv1.Duration("30s")),
+						QueueConfig: &monitoringv1.QueueConfig{
+							MaxShards: 10,
+						},
+						TLSConfig: &monitoringv1.TLSConfig{
+							SafeTLSConfig: monitoringv1.SafeTLSConfig{
+								InsecureSkipVerify: ptr.To(true),
+							},
+						},
+						Authorization: &monitoringv1.Authorization{
+							SafeAuthorization: monitoringv1.SafeAuthorization{
+								Type: "Bearer",
+							},
+						},
+						Headers: map[string]string{
+							"X-Hub": "ACM",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	gotList, err := Transpile(scrapeConfig, originalAgent)
+	if err != nil {
+		t.Fatalf("Transpile returned error: %v", err)
+	}
+	if len(gotList) != 1 {
+		t.Fatalf("Expected exactly 1 transpiled spec, got %d", len(gotList))
+	}
+	got := gotList[0]
+
+	// Downstream mutation of the generated RemoteWriteSpec pointers/maps
+	got.QueueConfig.MaxShards = 99
+	*got.TLSConfig.InsecureSkipVerify = false
+	*got.RemoteTimeout = "99s"
+	got.Authorization.Type = "Basic"
+	got.Headers["X-Hub"] = "Mutated"
+
+	// Assert that the original agent's values are perfectly untouched
+	// (Resolves high priority bug 3: Shared Pointer and Reference Mutation Risk)
+	if originalAgent.Spec.RemoteWrite[0].QueueConfig.MaxShards != 10 {
+		t.Errorf("Memory leak/aliasing detected! Original agent QueueConfig was mutated to %d", originalAgent.Spec.RemoteWrite[0].QueueConfig.MaxShards)
+	}
+	if !*originalAgent.Spec.RemoteWrite[0].TLSConfig.InsecureSkipVerify {
+		t.Errorf("Memory leak/aliasing detected! Original agent TLSConfig was mutated")
+	}
+	if *originalAgent.Spec.RemoteWrite[0].RemoteTimeout != "30s" {
+		t.Errorf("Memory leak/aliasing detected! Original agent RemoteTimeout was mutated")
+	}
+	if originalAgent.Spec.RemoteWrite[0].Authorization.Type != "Bearer" {
+		t.Errorf("Memory leak/aliasing detected! Original agent Authorization was mutated to %s", originalAgent.Spec.RemoteWrite[0].Authorization.Type)
+	}
+	if originalAgent.Spec.RemoteWrite[0].Headers["X-Hub"] != "ACM" {
+		t.Errorf("Memory leak/aliasing detected! Original agent Headers map was mutated")
+	}
+}
+
+func TestTranspile_MultipleRemoteWrites(t *testing.T) {
+	scrapeConfig := &monitoringv1alpha1.ScrapeConfig{
+		Spec: monitoringv1alpha1.ScrapeConfigSpec{
+			Params: map[string][]string{
+				"match[]": {"up"},
+			},
+		},
+	}
+
+	agent := &monitoringv1alpha1.PrometheusAgent{
+		Spec: monitoringv1alpha1.PrometheusAgentSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				RemoteWrite: []monitoringv1.RemoteWriteSpec{
+					{
+						Name: ptr.To("primary-hub"),
+						URL:  "https://hub-primary.example.com",
+					},
+					{
+						Name: ptr.To("secondary-hub"),
+						URL:  "https://hub-secondary.example.com",
+					},
+				},
+			},
+		},
+	}
+
+	gotList, err := Transpile(scrapeConfig, agent)
+	if err != nil {
+		t.Fatalf("Transpile returned error: %v", err)
+	}
+
+	if len(gotList) != 2 {
+		t.Fatalf("Expected exactly 2 transpiled specs, got %d", len(gotList))
+	}
+
+	// Verify both specs are populated and preserve their respective properties
+	if gotList[0].Name == nil || *gotList[0].Name != "primary-hub" || gotList[0].URL != "https://hub-primary.example.com" {
+		t.Errorf("First spec incorrect: name=%v, url=%s", gotList[0].Name, gotList[0].URL)
+	}
+	if gotList[1].Name == nil || *gotList[1].Name != "secondary-hub" || gotList[1].URL != "https://hub-secondary.example.com" {
+		t.Errorf("Second spec incorrect: name=%v, url=%s", gotList[1].Name, gotList[1].URL)
+	}
+
+	// Verify both specs successfully receive the transpiled relabel configurations
+	if len(gotList[0].WriteRelabelConfigs) == 0 {
+		t.Errorf("First spec missing relabel configs")
+	}
+	if len(gotList[1].WriteRelabelConfigs) == 0 {
+		t.Errorf("Second spec missing relabel configs")
+	}
+
+	// Verify deep copy isolation: mutating pointers/slices in gotList[0] must not affect gotList[1]
+	origReplacement := *gotList[1].WriteRelabelConfigs[0].Replacement
+	gotList[0].WriteRelabelConfigs[0].Replacement = ptr.To("MUTATED")
+	gotList[0].WriteRelabelConfigs[0].SourceLabels[0] = "MUTATED"
+
+	if *gotList[1].WriteRelabelConfigs[0].Replacement != origReplacement {
+		t.Errorf("Shared pointer leakage: second spec's replacement was mutated to %q", *gotList[1].WriteRelabelConfigs[0].Replacement)
+	}
+	if string(gotList[1].WriteRelabelConfigs[0].SourceLabels[0]) == "MUTATED" {
+		t.Errorf("Shared slice leakage: second spec's source label was mutated")
+	}
+}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -49,7 +49,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
-	workv1 "open-cluster-management.io/api/work/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -86,7 +85,6 @@ type MultiClusterObservabilityReconciler struct {
 	Log               logr.Logger
 	Scheme            *runtime.Scheme
 	CRDMap            map[string]bool
-	APIReader         client.Reader
 	RESTMapper        meta.RESTMapper
 	ImageClient       imagev1client.ImageV1Interface
 	LastStorageConfig *mcov1beta2.StorageConfig
@@ -1224,17 +1222,8 @@ func (r *MultiClusterObservabilityReconciler) deleteMCOACMA(ctx context.Context)
 }
 
 // hasMCOAManifestWorks checks if there are any remaining ManifestWorks for the MCOA addon on the hub.
-func (r *MultiClusterObservabilityReconciler) hasMCOAManifestWorks(ctx context.Context) (bool, error) {
-	workList := &workv1.ManifestWorkList{}
-	opts := []client.ListOption{
-		client.MatchingLabels{
-			addonv1beta1.AddonLabelKey: config.MultiClusterObservabilityAddon,
-		},
-	}
-	if err := r.Client.List(ctx, workList, opts...); err != nil {
-		return false, fmt.Errorf("failed to list ManifestWorks: %w", err)
-	}
-	return len(workList.Items) > 0, nil
+func (r *MultiClusterObservabilityReconciler) hasMCOAManifestWorks(ctx context.Context) ([]string, error) {
+	return util.HasMCOAManifestWorks(ctx, r.Client)
 }
 
 // cleanupMCOAManifestWorks deletes the ClusterManagementAddOn (CMA) and waits for its ManifestWorks to be cleaned up.
@@ -1244,12 +1233,17 @@ func (r *MultiClusterObservabilityReconciler) cleanupMCOAManifestWorks(ctx conte
 		return false, ctrl.Result{}, err
 	}
 
-	hasWorks, err := r.hasMCOAManifestWorks(ctx)
+	blockingClusters, err := r.hasMCOAManifestWorks(ctx)
 	if err != nil {
 		return false, ctrl.Result{}, fmt.Errorf("failed to check for remaining ManifestWorks during MCOA cleanup: %w", err)
 	}
-	if hasWorks {
-		logger.Info("Waiting for MCOA ManifestWorks to be deleted")
+	if len(blockingClusters) > 0 {
+		logClusters := blockingClusters
+		if len(logClusters) > 10 {
+			logClusters = logClusters[:10:10]
+			logClusters = append(logClusters, fmt.Sprintf("...and %d more", len(blockingClusters)-10))
+		}
+		logger.Info("Waiting for MCOA ManifestWorks to be deleted", "blockingClusters", logClusters)
 		return true, ctrl.Result{RequeueAfter: mcoaCleanupRequeueInterval}, nil
 	}
 

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_integration_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_integration_test.go
@@ -94,7 +94,6 @@ func TestIntegrationMCO_HubRules(t *testing.T) {
 		Log:         ctrl.Log.WithName("controllers").WithName("MultiClusterObservability"),
 		Scheme:      scheme,
 		CRDMap:      nil,
-		APIReader:   nil,
 		RESTMapper:  mgr.GetRESTMapper(),
 		ImageClient: imageClient,
 	}

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -1824,6 +1824,7 @@ func TestMCOAWaitForManifestWorks(t *testing.T) {
 	require.NoError(t, routev1.Install(s))
 	require.NoError(t, workv1.Install(s))
 	require.NoError(t, addonv1beta1.Install(s))
+	require.NoError(t, clusterv1.Install(s))
 	require.NoError(t, mcov1beta2.SchemeBuilder.AddToScheme(s))
 
 	mw := &workv1.ManifestWork{
@@ -1834,6 +1835,15 @@ func TestMCOAWaitForManifestWorks(t *testing.T) {
 				addonv1beta1.AddonLabelKey: config.MultiClusterObservabilityAddon,
 			},
 		},
+		Spec: workv1.ManifestWorkSpec{
+			Workload: workv1.ManifestsTemplate{
+				Manifests: []workv1.Manifest{
+					{RawExtension: runtime.RawExtension{
+						Raw: []byte(`{"apiVersion":"monitoring.rhobs/v1","kind":"PrometheusAgent","metadata":{"name":"test"}}`),
+					}},
+				},
+			},
+		},
 	}
 
 	t.Run("hasMCOAManifestWorks helper", func(t *testing.T) {
@@ -1842,18 +1852,18 @@ func TestMCOAWaitForManifestWorks(t *testing.T) {
 			Client: clientWithWork,
 			Scheme: s,
 		}
-		hasWorks, err := r1.hasMCOAManifestWorks(t.Context())
+		blocking, err := r1.hasMCOAManifestWorks(t.Context())
 		assert.NoError(t, err)
-		assert.True(t, hasWorks)
+		assert.Contains(t, blocking, "test-ns")
 
 		clientEmpty := fake.NewClientBuilder().WithScheme(s).Build()
 		r2 := &MultiClusterObservabilityReconciler{
 			Client: clientEmpty,
 			Scheme: s,
 		}
-		hasWorks, err = r2.hasMCOAManifestWorks(t.Context())
+		blocking, err = r2.hasMCOAManifestWorks(t.Context())
 		assert.NoError(t, err)
-		assert.False(t, hasWorks)
+		assert.Empty(t, blocking)
 	})
 
 	t.Run("initFinalization delay", func(t *testing.T) {

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork.go
@@ -223,6 +223,8 @@ func removePostponeDeleteAnnotationForManifestwork(c client.Client, namespace st
 	})
 }
 
+var ErrManifestWorkTerminating = errors.New("existing manifestwork is terminating, skip and reconcile later")
+
 func createManifestwork(ctx context.Context, c client.Client, work *workv1.ManifestWork) error {
 	if work.Namespace == config.GetDefaultNamespace() {
 		return nil
@@ -246,7 +248,7 @@ func createManifestwork(ctx context.Context, c client.Client, work *workv1.Manif
 
 	if found.GetDeletionTimestamp() != nil {
 		log.Info("Existing manifestwork is terminating, skip and reconcile later")
-		return errors.New("existing manifestwork is terminating, skip and reconcile later")
+		return ErrManifestWorkTerminating
 	}
 
 	if !shouldUpdateManifestWork(work, found) {

--- a/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/manifestwork_test.go
@@ -7,6 +7,7 @@ package placementrule
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -21,13 +22,14 @@ import (
 	"gopkg.in/yaml.v2"
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -659,7 +661,7 @@ func TestManifestWork(t *testing.T) {
 		t.Fatalf("Failed to delete manifestworks: (%v)", err)
 	}
 	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace + workNameSuffix, Namespace: namespace}, found)
-	if err == nil || !errors.IsNotFound(err) {
+	if err == nil || !k8serrors.IsNotFound(err) {
 		t.Fatalf("Manifestwork not deleted: (%v)", err)
 	}
 
@@ -1036,5 +1038,28 @@ func TestShouldUpdateManifestWork(t *testing.T) {
 					tt.description, result, tt.shouldUpdate, tt.foundAnno, tt.desiredAnno)
 			}
 		})
+	}
+}
+
+func TestCreateManifestwork_Terminating(t *testing.T) {
+	s := scheme.Scheme
+	_ = workv1.Install(s)
+
+	now := metav1.Now()
+	mw := &workv1.ManifestWork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-work",
+			Namespace:         "test-ns",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"test-finalizer"},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mw).Build()
+
+	// Call createManifestwork (it tries to check if the manifestwork already exists and is terminating)
+	err := createManifestwork(context.Background(), cl, mw)
+	if !errors.Is(err, ErrManifestWorkTerminating) {
+		t.Fatalf("Expected ErrManifestWorkTerminating, got %v", err)
 	}
 }

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -6,7 +6,6 @@ package placementrule
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -169,12 +168,17 @@ func (r *PlacementRuleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		// Block legacy addon deployment while MCOA is still actively managing metrics collection.
 		// RS-only ManifestWorks (PrometheusRules) are safe to coexist with the legacy addon
 		// and do not trigger this guard — only PrometheusAgent presence indicates active metrics.
-		hasMetricsWorks, err := r.hasMCOAMetricsManifestWorks(ctx)
+		blockingClusters, err := r.hasMCOAMetricsManifestWorks(ctx)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to check for MCOA metrics ManifestWorks: %w", err)
 		}
-		if hasMetricsWorks {
-			reqLogger.Info("MCOA metrics ManifestWorks still active, waiting before deploying legacy addon resources")
+		if len(blockingClusters) > 0 {
+			logClusters := blockingClusters
+			if len(logClusters) > 10 {
+				logClusters = logClusters[:10:10]
+				logClusters = append(logClusters, fmt.Sprintf("...and %d more", len(blockingClusters)-10))
+			}
+			reqLogger.Info("MCOA metrics ManifestWorks still active, waiting before deploying legacy addon resources", "blockingClusters", logClusters)
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 
@@ -640,8 +644,12 @@ func createAllRelatedRes(
 				return createManifestwork(ctx, c, manifestWork)
 			})
 			if retryErr != nil {
-				allErrors = append(allErrors, fmt.Errorf("failed to create manifestwork: %w", retryErr))
-				log.Error(retryErr, "Failed to create manifestwork")
+				if errors.Is(retryErr, ErrManifestWorkTerminating) {
+					log.Info("ManifestWork is currently terminating, skipping and waiting for deletion event watch to trigger recreate", "namespace", namespace, "name", manifestWork.Name)
+				} else {
+					allErrors = append(allErrors, fmt.Errorf("failed to create manifestwork: %w", retryErr))
+					log.Error(retryErr, "Failed to create manifestwork")
+				}
 				continue
 			}
 		}
@@ -1336,31 +1344,8 @@ func mcoaForMetricsIsEnabled(mco *mcov1beta2.MultiClusterObservability) bool {
 // PrometheusAgent is the definitive metrics marker: it is always present when MCOA
 // platform metrics collection is active, always absent when disabled, and never
 // produced by right-sizing.
-func (r *PlacementRuleReconciler) hasMCOAMetricsManifestWorks(ctx context.Context) (bool, error) {
-	workList := &workv1.ManifestWorkList{}
-	opts := []client.ListOption{
-		client.MatchingLabels{
-			addonv1beta1.AddonLabelKey: config.MultiClusterObservabilityAddon,
-		},
-	}
-	if err := r.Client.List(ctx, workList, opts...); err != nil {
-		return false, fmt.Errorf("failed to list ManifestWorks: %w", err)
-	}
-
-	for i := range workList.Items {
-		for _, manifest := range workList.Items[i].Spec.Workload.Manifests {
-			var meta struct {
-				Kind string `json:"kind"`
-			}
-			if err := json.Unmarshal(manifest.Raw, &meta); err != nil {
-				continue
-			}
-			if meta.Kind == "PrometheusAgent" {
-				return true, nil
-			}
-		}
-	}
-	return false, nil
+func (r *PlacementRuleReconciler) hasMCOAMetricsManifestWorks(ctx context.Context) ([]string, error) {
+	return util.HasMCOAManifestWorks(ctx, r.Client)
 }
 
 // isCustomIngressCertificate checks if the given secret name is referenced by the IngressController

--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller_test.go
@@ -26,7 +26,7 @@ import (
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -229,7 +229,7 @@ func TestObservabilityAddonController(t *testing.T) {
 	}
 
 	err = c.Get(context.TODO(), types.NamespacedName{Name: namespace2 + workNameSuffix, Namespace: namespace2}, found)
-	if err == nil || !errors.IsNotFound(err) {
+	if err == nil || !k8serrors.IsNotFound(err) {
 		t.Fatalf("Failed to delete manifestwork for cluster2: (%v)", err)
 	}
 

--- a/operators/multiclusterobservability/main.go
+++ b/operators/multiclusterobservability/main.go
@@ -187,15 +187,18 @@ func main() {
 
 		workv1.SchemeGroupVersion.WithKind("ManifestWork"): { //nolint:staticcheck // SA1019 SchemeGroupVersion is deprecated but metav1.GroupVersion lacks WithKind().
 			{LabelSelector: "owner==multicluster-observability-operator"},
+			{LabelSelector: fmt.Sprintf("%s==%s", addonv1beta1.AddonLabelKey, config.MultiClusterObservabilityAddon)},
 		},
 		clusterv1.SchemeGroupVersion.WithKind("ManagedCluster"): { //nolint:staticcheck // SA1019 SchemeGroupVersion is deprecated but metav1.GroupVersion lacks WithKind().
 			{LabelSelector: "vendor!=auto-detect,observability!=disabled"},
 		},
-		addonv1beta1.SchemeGroupVersion.WithKind("ClusterManagementAddOn"): { //nolint:staticcheck // SA1019 SchemeGroupVersion is deprecated but metav1.GroupVersion lacks WithKind().
+		schema.GroupVersion{Group: addonv1beta1.GroupVersion.Group, Version: addonv1beta1.GroupVersion.Version}.WithKind("ClusterManagementAddOn"): {
 			{FieldSelector: fmt.Sprintf("metadata.name=%s", util.ObservabilityController)},
 		},
-		addonv1beta1.SchemeGroupVersion.WithKind("ManagedClusterAddOn"): { //nolint:staticcheck // SA1019 SchemeGroupVersion is deprecated but metav1.GroupVersion lacks WithKind().
+		schema.GroupVersion{Group: addonv1beta1.GroupVersion.Group, Version: addonv1beta1.GroupVersion.Version}.WithKind("ManagedClusterAddOn"): {
 			{FieldSelector: fmt.Sprintf("metadata.name=%s", config.ManagedClusterAddonName)},
+			{FieldSelector: fmt.Sprintf("metadata.name=%s", config.MultiClusterObservabilityAddon)},
+			{LabelSelector: "owner==multicluster-observability-operator"},
 		},
 	}
 
@@ -223,11 +226,6 @@ func main() {
 		{LabelSelector: "owner==multicluster-observability-operator"},
 	}
 	gvkLabelsMap[rbacv1.SchemeGroupVersion.WithKind("RoleBinding")] = []filteredcache.Selector{
-		{LabelSelector: "owner==multicluster-observability-operator"},
-	}
-
-	// Add filter for ManagedClusterAddOn to reduce the cache size when the managedclusters scale.
-	gvkLabelsMap[addonv1beta1.SchemeGroupVersion.WithKind("ManagedClusterAddOn")] = []filteredcache.Selector{ //nolint:staticcheck // SA1019 SchemeGroupVersion is deprecated but metav1.GroupVersion lacks WithKind().
 		{LabelSelector: "owner==multicluster-observability-operator"},
 	}
 
@@ -309,7 +307,6 @@ func main() {
 		Log:         ctrl.Log.WithName("controllers").WithName("MultiClusterObservability"),
 		Scheme:      mgr.GetScheme(),
 		CRDMap:      crdMaps,
-		APIReader:   mgr.GetAPIReader(),
 		RESTMapper:  mgr.GetRESTMapper(),
 		ImageClient: imageClient,
 	}).SetupWithManager(mgr); err != nil {

--- a/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_management_addon.yaml
+++ b/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_management_addon.yaml
@@ -36,6 +36,10 @@ spec:
       resource: scrapeconfigs
     - group: monitoring.coreos.com
       resource: prometheusrules
+    - group: monitoring.rhobs
+      resource: scrapeconfigs
+    - group: monitoring.rhobs
+      resource: prometheusrules
   installStrategy:
     type: Placements
     placements:

--- a/operators/multiclusterobservability/pkg/util/mcoa_util.go
+++ b/operators/multiclusterobservability/pkg/util/mcoa_util.go
@@ -5,7 +5,18 @@
 package util
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
+	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	"k8s.io/apimachinery/pkg/api/meta"
+	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // IsMCOAEnabled returns true if any MCOA capability is enabled.
@@ -29,5 +40,79 @@ func IsMCOAEnabled(mco *mcov1beta2.MultiClusterObservability) bool {
 		}
 	}
 
+	return false
+}
+
+// HasMCOAManifestWorks checks for remaining MCOA ManifestWorks that contain metrics-specific
+// resources (PrometheusAgent), and returns a sorted list of namespaces where such ManifestWorks
+// are blocking the legacy addon deployment.
+//
+// RS-only ManifestWorks (containing only PrometheusRules) are safe to coexist with the legacy
+// addon and are not included. PrometheusAgent is the definitive metrics marker: it is always
+// present when MCOA platform metrics collection is active, always absent when disabled, and
+// never produced by right-sizing.
+//
+// ManifestWorks on unavailable ManagedClusters are ignored to prevent disconnected spokes from
+// hanging the cleanup process.
+func HasMCOAManifestWorks(ctx context.Context, c client.Client) ([]string, error) {
+	clusterList := &clusterv1.ManagedClusterList{}
+	if err := c.List(ctx, clusterList); err != nil {
+		return nil, fmt.Errorf("failed to list ManagedClusters: %w", err)
+	}
+
+	ignoredNamespaces := make(map[string]struct{})
+	for _, mc := range clusterList.Items {
+		isAvailable := meta.IsStatusConditionTrue(mc.Status.Conditions, clusterv1.ManagedClusterConditionAvailable)
+		if !isAvailable {
+			ignoredNamespaces[mc.Name] = struct{}{}
+		}
+	}
+
+	workList := &workv1.ManifestWorkList{}
+	opts := []client.ListOption{
+		client.MatchingLabels{
+			addonv1beta1.AddonLabelKey: config.MultiClusterObservabilityAddon,
+		},
+	}
+	if err := c.List(ctx, workList, opts...); err != nil {
+		return nil, fmt.Errorf("failed to list ManifestWorks: %w", err)
+	}
+
+	blockingMap := make(map[string]struct{})
+	for _, work := range workList.Items {
+		if _, ignored := ignoredNamespaces[work.Namespace]; ignored {
+			continue
+		}
+		if containsPrometheusAgent(work) {
+			blockingMap[work.Namespace] = struct{}{}
+		}
+	}
+
+	if len(blockingMap) == 0 {
+		return nil, nil
+	}
+
+	blockingNamespaces := make([]string, 0, len(blockingMap))
+	for ns := range blockingMap {
+		blockingNamespaces = append(blockingNamespaces, ns)
+	}
+	slices.Sort(blockingNamespaces)
+
+	return blockingNamespaces, nil
+}
+
+// containsPrometheusAgent returns true if any manifest in the work has Kind "PrometheusAgent".
+func containsPrometheusAgent(work workv1.ManifestWork) bool {
+	for _, manifest := range work.Spec.Workload.Manifests {
+		var partial struct {
+			Kind string `json:"kind"`
+		}
+		if err := json.Unmarshal(manifest.Raw, &partial); err != nil {
+			continue
+		}
+		if partial.Kind == "PrometheusAgent" {
+			return true
+		}
+	}
 	return false
 }

--- a/operators/multiclusterobservability/pkg/util/mcoa_util_test.go
+++ b/operators/multiclusterobservability/pkg/util/mcoa_util_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package util
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func prometheusAgentManifest() workv1.Manifest {
+	return workv1.Manifest{
+		RawExtension: runtime.RawExtension{
+			Raw: []byte(`{"apiVersion":"monitoring.rhobs/v1","kind":"PrometheusAgent","metadata":{"name":"test"}}`),
+		},
+	}
+}
+
+func prometheusRuleManifest() workv1.Manifest {
+	return workv1.Manifest{
+		RawExtension: runtime.RawExtension{
+			Raw: []byte(`{"apiVersion":"monitoring.coreos.com/v1","kind":"PrometheusRule","metadata":{"name":"test"}}`),
+		},
+	}
+}
+
+func TestHasMCOAManifestWorks(t *testing.T) {
+	s := scheme.Scheme
+	_ = addonv1beta1.Install(s)
+	_ = clusterv1.Install(s)
+	_ = workv1.Install(s)
+
+	t.Run("returns blocking namespaces when healthy cluster has ManifestWork with PrometheusAgent", func(t *testing.T) {
+		mw := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "addon-multicluster-observability-addon-deploy-0",
+				Namespace: "healthy-cluster",
+				Labels: map[string]string{
+					addonv1beta1.AddonLabelKey: config.MultiClusterObservabilityAddon,
+				},
+			},
+			Spec: workv1.ManifestWorkSpec{
+				Workload: workv1.ManifestsTemplate{
+					Manifests: []workv1.Manifest{prometheusAgentManifest()},
+				},
+			},
+		}
+		mc := &clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "healthy-cluster",
+			},
+			Status: clusterv1.ManagedClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   clusterv1.ManagedClusterConditionAvailable,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mw, mc).Build()
+		blocking, err := HasMCOAManifestWorks(context.Background(), cl)
+		assert.NoError(t, err)
+		assert.Contains(t, blocking, "healthy-cluster")
+	})
+
+	t.Run("returns empty slice when ManifestWork is in a disconnected/offline cluster", func(t *testing.T) {
+		mw := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "addon-multicluster-observability-addon-deploy-0",
+				Namespace: "offline-cluster",
+				Labels: map[string]string{
+					addonv1beta1.AddonLabelKey: config.MultiClusterObservabilityAddon,
+				},
+			},
+			Spec: workv1.ManifestWorkSpec{
+				Workload: workv1.ManifestsTemplate{
+					Manifests: []workv1.Manifest{prometheusAgentManifest()},
+				},
+			},
+		}
+		mc := &clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "offline-cluster",
+			},
+			Status: clusterv1.ManagedClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   clusterv1.ManagedClusterConditionAvailable,
+						Status: metav1.ConditionFalse,
+					},
+				},
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mw, mc).Build()
+		blocking, err := HasMCOAManifestWorks(context.Background(), cl)
+		assert.NoError(t, err)
+		assert.Empty(t, blocking)
+	})
+
+	t.Run("RS-only ManifestWorks (PrometheusRule) do not block", func(t *testing.T) {
+		mw := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "addon-multicluster-observability-addon-deploy-0",
+				Namespace: "healthy-cluster",
+				Labels: map[string]string{
+					addonv1beta1.AddonLabelKey: config.MultiClusterObservabilityAddon,
+				},
+			},
+			Spec: workv1.ManifestWorkSpec{
+				Workload: workv1.ManifestsTemplate{
+					Manifests: []workv1.Manifest{prometheusRuleManifest()},
+				},
+			},
+		}
+		mc := &clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "healthy-cluster",
+			},
+			Status: clusterv1.ManagedClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   clusterv1.ManagedClusterConditionAvailable,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mw, mc).Build()
+		blocking, err := HasMCOAManifestWorks(context.Background(), cl)
+		assert.NoError(t, err)
+		assert.Empty(t, blocking, "RS-only ManifestWorks should not block legacy addon deployment")
+	})
+
+	t.Run("returns blocking namespaces when ManifestWork with PrometheusAgent exists but no ManagedCluster exists", func(t *testing.T) {
+		mw := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "addon-multicluster-observability-addon-deploy-0",
+				Namespace: "test-cluster",
+				Labels: map[string]string{
+					addonv1beta1.AddonLabelKey: config.MultiClusterObservabilityAddon,
+				},
+			},
+			Spec: workv1.ManifestWorkSpec{
+				Workload: workv1.ManifestsTemplate{
+					Manifests: []workv1.Manifest{prometheusAgentManifest()},
+				},
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mw).Build()
+		blocking, err := HasMCOAManifestWorks(context.Background(), cl)
+		assert.NoError(t, err)
+		assert.Contains(t, blocking, "test-cluster")
+	})
+}

--- a/tests/pkg/tests/observability_mcoa_test.go
+++ b/tests/pkg/tests/observability_mcoa_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/utils"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -208,7 +209,7 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 				ruleMetricName := "test_platform_metric_from_rule"
 				scrapeConfigName := "test-prom-rule-metric"
 				By("Creating a new PrometheusRule on the hub", func() {
-					Expect(utils.CreatePrometheusRule(testOptions, ruleName, utils.MCO_NAMESPACE, "platform-metrics-collector", ruleMetricName, "")).NotTo(HaveOccurred())
+					Expect(utils.CreatePrometheusRule(ctx, testOptions, ruleName, utils.MCO_NAMESPACE, "platform-metrics-collector", ruleMetricName, "")).NotTo(HaveOccurred())
 					Expect(
 						utils.AddConfigToPlacementInClusterManagementAddon(
 							ctx,
@@ -261,7 +262,7 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 							utils.MCO_NAMESPACE,
 						),
 					).NotTo(HaveOccurred())
-					Expect(utils.DeletePrometheusRule(testOptions, ruleName, utils.MCO_NAMESPACE)).NotTo(HaveOccurred())
+					Expect(utils.DeletePrometheusRule(ctx, testOptions, ruleName, utils.MCO_NAMESPACE)).NotTo(HaveOccurred())
 				})
 
 				By("Deleting the custom ScrapeConfig", func() {
@@ -315,7 +316,7 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 				scrapeConfigName := "test-uwl-prom-rule-metric"
 
 				By("Creating a new PrometheusRule on the hub", func() {
-					Expect(utils.CreatePrometheusRule(testOptions, ruleName, utils.MCO_NAMESPACE, "user-workload-metrics-collector", ruleMetricName, "default")).NotTo(HaveOccurred())
+					Expect(utils.CreatePrometheusRule(ctx, testOptions, ruleName, utils.MCO_NAMESPACE, "user-workload-metrics-collector", ruleMetricName, "default")).NotTo(HaveOccurred())
 					Expect(
 						utils.AddConfigToPlacementInClusterManagementAddon(
 							ctx,
@@ -388,7 +389,7 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 							utils.MCO_NAMESPACE,
 						),
 					).NotTo(HaveOccurred())
-					Expect(utils.DeletePrometheusRule(testOptions, ruleName, utils.MCO_NAMESPACE)).NotTo(HaveOccurred())
+					Expect(utils.DeletePrometheusRule(ctx, testOptions, ruleName, utils.MCO_NAMESPACE)).NotTo(HaveOccurred())
 				})
 			})
 		},
@@ -698,6 +699,450 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 						}
 						return nil
 					}, 120, 5).Should(Succeed())
+				})
+			})
+		},
+	)
+
+	Context(
+		"when raw resolution (DDR) is enabled for MCOA [P1][Sev1][Observability][Stable]@ocpInterop (mcoa_ddr/g0)",
+		func() {
+			var hubClient kubernetes.Interface
+			cooMonitoringStackNamespace := "default"
+			cooMonitoringStackName := "test-monitoring-stack"
+
+			BeforeAll(func(ctx SpecContext) {
+				hubClient = utils.NewKubeClient(
+					testOptions.HubCluster.ClusterServerURL,
+					testOptions.KubeConfig,
+					testOptions.HubCluster.KubeContext)
+
+				By("Enabling user workload monitoring on all openshift managed clusters", func() {
+					Expect(utils.EnableUWLMonitoringOnManagedClusters(testOptions, accessibleOCPClusters)).NotTo(HaveOccurred())
+				})
+
+				// This part is to be reenabled once raw metrics collection for COO is working
+				// onlyTheHub := []utils.Cluster{testOptions.HubCluster}
+				// By("Installing COO on the hub", func() {
+				// 	Expect(utils.CreateCOOSubscription(onlyTheHub)).NotTo(HaveOccurred())
+				// 	DeferCleanup(func(ctx SpecContext) {
+				// 		utils.DeleteCOOSubscription(onlyTheHub)
+				// 		Expect(utils.DeleteMonitoringCRDs(testOptions, onlyTheHub)).NotTo(HaveOccurred())
+				// 	})
+				// 	// Wait for COO to be running
+				// 	utils.CheckCOODeployment(onlyTheHub)
+				// })
+
+				// By("Creating a dummy MonitoringStack on the Hub as a target", func() {
+				// 	Expect(utils.CreateMonitoringStack(ctx, testOptions, testOptions.HubCluster, cooMonitoringStackName, cooMonitoringStackNamespace)).NotTo(HaveOccurred())
+				// 	DeferCleanup(func(ctx SpecContext) {
+				// 		Expect(utils.DeleteMonitoringStack(ctx, testOptions, testOptions.HubCluster, cooMonitoringStackName, cooMonitoringStackNamespace)).NotTo(HaveOccurred())
+				// 	})
+				// })
+
+				By("Enabling platform and user workload metrics for MCOA", func() {
+					Expect(utils.SetMCOACapabilities(testOptions, true, true)).NotTo(HaveOccurred())
+				})
+
+				By("Configuring the platform and user workload scrape intervals to 30s", func() {
+					Eventually(func() error {
+						return utils.UpdatePrometheusAgentScrapeInterval(testOptions, "platform-metrics-collector", "30s")
+					}, 120, 2).Should(Not(HaveOccurred()))
+					Eventually(func() error {
+						return utils.UpdatePrometheusAgentScrapeInterval(testOptions, "user-workload-metrics-collector", "30s")
+					}, 120, 2).Should(Not(HaveOccurred()))
+				})
+			})
+
+			It("should allow enabling and forwarding raw metrics for platform and uwl directly to the hub via remote write", SpecTimeout(15*time.Minute), func(ctx SpecContext) {
+				platformMetricName := "go_memstats_alloc_bytes"
+				uwlRuleName := "test-uwl-prom-rule"
+				uwlMetricName := "test_uwl_metric_from_rule"
+
+				platformScrapeConfigCR := "test-raw-platform-config"
+				uwlScrapeConfigCR := "test-raw-uwl-config"
+
+				By("Creating a new PrometheusRule on the hub for UWL", func() {
+					Expect(utils.CreatePrometheusRule(ctx, testOptions, uwlRuleName, utils.MCO_NAMESPACE, "user-workload-metrics-collector", uwlMetricName, "default")).NotTo(HaveOccurred())
+					Expect(
+						utils.AddConfigToPlacementInClusterManagementAddon(
+							ctx,
+							testOptions,
+							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
+							globalPlacementName,
+							utils.NewPrometheusRuleGVR(),
+							uwlRuleName,
+							utils.MCO_NAMESPACE,
+						),
+					).NotTo(HaveOccurred())
+					DeferCleanup(func(ctx SpecContext) {
+						_ = utils.RemoveConfigFromPlacementInClusterManagementAddon(
+							ctx,
+							testOptions,
+							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
+							globalPlacementName,
+							utils.NewPrometheusRuleGVR(),
+							uwlRuleName,
+							utils.MCO_NAMESPACE,
+						)
+						_ = utils.DeletePrometheusRule(ctx, testOptions, uwlRuleName, utils.MCO_NAMESPACE)
+					})
+				})
+
+				By("Creating raw ScrapeConfig for Platform", func() {
+					annotations := map[string]string{
+						"observability.open-cluster-management.io/resolution-strategy": "raw",
+					}
+					Expect(
+						utils.CreateScrapeConfigWithAnnotations(
+							ctx,
+							testOptions,
+							platformScrapeConfigCR,
+							"platform-metrics-collector",
+							[]string{fmt.Sprintf(`{__name__="%s"}`, platformMetricName)},
+							annotations,
+						),
+					).NotTo(HaveOccurred())
+					Expect(
+						utils.AddConfigToPlacementInClusterManagementAddon(
+							ctx,
+							testOptions,
+							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
+							globalPlacementName,
+							utils.NewScrapeConfigGVR(),
+							platformScrapeConfigCR,
+							utils.MCO_NAMESPACE,
+						),
+					).NotTo(HaveOccurred())
+					DeferCleanup(func(ctx SpecContext) {
+						_ = utils.RemoveConfigFromPlacementInClusterManagementAddon(
+							ctx,
+							testOptions,
+							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
+							globalPlacementName,
+							utils.NewScrapeConfigGVR(),
+							platformScrapeConfigCR,
+							utils.MCO_NAMESPACE,
+						)
+						_ = utils.DeleteScrapeConfig(testOptions, platformScrapeConfigCR)
+					})
+				})
+
+				By("Creating raw ScrapeConfig for User Workload", func() {
+					annotations := map[string]string{
+						"observability.open-cluster-management.io/resolution-strategy": "raw",
+					}
+					Expect(
+						utils.CreateScrapeConfigWithAnnotations(
+							ctx,
+							testOptions,
+							uwlScrapeConfigCR,
+							"user-workload-metrics-collector",
+							[]string{fmt.Sprintf(`{__name__="%s"}`, uwlMetricName)},
+							annotations,
+						),
+					).NotTo(HaveOccurred())
+					Expect(
+						utils.AddConfigToPlacementInClusterManagementAddon(
+							ctx,
+							testOptions,
+							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
+							globalPlacementName,
+							utils.NewScrapeConfigGVR(),
+							uwlScrapeConfigCR,
+							utils.MCO_NAMESPACE,
+						),
+					).NotTo(HaveOccurred())
+					DeferCleanup(func(ctx SpecContext) {
+						_ = utils.RemoveConfigFromPlacementInClusterManagementAddon(
+							ctx,
+							testOptions,
+							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
+							globalPlacementName,
+							utils.NewScrapeConfigGVR(),
+							uwlScrapeConfigCR,
+							utils.MCO_NAMESPACE,
+						)
+						_ = utils.DeleteScrapeConfig(testOptions, uwlScrapeConfigCR)
+					})
+				})
+
+				By("Checking that CMO ConfigMap is updated with raw platform metrics remoteWrite config on managed clusters", func() {
+					namespace := "openshift-monitoring"
+					configMapName := "cluster-monitoring-config"
+
+					Eventually(func() error {
+						cm, err := hubClient.CoreV1().ConfigMaps(namespace).Get(ctx, configMapName, metav1.GetOptions{})
+						if err != nil {
+							return err
+						}
+						configContent := cm.Data["config.yaml"]
+						if !strings.Contains(configContent, "mcoa-raw-") {
+							return fmt.Errorf("ConfigMap does not contain mcoa-raw RemoteWrite configuration: %s", configContent)
+						}
+						return nil
+					}, 120, 5).Should(Succeed())
+				})
+
+				By("Checking that UWL ConfigMap is updated with raw uwl metrics remoteWrite config on managed clusters", func() {
+					namespace := "openshift-user-workload-monitoring"
+					configMapName := "user-workload-monitoring-config"
+
+					Eventually(func() error {
+						cm, err := hubClient.CoreV1().ConfigMaps(namespace).Get(ctx, configMapName, metav1.GetOptions{})
+						if err != nil {
+							return err
+						}
+						configContent := cm.Data["config.yaml"]
+						if !strings.Contains(configContent, "mcoa-raw-") {
+							return fmt.Errorf("UWL ConfigMap does not contain mcoa-raw RemoteWrite configuration: %s", configContent)
+						}
+						return nil
+					}, 120, 5).Should(Succeed())
+				})
+
+				By("Verifying the platform raw metric is queryable on the hub", func() {
+					Eventually(func() error {
+						res, err := utils.QueryGrafana(testOptions, platformMetricName)
+						if err != nil {
+							return err
+						}
+						if len(res.Data.Result) == 0 {
+							return fmt.Errorf("No results found for metric %q", platformMetricName)
+						}
+						return nil
+					}, 300, 5).Should(Not(HaveOccurred()))
+				})
+
+				By("Verifying the uwl raw metric is queryable on the hub", func() {
+					Eventually(func() error {
+						res, err := utils.QueryGrafana(testOptions, uwlMetricName)
+						if err != nil {
+							return err
+						}
+						if len(res.Data.Result) == 0 {
+							return fmt.Errorf("No results found for metric %q", uwlMetricName)
+						}
+						return nil
+					}, 300, 5).Should(Not(HaveOccurred()))
+				})
+
+				By("Cleaning up Platform raw configuration", func() {
+					Expect(
+						utils.RemoveConfigFromPlacementInClusterManagementAddon(
+							ctx,
+							testOptions,
+							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
+							globalPlacementName,
+							utils.NewScrapeConfigGVR(),
+							platformScrapeConfigCR,
+							utils.MCO_NAMESPACE,
+						),
+					).NotTo(HaveOccurred())
+					Expect(utils.DeleteScrapeConfig(testOptions, platformScrapeConfigCR)).NotTo(HaveOccurred())
+				})
+
+				By("Cleaning up UWL raw configuration", func() {
+					Expect(
+						utils.RemoveConfigFromPlacementInClusterManagementAddon(
+							ctx,
+							testOptions,
+							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
+							globalPlacementName,
+							utils.NewScrapeConfigGVR(),
+							uwlScrapeConfigCR,
+							utils.MCO_NAMESPACE,
+						),
+					).NotTo(HaveOccurred())
+					Expect(utils.DeleteScrapeConfig(testOptions, uwlScrapeConfigCR)).NotTo(HaveOccurred())
+				})
+
+				By("Cleaning up UWL PrometheusRule", func() {
+					Expect(
+						utils.RemoveConfigFromPlacementInClusterManagementAddon(
+							ctx,
+							testOptions,
+							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
+							globalPlacementName,
+							utils.NewPrometheusRuleGVR(),
+							uwlRuleName,
+							utils.MCO_NAMESPACE,
+						),
+					).NotTo(HaveOccurred())
+					Expect(utils.DeletePrometheusRule(ctx, testOptions, uwlRuleName, utils.MCO_NAMESPACE)).NotTo(HaveOccurred())
+				})
+
+				By("Checking that CMO ConfigMap is cleaned up of raw platform metrics remoteWrite config on managed clusters", func() {
+					namespace := "openshift-monitoring"
+					configMapName := "cluster-monitoring-config"
+
+					Eventually(func() error {
+						cm, err := hubClient.CoreV1().ConfigMaps(namespace).Get(ctx, configMapName, metav1.GetOptions{})
+						if err != nil {
+							return err
+						}
+						configContent := cm.Data["config.yaml"]
+						if strings.Contains(configContent, "mcoa-raw-") {
+							return fmt.Errorf("ConfigMap still contains mcoa-raw RemoteWrite configuration: %s", configContent)
+						}
+						return nil
+					}, 120, 5).Should(Succeed())
+				})
+
+				By("Checking that UWL ConfigMap is cleaned up of raw uwl metrics remoteWrite config on managed clusters", func() {
+					namespace := "openshift-user-workload-monitoring"
+					configMapName := "user-workload-monitoring-config"
+
+					Eventually(func() error {
+						cm, err := hubClient.CoreV1().ConfigMaps(namespace).Get(ctx, configMapName, metav1.GetOptions{})
+						if err != nil {
+							return err
+						}
+						configContent := cm.Data["config.yaml"]
+						if strings.Contains(configContent, "mcoa-raw-") {
+							return fmt.Errorf("UWL ConfigMap still contains mcoa-raw RemoteWrite configuration: %s", configContent)
+						}
+						return nil
+					}, 120, 5).Should(Succeed())
+				})
+			})
+
+			It("should allow enabling and forwarding raw metrics for coo directly to the hub via remote write", SpecTimeout(15*time.Minute), func(ctx SpecContext) {
+				Skip("Skipping COO raw metrics verification")
+
+				cooRuleName := "test-coo-prom-rule"
+				cooMetricName := "test_coo_metric_from_rule"
+				cooScrapeConfigCR := "test-raw-coo-config"
+
+				By("Creating a new PrometheusRule on the hub for COO", func() {
+					Expect(
+						utils.CreateMCOAPrometheusRule(ctx, testOptions, cooRuleName, utils.MCO_NAMESPACE, "user-workload-metrics-collector", cooMetricName, cooMonitoringStackNamespace),
+					).NotTo(HaveOccurred())
+					Expect(
+						utils.AddConfigToPlacementInClusterManagementAddon(
+							ctx,
+							testOptions,
+							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
+							globalPlacementName,
+							utils.NewMCOAPrometheusRuleGVR(),
+							cooRuleName,
+							utils.MCO_NAMESPACE,
+						),
+					).NotTo(HaveOccurred())
+					DeferCleanup(func(ctx SpecContext) {
+						_ = utils.RemoveConfigFromPlacementInClusterManagementAddon(
+							ctx,
+							testOptions,
+							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
+							globalPlacementName,
+							utils.NewMCOAPrometheusRuleGVR(),
+							cooRuleName,
+							utils.MCO_NAMESPACE,
+						)
+						_ = utils.DeleteMCOAPrometheusRule(ctx, testOptions, cooRuleName, utils.MCO_NAMESPACE)
+					})
+				})
+
+				By("Creating raw ScrapeConfig for COO MonitoringStack", func() {
+					annotations := map[string]string{
+						"observability.open-cluster-management.io/resolution-strategy":   "raw",
+						"observability.open-cluster-management.io/coo-monitoring-stacks": fmt.Sprintf("%s/%s", cooMonitoringStackNamespace, cooMonitoringStackName),
+					}
+					Expect(
+						utils.CreateScrapeConfigWithAnnotations(
+							ctx,
+							testOptions,
+							cooScrapeConfigCR,
+							"user-workload-metrics-collector",
+							[]string{fmt.Sprintf(`{__name__="%s"}`, cooMetricName)},
+							annotations,
+						),
+					).NotTo(HaveOccurred())
+					Expect(
+						utils.AddConfigToPlacementInClusterManagementAddon(
+							ctx,
+							testOptions,
+							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
+							globalPlacementName,
+							utils.NewScrapeConfigGVR(),
+							cooScrapeConfigCR,
+							utils.MCO_NAMESPACE,
+						),
+					).NotTo(HaveOccurred())
+					DeferCleanup(func(ctx SpecContext) {
+						_ = utils.RemoveConfigFromPlacementInClusterManagementAddon(
+							ctx,
+							testOptions,
+							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
+							globalPlacementName,
+							utils.NewScrapeConfigGVR(),
+							cooScrapeConfigCR,
+							utils.MCO_NAMESPACE,
+						)
+						_ = utils.DeleteScrapeConfig(testOptions, cooScrapeConfigCR)
+					})
+				})
+
+				By("Checking that COO MonitoringStack is updated with raw coo metrics remoteWrite config on the hub", func() {
+					clientDynamic := utils.NewKubeClientDynamic(
+						testOptions.HubCluster.ClusterServerURL,
+						testOptions.KubeConfig,
+						testOptions.HubCluster.KubeContext)
+
+					Eventually(func() error {
+						ms, err := clientDynamic.Resource(utils.NewMonitoringStackGVR()).Namespace(cooMonitoringStackNamespace).Get(ctx, cooMonitoringStackName, metav1.GetOptions{})
+						if err != nil {
+							return err
+						}
+
+						spec, exists, err := unstructured.NestedMap(ms.Object, "spec")
+						if err != nil {
+							return fmt.Errorf("failed to retrieve spec map: %w", err)
+						}
+						if !exists {
+							return fmt.Errorf("spec field missing on MonitoringStack")
+						}
+
+						prometheusConfig, exists := spec["prometheusConfig"].(map[string]any)
+						if !exists {
+							return fmt.Errorf("prometheusConfig missing in MonitoringStack spec")
+						}
+
+						remoteWrite, exists := prometheusConfig["remoteWrite"].([]any)
+						if !exists || len(remoteWrite) == 0 {
+							return fmt.Errorf("remoteWrite missing or empty in MonitoringStack spec: %v", prometheusConfig)
+						}
+
+						return nil
+					}, 120, 5).Should(Succeed())
+				})
+
+				By("Verifying the coo raw metric is queryable on the hub", func() {
+					Eventually(func() error {
+						res, err := utils.QueryGrafana(testOptions, cooMetricName)
+						if err != nil {
+							return err
+						}
+						if len(res.Data.Result) == 0 {
+							return fmt.Errorf("No results found for metric %q", cooMetricName)
+						}
+						return nil
+					}, 300, 5).Should(Not(HaveOccurred()))
+				})
+
+				By("Cleaning up COO raw configuration", func() {
+					Expect(
+						utils.RemoveConfigFromPlacementInClusterManagementAddon(
+							ctx,
+							testOptions,
+							utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME,
+							globalPlacementName,
+							utils.NewScrapeConfigGVR(),
+							cooScrapeConfigCR,
+							utils.MCO_NAMESPACE,
+						),
+					).NotTo(HaveOccurred())
+					Expect(utils.DeleteScrapeConfig(testOptions, cooScrapeConfigCR)).NotTo(HaveOccurred())
 				})
 			})
 		},

--- a/tests/pkg/utils/clustermanagementaddon.go
+++ b/tests/pkg/utils/clustermanagementaddon.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -157,10 +158,8 @@ func waitForConfigHashPopulated(ctx context.Context, opt TestOptions, addonName 
 				Namespace(cluster.Name).
 				Get(ctx, addonName, metav1.GetOptions{})
 			if err != nil {
-				if apierrors.IsNotFound(err) ||
-					apierrors.IsTimeout(err) ||
-					apierrors.IsServerTimeout(err) ||
-					apierrors.IsTooManyRequests(err) {
+				if isTransientAddonError(err) {
+					klog.V(1).InfoS("Transient error getting ManagedClusterAddon, retrying", "cluster", cluster.Name, "addon", addonName, "err", err)
 					return false, nil // transient, retry
 				}
 				return false, fmt.Errorf("failed to get ManagedClusterAddon %s/%s: %w", cluster.Name, addonName, err)
@@ -211,6 +210,17 @@ func waitForConfigHashPopulated(ctx context.Context, opt TestOptions, addonName 
 
 		return true, nil
 	})
+}
+
+func isTransientAddonError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return apierrors.IsNotFound(err) ||
+		apierrors.IsTimeout(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		errors.Is(err, context.DeadlineExceeded)
 }
 
 func RemoveConfigFromPlacementInClusterManagementAddon(

--- a/tests/pkg/utils/coo_monitoringstack.go
+++ b/tests/pkg/utils/coo_monitoringstack.go
@@ -1,0 +1,92 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func NewMonitoringStackGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "monitoring.rhobs",
+		Version:  "v1alpha1",
+		Resource: "monitoringstacks",
+	}
+}
+
+func CreateMonitoringStack(ctx context.Context, opt TestOptions, cluster Cluster, name, namespace string) error {
+	clientDynamic := NewKubeClientDynamic(
+		cluster.ClusterServerURL,
+		opt.KubeConfig,
+		cluster.KubeContext)
+
+	ms := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "monitoring.rhobs/v1alpha1",
+			"kind":       "MonitoringStack",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"prometheusConfig": map[string]any{
+					"replicas": 1,
+				},
+				"resources": map[string]any{
+					"limits": map[string]any{
+						"cpu":    "100m",
+						"memory": "128Mi",
+					},
+					"requests": map[string]any{
+						"cpu":    "50m",
+						"memory": "64Mi",
+					},
+				},
+				"resourceSelector": map[string]any{},
+				"retention":        "120h",
+			},
+		},
+	}
+
+	_, err := clientDynamic.Resource(NewMonitoringStackGVR()).Namespace(namespace).Create(ctx, ms, metav1.CreateOptions{})
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			existing, errGet := clientDynamic.Resource(NewMonitoringStackGVR()).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+			if errGet != nil {
+				return fmt.Errorf("failed to get MonitoringStack %s/%s: %w", namespace, name, errGet)
+			}
+			existing.Object["spec"] = ms.Object["spec"]
+			_, errUpdate := clientDynamic.Resource(NewMonitoringStackGVR()).Namespace(namespace).Update(ctx, existing, metav1.UpdateOptions{})
+			if errUpdate != nil {
+				return fmt.Errorf("failed to update MonitoringStack %s/%s: %w", namespace, name, errUpdate)
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to create MonitoringStack %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}
+
+func DeleteMonitoringStack(ctx context.Context, opt TestOptions, cluster Cluster, name, namespace string) error {
+	clientDynamic := NewKubeClientDynamic(
+		cluster.ClusterServerURL,
+		opt.KubeConfig,
+		cluster.KubeContext)
+
+	err := clientDynamic.Resource(NewMonitoringStackGVR()).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to delete MonitoringStack %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}

--- a/tests/pkg/utils/mco_deploy.go
+++ b/tests/pkg/utils/mco_deploy.go
@@ -127,6 +127,14 @@ func NewPrometheusRuleGVR() schema.GroupVersionResource {
 	}
 }
 
+func NewMCOAPrometheusRuleGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "monitoring.rhobs",
+		Version:  "v1",
+		Resource: "prometheusrules",
+	}
+}
+
 func NewScrapeConfigGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group:    "monitoring.rhobs",

--- a/tests/pkg/utils/mco_openshift.go
+++ b/tests/pkg/utils/mco_openshift.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -26,39 +27,36 @@ func EnableUWLMonitoringOnManagedClusters(opt TestOptions, ocpClusters []Cluster
 			cluster.ClusterServerURL,
 			cluster.KubeConfig,
 			cluster.KubeContext)
-		cm, err := kubeClient.CoreV1().ConfigMaps(openshiftMonitoringNamespace).Get(context.TODO(), clusterMonitoringConfigMapName, metav1.GetOptions{})
-		if err != nil {
-			if errors.IsNotFound(err) {
-				// Create configmap if it does not exist
-				config := map[string]any{
-					"enableUserWorkload": true,
-				}
-				yamlData, err := yaml.Marshal(config)
-				if err != nil {
-					return err
-				}
-				newCM := &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      clusterMonitoringConfigMapName,
-						Namespace: openshiftMonitoringNamespace,
-					},
-					Data: map[string]string{
-						configKey: string(yamlData),
-					},
-				}
-				_, createErr := kubeClient.CoreV1().ConfigMaps(openshiftMonitoringNamespace).Create(context.TODO(), newCM, metav1.CreateOptions{})
-				if createErr != nil {
+
+		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			cm, err := kubeClient.CoreV1().ConfigMaps(openshiftMonitoringNamespace).Get(context.TODO(), clusterMonitoringConfigMapName, metav1.GetOptions{})
+			if err != nil {
+				if errors.IsNotFound(err) {
+					config := map[string]any{
+						"enableUserWorkload": true,
+					}
+					yamlData, err := yaml.Marshal(config)
+					if err != nil {
+						return err
+					}
+					newCM := &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      clusterMonitoringConfigMapName,
+							Namespace: openshiftMonitoringNamespace,
+						},
+						Data: map[string]string{
+							configKey: string(yamlData),
+						},
+					}
+					_, createErr := kubeClient.CoreV1().ConfigMaps(openshiftMonitoringNamespace).Create(context.TODO(), newCM, metav1.CreateOptions{})
 					return createErr
 				}
-			} else {
 				return err
 			}
-		} else {
-			// Update existing configmap
+
 			config := make(map[string]any)
 			if cm.Data != nil && cm.Data[configKey] != "" {
-				err = yaml.Unmarshal([]byte(cm.Data[configKey]), &config)
-				if err != nil {
+				if err = yaml.Unmarshal([]byte(cm.Data[configKey]), &config); err != nil {
 					return err
 				}
 			}
@@ -72,9 +70,10 @@ func EnableUWLMonitoringOnManagedClusters(opt TestOptions, ocpClusters []Cluster
 			}
 			cm.Data[configKey] = string(yamlData)
 			_, updateErr := kubeClient.CoreV1().ConfigMaps(openshiftMonitoringNamespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
-			if updateErr != nil {
-				return updateErr
-			}
+			return updateErr
+		})
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/tests/pkg/utils/mco_prometheusrule.go
+++ b/tests/pkg/utils/mco_prometheusrule.go
@@ -6,16 +6,18 @@ package utils
 
 import (
 	"context"
+	"fmt"
 
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func CreatePrometheusRule(opt TestOptions, name, namespace, componentLabel, metricName, targetNamespace string) error {
+func createPrometheusRuleGeneric(ctx context.Context, opt TestOptions, name, namespace, componentLabel, metricName, targetNamespace string, gvr schema.GroupVersionResource, apiVersion string) error {
 	clientDynamic := NewKubeClientDynamic(
 		opt.HubCluster.ClusterServerURL,
 		opt.KubeConfig,
@@ -23,7 +25,7 @@ func CreatePrometheusRule(opt TestOptions, name, namespace, componentLabel, metr
 
 	rule := &prometheusv1.PrometheusRule{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: prometheusv1.SchemeGroupVersion.String(),
+			APIVersion: apiVersion,
 			Kind:       prometheusv1.PrometheusRuleKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -57,31 +59,66 @@ func CreatePrometheusRule(opt TestOptions, name, namespace, componentLabel, metr
 
 	ruleMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(rule)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to convert PrometheusRule %s/%s: %w", namespace, name, err)
 	}
 
 	ruleUnstructured := &unstructured.Unstructured{Object: ruleMap}
 
-	_, err = clientDynamic.Resource(NewPrometheusRuleGVR()).Namespace(namespace).Create(context.TODO(), ruleUnstructured, metav1.CreateOptions{})
+	_, err = clientDynamic.Resource(gvr).Namespace(namespace).Create(ctx, ruleUnstructured, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			existing, err := clientDynamic.Resource(NewPrometheusRuleGVR()).Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-			if err != nil {
-				return err
+			existing, errGet := clientDynamic.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+			if errGet != nil {
+				return fmt.Errorf("failed to get PrometheusRule %s/%s: %w", namespace, name, errGet)
 			}
-			ruleUnstructured.SetResourceVersion(existing.GetResourceVersion())
-			_, err = clientDynamic.Resource(NewPrometheusRuleGVR()).Namespace(namespace).Update(context.TODO(), ruleUnstructured, metav1.UpdateOptions{})
-			return err
+			existing.Object["spec"] = ruleUnstructured.Object["spec"]
+			_, errUpdate := clientDynamic.Resource(gvr).Namespace(namespace).Update(ctx, existing, metav1.UpdateOptions{})
+			if errUpdate != nil {
+				return fmt.Errorf("failed to update PrometheusRule %s/%s: %w", namespace, name, errUpdate)
+			}
+			return nil
 		}
+		return fmt.Errorf("failed to create PrometheusRule %s/%s: %w", namespace, name, err)
 	}
-	return err
+	return nil
 }
 
-func DeletePrometheusRule(opt TestOptions, name, namespace string) error {
+func CreatePrometheusRule(ctx context.Context, opt TestOptions, name, namespace, componentLabel, metricName, targetNamespace string) error {
+	return createPrometheusRuleGeneric(ctx, opt, name, namespace, componentLabel, metricName, targetNamespace, NewPrometheusRuleGVR(), prometheusv1.SchemeGroupVersion.String())
+}
+
+func DeletePrometheusRule(ctx context.Context, opt TestOptions, name, namespace string) error {
 	clientDynamic := NewKubeClientDynamic(
 		opt.HubCluster.ClusterServerURL,
 		opt.KubeConfig,
 		opt.HubCluster.KubeContext)
 
-	return clientDynamic.Resource(NewPrometheusRuleGVR()).Namespace(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	err := clientDynamic.Resource(NewPrometheusRuleGVR()).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete PrometheusRule %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}
+
+func CreateMCOAPrometheusRule(ctx context.Context, opt TestOptions, name, namespace, componentLabel, metricName, targetNamespace string) error {
+	return createPrometheusRuleGeneric(ctx, opt, name, namespace, componentLabel, metricName, targetNamespace, NewMCOAPrometheusRuleGVR(), "monitoring.rhobs/v1")
+}
+
+func DeleteMCOAPrometheusRule(ctx context.Context, opt TestOptions, name, namespace string) error {
+	clientDynamic := NewKubeClientDynamic(
+		opt.HubCluster.ClusterServerURL,
+		opt.KubeConfig,
+		opt.HubCluster.KubeContext)
+
+	err := clientDynamic.Resource(NewMCOAPrometheusRuleGVR()).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete MCOA PrometheusRule %s/%s: %w", namespace, name, err)
+	}
+	return nil
 }

--- a/tests/pkg/utils/mco_scrapeconfig.go
+++ b/tests/pkg/utils/mco_scrapeconfig.go
@@ -6,6 +6,8 @@ package utils
 
 import (
 	"context"
+	"fmt"
+	"maps"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,16 +44,20 @@ func CreateScrapeConfig(opt TestOptions, name, componentLabel string, matchParam
 	_, err := clientDynamic.Resource(NewScrapeConfigGVR()).Namespace(MCO_NAMESPACE).Create(context.TODO(), scrapeConfig, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			existing, err := clientDynamic.Resource(NewScrapeConfigGVR()).Namespace(MCO_NAMESPACE).Get(context.TODO(), name, metav1.GetOptions{})
-			if err != nil {
-				return err
+			existing, errGet := clientDynamic.Resource(NewScrapeConfigGVR()).Namespace(MCO_NAMESPACE).Get(context.TODO(), name, metav1.GetOptions{})
+			if errGet != nil {
+				return fmt.Errorf("failed to get ScrapeConfig %s/%s: %w", MCO_NAMESPACE, name, errGet)
 			}
 			scrapeConfig.SetResourceVersion(existing.GetResourceVersion())
-			_, err = clientDynamic.Resource(NewScrapeConfigGVR()).Namespace(MCO_NAMESPACE).Update(context.TODO(), scrapeConfig, metav1.UpdateOptions{})
-			return err
+			_, errUpdate := clientDynamic.Resource(NewScrapeConfigGVR()).Namespace(MCO_NAMESPACE).Update(context.TODO(), scrapeConfig, metav1.UpdateOptions{})
+			if errUpdate != nil {
+				return fmt.Errorf("failed to update ScrapeConfig %s/%s: %w", MCO_NAMESPACE, name, errUpdate)
+			}
+			return nil
 		}
+		return fmt.Errorf("failed to create ScrapeConfig %s/%s: %w", MCO_NAMESPACE, name, err)
 	}
-	return err
+	return nil
 }
 
 func DeleteScrapeConfig(opt TestOptions, name string) error {
@@ -61,4 +67,62 @@ func DeleteScrapeConfig(opt TestOptions, name string) error {
 		opt.HubCluster.KubeContext)
 
 	return clientDynamic.Resource(NewScrapeConfigGVR()).Namespace(MCO_NAMESPACE).Delete(context.TODO(), name, metav1.DeleteOptions{})
+}
+
+func CreateScrapeConfigWithAnnotations(ctx context.Context, opt TestOptions, name, componentLabel string, matchParams []string, annotations map[string]string) error {
+	clientDynamic := NewKubeClientDynamic(
+		opt.HubCluster.ClusterServerURL,
+		opt.KubeConfig,
+		opt.HubCluster.KubeContext)
+
+	scrapeConfig := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "monitoring.rhobs/v1alpha1",
+			"kind":       "ScrapeConfig",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": MCO_NAMESPACE,
+				"labels": map[string]string{
+					"app.kubernetes.io/component": componentLabel,
+				},
+			},
+			"spec": map[string]any{
+				"jobName":     name,
+				"metricsPath": "/federate",
+				"params": map[string][]string{
+					"match[]": matchParams,
+				},
+			},
+		},
+	}
+
+	if annotations != nil {
+		scrapeConfig.SetAnnotations(annotations)
+	}
+
+	_, err := clientDynamic.Resource(NewScrapeConfigGVR()).Namespace(MCO_NAMESPACE).Create(ctx, scrapeConfig, metav1.CreateOptions{})
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			existing, errGet := clientDynamic.Resource(NewScrapeConfigGVR()).Namespace(MCO_NAMESPACE).Get(ctx, name, metav1.GetOptions{})
+			if errGet != nil {
+				return fmt.Errorf("failed to get ScrapeConfig %s/%s: %w", MCO_NAMESPACE, name, errGet)
+			}
+			scrapeConfig.SetResourceVersion(existing.GetResourceVersion())
+			if annotations != nil {
+				existingAnnotations := existing.GetAnnotations()
+				if existingAnnotations == nil {
+					existingAnnotations = make(map[string]string)
+				}
+				maps.Copy(existingAnnotations, annotations)
+				scrapeConfig.SetAnnotations(existingAnnotations)
+			}
+			_, errUpdate := clientDynamic.Resource(NewScrapeConfigGVR()).Namespace(MCO_NAMESPACE).Update(ctx, scrapeConfig, metav1.UpdateOptions{})
+			if errUpdate != nil {
+				return fmt.Errorf("failed to update ScrapeConfig %s/%s: %w", MCO_NAMESPACE, name, errUpdate)
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to create ScrapeConfig %s/%s: %w", MCO_NAMESPACE, name, err)
+	}
+	return nil
 }

--- a/tests/pkg/utils/utils.go
+++ b/tests/pkg/utils/utils.go
@@ -199,33 +199,50 @@ func LoadConfig(url, kubeconfig, ctx string) (*rest.Config, error) {
 	if kubeconfig == "" {
 		kubeconfig = os.Getenv("KUBECONFIG")
 	}
+	var config *rest.Config
+	var err error
 	// If we have an explicit indication of where the kubernetes config lives, read that.
 	if kubeconfig != "" {
 		if ctx == "" {
-			return clientcmd.BuildConfigFromFlags(url, kubeconfig)
+			config, err = clientcmd.BuildConfigFromFlags(url, kubeconfig)
+			if err != nil {
+				err = fmt.Errorf("failed to build config from flags: %w", err)
+			}
 		} else {
-			return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			config, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 				&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
 				&clientcmd.ConfigOverrides{
 					CurrentContext: ctx,
 				}).ClientConfig()
 		}
-	}
-	// If not, try the in-cluster config.
-	if c, err := rest.InClusterConfig(); err == nil {
-		return c, nil
-	}
-	// If no in-cluster config, try the default location in the user's home directory.
-	if usr, err := user.Current(); err == nil {
-		klog.V(5).Infof("clientcmd.BuildConfigFromFlags for url %s using %s\n",
-			url,
-			filepath.Join(usr.HomeDir, ".kube", "config"))
-		if c, err := clientcmd.BuildConfigFromFlags(url, filepath.Join(usr.HomeDir, ".kube", "config")); err == nil {
-			return c, nil
+	} else if c, errInCluster := rest.InClusterConfig(); errInCluster == nil {
+		// If not, try the in-cluster config.
+		config = c
+	} else {
+		usr, errUser := user.Current()
+		if errUser != nil {
+			err = fmt.Errorf("failed to get current user: %w", errUser)
+		} else {
+			// If no in-cluster config, try the default location in the user's home directory.
+			klog.V(5).Infof("clientcmd.BuildConfigFromFlags for url %s using %s\n",
+				url,
+				filepath.Join(usr.HomeDir, ".kube", "config"))
+			config, err = clientcmd.BuildConfigFromFlags(url, filepath.Join(usr.HomeDir, ".kube", "config"))
+			if err != nil {
+				err = fmt.Errorf("failed to build config from flags: %w", err)
+			}
 		}
 	}
 
-	return nil, errors.New("could not create a valid kubeconfig")
+	if err != nil || config == nil {
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New("could not create a valid kubeconfig")
+	}
+
+	config.QPS = -1
+	return config, nil
 }
 
 func ApplyRetryOnConflict(url string, kubeconfig string, ctx string, yamlB []byte) error {


### PR DESCRIPTION
See https://github.com/stolostron/multicluster-observability-operator/pull/2579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for platform and user-workload raw metrics forwarding.
  * Added reconciliation for scrape configurations, Prometheus agents, alert forwarding, external labels, TLS settings, and remote-write targets.
  * Improved multicluster deployment checks by identifying clusters that block rollout.
  * Added support for monitoring configuration resources, including scrape configs and recording rules.
  * Updated dashboard folder handling to use stable folder UIDs.

* **Bug Fixes**
  * Improved retry behavior for transient monitoring and addon errors.
  * Prevented terminating resources from incorrectly blocking cleanup or reconciliation.
  * Preserved unrelated monitoring configuration during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->