### PR TITLE
[release-5.0] fix(rbac): restore watch on legacy policies/placements for RS cleanup

### DIFF
--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -493,6 +493,7 @@ spec:
           - placementbindings
           verbs:
           - list
+          - watch
           - delete
         - apiGroups:
           - cluster.open-cluster-management.io
@@ -500,6 +501,7 @@ spec:
           - placements
           verbs:
           - list
+          - watch
           - delete
         serviceAccountName: multicluster-observability-operator
       deployments:

--- a/operators/multiclusterobservability/config/rbac/mco_role.yaml
+++ b/operators/multiclusterobservability/config/rbac/mco_role.yaml
@@ -409,6 +409,7 @@ rules:
   - placementbindings
   verbs:
   - list
+  - watch
   - delete
 - apiGroups:
   - cluster.open-cluster-management.io
@@ -416,4 +417,5 @@ rules:
   - placements
   verbs:
   - list
+  - watch
   - delete


### PR DESCRIPTION
PR #2567 reduced the operator RBAC for policies/placementbindings
(policy.open-cluster-management.io) and placements
(cluster.open-cluster-management.io) to `list` and `delete`, on the basis
that the analytics controller only lists and deletes leftover legacy
right-sizing Policy resources during upgrade migration.

But that cleanup runs through the cached controller-runtime client, whose
List() starts an informer that needs `watch` as well as `list`. Without
`watch`, the informer can never sync and the reflector retries forever,
flooding the operator log with:

  "Failed to watch ... policies.policy.open-cluster-management.io is
   forbidden: ... cannot watch resource ... at the cluster scope"

(same for placementbindings and placements).

Restore `watch` on these rules so the cleanup informers sync cleanly.
`get`/`create`/`update` remain out, since the cleanup path only lists and
deletes.

Verified on a live hub: with the SA lacking `watch` the errors reproduce
continuously; with `watch` granted the one-time cleanup completes with
zero watch errors.