### PR TITLE
Unblock main CI: Go 1.26 bump plus e2e-kind and images fixes

### DIFF
--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -79,6 +79,12 @@ deploy_hub_spoke_core() {
   ${SED_COMMAND} 's/imagePullSecrets:.*//g' ./_repo_ocm/deploy/cluster-manager/chart/cluster-manager/templates/operator.yaml
   ${SED_COMMAND} 's/imagePullSecrets:.*//g' ./_repo_ocm/deploy/cluster-manager/chart/cluster-manager/templates/service_account.yaml
 
+  # SED_COMMAND uses `sed -i-e`, which leaves *-e backup files next to the originals.
+  # Helm renders every file under templates/, so those backups would emit a second
+  # cluster-manager Deployment and ServiceAccount and the install would fail with
+  # "already exists". Drop them before running the chart.
+  rm -f ./_repo_ocm/deploy/cluster-manager/chart/cluster-manager/templates/*-e
+
   make deploy-hub deploy-spoke-operator apply-spoke-cr -C ./_repo_ocm
 
   # wait until hub and spoke are ready

--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -75,6 +75,10 @@ deploy_hub_spoke_core() {
   fi
   ${SED_COMMAND} "s~clusterName: cluster1$~clusterName: ${MANAGED_CLUSTER}~g" ./_repo_ocm/deploy/klusterlet/config/samples/operator_open-cluster-management_klusterlets.cr.yaml
 
+  ${SED_COMMAND} '/--image-pull-secret-name/d' ./_repo_ocm/deploy/cluster-manager/chart/cluster-manager/templates/operator.yaml
+  ${SED_COMMAND} 's/imagePullSecrets:.*//g' ./_repo_ocm/deploy/cluster-manager/chart/cluster-manager/templates/operator.yaml
+  ${SED_COMMAND} 's/imagePullSecrets:.*//g' ./_repo_ocm/deploy/cluster-manager/chart/cluster-manager/templates/service_account.yaml
+
   make deploy-hub deploy-spoke-operator apply-spoke-cr -C ./_repo_ocm
 
   # wait until hub and spoke are ready

--- a/collectors/metrics/Containerfile.operator
+++ b/collectors/metrics/Containerfile.operator
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 # Licensed under the Apache License 2.0
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/collectors/metrics/Dockerfile
+++ b/collectors/metrics/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/loaders/dashboards/Containerfile.operator
+++ b/loaders/dashboards/Containerfile.operator
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 # Licensed under the Apache License 2.0
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./loaders/dashboards ./

--- a/loaders/dashboards/Dockerfile
+++ b/loaders/dashboards/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./loaders/dashboards ./

--- a/operators/endpointmetrics/Containerfile.operator
+++ b/operators/endpointmetrics/Containerfile.operator
@@ -1,6 +1,6 @@
 # Copyright (c) 2021 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project.
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/operators/endpointmetrics/Dockerfile
+++ b/operators/endpointmetrics/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2021 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project.
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/operators/multiclusterobservability/Containerfile.operator
+++ b/operators/multiclusterobservability/Containerfile.operator
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 # Licensed under the Apache License 2.0
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/operators/multiclusterobservability/Dockerfile
+++ b/operators/multiclusterobservability/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 
 WORKDIR /workspace

--- a/proxy/Containerfile.operator
+++ b/proxy/Containerfile.operator
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/scripts/test-utils.sh
+++ b/scripts/test-utils.sh
@@ -48,8 +48,8 @@ get_latest_mce_snapshot() {
   # matches:
   # version number (i.e 2.11)
   # z version 1-2 digits
-  # -SNAPSHOT
-  MATCH=$SNAPSHOT_RELEASE".\d{1,2}-SNAPSHOT"
+  # -BACKPLANE
+  MATCH=$SNAPSHOT_RELEASE".\d{1,2}-BACKPLANE"
   LATEST_SNAPSHOT=$(curl -s "https://quay.io/api/v1/repository/stolostron/registration/tag/?filter_tag_name=like:$SNAPSHOT_RELEASE&limit=100" | jq --arg MATCH "$MATCH" '.tags[] | select(.name | match($MATCH; "i")  ).name' | sort -r --version-sort | head -n 1)
 
   # trim the leading and tailing quotes

--- a/tests/Containerfile.operator
+++ b/tests/Containerfile.operator
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 # Licensed under the Apache License 2.0
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 # copy go tests into build image

--- a/tests/Containerfile.operator
+++ b/tests/Containerfile.operator
@@ -10,7 +10,9 @@ COPY ./operators ./operators
 COPY ./tests ./tests
 
 # compile go tests in build image
-RUN GOFLAGS="" go install github.com/onsi/ginkgo/v2/ginkgo@v2.29.0 && go mod vendor && ginkgo build ./tests/pkg/tests/
+RUN GOFLAGS="" GOBIN=/go/bin go install github.com/onsi/ginkgo/v2/ginkgo@v2.29.0 \
+    && go mod vendor \
+    && /go/bin/ginkgo build ./tests/pkg/tests/
 
 # create new docker image to hold built artifacts
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/tests/Containerfile.operator
+++ b/tests/Containerfile.operator
@@ -10,7 +10,7 @@ COPY ./operators ./operators
 COPY ./tests ./tests
 
 # compile go tests in build image
-RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.29.0 && go mod vendor && ginkgo build ./tests/pkg/tests/
+RUN GOFLAGS="" go install github.com/onsi/ginkgo/v2/ginkgo@v2.29.0 && go mod vendor && ginkgo build ./tests/pkg/tests/
 
 # create new docker image to hold built artifacts
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 # copy go tests into build image

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -7,7 +7,7 @@ COPY ./operators ./operators
 COPY ./tests ./tests
 
 # compile go tests in build image
-RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.2 && go mod vendor && ginkgo build ./tests/pkg/tests/
+RUN GOFLAGS="" go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.2 && go mod vendor && ginkgo build ./tests/pkg/tests/
 
 # create new docker image to hold built artifacts
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -7,7 +7,9 @@ COPY ./operators ./operators
 COPY ./tests ./tests
 
 # compile go tests in build image
-RUN GOFLAGS="" go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.2 && go mod vendor && ginkgo build ./tests/pkg/tests/
+RUN GOFLAGS="" GOBIN=/go/bin go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.2 \
+    && go mod vendor \
+    && /go/bin/ginkgo build ./tests/pkg/tests/
 
 # create new docker image to hold built artifacts
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/tests/run-in-kind/kind/kind-hub.config.yaml
+++ b/tests/run-in-kind/kind/kind-hub.config.yaml
@@ -1,5 +1,7 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  apiServerAddress: "127.0.0.1"
 nodes:
 - role: control-plane
   extraPortMappings:
@@ -11,7 +13,7 @@ nodes:
     listenAddress: "0.0.0.0"
   - containerPort: 6443
     hostPort: 32806
-    listenAddress: "0.0.0.0"
+    listenAddress: "127.0.0.1"
   - containerPort: 31001
     hostPort: 31001
     listenAddress: "127.0.0.1"

--- a/tools/simulator/alert-forward/Containerfile.operator
+++ b/tools/simulator/alert-forward/Containerfile.operator
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 # Licensed under the Apache License 2.0
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/tools/simulator/alert-forward/Dockerfile
+++ b/tools/simulator/alert-forward/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 COPY go.sum go.mod ./

--- a/tools/simulator/metrics-collector/metrics-extractor/Containerfile.operator
+++ b/tools/simulator/metrics-collector/metrics-extractor/Containerfile.operator
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 # Licensed under the Apache License 2.0
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 RUN GOBIN=/usr/local/bin go install github.com/brancz/gojsontoyaml@latest
 

--- a/tools/simulator/metrics-collector/metrics-extractor/Dockerfile
+++ b/tools/simulator/metrics-collector/metrics-extractor/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 RUN GOBIN=/usr/local/bin go install github.com/brancz/gojsontoyaml@latest
 


### PR DESCRIPTION
Continues @coleenquadros's #2670 so `main` can be unblocked. The first four commits are cherry-picked from that PR with authorship intact; the last two are the remaining fixes needed to get its two red jobs green. Happy to close this in favour of #2670 if Coleen would rather land the fixes there.

### Why this is urgent

`ci/prow/e2e-kind` has been red on **every** PR targeting `main` since 2026-08-14 16:01 UTC — 27 consecutive failures/aborts across five unrelated PRs (2407, 2616, 2661, 2668, 2670). Last green was #2663, run `2088288363617456128`.

`0dc424f2` (#2665) bumped `COMPONENT_VERSION` to `5.1.0`, and the MCE image lookup has returned empty ever since:

```
****ERROR**** Unable to find MCE image for release: 5.1
→ OPERATOR_IMAGE_NAME=quay.io/stolostron/registration-operator:      # bare colon
→ Error: INSTALLATION FAILED: YAML parse error on cluster-manager/templates/operator.yaml
```

It is a paging effect rather than missing tags: `get_latest_mce_snapshot()` reads one page (`limit=100`) of the 531 tags matching `5.1`. MCE 5.1 still has 64 `-SNAPSHOT` tags, but the newest is `5.1.0-SNAPSHOT-2026-07-02-20-14-47`; everything since is `-BACKPLANE`, so no `-SNAPSHOT` tag appears on page 1. This is the exact caveat the function's own comment describes.

### Commits from #2670 (unchanged)

| commit | |
|---|---|
| `Bump Go builder to 1.26` | Containerfiles |
| `Bump Prow Dockerfiles to Go 1.26` | Dockerfiles |
| `Fix MCE snapshot lookup to use BACKPLANE tags` | unblocks the lookup above |
| `Fix e2e-kind CI failures caused by OCM chart/binary mismatch` | imagePullSecret handling + kind networking |

### Added here

**1. Remove `sed` backup files before rendering the cluster-manager chart** — fixes `e2e-kind`

`SED_COMMAND` is `sed -i-e` (`cicd-scripts/setup-e2e-tests.sh:27`), which writes a backup with suffix `-e`. The imagePullSecret edits target files inside the chart's `templates/` directory, leaving `operator.yaml-e` and `service_account.yaml-e` there. Helm renders every file under `templates/` — `SortManifests` skips only `_`-prefixed and empty files, there is no extension filter — so the chart emitted `cluster-manager` twice:

```
Error: INSTALLATION FAILED: 2 errors occurred:
	* serviceaccounts "cluster-manager" already exists
	* deployments.apps "cluster-manager" already exists
```

Two files edited, two duplicate resources, two errors. Reproduced with GNU sed 4.8 on ubi9. There is precedent for this cleanup in `cicd-scripts/update-check-mco-csv.sh:30`.

**2. Clear `GOFLAGS` for the ginkgo install in the test images** — fixes `images`

```
[1/2] STEP 7/7: RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.29.0 && go mod vendor && ginkgo build ./tests/pkg/tests/
go: github.com/onsi/ginkgo/v2/ginkgo@v2.29.0: cannot query module due to -mod=vendor
```

`go install pkg@version` will not run under `-mod=vendor`. There is no committed `vendor/` and `go mod vendor` runs later in the same `RUN` line, so it comes from `GOFLAGS` in the builder image. On `main` the builder `FROM` is pulled straight from `brew.registry.redhat.io` rather than being substituted with a CI image, so the Go 1.26 builder's `GOFLAGS` applies.

Five of the six `Containerfile.operator` files ci-operator builds on `main` already clear `GOFLAGS`; `tests/` was the only one that did not.

### Testing

`ci/prow/test-e2e` already passes on #2670's head with these same four commits — run `2089624436947816448`, 101 of 104 specs, 0 failures, including all three MCOA groups. The two added commits touch only the kind setup script and the test image build, so `test-e2e` is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Maintenance**
  * Updated container build environments to Go 1.26 across services and test tooling.
  * Improved deployment setup by removing obsolete image-pull settings and temporary backup files.
  * Updated end-to-end test image selection for current backplane snapshots.
* **Security**
  * Restricted local test-cluster API access to loopback addresses.
* **Tests**
  * Improved test builds by ensuring required Go build settings are applied consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->