### PR TITLE
ACM-41566: Switch to PQC base images

### DIFF
--- a/collectors/metrics/Containerfile.operator
+++ b/collectors/metrics/Containerfile.operator
@@ -16,7 +16,7 @@ RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -v -o metrics-collec
 # 3. Update 'cpe' label with correct RHEL version (::el9 → ::el10)
 # 4. Verify destination repository exists in registry.redhat.io
 # 5. Run 'make verify-containerfile-labels' to check consistency
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 ARG vcs_ref
 ARG VCS_URL

--- a/loaders/dashboards/Containerfile.operator
+++ b/loaders/dashboards/Containerfile.operator
@@ -15,7 +15,7 @@ RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -v -o main loaders/d
 # 3. Update 'cpe' label with correct RHEL version (::el9 → ::el10)
 # 4. Verify destination repository exists in registry.redhat.io
 # 5. Run 'make verify-containerfile-labels' to check consistency
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 ARG VCS_REF
 ARG VCS_URL

--- a/operators/endpointmetrics/Containerfile.operator
+++ b/operators/endpointmetrics/Containerfile.operator
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -o build/_output/bin
 # 3. Update 'cpe' label with correct RHEL version (::el9 → ::el10)
 # 4. Verify destination repository exists in registry.redhat.io
 # 5. Run 'make verify-containerfile-labels' to check consistency
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 ARG VCS_REF
 ARG VCS_URL

--- a/operators/multiclusterobservability/Containerfile.operator
+++ b/operators/multiclusterobservability/Containerfile.operator
@@ -16,7 +16,7 @@ RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -o bin/manager opera
 # 3. Update 'cpe' label with correct RHEL version (::el9 → ::el10)
 # 4. Verify destination repository exists in registry.redhat.io
 # 5. Run 'make verify-containerfile-labels' to check consistency
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 ARG VCS_REF
 ARG VCS_URL

--- a/proxy/Containerfile.operator
+++ b/proxy/Containerfile.operator
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -v -o main proxy/cmd
 # 3. Update 'cpe' label with correct RHEL version (::el9 → ::el10)
 # 4. Verify destination repository exists in registry.redhat.io
 # 5. Run 'make verify-containerfile-labels' to check consistency
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 ARG VCS_REF
 ARG VCS_URL

--- a/tests/Containerfile.operator
+++ b/tests/Containerfile.operator
@@ -13,7 +13,7 @@ COPY ./tests ./tests
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.2 && go mod vendor && ginkgo build ./tests/pkg/tests/
 
 # create new docker image to hold built artifacts
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 # pre-create directories and set permissions
 RUN mkdir -p /resources /results /workspace/.kube && \

--- a/tools/simulator/alert-forward/Containerfile.operator
+++ b/tools/simulator/alert-forward/Containerfile.operator
@@ -9,7 +9,7 @@ COPY tools/simulator/alert-forward/main.go tools/simulator/alert-forward/main.go
 
 RUN CGO_ENABLED=1 GOFLAGS="" go build -a -installsuffix cgo -o bin/alert-forwarder tools/simulator/alert-forward/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 ENV MAIN_BINARY=/usr/local/bin/alert-forwarder \
     USER_UID=1001 \

--- a/tools/simulator/metrics-collector/metrics-extractor/Containerfile.operator
+++ b/tools/simulator/metrics-collector/metrics-extractor/Containerfile.operator
@@ -6,7 +6,7 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS bui
 RUN GOBIN=/usr/local/bin go install github.com/brancz/gojsontoyaml@latest
 
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 RUN mkdir /metrics-extractor
 RUN mkdir /ocp-tools
 RUN microdnf install wget -y \


### PR DESCRIPTION
## Summary
- Switch all `Containerfile.operator` runtime base images from `ubi9/ubi-minimal` to `ubi9/ubi-minimal-pqc` to enable post-quantum cryptography in OpenSSL
- Part of [ACM-40663](https://redhat.atlassian.net/browse/ACM-40663) / [ACM-41566](https://redhat.atlassian.net/browse/ACM-41566)

### Components updated:
- endpoint-monitoring-operator
- grafana-dashboard-loader
- metrics-collector
- multicluster-observability-operator
- rbac-query-proxy
- observability-e2e-test
- alert-forward simulator
- metrics-extractor simulator

## Test plan
- [ ] Verify Konflux builds succeed with the new base image
- [ ] Verify no regression in regular mode
- [ ] Verify no regression in FIPS mode

[ACM-40663]: https://redhat.atlassian.net/browse/ACM-40663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-41566]: https://redhat.atlassian.net/browse/ACM-41566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ