### PR TITLE
Bump e2e Minio test image from 2021 release

### DIFF
--- a/examples/minio-tls/minio-deployment.yaml
+++ b/examples/minio-tls/minio-deployment.yaml
@@ -23,11 +23,11 @@ spec:
         - -c
         - mkdir -p /storage/thanos && /usr/bin/minio server --certs-dir /etc/minio/certs /storage
         env:
-        - name: MINIO_ACCESS_KEY
+        - name: MINIO_ROOT_USER
           value: minio
-        - name: MINIO_SECRET_KEY
+        - name: MINIO_ROOT_PASSWORD
           value: minio123
-        image:  quay.io/minio/minio:RELEASE.2021-08-25T00-41-18Z
+        image:  quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z-cpuv1
         name: minio
         ports:
         - containerPort: 9000

--- a/examples/minio/minio-deployment.yaml
+++ b/examples/minio/minio-deployment.yaml
@@ -23,11 +23,11 @@ spec:
         - -c
         - mkdir -p /storage/thanos && /usr/bin/minio server /storage
         env:
-        - name: MINIO_ACCESS_KEY
+        - name: MINIO_ROOT_USER
           value: minio
-        - name: MINIO_SECRET_KEY
+        - name: MINIO_ROOT_PASSWORD
           value: minio123
-        image:  quay.io/minio/minio:RELEASE.2021-08-25T00-41-18Z
+        image:  quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z-cpuv1
         name: minio
         ports:
         - containerPort: 9000


### PR DESCRIPTION
## Summary
- `examples/minio` and `examples/minio-tls` deployment manifests used by the e2e suite were pinned to `quay.io/minio/minio:RELEASE.2021-08-25T00-41-18Z` (2021).
- Recent e2e runs show thanos object-storage components (store, receive, rule, query) crash-looping while everything else stays healthy — likely an old Minio server incompatible with a newer AWS S3 client.
- Bump to `RELEASE.2025-09-07T16-13-09Z-cpuv1` (already used in `dev-scripts`) and switch `MINIO_ACCESS_KEY`/`MINIO_SECRET_KEY` to `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD`, same credential values.

## Test plan
- [ ] `ci/prow/e2e-kind` and `ci/prow/test-e2e` pass with MCO reaching Ready

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated MinIO deployment examples to use the current root username and password configuration.
  * Upgraded the MinIO container image to a newer release.
  * Applied the same configuration updates to both standard and TLS deployment examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->