### PR TITLE
fix(mcoa): preserve AddOnDeploymentConfig during MCOA cleanup when right-sizing is configured but disabled

### DIFF
--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -45,7 +45,7 @@ deploy_hub_spoke_core() {
     export OCM_BRANCH="main"
   else
     VERSION=$(awk -F '.' '{ print $1"."$2 }' <"${ROOTDIR}/COMPONENT_VERSION")
-    export OCM_BRANCH="release-${VERSION}"
+    export OCM_BRANCH="backplane-${VERSION}"
   fi
   export OPERATOR_IMAGE_NAME=quay.io/stolostron/registration-operator:$LATEST_MCE_SNAPSHOT
   export REGISTRATION_IMAGE=quay.io/stolostron/registration:$LATEST_MCE_SNAPSHOT

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -351,6 +351,15 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 			return ctrl.Result{}, fmt.Errorf("failed to list MCOA resources for deletion in namespace %s: %w", namespace, err)
 		}
 		for _, res := range toDelete {
+			// Keep the AddOnDeploymentConfig when right-sizing has been configured
+			// (even with all RS features disabled): the analytics controller syncs its
+			// RS variables to explicit "disabled" values (MCOA auto-enables right-sizing
+			// when the variables are absent, so deleting the ADC would fail open), and
+			// the ADC is GC'd with the MCO CR via its ownerReference. Never-configured
+			// installs (Capabilities.Platform == nil) still get full cleanup.
+			if res.GetKind() == "AddOnDeploymentConfig" && rendering.RightSizingConfigured(instance) {
+				continue
+			}
 			resNS := res.GetNamespace()
 			if err := deployer.Undeploy(ctx, res, instance); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to undeploy %s %s/%s: %w", res.GetKind(), resNS, res.GetName(), err)

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -55,6 +55,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/util/workqueue"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
@@ -1918,4 +1919,188 @@ func TestMCOAWaitForManifestWorks(t *testing.T) {
 		err = r2.Client.Get(t.Context(), types.NamespacedName{Name: mcoToDelete2.Name}, fetchedMCO)
 		assert.True(t, errors.IsNotFound(err)) // The object is successfully garbage collected on the API-side
 	})
+}
+
+// TestMCOACleanupADCPreservation drives the full Reconcile into the MCOA cleanup
+// block (entered when !MCOAEnabled && !RightSizingEnabled) and verifies the fate
+// of the AddOnDeploymentConfig:
+//   - When right-sizing has been configured (Capabilities.Platform != nil) but all
+//     features are disabled, the ADC must SURVIVE cleanup so the analytics
+//     controller can sync its RS variables to "disabled" (e2e rightsizing/g2
+//     "Should set both ADC RS variables to 'disabled'").
+//   - When capabilities were never configured, the ADC is undeployed with the
+//     rest of the MCOA resources (fresh-install cleanup unchanged).
+func TestMCOACleanupADCPreservation(t *testing.T) {
+	var (
+		name      = "monitoring"
+		namespace = config.GetDefaultNamespace()
+		mcoUID    = types.UID("mco-uid-adc-cleanup-test")
+	)
+
+	newMCO := func(caps *mcov1beta2.CapabilitiesSpec) *mcov1beta2.MultiClusterObservability {
+		return &mcov1beta2.MultiClusterObservability{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: mcov1beta2.GroupVersion.String(),
+				Kind:       "MultiClusterObservability",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				UID:  mcoUID,
+			},
+			Spec: mcov1beta2.MultiClusterObservabilitySpec{
+				Capabilities: caps,
+				StorageConfig: &mcov1beta2.StorageConfig{
+					MetricObjectStorage: &mcoshared.PreConfiguredStorage{
+						Key:  "test",
+						Name: "test",
+					},
+					StorageClass:            "gp2",
+					AlertmanagerStorageSize: "1Gi",
+					CompactStorageSize:      "1Gi",
+					RuleStorageSize:         "1Gi",
+					ReceiveStorageSize:      "1Gi",
+					StoreStorageSize:        "1Gi",
+				},
+				ObservabilityAddonSpec: &mcoshared.ObservabilityAddonSpec{
+					EnableMetrics: false,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		capabilities *mcov1beta2.CapabilitiesSpec
+		expectADC    bool
+	}{
+		{
+			name: "ADC preserved when right-sizing configured but both features disabled",
+			// Platform != nil => RightSizingConfigured == true; every feature false
+			// => MCOAEnabled == false && RightSizingEnabled == false => cleanup runs.
+			capabilities: &mcov1beta2.CapabilitiesSpec{
+				Platform: &mcov1beta2.PlatformCapabilitiesSpec{},
+			},
+			expectADC: true,
+		},
+		{
+			name:         "ADC undeployed when capabilities never configured",
+			capabilities: nil,
+			expectADC:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer setupTest(t)()
+			tlstesting.NewFakeTLSClientBuilder().Build(t)
+
+			mco := newMCO(tt.capabilities)
+
+			// Seed the ADC exactly as the operator deploys it: rendered from
+			// manifests/base/multicluster-observability-addon (v1alpha1 GVK) and
+			// controller-owned by the MCO CR (SetControllerReference in Reconcile).
+			adc := &unstructured.Unstructured{}
+			adc.SetAPIVersion(addonv1alpha1.SchemeGroupVersion.String())
+			adc.SetKind("AddOnDeploymentConfig")
+			adc.SetName(config.MultiClusterObservabilityAddon)
+			adc.SetNamespace(namespace)
+			controllerRef := metav1.NewControllerRef(mco, mcov1beta2.GroupVersion.WithKind("MultiClusterObservability"))
+			adc.SetOwnerReferences([]metav1.OwnerReference{*controllerRef})
+
+			s := runtime.NewScheme()
+			require.NoError(t, scheme.AddToScheme(s))
+			require.NoError(t, mcov1beta2.SchemeBuilder.AddToScheme(s))
+			require.NoError(t, oav1beta1.AddToScheme(s))
+			require.NoError(t, observatoriumv1alpha1.AddToScheme(s))
+			require.NoError(t, routev1.Install(s))
+			require.NoError(t, oauthv1.AddToScheme(s))
+			require.NoError(t, clusterv1.Install(s))
+			require.NoError(t, clusterv1beta1.Install(s))
+			require.NoError(t, policyv1.AddToScheme(s))
+			require.NoError(t, addonv1beta1.Install(s))
+			require.NoError(t, addonv1alpha1.Install(s))
+			require.NoError(t, workv1.Install(s))
+			require.NoError(t, migrationv1alpha1.SchemeBuilder.AddToScheme(s))
+			require.NoError(t, operatorv1.AddToScheme(s))
+			require.NoError(t, storev1.AddToScheme(s))
+
+			objs := []runtime.Object{
+				mco, adc,
+				createObservatoriumAPIService(name, namespace),
+				newTestCert(config.ServerCACerts, namespace),
+				newTestCert(config.ClientCACerts, namespace),
+				newTestCert(config.GrafanaCerts, namespace),
+				newTestCert(config.ServerCerts, namespace),
+				newTestCert(config.ProxyRouteBYOCAName, namespace),
+				newTestCert(config.ProxyRouteBYOCERTName, namespace),
+				newClusterManagementAddon(),
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "extension-apiserver-authentication",
+						Namespace: "kube-system",
+					},
+					Data: map[string]string{"client-ca-file": "test"},
+				},
+				newStorageClass("gp2", true),
+			}
+
+			cl := fake.NewClientBuilder().
+				WithScheme(s).
+				WithRuntimeObjects(objs...).
+				WithStatusSubresource(
+					&addonv1beta1.ManagedClusterAddOn{},
+					&mcov1beta2.MultiClusterObservability{},
+					&oav1beta1.ObservabilityAddon{},
+				).
+				Build()
+
+			imageClient := &fakeimagev1client.FakeImageV1{Fake: &(fakeimageclient.NewSimpleClientset().Fake)}
+			_, err := imageClient.ImageStreams(config.OauthProxyImageStreamNamespace).Create(t.Context(),
+				&imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      config.OauthProxyImageStreamName,
+						Namespace: config.OauthProxyImageStreamNamespace,
+					},
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{
+								Name: "v4.4",
+								From: &corev1.ObjectReference{
+									Kind: "DockerImage",
+									Name: "quay.io/openshift-release-dev/ocp-v4.0-art-dev",
+								},
+							},
+						},
+					},
+				}, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			r := &MultiClusterObservabilityReconciler{
+				Client:      cl,
+				Scheme:      s,
+				CRDMap:      map[string]bool{config.IngressControllerCRD: true},
+				ImageClient: imageClient,
+			}
+			config.SetMonitoringCRName(name)
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: name}}
+
+			_, err = r.Reconcile(t.Context(), req)
+			require.NoError(t, err)
+
+			got := &unstructured.Unstructured{}
+			got.SetAPIVersion(addonv1alpha1.SchemeGroupVersion.String())
+			got.SetKind("AddOnDeploymentConfig")
+			err = cl.Get(t.Context(), types.NamespacedName{
+				Name:      config.MultiClusterObservabilityAddon,
+				Namespace: namespace,
+			}, got)
+			if tt.expectADC {
+				require.NoError(t, err,
+					"AddOnDeploymentConfig must survive MCOA cleanup when right-sizing is configured but disabled")
+			} else {
+				assert.True(t, errors.IsNotFound(err),
+					"AddOnDeploymentConfig should be undeployed when capabilities were never configured")
+			}
+		})
+	}
 }

--- a/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_mcoa.go
@@ -421,6 +421,23 @@ func MCOAEnabled(cr *obv1beta2.MultiClusterObservability) bool {
 	return mcoaEnabled
 }
 
+// RightSizingConfigured returns true when the platform capabilities block exists in
+// the MCO CR spec (Capabilities.Platform != nil), even if every right-sizing feature
+// under it is disabled. It distinguishes "right-sizing was configured but disabled"
+// from "right-sizing was never configured", so MCOA cleanup can preserve the
+// AddOnDeploymentConfig: the ADC must survive carrying the RS variables as explicit
+// "disabled" values, because MCOA auto-enables right-sizing when the variables are
+// absent — deleting the ADC would fail open.
+//
+// Note: the analytics controller's ensureRightSizingDefaults patches the RS fields
+// into the CR spec whenever they are absent, so on a running hub this is effectively
+// always true. Removing spec.capabilities entirely makes it transiently false (the
+// ADC is undeployed with the rest of the MCOA resources), after which the defaulting
+// re-enables right-sizing and the render path recreates the ADC.
+func RightSizingConfigured(cr *obv1beta2.MultiClusterObservability) bool {
+	return cr.Spec.Capabilities != nil && cr.Spec.Capabilities.Platform != nil
+}
+
 // MCOAPlatformMetricsEnabled checks if platform metrics collection is enabled in the MCO CR capabilities.
 func MCOAPlatformMetricsEnabled(cr *obv1beta2.MultiClusterObservability) bool {
 	if cr.Spec.Capabilities == nil {

--- a/operators/multiclusterobservability/pkg/rendering/renderer_mcoa_test.go
+++ b/operators/multiclusterobservability/pkg/rendering/renderer_mcoa_test.go
@@ -673,3 +673,56 @@ func TestRenderClusterManagementAddOnNilCapabilities(t *testing.T) {
 	assert.NotNil(t, uobj)
 	assert.NotContains(t, uobj.GetAnnotations(), "console.open-cluster-management.io/launch-link")
 }
+
+func TestRightSizingConfigured(t *testing.T) {
+	crWithRSEnabled := &mcov1beta2.MultiClusterObservability{
+		Spec: mcov1beta2.MultiClusterObservabilitySpec{
+			Capabilities: &mcov1beta2.CapabilitiesSpec{
+				Platform: &mcov1beta2.PlatformCapabilitiesSpec{},
+			},
+		},
+	}
+	crWithRSEnabled.Spec.Capabilities.Platform.Analytics.NamespaceRightSizingRecommendation.Enabled = true
+
+	tests := []struct {
+		name     string
+		cr       *mcov1beta2.MultiClusterObservability
+		expected bool
+	}{
+		{
+			name:     "capabilities not set",
+			cr:       &mcov1beta2.MultiClusterObservability{},
+			expected: false,
+		},
+		{
+			name: "capabilities set without platform",
+			cr: &mcov1beta2.MultiClusterObservability{
+				Spec: mcov1beta2.MultiClusterObservabilitySpec{
+					Capabilities: &mcov1beta2.CapabilitiesSpec{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "platform set with all features disabled",
+			cr: &mcov1beta2.MultiClusterObservability{
+				Spec: mcov1beta2.MultiClusterObservabilitySpec{
+					Capabilities: &mcov1beta2.CapabilitiesSpec{
+						Platform: &mcov1beta2.PlatformCapabilitiesSpec{},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:     "platform set with namespace right-sizing enabled",
+			cr:       crWithRSEnabled,
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, RightSizingConfigured(tt.cr))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Disabling both right-sizing features (with no other MCOA capability enabled) made the MCO
  controller delete the ADC during MCOA cleanup. MCOA auto-enables right-sizing when the ADC
  variables are absent — deleting the ADC fails open instead of disabling RS.
- Added `RightSizingConfigured()` to skip ADC deletion when `spec.capabilities.platform` exists.
  Never-configured installs (`Capabilities.Platform == nil`) keep full cleanup. The ADC is GC'd
  with the MCO CR via its ownerReference.

## Root cause
The ADC-deleting cleanup body predates always-MCOA and was unreachable under the old
annotation-latched gate (`!rightSizingDelegated` — never flips back). PR #2567 swapped in the
dynamic gate (`!RightSizingEnabled`) without re-auditing the body it made reachable. CI stayed
green on `main` only because ManifestWork drain latency delays the Undeploy loop past the e2e
polling window; on the release-5.0 SNO/no-spoke environment the deletion is immediate and
`rightsizing/g2` fails deterministically.

## Testing
- `go build ./operators/...` clean; full `go test ./operators/... -count=1`: all packages ok
- `TestMCOACleanupADCPreservation` drives full Reconcile through the cleanup block and pins
  both fates (survive when configured-but-disabled; undeploy when never configured) — reverting
  the skip turns it red with the exact CI failure signature
- `TestRightSizingConfigured` table coverage over nil/partial/disabled/enabled capability shapes
- Fixes e2e `rightsizing/g2` "Should set both ADC RS variables to 'disabled'" and de-flakes
  the g1 AfterAll ADC check
- Note: The prow test-e2e job deploys the PR-built operator (CSV substitution in the clusterpool deploy step), so this PR's own test-e2e validates the fix end-to-end.

 ## Additional
  - Cherry-picked `setup-e2e-tests.sh` fix from #2658 to unblock e2e-kind (OCM repo uses`backplane-X.Y` branches, not `release-X.Y`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)