### PR TITLE
fix: add replace directive for prometheus to fix CVE-2026-42151 [rhacm-2.14]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,8 @@ replace (
 	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20241106000323-9fcf3125a28e
 
 	// CVE-2026-42151: Azure AD OAuth client_secret exposed via config API.
-	// Upstream fix is in v0.311.3 but requires incompatible API changes.
-	// Fix cherry-picked onto stolostron/prometheus branch cve-2026-42151/v0.55.1 — do not delete branch.
-	github.com/prometheus/prometheus => github.com/stolostron/prometheus v0.0.0-20260805153507-383a8f4f8330
+	// stolostron release-2.14 commit 882a9e6500b4
+	github.com/prometheus/prometheus => github.com/stolostron/prometheus v1.8.2-0.20260807141503-882a9e6500b4
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.19.7
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,11 @@ replace (
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20241001152557-e415140e5d5f
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f
 	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20241106000323-9fcf3125a28e
+
+	// CVE-2026-42151: Azure AD OAuth client_secret exposed via config API.
+	// Upstream fix is in v0.311.3 but requires incompatible API changes.
+	// This replace points to katekeiroz-dev/prometheus with the fix cherry-picked onto v0.55.1.
+	github.com/prometheus/prometheus => github.com/katekeiroz-dev/prometheus v0.0.0-20260805153507-383a8f4f8330
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.19.7
 )
 

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ replace (
 
 	// CVE-2026-42151: Azure AD OAuth client_secret exposed via config API.
 	// Upstream fix is in v0.311.3 but requires incompatible API changes.
-	// This replace points to katekeiroz-dev/prometheus with the fix cherry-picked onto v0.55.1.
-	github.com/prometheus/prometheus => github.com/katekeiroz-dev/prometheus v0.0.0-20260805153507-383a8f4f8330
+	// Fix cherry-picked onto stolostron/prometheus branch cve-2026-42151/v0.55.1 — do not delete branch.
+	github.com/prometheus/prometheus => github.com/stolostron/prometheus v0.0.0-20260805153507-383a8f4f8330
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.19.7
 )
 

--- a/go.sum
+++ b/go.sum
@@ -355,8 +355,6 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/katekeiroz-dev/prometheus v0.0.0-20260805153507-383a8f4f8330 h1:D/du3ihp5L3+K9Ztw8IIPidLj+bBOIL254lSC6WApZU=
-github.com/katekeiroz-dev/prometheus v0.0.0-20260805153507-383a8f4f8330/go.mod h1:GGS7QlWKCqCbcEzWsVahYIfQwiGhcExkarHyLJTsv6I=
 github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6 h1:IsMZxCuZqKuao2vNdfD82fjjgPLfyHLpR41Z88viRWs=
 github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6/go.mod h1:3VeWNIJaW+O5xpRQbPp0Ybqu1vJd/pm7s2F473HRrkw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -535,6 +533,8 @@ github.com/stolostron/multiclusterhub-operator v0.0.0-20240626140553-4f1ed6be3b8
 github.com/stolostron/multiclusterhub-operator v0.0.0-20240626140553-4f1ed6be3b84/go.mod h1:fVXNVgAb4lcyAurs9qi3UG5bkpRCO2hYmEkj9s9++MY=
 github.com/stolostron/observatorium-operator v0.0.0-20250924055856-a17f072986da h1:Ocy5cAFQQVbBtlb5G2HWExAYiHfyBfOFuCFrI0mtnLc=
 github.com/stolostron/observatorium-operator v0.0.0-20250924055856-a17f072986da/go.mod h1:ZDh8f7Fj7GzUR5BXqH9FMmJwelVOnC+mUF9qt5BandI=
+github.com/stolostron/prometheus v0.0.0-20260805153507-383a8f4f8330 h1:JTtm2wgflYAeQKQnE4VsEratAzUtGqlGfa3NnuL5O8g=
+github.com/stolostron/prometheus v0.0.0-20260805153507-383a8f4f8330/go.mod h1:GGS7QlWKCqCbcEzWsVahYIfQwiGhcExkarHyLJTsv6I=
 github.com/stolostron/rbac-api-utils v0.0.0-20240404212618-7f57fc664256 h1:BeTUZoAkKzPKSH0sG4a9PaakKHuJ0h9Cks9joBn3Ns8=
 github.com/stolostron/rbac-api-utils v0.0.0-20240404212618-7f57fc664256/go.mod h1:zYGYkVgY+sL501na1x5RDCKMrHD+JAwb6oRFU8e9XlU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -533,8 +533,8 @@ github.com/stolostron/multiclusterhub-operator v0.0.0-20240626140553-4f1ed6be3b8
 github.com/stolostron/multiclusterhub-operator v0.0.0-20240626140553-4f1ed6be3b84/go.mod h1:fVXNVgAb4lcyAurs9qi3UG5bkpRCO2hYmEkj9s9++MY=
 github.com/stolostron/observatorium-operator v0.0.0-20250924055856-a17f072986da h1:Ocy5cAFQQVbBtlb5G2HWExAYiHfyBfOFuCFrI0mtnLc=
 github.com/stolostron/observatorium-operator v0.0.0-20250924055856-a17f072986da/go.mod h1:ZDh8f7Fj7GzUR5BXqH9FMmJwelVOnC+mUF9qt5BandI=
-github.com/stolostron/prometheus v0.0.0-20260805153507-383a8f4f8330 h1:JTtm2wgflYAeQKQnE4VsEratAzUtGqlGfa3NnuL5O8g=
-github.com/stolostron/prometheus v0.0.0-20260805153507-383a8f4f8330/go.mod h1:GGS7QlWKCqCbcEzWsVahYIfQwiGhcExkarHyLJTsv6I=
+github.com/stolostron/prometheus v1.8.2-0.20260807141503-882a9e6500b4 h1:kMB3w5t0+NIx5uqW4RVcbTGdIhvkyJwDAHOLc4dfXsA=
+github.com/stolostron/prometheus v1.8.2-0.20260807141503-882a9e6500b4/go.mod h1:hC8WSsGlgj3d2zRv1Q0wsWvsYMFkwwo0AIt1dBeB3b4=
 github.com/stolostron/rbac-api-utils v0.0.0-20240404212618-7f57fc664256 h1:BeTUZoAkKzPKSH0sG4a9PaakKHuJ0h9Cks9joBn3Ns8=
 github.com/stolostron/rbac-api-utils v0.0.0-20240404212618-7f57fc664256/go.mod h1:zYGYkVgY+sL501na1x5RDCKMrHD+JAwb6oRFU8e9XlU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -355,6 +355,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/katekeiroz-dev/prometheus v0.0.0-20260805153507-383a8f4f8330 h1:D/du3ihp5L3+K9Ztw8IIPidLj+bBOIL254lSC6WApZU=
+github.com/katekeiroz-dev/prometheus v0.0.0-20260805153507-383a8f4f8330/go.mod h1:GGS7QlWKCqCbcEzWsVahYIfQwiGhcExkarHyLJTsv6I=
 github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6 h1:IsMZxCuZqKuao2vNdfD82fjjgPLfyHLpR41Z88viRWs=
 github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6/go.mod h1:3VeWNIJaW+O5xpRQbPp0Ybqu1vJd/pm7s2F473HRrkw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -498,8 +500,6 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
-github.com/prometheus/prometheus v0.55.1 h1:+NM9V/h4A+wRkOyQzGewzgPPgq/iX2LUQoISNvmjZmI=
-github.com/prometheus/prometheus v0.55.1/go.mod h1:GGS7QlWKCqCbcEzWsVahYIfQwiGhcExkarHyLJTsv6I=
 github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
 github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=


### PR DESCRIPTION
Adds a replace directive pointing `github.com/prometheus/prometheus` to `stolostron/prometheus` with the CVE-2026-42151 fix (Azure AD OAuth `client_secret` exposure) cherry-picked onto v0.55.1.

Direct upgrade to v0.305.3+ is not feasible on release-2.14 due to incompatible API changes between v0.55.1 (Prometheus 2.55) and the patched v3.x releases.

Fork commit verification:
- Commit [`383a8f4f8330`](https://github.com/stolostron/prometheus/commit/383a8f4f833043a9dce8c746cabc9d9a5c11b26f) on branch `cve-2026-42151/v0.55.1`
- Changes `ClientSecret` from `string` to `config_util.Secret` to prevent exposure via the config API

Verification performed:
- `go mod verify` ✅
- `go build ./...` ✅
- `make unit-tests` (operators, loaders, proxy, collectors) ✅ all packages pass

Affects components: acm-multicluster-observability-operator, grafana-dashboard-loader, rbac-query-proxy, metrics-collector

Related: ACM-36200, ACM-36188, ACM-36206