### PR TITLE
ACM-33383 - feat: manage HCP metrics on MCOA endpoint-operator

### DIFF
--- a/operators/endpointmetrics/controllers/mcoa/hypershift_reconciler.go
+++ b/operators/endpointmetrics/controllers/mcoa/hypershift_reconciler.go
@@ -1,0 +1,450 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package mcoa
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	prometheusv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/hypershift"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	hypershiftReconcileTriggerName = "hypershift-reconcile"
+
+	etcdHcpComponentLabel      = "etcd-hcp-user-workload-metrics-collector"
+	apiserverHcpComponentLabel = "apiserver-hcp-user-workload-metrics-collector"
+
+	clusterIDMetricLabel             = "clusterID"
+	clusterNameMetricLabel           = "cluster"
+	managementClusterIDMetricLabel   = "managementclusterID"
+	managementClusterNameMetricLabel = "managementcluster"
+)
+
+type hcpClusterIdentity struct {
+	id   string
+	name string
+}
+
+// ReconcileHyperShift creates ACM ServiceMonitors for Hypershift hosted clusters so
+// UWL Prometheus can scrape HCP etcd and apiserver metrics for federation by PrometheusAgent.
+func (r *MCOAAgentReconciler) ReconcileHyperShift(ctx context.Context) error {
+	isHypershift, err := hypershift.IsHypershiftCluster()
+	if err != nil {
+		return fmt.Errorf("failed to check if the cluster is hypershift: %w", err)
+	}
+	if !isHypershift {
+		r.Log.Info("Hypershift CRD not present, skipping hosted cluster ServiceMonitor reconciliation")
+		return nil
+	}
+
+	if r.Namespace == "" {
+		return fmt.Errorf("namespace is required for MCOA hypershift reconcile")
+	}
+
+	etcdScrapeConfigs, err := r.listScrapeConfigsByComponent(ctx, etcdHcpComponentLabel)
+	if err != nil {
+		return fmt.Errorf("failed to list etcd HCP scrape configs: %w", err)
+	}
+	if len(etcdScrapeConfigs) == 0 {
+		r.Log.V(1).Info("no etcd HCP scrape configs found", "namespace", r.Namespace, "component", etcdHcpComponentLabel)
+	}
+
+	apiserverScrapeConfigs, err := r.listScrapeConfigsByComponent(ctx, apiserverHcpComponentLabel)
+	if err != nil {
+		return fmt.Errorf("failed to list apiserver HCP scrape configs: %w", err)
+	}
+	if len(apiserverScrapeConfigs) == 0 {
+		r.Log.V(1).Info("no apiserver HCP scrape configs found", "namespace", r.Namespace, "component", apiserverHcpComponentLabel)
+	}
+
+	if err := r.reconcileHCPScrapeConfigFederationFilters(ctx, append(etcdScrapeConfigs, apiserverScrapeConfigs...)); err != nil {
+		return fmt.Errorf("failed to reconcile HCP scrape config federation filters: %w", err)
+	}
+
+	etcdRules, err := r.listPrometheusRulesByComponent(ctx, etcdHcpComponentLabel)
+	if err != nil {
+		return fmt.Errorf("failed to list etcd HCP prometheus rules: %w", err)
+	}
+
+	apiserverRules, err := r.listPrometheusRulesByComponent(ctx, apiserverHcpComponentLabel)
+	if err != nil {
+		return fmt.Errorf("failed to list apiserver HCP prometheus rules: %w", err)
+	}
+
+	etcdMetrics, err := r.extractDependentMetrics(etcdScrapeConfigs, etcdRules)
+	if err != nil {
+		return fmt.Errorf("failed to extract etcd dependent metrics: %w", err)
+	}
+
+	apiserverMetrics, err := r.extractDependentMetrics(apiserverScrapeConfigs, apiserverRules)
+	if err != nil {
+		return fmt.Errorf("failed to extract apiserver dependent metrics: %w", err)
+	}
+
+	hostedClusters := &hyperv1.HostedClusterList{}
+	if err := r.List(ctx, hostedClusters, &client.ListOptions{}); err != nil {
+		return fmt.Errorf("failed to list HostedClusterList: %w", err)
+	}
+
+	for _, hostedCluster := range hostedClusters.Items {
+		if len(hostedCluster.Spec.ClusterID) == 0 {
+			r.Log.Info("hosted cluster is missing clusterID, skipping ServiceMonitor creation", "name", hostedCluster.Name)
+			continue
+		}
+
+		namespace := hypershift.HostedClusterNamespace(&hostedCluster)
+		identity := hcpClusterIdentity{
+			id:   hostedCluster.Spec.ClusterID,
+			name: hostedCluster.Name,
+		}
+
+		etcdSMDesired, err := r.generateMCOAEtcdServiceMonitor(ctx, namespace, identity, etcdMetrics)
+		if err != nil {
+			r.Log.Error(err, "failed to generate etcd ServiceMonitor", "namespace", namespace)
+			continue
+		}
+		if etcdSMDesired != nil {
+			if err := hypershift.CreateOrUpdateServiceMonitor(ctx, r.Client, etcdSMDesired); err != nil {
+				r.Log.Error(err, "failed to create/update etcd ServiceMonitor", "namespace", namespace)
+				continue
+			}
+		}
+
+		apiServerSMDesired, err := r.generateMCOAApiServerServiceMonitor(ctx, namespace, identity, apiserverMetrics)
+		if err != nil {
+			r.Log.Error(err, "failed to generate api server ServiceMonitor", "namespace", namespace)
+			continue
+		}
+		if apiServerSMDesired != nil {
+			if err := hypershift.CreateOrUpdateServiceMonitor(ctx, r.Client, apiServerSMDesired); err != nil {
+				r.Log.Error(err, "failed to create/update api-server ServiceMonitor", "namespace", namespace)
+				continue
+			}
+		}
+	}
+
+	return nil
+}
+
+func isHypershiftReconcileRequest(req ctrl.Request) bool {
+	return req.Name == hypershiftReconcileTriggerName && req.Namespace == ""
+}
+
+// reconcileHCPScrapeConfigFederationFilters ensures HCP ScrapeConfigs only federate metrics
+// scraped via acm-etcd/acm-kube-apiserver ServiceMonitors, not Hypershift's native ServiceMonitors.
+func (r *MCOAAgentReconciler) reconcileHCPScrapeConfigFederationFilters(ctx context.Context, scrapeConfigs []prometheusv1alpha1.ScrapeConfig) error {
+	if len(scrapeConfigs) == 0 {
+		return nil
+	}
+	if r.ClusterID == "" {
+		r.Log.Info("cluster ID is empty, skipping HCP scrape config federation filter reconciliation")
+		return nil
+	}
+
+	filters := []promv1.RelabelConfig{
+		{
+			SourceLabels: []promv1.LabelName{clusterIDMetricLabel},
+			Regex:        ".+",
+			Action:       "keep",
+		},
+		{
+			SourceLabels: []promv1.LabelName{managementClusterIDMetricLabel},
+			Regex:        r.ClusterID,
+			Action:       "keep",
+		},
+	}
+
+	isHCPScrapeConfigFederationFilter := func(cfg promv1.RelabelConfig) bool {
+		return cfg.Action == "keep" && len(cfg.SourceLabels) == 1 &&
+			(cfg.SourceLabels[0] == clusterIDMetricLabel ||
+				cfg.SourceLabels[0] == managementClusterIDMetricLabel)
+	}
+
+	for _, sc := range scrapeConfigs {
+		desired := sc.DeepCopy()
+		desired.Spec.MetricRelabelConfigs = slices.DeleteFunc(desired.Spec.MetricRelabelConfigs, isHCPScrapeConfigFederationFilter)
+		desired.Spec.MetricRelabelConfigs = append(desired.Spec.MetricRelabelConfigs, filters...)
+
+		if reflect.DeepEqual(sc.Spec.MetricRelabelConfigs, desired.Spec.MetricRelabelConfigs) {
+			continue
+		}
+
+		if err := r.Update(ctx, desired, &client.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to update scrape config %s/%s: %w", sc.Namespace, sc.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func (r *MCOAAgentReconciler) listPrometheusRulesByComponent(ctx context.Context, component string) ([]promv1.PrometheusRule, error) {
+	list := &promv1.PrometheusRuleList{}
+	if err := r.List(ctx, list,
+		client.InNamespace(r.Namespace),
+		client.MatchingLabels{labelKeyComponent: component},
+	); err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+func (r *MCOAAgentReconciler) extractDependentMetrics(scrapeConfigs []prometheusv1alpha1.ScrapeConfig, rules []promv1.PrometheusRule) ([]string, error) {
+	scPtrs := make([]*prometheusv1alpha1.ScrapeConfig, len(scrapeConfigs))
+	for i := range scrapeConfigs {
+		scPtrs[i] = &scrapeConfigs[i]
+	}
+
+	scMetrics, err := r.federatedMetrics(scPtrs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract federated metrics from ScrapeConfig: %w", err)
+	}
+
+	dedup := make(map[string]struct{}, len(scMetrics))
+	for _, metricsName := range scMetrics {
+		dedup[metricsName] = struct{}{}
+	}
+
+	rulePtrs := make([]*promv1.PrometheusRule, len(rules))
+	for i := range rules {
+		rulePtrs[i] = &rules[i]
+	}
+
+	ruleMetrics, err := r.rulesDependentMetrics(rulePtrs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract dependent metrics from PrometheusRule: %w", err)
+	}
+
+	for _, metricsName := range ruleMetrics {
+		dedup[metricsName] = struct{}{}
+	}
+
+	return slices.Sorted(maps.Keys(dedup)), nil
+}
+
+func (r *MCOAAgentReconciler) federatedMetrics(scrapeConfigs []*prometheusv1alpha1.ScrapeConfig) ([]string, error) {
+	ret := []string{}
+
+	for _, scrapeConfig := range scrapeConfigs {
+		if scrapeConfig == nil {
+			continue
+		}
+
+		for _, query := range scrapeConfig.Spec.Params["match[]"] {
+			expr, err := parser.ParseExpr(query)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse query %s: %w", query, err)
+			}
+
+			selectors := parser.ExtractSelectors(expr)
+			for _, node := range selectors {
+				for _, matcher := range node {
+					if matcher.Name != "__name__" || isRuleMetricName(matcher.Value) {
+						continue
+					}
+
+					if matcher.Type != labels.MatchEqual {
+						r.Log.V(1).Info("ignoring non equal type labels matcher in scrapeConfig, not supported", "scrapeConfig", scrapeConfig.Name, "matcher", matcher.String())
+						continue
+					}
+
+					ret = append(ret, matcher.Value)
+				}
+			}
+		}
+	}
+
+	return ret, nil
+}
+
+func (r *MCOAAgentReconciler) rulesDependentMetrics(promRules []*promv1.PrometheusRule) ([]string, error) {
+	ret := []string{}
+
+	for _, promRule := range promRules {
+		if promRule == nil {
+			continue
+		}
+
+		for _, group := range promRule.Spec.Groups {
+			for _, rule := range group.Rules {
+				expr, err := parser.ParseExpr(rule.Expr.StrVal)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse query for rule named %q: %w", rule.Record, err)
+				}
+
+				selectors := parser.ExtractSelectors(expr)
+				for _, node := range selectors {
+					for _, matcher := range node {
+						if matcher.Name != "__name__" || isRuleMetricName(matcher.Value) {
+							continue
+						}
+
+						if matcher.Type != labels.MatchEqual {
+							r.Log.V(1).Info("ignoring non equal type labels matcher in rule, not supported", "promRule", promRule.Name, "matcher", matcher.String())
+							continue
+						}
+
+						ret = append(ret, matcher.Value)
+					}
+				}
+			}
+		}
+	}
+
+	return ret, nil
+}
+
+func (r *MCOAAgentReconciler) generateMCOAEtcdServiceMonitor(
+	ctx context.Context,
+	namespace string,
+	hostedCluster hcpClusterIdentity,
+	metrics []string,
+) (*promv1.ServiceMonitor, error) {
+	if len(metrics) == 0 {
+		r.Log.V(1).Info("no metrics to collect for etcd, skipping serviceMonitor creation", "hostedClusterName", hostedCluster.name)
+		return nil, nil
+	}
+
+	hypershiftEtcdSM := &promv1.ServiceMonitor{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: hypershift.EtcdSmName}, hypershiftEtcdSM); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.Log.Error(err, "hypershift etcd ServiceMonitor not found, cannot set observability for etcd", "namespace", namespace, "hostedClusterName", hostedCluster.name)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get hypershift's etcd ServiceMonitor: %w", err)
+	}
+
+	ret := &promv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hypershift.AcmEtcdSmName,
+			Namespace: namespace,
+		},
+		Spec: promv1.ServiceMonitorSpec{
+			Selector:          hypershiftEtcdSM.Spec.Selector,
+			NamespaceSelector: hypershiftEtcdSM.Spec.NamespaceSelector,
+		},
+	}
+
+	for _, endpoint := range hypershiftEtcdSM.Spec.Endpoints {
+		ret.Spec.Endpoints = append(ret.Spec.Endpoints, promv1.Endpoint{
+			Interval:             "30s",
+			Scheme:               endpoint.Scheme,
+			Port:                 endpoint.Port,
+			TargetPort:           endpoint.TargetPort,
+			TLSConfig:            endpoint.TLSConfig,
+			MetricRelabelConfigs: r.generateMCOAMetricsRelabelConfigs(hostedCluster, metrics),
+			RelabelConfigs: []promv1.RelabelConfig{
+				{
+					TargetLabel: "job",
+					Action:      "replace",
+					Replacement: ptr.To("etcd"),
+				},
+			},
+		})
+	}
+
+	return ret, nil
+}
+
+func (r *MCOAAgentReconciler) generateMCOAApiServerServiceMonitor(
+	ctx context.Context,
+	namespace string,
+	hostedCluster hcpClusterIdentity,
+	metrics []string,
+) (*promv1.ServiceMonitor, error) {
+	if len(metrics) == 0 {
+		r.Log.V(1).Info("no metrics to collect for apiserver, skipping serviceMonitor creation", "hostedClusterName", hostedCluster.name)
+		return nil, nil
+	}
+
+	hypershiftApiServerSM := &promv1.ServiceMonitor{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: hypershift.ApiServerSmName}, hypershiftApiServerSM); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.Log.Error(err, "hypershift apiserver ServiceMonitor not found, cannot set observability for api server", "namespace", namespace, "hostedClusterName", hostedCluster.name)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get hypershift's kube-apiserver ServiceMonitor: %w", err)
+	}
+
+	ret := &promv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hypershift.AcmApiServerSmName,
+			Namespace: namespace,
+		},
+		Spec: promv1.ServiceMonitorSpec{
+			Selector:          hypershiftApiServerSM.Spec.Selector,
+			NamespaceSelector: hypershiftApiServerSM.Spec.NamespaceSelector,
+		},
+	}
+
+	for _, endpoint := range hypershiftApiServerSM.Spec.Endpoints {
+		ret.Spec.Endpoints = append(ret.Spec.Endpoints, promv1.Endpoint{
+			Interval:             "30s",
+			Scheme:               endpoint.Scheme,
+			Port:                 endpoint.Port,
+			TargetPort:           endpoint.TargetPort,
+			TLSConfig:            endpoint.TLSConfig,
+			MetricRelabelConfigs: r.generateMCOAMetricsRelabelConfigs(hostedCluster, metrics),
+			RelabelConfigs: []promv1.RelabelConfig{
+				{
+					TargetLabel: "job",
+					Action:      "replace",
+					Replacement: ptr.To("apiserver"),
+				},
+			},
+		})
+	}
+
+	return ret, nil
+}
+
+func (r *MCOAAgentReconciler) generateMCOAMetricsRelabelConfigs(hostedCluster hcpClusterIdentity, metrics []string) []promv1.RelabelConfig {
+	return []promv1.RelabelConfig{
+		{
+			SourceLabels: []promv1.LabelName{"__name__"},
+			Action:       "keep",
+			Regex:        fmt.Sprintf("(%s)", strings.Join(metrics, "|")),
+		},
+		{
+			TargetLabel: clusterIDMetricLabel,
+			Action:      "replace",
+			Replacement: &hostedCluster.id,
+		},
+		{
+			TargetLabel: clusterNameMetricLabel,
+			Action:      "replace",
+			Replacement: &hostedCluster.name,
+		},
+		{
+			TargetLabel: managementClusterIDMetricLabel,
+			Action:      "replace",
+			Replacement: &r.ClusterID,
+		},
+		{
+			TargetLabel: managementClusterNameMetricLabel,
+			Action:      "replace",
+			Replacement: &r.ClusterName,
+		},
+	}
+}
+
+func isRuleMetricName(name string) bool {
+	return strings.Contains(name, ":")
+}

--- a/operators/endpointmetrics/controllers/mcoa/hypershift_reconciler.go
+++ b/operators/endpointmetrics/controllers/mcoa/hypershift_reconciler.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"reflect"
 	"slices"
 	"strings"
 
@@ -73,10 +72,6 @@ func (r *MCOAAgentReconciler) ReconcileHyperShift(ctx context.Context) error {
 	}
 	if len(apiserverScrapeConfigs) == 0 {
 		r.Log.V(1).Info("no apiserver HCP scrape configs found", "namespace", r.Namespace, "component", apiserverHcpComponentLabel)
-	}
-
-	if err := r.reconcileHCPScrapeConfigFederationFilters(ctx, append(etcdScrapeConfigs, apiserverScrapeConfigs...)); err != nil {
-		return fmt.Errorf("failed to reconcile HCP scrape config federation filters: %w", err)
 	}
 
 	etcdRules, err := r.listPrometheusRulesByComponent(ctx, etcdHcpComponentLabel)
@@ -146,53 +141,6 @@ func (r *MCOAAgentReconciler) ReconcileHyperShift(ctx context.Context) error {
 
 func isHypershiftReconcileRequest(req ctrl.Request) bool {
 	return req.Name == hypershiftReconcileTriggerName && req.Namespace == ""
-}
-
-// reconcileHCPScrapeConfigFederationFilters ensures HCP ScrapeConfigs only federate metrics
-// scraped via acm-etcd/acm-kube-apiserver ServiceMonitors, not Hypershift's native ServiceMonitors.
-func (r *MCOAAgentReconciler) reconcileHCPScrapeConfigFederationFilters(ctx context.Context, scrapeConfigs []prometheusv1alpha1.ScrapeConfig) error {
-	if len(scrapeConfigs) == 0 {
-		return nil
-	}
-	if r.ClusterID == "" {
-		r.Log.Info("cluster ID is empty, skipping HCP scrape config federation filter reconciliation")
-		return nil
-	}
-
-	filters := []promv1.RelabelConfig{
-		{
-			SourceLabels: []promv1.LabelName{clusterIDMetricLabel},
-			Regex:        ".+",
-			Action:       "keep",
-		},
-		{
-			SourceLabels: []promv1.LabelName{managementClusterIDMetricLabel},
-			Regex:        r.ClusterID,
-			Action:       "keep",
-		},
-	}
-
-	isHCPScrapeConfigFederationFilter := func(cfg promv1.RelabelConfig) bool {
-		return cfg.Action == "keep" && len(cfg.SourceLabels) == 1 &&
-			(cfg.SourceLabels[0] == clusterIDMetricLabel ||
-				cfg.SourceLabels[0] == managementClusterIDMetricLabel)
-	}
-
-	for _, sc := range scrapeConfigs {
-		desired := sc.DeepCopy()
-		desired.Spec.MetricRelabelConfigs = slices.DeleteFunc(desired.Spec.MetricRelabelConfigs, isHCPScrapeConfigFederationFilter)
-		desired.Spec.MetricRelabelConfigs = append(desired.Spec.MetricRelabelConfigs, filters...)
-
-		if reflect.DeepEqual(sc.Spec.MetricRelabelConfigs, desired.Spec.MetricRelabelConfigs) {
-			continue
-		}
-
-		if err := r.Update(ctx, desired, &client.UpdateOptions{}); err != nil {
-			return fmt.Errorf("failed to update scrape config %s/%s: %w", sc.Namespace, sc.Name, err)
-		}
-	}
-
-	return nil
 }
 
 func (r *MCOAAgentReconciler) listPrometheusRulesByComponent(ctx context.Context, component string) ([]promv1.PrometheusRule, error) {

--- a/operators/endpointmetrics/controllers/mcoa/hypershift_reconciler_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/hypershift_reconciler_test.go
@@ -1,0 +1,345 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package mcoa
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	prometheusv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/hypershift"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	intstr "k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReconcileHyperShift(t *testing.T) {
+	t.Setenv("UNIT_TEST", "true")
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, hyperv1.AddToScheme(scheme))
+	require.NoError(t, promv1.AddToScheme(scheme))
+	require.NoError(t, prometheusv1alpha1.AddToScheme(scheme))
+
+	namespace := "addon-ns"
+	hcpNamespace := "clusters-myhc"
+
+	hostedCluster := &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "myhc", Namespace: "clusters"},
+		Spec:       hyperv1.HostedClusterSpec{ClusterID: "hcp-cluster-id"},
+	}
+	targetPort := intstr.FromString("metrics")
+	hypershiftEtcdSM := &promv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{Name: hypershift.EtcdSmName, Namespace: hcpNamespace},
+		Spec: promv1.ServiceMonitorSpec{
+			Endpoints: []promv1.Endpoint{{Port: "metrics", TargetPort: &targetPort}},
+			Selector:  *metav1.SetAsLabelSelector(map[string]string{"k8s-app": "etcd"}),
+		},
+	}
+	hypershiftApiServerSM := &promv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{Name: hypershift.ApiServerSmName, Namespace: hcpNamespace},
+		Spec: promv1.ServiceMonitorSpec{
+			Endpoints: []promv1.Endpoint{{Port: "client", TargetPort: &targetPort}},
+			Selector:  *metav1.SetAsLabelSelector(map[string]string{"k8s-app": "apiserver"}),
+		},
+	}
+	etcdScrapeConfig := &prometheusv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "etcd-hcp-uwl-metrics", Namespace: namespace,
+			Labels: map[string]string{labelKeyComponent: etcdHcpComponentLabel},
+		},
+		Spec: prometheusv1alpha1.ScrapeConfigSpec{
+			Params: map[string][]string{"match[]": {`{__name__="etcd_mvcc_db_total_size_in_bytes"}`}},
+		},
+	}
+	apiserverScrapeConfig := &prometheusv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "apiserver-hcp-uwl-metrics", Namespace: namespace,
+			Labels: map[string]string{labelKeyComponent: apiserverHcpComponentLabel},
+		},
+		Spec: prometheusv1alpha1.ScrapeConfigSpec{
+			Params: map[string][]string{"match[]": {`{__name__="grpc_server_handled_total"}`}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(
+		hostedCluster, hypershiftEtcdSM, hypershiftApiServerSM, etcdScrapeConfig, apiserverScrapeConfig,
+	).Build()
+
+	r := NewMCOAAgentReconciler(
+		c, logr.Discard(), scheme, events.NewFakeRecorder(10),
+		namespace, "spoke-id", "spoke-name",
+		"", "", "", "", true, true,
+	)
+
+	require.NoError(t, r.ReconcileHyperShift(context.Background()))
+
+	acmEtcdSM := &promv1.ServiceMonitor{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: hcpNamespace, Name: hypershift.AcmEtcdSmName}, acmEtcdSM))
+	assert.Equal(t, "hcp-cluster-id", *acmEtcdSM.Spec.Endpoints[0].MetricRelabelConfigs[1].Replacement)
+
+	acmApiServerSM := &promv1.ServiceMonitor{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: hcpNamespace, Name: hypershift.AcmApiServerSmName}, acmApiServerSM))
+	assert.Equal(t, "spoke-id", *acmApiServerSM.Spec.Endpoints[0].MetricRelabelConfigs[3].Replacement)
+
+	updatedEtcdSC := &prometheusv1alpha1.ScrapeConfig{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: etcdScrapeConfig.Name}, updatedEtcdSC))
+	require.Len(t, updatedEtcdSC.Spec.MetricRelabelConfigs, 2)
+	assert.Equal(t, "keep", updatedEtcdSC.Spec.MetricRelabelConfigs[0].Action)
+	assert.Equal(t, promv1.LabelName(clusterIDMetricLabel), updatedEtcdSC.Spec.MetricRelabelConfigs[0].SourceLabels[0])
+	assert.Equal(t, ".+", updatedEtcdSC.Spec.MetricRelabelConfigs[0].Regex)
+	assert.Equal(t, promv1.LabelName(managementClusterIDMetricLabel), updatedEtcdSC.Spec.MetricRelabelConfigs[1].SourceLabels[0])
+	assert.Equal(t, "spoke-id", updatedEtcdSC.Spec.MetricRelabelConfigs[1].Regex)
+}
+
+func TestReconcileHostedClustersServiceMonitorsFromMCOAConfig_Nominal(t *testing.T) {
+	t.Setenv("UNIT_TEST", "true")
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, hyperv1.AddToScheme(scheme))
+	require.NoError(t, promv1.AddToScheme(scheme))
+	require.NoError(t, prometheusv1alpha1.AddToScheme(scheme))
+
+	namespace := "addon-ns"
+	hcpNamespace := "clusters-myhc"
+
+	hostedCluster := &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myhc",
+			Namespace: "clusters",
+		},
+		Spec: hyperv1.HostedClusterSpec{
+			ClusterID: "hcp-cluster-id",
+		},
+	}
+
+	targetPort := intstr.FromString("metrics")
+	hypershiftEtcdSM := &promv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hypershift.EtcdSmName,
+			Namespace: hcpNamespace,
+		},
+		Spec: promv1.ServiceMonitorSpec{
+			Endpoints: []promv1.Endpoint{{Port: "metrics", TargetPort: &targetPort}},
+			Selector:  *metav1.SetAsLabelSelector(map[string]string{"k8s-app": "etcd"}),
+		},
+	}
+	hypershiftApiServerSM := &promv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hypershift.ApiServerSmName,
+			Namespace: hcpNamespace,
+		},
+		Spec: promv1.ServiceMonitorSpec{
+			Endpoints: []promv1.Endpoint{{Port: "client", TargetPort: &targetPort}},
+			Selector:  *metav1.SetAsLabelSelector(map[string]string{"k8s-app": "apiserver"}),
+		},
+	}
+
+	etcdScrapeConfig := &prometheusv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd-hcp-uwl-metrics",
+			Namespace: namespace,
+			Labels: map[string]string{
+				labelKeyComponent: etcdHcpComponentLabel,
+			},
+		},
+		Spec: prometheusv1alpha1.ScrapeConfigSpec{
+			Params: map[string][]string{
+				"match[]": {`{__name__="etcd_mvcc_db_total_size_in_bytes"}`},
+			},
+		},
+	}
+	apiserverScrapeConfig := &prometheusv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "apiserver-hcp-uwl-metrics",
+			Namespace: namespace,
+			Labels: map[string]string{
+				labelKeyComponent: apiserverHcpComponentLabel,
+			},
+		},
+		Spec: prometheusv1alpha1.ScrapeConfigSpec{
+			Params: map[string][]string{
+				"match[]": {`{__name__="grpc_server_handled_total"}`},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(
+		hostedCluster,
+		hypershiftEtcdSM,
+		hypershiftApiServerSM,
+		etcdScrapeConfig,
+		apiserverScrapeConfig,
+	).Build()
+
+	r := NewMCOAAgentReconciler(
+		c, logr.Discard(), scheme, events.NewFakeRecorder(10),
+		namespace, "spoke-id", "spoke-name",
+		"", "", "", "", true, true,
+	)
+
+	require.NoError(t, r.ReconcileHyperShift(context.Background()))
+
+	acmEtcdSM := &promv1.ServiceMonitor{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: hcpNamespace, Name: hypershift.AcmEtcdSmName}, acmEtcdSM))
+	assert.Contains(t, acmEtcdSM.Spec.Endpoints[0].MetricRelabelConfigs[0].Regex, "etcd_mvcc_db_total_size_in_bytes")
+	assert.Equal(t, "hcp-cluster-id", *acmEtcdSM.Spec.Endpoints[0].MetricRelabelConfigs[1].Replacement)
+	assert.Equal(t, "spoke-id", *acmEtcdSM.Spec.Endpoints[0].MetricRelabelConfigs[3].Replacement)
+
+	acmApiServerSM := &promv1.ServiceMonitor{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: hcpNamespace, Name: hypershift.AcmApiServerSmName}, acmApiServerSM))
+	assert.Contains(t, acmApiServerSM.Spec.Endpoints[0].MetricRelabelConfigs[0].Regex, "grpc_server_handled_total")
+}
+
+func TestReconcileHostedClustersServiceMonitorsFromMCOAConfig_NoHypershiftSMs(t *testing.T) {
+	t.Setenv("UNIT_TEST", "true")
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, hyperv1.AddToScheme(scheme))
+	require.NoError(t, promv1.AddToScheme(scheme))
+	require.NoError(t, prometheusv1alpha1.AddToScheme(scheme))
+
+	namespace := "addon-ns"
+	hostedCluster := &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "myhc", Namespace: "clusters"},
+		Spec:       hyperv1.HostedClusterSpec{ClusterID: "hcp-cluster-id"},
+	}
+	etcdScrapeConfig := &prometheusv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd-hcp-uwl-metrics",
+			Namespace: namespace,
+			Labels:    map[string]string{labelKeyComponent: etcdHcpComponentLabel},
+		},
+		Spec: prometheusv1alpha1.ScrapeConfigSpec{
+			Params: map[string][]string{"match[]": {`{__name__="etcd_mvcc_db_total_size_in_bytes"}`}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(hostedCluster, etcdScrapeConfig).Build()
+
+	r := NewMCOAAgentReconciler(
+		c, logr.Discard(), scheme, events.NewFakeRecorder(10),
+		namespace, "spoke-id", "spoke-name",
+		"", "", "", "", true, true,
+	)
+
+	require.NoError(t, r.ReconcileHyperShift(context.Background()))
+
+	acmEtcdSM := &promv1.ServiceMonitor{}
+	err := c.Get(context.Background(), types.NamespacedName{Namespace: "clusters-myhc", Name: hypershift.AcmEtcdSmName}, acmEtcdSM)
+	require.Error(t, err)
+}
+
+func TestExtractDependentMetrics(t *testing.T) {
+	r := NewMCOAAgentReconciler(
+		nil, logr.Discard(), nil, events.NewFakeRecorder(10),
+		"", "", "",
+		"", "", "", "", true, true,
+	)
+
+	testCases := map[string]struct {
+		scrapeConfig []prometheusv1alpha1.ScrapeConfig
+		rules        []promv1.PrometheusRule
+		expectResult []string
+		expectError  bool
+	}{
+		"none": {},
+		"invalid scrape config": {
+			scrapeConfig: []prometheusv1alpha1.ScrapeConfig{{
+				Spec: prometheusv1alpha1.ScrapeConfigSpec{
+					Params: map[string][]string{"match[]": {`{__name__"acm_label_names"}`}},
+				},
+			}},
+			expectError: true,
+		},
+		"scrape config": {
+			scrapeConfig: []prometheusv1alpha1.ScrapeConfig{{
+				Spec: prometheusv1alpha1.ScrapeConfigSpec{
+					Params: map[string][]string{
+						"match[]": {
+							`{__name__=":node_memory_MemAvailable_bytes:sum"}`,
+							`{__name__=~"acm_"}`,
+							`{__name__="acm_managed_cluster_labels"}`,
+						},
+					},
+				},
+			}},
+			expectResult: []string{"acm_managed_cluster_labels"},
+		},
+		"rule": {
+			rules: []promv1.PrometheusRule{{
+				Spec: promv1.PrometheusRuleSpec{
+					Groups: []promv1.RuleGroup{{
+						Rules: []promv1.Rule{{
+							Expr: intstr.FromString(`sum(grpc_server_started_total{job="etcd",clusterID!=""})`),
+						}},
+					}},
+				},
+			}},
+			expectResult: []string{"grpc_server_started_total"},
+		},
+		"merged scrape config and rule": {
+			scrapeConfig: []prometheusv1alpha1.ScrapeConfig{{
+				Spec: prometheusv1alpha1.ScrapeConfigSpec{
+					Params: map[string][]string{
+						"match[]": {
+							`{__name__="grpc_server_started_total"}`,
+							`{__name__="apiserver_request_duration_seconds_bucket"}`,
+						},
+					},
+				},
+			}},
+			rules: []promv1.PrometheusRule{{
+				Spec: promv1.PrometheusRuleSpec{
+					Groups: []promv1.RuleGroup{{
+						Rules: []promv1.Rule{{
+							Expr: intstr.FromString(`sum(grpc_server_handled_total{job="etcd",clusterID!=""})`),
+						}},
+					}},
+				},
+			}},
+			expectResult: []string{
+				"apiserver_request_duration_seconds_bucket",
+				"grpc_server_handled_total",
+				"grpc_server_started_total",
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			res, err := r.extractDependentMetrics(tc.scrapeConfig, tc.rules)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectResult, res)
+		})
+	}
+}
+
+func TestIsHypershiftReconcileRequest(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isHypershiftReconcileRequest(ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: hypershiftReconcileTriggerName},
+	}))
+	assert.False(t, isHypershiftReconcileRequest(ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: hypershift.EtcdSmName, Namespace: "clusters-myhc"},
+	}))
+	assert.False(t, isHypershiftReconcileRequest(ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: hypershift.AcmEtcdSmName, Namespace: "clusters-myhc"},
+	}))
+}

--- a/operators/endpointmetrics/controllers/mcoa/hypershift_reconciler_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/hypershift_reconciler_test.go
@@ -95,12 +95,7 @@ func TestReconcileHyperShift(t *testing.T) {
 
 	updatedEtcdSC := &prometheusv1alpha1.ScrapeConfig{}
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: etcdScrapeConfig.Name}, updatedEtcdSC))
-	require.Len(t, updatedEtcdSC.Spec.MetricRelabelConfigs, 2)
-	assert.Equal(t, "keep", updatedEtcdSC.Spec.MetricRelabelConfigs[0].Action)
-	assert.Equal(t, promv1.LabelName(clusterIDMetricLabel), updatedEtcdSC.Spec.MetricRelabelConfigs[0].SourceLabels[0])
-	assert.Equal(t, ".+", updatedEtcdSC.Spec.MetricRelabelConfigs[0].Regex)
-	assert.Equal(t, promv1.LabelName(managementClusterIDMetricLabel), updatedEtcdSC.Spec.MetricRelabelConfigs[1].SourceLabels[0])
-	assert.Equal(t, "spoke-id", updatedEtcdSC.Spec.MetricRelabelConfigs[1].Regex)
+	assert.Empty(t, updatedEtcdSC.Spec.MetricRelabelConfigs)
 }
 
 func TestReconcileHostedClustersServiceMonitorsFromMCOAConfig_Nominal(t *testing.T) {

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
@@ -9,12 +9,16 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	prometheusv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
+	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/pkg/hypershift"
 	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
@@ -89,7 +93,11 @@ func (r *MCOAAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile UWL config: %w", err)
 		}
 		return ctrl.Result{}, nil
-
+	case isHypershiftReconcileRequest(req):
+		if err := r.ReconcileHyperShift(ctx); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to reconcile HyperShift: %w", err)
+		}
+		return ctrl.Result{}, nil
 	case isManagedCRDName(req.Name) && req.Namespace == "":
 		// The predicate already filters by name; the empty-namespace guard here
 		// disambiguates from any future watch source that might use the same name
@@ -133,53 +141,71 @@ func (r *MCOAAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		Watches(
 			&prometheusv1alpha1.ScrapeConfig{},
-			handler.EnqueueRequestsFromMapFunc(r.mapComponentLabelToRequests(
-				platformMetricsCollectorRawComponent,
-				userWorkloadMetricsCollectorRawComponent,
-			)),
+			handler.EnqueueRequestsFromMapFunc(r.mapComponentLabelToRequests()),
 		).
 		Watches(
 			&prometheusv1alpha1.PrometheusAgent{},
-			handler.EnqueueRequestsFromMapFunc(r.mapComponentLabelToRequests(
-				platformMetricsCollectorComponent,
-				userWorkloadMetricsCollectorComponent,
-			)),
+			handler.EnqueueRequestsFromMapFunc(r.mapComponentLabelToRequests()),
+		).
+		Watches(
+			&prometheusv1.ServiceMonitor{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueHypershiftReconcile()),
+			ctrlbuilder.WithPredicates(predicate.Funcs{
+				CreateFunc: func(e event.CreateEvent) bool {
+					return e.Object.GetName() == hypershift.EtcdSmName || e.Object.GetName() == hypershift.ApiServerSmName
+				},
+				DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+				UpdateFunc:  func(_ event.UpdateEvent) bool { return false },
+				GenericFunc: func(_ event.GenericEvent) bool { return false },
+			}),
+		).
+		Watches(
+			&hyperv1.HostedCluster{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueHypershiftReconcile()),
+			ctrlbuilder.WithPredicates(predicate.Funcs{
+				CreateFunc: func(_ event.CreateEvent) bool { return true },
+				DeleteFunc: func(_ event.DeleteEvent) bool { return true },
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldHC, okOld := e.ObjectOld.(*hyperv1.HostedCluster)
+					newHC, okNew := e.ObjectNew.(*hyperv1.HostedCluster)
+					if !okOld || !okNew {
+						return false
+					}
+					return newHC.Spec.ClusterID != oldHC.Spec.ClusterID
+				},
+				GenericFunc: func(_ event.GenericEvent) bool { return false },
+			}),
 		).
 		Complete(r)
 }
 
-func (r *MCOAAgentReconciler) mapComponentLabelToRequests(
-	platformComp, uwlComp string,
-) handler.MapFunc {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+func (r *MCOAAgentReconciler) mapComponentLabelToRequests() handler.MapFunc {
+	return func(_ context.Context, obj client.Object) []reconcile.Request {
 		if obj.GetNamespace() != r.Namespace {
 			return nil
 		}
-		labels := obj.GetLabels()
-		if labels == nil {
+		comp := obj.GetLabels()[labelKeyComponent]
+		switch comp {
+		case platformMetricsCollectorRawComponent:
+			return []reconcile.Request{{NamespacedName: types.NamespacedName{
+				Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+			}}}
+		case userWorkloadMetricsCollectorRawComponent:
+			return []reconcile.Request{{NamespacedName: types.NamespacedName{
+				Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
+				Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
+			}}}
+		case etcdHcpComponentLabel, apiserverHcpComponentLabel:
+			return r.enqueueHypershiftReconcile()(context.Background(), obj)
+		default:
 			return nil
 		}
-		comp := labels[labelKeyComponent]
-		switch comp {
-		case platformComp:
-			return []reconcile.Request{
-				{
-					NamespacedName: client.ObjectKey{
-						Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
-						Namespace: operatorconfig.OCPClusterMonitoringNamespace,
-					},
-				},
-			}
-		case uwlComp:
-			return []reconcile.Request{
-				{
-					NamespacedName: client.ObjectKey{
-						Name:      operatorconfig.OCPUserWorkloadMonitoringConfigMap,
-						Namespace: operatorconfig.OCPUserWorkloadMonitoringNamespace,
-					},
-				},
-			}
-		}
-		return nil
+	}
+}
+
+func (r *MCOAAgentReconciler) enqueueHypershiftReconcile() handler.MapFunc {
+	return func(context.Context, client.Object) []reconcile.Request {
+		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: hypershiftReconcileTriggerName}}}
 	}
 }

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
@@ -116,7 +116,7 @@ func (r *MCOAAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *MCOAAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	builder := ctrl.NewControllerManagedBy(mgr).
 		// Watch ConfigMaps we manage across multiple namespaces.
 		// The cache FieldSelectors already limit this to exactly the CMs we need.
 		For(&corev1.ConfigMap{}, ctrlbuilder.WithPredicates(observabilityendpoint.ConfigMapDataChangedPredicate("", ""))).
@@ -158,8 +158,14 @@ func (r *MCOAAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				UpdateFunc:  func(_ event.UpdateEvent) bool { return false },
 				GenericFunc: func(_ event.GenericEvent) bool { return false },
 			}),
-		).
-		Watches(
+		)
+
+	isHypershift, err := hypershift.IsHypershiftCluster()
+	if err != nil {
+		return fmt.Errorf("failed to check if the cluster is hypershift: %w", err)
+	}
+	if isHypershift {
+		builder = builder.Watches(
 			&hyperv1.HostedCluster{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueHypershiftReconcile()),
 			ctrlbuilder.WithPredicates(predicate.Funcs{
@@ -175,8 +181,12 @@ func (r *MCOAAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				},
 				GenericFunc: func(_ event.GenericEvent) bool { return false },
 			}),
-		).
-		Complete(r)
+		)
+	} else {
+		r.Log.Info("Hypershift CRD not present, skipping HostedCluster watch registration")
+	}
+
+	return builder.Complete(r)
 }
 
 func (r *MCOAAgentReconciler) mapComponentLabelToRequests() handler.MapFunc {

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
@@ -17,6 +17,8 @@ import (
 
 	ocinfrav1 "github.com/openshift/api/config/v1"
 	cmomanifests "github.com/openshift/cluster-monitoring-operator/pkg/manifests"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	prometheusv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/stolostron/multicluster-observability-operator/operators/endpointmetrics/controllers/observabilityendpoint"
 	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
@@ -58,6 +60,8 @@ func TestMain(m *testing.M) {
 		filepath.Join("..", "observabilityendpoint", "testdata", "crd", "clusterversions-crd.yaml"),
 		filepath.Join("crds", "monitoring.rhobs_scrapeconfigs.yaml"),
 		filepath.Join("crds", "monitoring.rhobs_prometheusagents.yaml"),
+		filepath.Join("..", "..", "manifests", "prometheus", "crd", "servicemonitor_crd_0_53_1.yaml"),
+		filepath.Join("..", "observabilityendpoint", "testdata", "crd", "hostedclusters.hypershift.yaml"),
 	)
 
 	testEnv = &envtest.Environment{
@@ -109,6 +113,9 @@ func TestMCOAAgentIntegration(t *testing.T) {
 	require.NoError(t, kubescheme.AddToScheme(s))
 	require.NoError(t, ocinfrav1.AddToScheme(s))
 	require.NoError(t, apiextensionsv1.AddToScheme(s))
+
+	require.NoError(t, promv1.AddToScheme(s))
+	require.NoError(t, hyperv1.AddToScheme(s))
 
 	// Register ScrapeConfig for the custom monitoring.rhobs/v1alpha1 API Group
 	addRhobsToScheme(t, s)

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
@@ -51,6 +51,9 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	// Skip IsHypershiftCluster CRD check.
+	os.Setenv("UNIT_TEST", "true")
+
 	opts := zap.Options{
 		Development: true,
 	}

--- a/operators/endpointmetrics/pkg/hypershift/hypershift.go
+++ b/operators/endpointmetrics/pkg/hypershift/hypershift.go
@@ -48,7 +48,7 @@ func ReconcileHostedClustersServiceMonitors(ctx context.Context, c client.Client
 		// In case hypershift's etcd ServiceMonitor is not created yet,
 		// we can skip this cluster and wait for the next reconciliation loop
 		if err == nil {
-			if err := createOrUpdateSM(ctx, c, etcdSMDesired); err != nil {
+			if err := CreateOrUpdateServiceMonitor(ctx, c, etcdSMDesired); err != nil {
 				return reconciledHCsCount, fmt.Errorf("failed to create/update etcd ServiceMonitor %s/%s: %w", etcdSMDesired.GetNamespace(), etcdSMDesired.GetName(), err)
 			}
 			reconciledSMsCount++
@@ -58,7 +58,7 @@ func ReconcileHostedClustersServiceMonitors(ctx context.Context, c client.Client
 
 		apiServerSMDesired, err := getKubeServiceMonitor(ctx, c, namespace, cluster.Spec.ClusterID, cluster.Name)
 		if err == nil {
-			if err := createOrUpdateSM(ctx, c, apiServerSMDesired); err != nil {
+			if err := CreateOrUpdateServiceMonitor(ctx, c, apiServerSMDesired); err != nil {
 				return reconciledHCsCount, fmt.Errorf("failed to create/update api-server ServiceMonitor %s/%s: %w", apiServerSMDesired.GetNamespace(), apiServerSMDesired.GetName(), err)
 			}
 			reconciledSMsCount++
@@ -83,11 +83,11 @@ func DeleteServiceMonitors(ctx context.Context, c client.Client) error {
 
 	for _, cluster := range hList.Items {
 		namespace := HostedClusterNamespace(&cluster)
-		if err := deleteServiceMonitor(ctx, c, AcmEtcdSmName, namespace); err != nil {
+		if err := DeleteServiceMonitor(ctx, c, AcmEtcdSmName, namespace); err != nil {
 			return fmt.Errorf("failed to delete ServiceMonitor %s/%s: %w", namespace, AcmEtcdSmName, err)
 		}
 
-		if err := deleteServiceMonitor(ctx, c, AcmApiServerSmName, namespace); err != nil {
+		if err := DeleteServiceMonitor(ctx, c, AcmApiServerSmName, namespace); err != nil {
 			return fmt.Errorf("failed to delete ServiceMonitor %s/%s: %w", namespace, AcmApiServerSmName, err)
 		}
 	}
@@ -118,7 +118,7 @@ func IsHypershiftCluster() (bool, error) {
 	return isHypershift, nil
 }
 
-func createOrUpdateSM(ctx context.Context, c client.Client, smDesired *promv1.ServiceMonitor) error {
+func CreateOrUpdateServiceMonitor(ctx context.Context, c client.Client, smDesired *promv1.ServiceMonitor) error {
 	smCurrent := &promv1.ServiceMonitor{}
 	if err := c.Get(ctx, types.NamespacedName{Name: smDesired.GetName(), Namespace: smDesired.GetNamespace()}, smCurrent); err != nil {
 		if !errors.IsNotFound(err) {
@@ -316,7 +316,7 @@ func getKubeServiceMonitor(ctx context.Context, c client.Client, namespace, clus
 	}, nil
 }
 
-func deleteServiceMonitor(ctx context.Context, c client.Client, name, namespace string) error {
+func DeleteServiceMonitor(ctx context.Context, c client.Client, name, namespace string) error {
 	sm := &promv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,


### PR DESCRIPTION
## Summary 
Move HCP ServiceMonitor reconciliation into the endpoint-operator running in MCOA mode. This fixes the previous gap where MCOA's hub-side Addon Manager could only see hub-local HCPs, leaving the Spoke HCP unmonitored.

The enpoint-operator reconciliation is similar to the MCO legacy existing logic: for each local HostedCluster it creates the ACM `acm-etcd` / `acm-kube-apiserver` SM in the HCP namespace, cloning the hypershift SM's selector/endpoints and adding the metric-relabel stamping that carries cluster identity.

MCOA is expected to deliver the HCP etcd/apiserver **ScrapeConfigs** and **PrometheusRules** through the ManifestWork (see https://github.com/stolostron/multicluster-observability-addon/pull/582).

### Relabeling
The created ACM ServiceMonitor is featured with metric-relabel rules that keep only the metrics referenced by the ScrapeConfig/Rules and stamp `clusterID` (HC), `cluster` (hosted cluster name), `managementclusterID` (MC ID) and `managementcluster`.

## Testing
This has been tested e2e on an ACM MC running a HCP.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HyperShift monitoring support for hosted clusters.
  * Automatically creates or updates hosted-cluster monitoring configurations for etcd and API server metrics.
  * Applies appropriate endpoint, security, filtering, and labeling settings to generated monitors.
  * Detects HyperShift changes and refreshes monitoring configurations automatically.

* **Bug Fixes**
  * Safely handles missing monitoring configurations, cluster identifiers, and labels.

* **Tests**
  * Added comprehensive unit and integration coverage for HyperShift reconciliation and metric processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->