### PR TITLE
ACM-41141: fix VM right-sizing stat/table divergence and table running VM filter (release-2.17)

### DIFF
--- a/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization.yaml
@@ -92,7 +92,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "sum(floor((max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", namespace=~\"$namespace\"}\n+ on(cluster, namespace, name) group_left(_blah)(0 * max by (cluster, namespace, name) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0))\n)[$days:])-\nmax_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", namespace=~\"$namespace\"}\n+ on(cluster, namespace, name) group_left(_blah)(0 * max by (cluster, namespace, name) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0))\n)[$days:])))>0)",
+              "expr": "sum(\n(floor(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])-\nmax_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])) > 0)\nand on (name, namespace) (max by (name, namespace) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) > 0)\n)",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -165,7 +165,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "sum(floor((max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", namespace=~\"$namespace\"}\n+ on(cluster, namespace, name) group_left(_blah)(0 * max by (cluster, namespace, name) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0))\n)[$days:])-\nmax_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", namespace=~\"$namespace\"}\n+ on(cluster, namespace, name) group_left(_blah)(0 * max by (cluster, namespace, name) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0))\n)[$days:])))<0) * (-1)",
+              "expr": "sum(\n(floor(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])-\nmax_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])) < 0) * (-1)\nand on (name, namespace) (max by (name, namespace) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) > 0)\n)",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -238,7 +238,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "sum(floor((max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", namespace=~\"$namespace\"}\n+ on(cluster, namespace, name) group_left(_blah)(0 * max by (cluster, namespace, name) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0))\n)[$days:]) / 1073741824)-\n(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", namespace=~\"$namespace\"}\n+ on(cluster, namespace, name) group_left(_blah)(0 * max by (cluster, namespace, name) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0))\n)[$days:]) / 1073741824))>0)",
+              "expr": "sum(\n(floor((max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]) / 1073741824)-\n(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]) / 1073741824)) > 0)\nand on (name, namespace) (max by (name, namespace) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) > 0)\n)",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -311,7 +311,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "sum(floor((max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", namespace=~\"$namespace\"}\n+ on(cluster, namespace, name) group_left(_blah)(0 * max by (cluster, namespace, name) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0))\n)[$days:]) / 1073741824)-\n(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", namespace=~\"$namespace\"}\n+ on(cluster, namespace, name) group_left(_blah)(0 * max by (cluster, namespace, name) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0))\n)[$days:]) / 1073741824))<0) * (-1)",
+              "expr": "sum(\n(floor((max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]) / 1073741824)-\n(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]) / 1073741824)) < 0) * (-1)\nand on (name, namespace) (max by (name, namespace) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) > 0)\n)",
               "format": "time_series",
               "instant": true,
               "interval": "",

--- a/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization.yaml
@@ -847,7 +847,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n  max by (name, namespace) (max_over_time(((kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) * 1000)[$days:])),\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n  max by (name, namespace) ((kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) * 1000),\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1464,7 +1464,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n  max by (name, namespace) (max_over_time(((kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) * 1000)[$days:])),\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n  max by (name, namespace) ((kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) * 1000),\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -2004,7 +2004,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n  max by (name, namespace) (max_over_time(((kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) * 1000)[$days:])),\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n  max by (name, namespace) ((kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) * 1000),\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -2542,7 +2542,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n  max by (name, namespace) (max_over_time(((kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) * 1000)[$days:])),\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n  max by (name, namespace) ((kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) * 1000),\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,


### PR DESCRIPTION
## Summary

- **Fix 1**: Align Grafana stat panel queries with table panels — replaced `group_left` arithmetic join inside `max_over_time` with post-aggregation `and on (name, namespace)` set intersection filter. Added missing `profile="$profile"` label selector. The inline join caused series multiplication when VMs had multiple `source` labels (OCP 4.22+ KubeVirt), inflating Memory stat totals compared to table sums.
- **Fix 2**: Changed Grafana table Query G from window-based `max_over_time(running_status > 0)[$days:]` to instant `(running_status > 0)`. Tables now only show currently running VMs, matching the design intent: "filter the VMs based on current state."

**JIRA**: https://redhat.atlassian.net/browse/ACM-41141

## Validated on live cluster (vm-spoke, OCP 4.22)

| | Old (stock) | New (fixed) |
|--|-------------|-------------|
| Stat total | 17 GiB | 11 GiB |
| Table total | 25 GiB (4 VMs) | 11 GiB (2 VMs) |
| Stat == Table? | 17 ≠ 25 **MISMATCH** | 11 == 11 **MATCH** |
| Stopped VMs in table? | Yes | No |

🤖 Generated with [Claude Code](https://claude.com/claude-code)