### PR TITLE
Bump Go builder to 1.26 and fix e2e kind setup

### DIFF
--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -79,6 +79,12 @@ deploy_hub_spoke_core() {
   ${SED_COMMAND} 's/imagePullSecrets:.*//g' ./_repo_ocm/deploy/cluster-manager/chart/cluster-manager/templates/operator.yaml
   ${SED_COMMAND} 's/imagePullSecrets:.*//g' ./_repo_ocm/deploy/cluster-manager/chart/cluster-manager/templates/service_account.yaml
 
+  # SED_COMMAND uses `sed -i-e`, which leaves *-e backup files next to the originals.
+  # Helm renders every file under templates/, so those backups would emit a second
+  # cluster-manager Deployment and ServiceAccount and the install would fail with
+  # "already exists". Drop them before running the chart.
+  rm -f ./_repo_ocm/deploy/cluster-manager/chart/cluster-manager/templates/*-e
+
   make deploy-hub deploy-spoke-operator apply-spoke-cr -C ./_repo_ocm
 
   # wait until hub and spoke are ready

--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -75,6 +75,10 @@ deploy_hub_spoke_core() {
   fi
   ${SED_COMMAND} "s~clusterName: cluster1$~clusterName: ${MANAGED_CLUSTER}~g" ./_repo_ocm/deploy/klusterlet/config/samples/operator_open-cluster-management_klusterlets.cr.yaml
 
+  ${SED_COMMAND} '/--image-pull-secret-name/d' ./_repo_ocm/deploy/cluster-manager/chart/cluster-manager/templates/operator.yaml
+  ${SED_COMMAND} 's/imagePullSecrets:.*//g' ./_repo_ocm/deploy/cluster-manager/chart/cluster-manager/templates/operator.yaml
+  ${SED_COMMAND} 's/imagePullSecrets:.*//g' ./_repo_ocm/deploy/cluster-manager/chart/cluster-manager/templates/service_account.yaml
+
   make deploy-hub deploy-spoke-operator apply-spoke-cr -C ./_repo_ocm
 
   # wait until hub and spoke are ready

--- a/collectors/metrics/Containerfile.operator
+++ b/collectors/metrics/Containerfile.operator
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 # Licensed under the Apache License 2.0
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/collectors/metrics/Dockerfile
+++ b/collectors/metrics/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/loaders/dashboards/Containerfile.operator
+++ b/loaders/dashboards/Containerfile.operator
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 # Licensed under the Apache License 2.0
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./loaders/dashboards ./

--- a/loaders/dashboards/Dockerfile
+++ b/loaders/dashboards/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./loaders/dashboards ./

--- a/operators/endpointmetrics/Containerfile.operator
+++ b/operators/endpointmetrics/Containerfile.operator
@@ -1,6 +1,6 @@
 # Copyright (c) 2021 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project.
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/operators/endpointmetrics/Dockerfile
+++ b/operators/endpointmetrics/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2021 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project.
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/operators/multiclusterobservability/Containerfile.operator
+++ b/operators/multiclusterobservability/Containerfile.operator
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 # Licensed under the Apache License 2.0
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/operators/multiclusterobservability/Dockerfile
+++ b/operators/multiclusterobservability/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 
 WORKDIR /workspace

--- a/proxy/Containerfile.operator
+++ b/proxy/Containerfile.operator
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/scripts/test-utils.sh
+++ b/scripts/test-utils.sh
@@ -48,8 +48,8 @@ get_latest_mce_snapshot() {
   # matches:
   # version number (i.e 2.11)
   # z version 1-2 digits
-  # -SNAPSHOT
-  MATCH=$SNAPSHOT_RELEASE".\d{1,2}-SNAPSHOT"
+  # -BACKPLANE
+  MATCH=$SNAPSHOT_RELEASE".\d{1,2}-BACKPLANE"
   LATEST_SNAPSHOT=$(curl -s "https://quay.io/api/v1/repository/stolostron/registration/tag/?filter_tag_name=like:$SNAPSHOT_RELEASE&limit=100" | jq --arg MATCH "$MATCH" '.tags[] | select(.name | match($MATCH; "i")  ).name' | sort -r --version-sort | head -n 1)
 
   # trim the leading and tailing quotes

--- a/tests/Containerfile.operator
+++ b/tests/Containerfile.operator
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 # Licensed under the Apache License 2.0
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 # copy go tests into build image

--- a/tests/Containerfile.operator
+++ b/tests/Containerfile.operator
@@ -10,7 +10,10 @@ COPY ./operators ./operators
 COPY ./tests ./tests
 
 # compile go tests in build image
-RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.29.0 && go mod vendor && ginkgo build ./tests/pkg/tests/
+RUN GOFLAGS="" go install github.com/onsi/ginkgo/v2/ginkgo@v2.29.0 && export PATH="$(go env GOPATH)/bin:${PATH}" && go mod vendor && ginkgo build ./tests/pkg/tests/
+
+RUN curl -sSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.19/openshift-client-linux.tar.gz \
+    | tar -xz -C /usr/local/bin oc kubectl
 
 # create new docker image to hold built artifacts
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -7,7 +7,7 @@ COPY ./operators ./operators
 COPY ./tests ./tests
 
 # compile go tests in build image
-RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.2 && go mod vendor && ginkgo build ./tests/pkg/tests/
+RUN GOFLAGS="" go install github.com/onsi/ginkgo/v2/ginkgo@v2.29.0 && export PATH="$(go env GOPATH)/bin:${PATH}" && go mod vendor && ginkgo build ./tests/pkg/tests/
 
 # create new docker image to hold built artifacts
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 # copy go tests into build image

--- a/tests/run-in-kind/kind/kind-hub.config.yaml
+++ b/tests/run-in-kind/kind/kind-hub.config.yaml
@@ -1,5 +1,7 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  apiServerAddress: "127.0.0.1"
 nodes:
 - role: control-plane
   extraPortMappings:
@@ -11,7 +13,7 @@ nodes:
     listenAddress: "0.0.0.0"
   - containerPort: 6443
     hostPort: 32806
-    listenAddress: "0.0.0.0"
+    listenAddress: "127.0.0.1"
   - containerPort: 31001
     hostPort: 31001
     listenAddress: "127.0.0.1"

--- a/tools/simulator/alert-forward/Containerfile.operator
+++ b/tools/simulator/alert-forward/Containerfile.operator
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 # Licensed under the Apache License 2.0
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/tools/simulator/alert-forward/Dockerfile
+++ b/tools/simulator/alert-forward/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/tools/simulator/metrics-collector/metrics-extractor/Containerfile.operator
+++ b/tools/simulator/metrics-collector/metrics-extractor/Containerfile.operator
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 # Licensed under the Apache License 2.0
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 RUN GOBIN=/usr/local/bin go install github.com/brancz/gojsontoyaml@latest
 

--- a/tools/simulator/metrics-collector/metrics-extractor/Dockerfile
+++ b/tools/simulator/metrics-collector/metrics-extractor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 RUN GOBIN=/usr/local/bin go install github.com/brancz/gojsontoyaml@latest
 


### PR DESCRIPTION
Bump openshift-golang-builder from rhel_9_1.25 to rhel_9_1.26 in all Containerfiles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build environments across services and tooling to use Go 1.26.
  * Preserved existing runtime images, build behavior, and execution configuration.
  * Updated snapshot validation to recognize the current MCE snapshot tag format while retaining existing ACM snapshot handling.
  * Improved end-to-end test setup by ensuring required namespaces exist and configuring image-pull credentials before deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->