### PR TITLE
fix(analytics): use APIReader for legacy policy and placement cleanup

### DIFF
--- a/operators/multiclusterobservability/controllers/analytics/analytics_controller.go
+++ b/operators/multiclusterobservability/controllers/analytics/analytics_controller.go
@@ -41,6 +41,7 @@ const analyticsStabilizationWindow = 10 * time.Second
 // that would not be consistent across replicas.
 type AnalyticsReconciler struct {
 	Client        client.Client
+	APIReader     client.Reader
 	Log           logr.Logger
 	migrationDone bool
 	cleanupAt     time.Time
@@ -109,7 +110,7 @@ func (r *AnalyticsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			reqLogger.Error(err, "rs - failed to re-sync disabled state before cleanup, ADC may already be deleted")
 		}
 
-		if err := rightsizingctrl.CleanupRightSizingResources(ctx, r.Client, instance); err != nil {
+		if err := rightsizingctrl.CleanupRightSizingResources(ctx, r.Client, r.APIReader, instance); err != nil {
 			return ctrl.Result{}, fmt.Errorf("rs - failed to cleanup right-sizing resources: %w", err)
 		}
 		instanceCopy := instance.DeepCopy()
@@ -151,12 +152,12 @@ func (r *AnalyticsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// In ACM 5.0 GA, MCOA (ManifestWork-based) is the only right-sizing deployment model.
 	// Run one-time migration on first reconcile to remove any legacy Policy resources
-	// left from a pre-GA (Policy-based) installation. ConfigMaps are preserved because
+	// left from a pre-GA (Policy-based) installations. ConfigMaps are preserved because
 	// MCOA reuses them for per-cluster configuration.
 	reqLogger.Info("rs - right-sizing handled by MCOA (ManifestWork-based)")
 	if !r.migrationDone {
 		reqLogger.Info("rs - running one-time legacy Policy resource cleanup for upgrade migration")
-		if err := rightsizingctrl.CleanupLegacyPolicyResources(ctx, r.Client, instance); err != nil {
+		if err := rightsizingctrl.CleanupLegacyPolicyResources(ctx, r.Client, r.APIReader, instance); err != nil {
 			return ctrl.Result{}, fmt.Errorf("rs - failed to cleanup legacy Policy resources: %w", err)
 		}
 		r.migrationDone = true

--- a/operators/multiclusterobservability/controllers/analytics/analytics_controller_test.go
+++ b/operators/multiclusterobservability/controllers/analytics/analytics_controller_test.go
@@ -681,3 +681,28 @@ func TestReconcile_MigrationRunsOnce(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, r.migrationDone, "migrationDone should remain true on subsequent reconciles")
 }
+
+func TestReconcile_MigrationWithAPIReader(t *testing.T) {
+	scheme := setupTestScheme(t)
+	mco := newTestMCO("open-cluster-management-global-set", true, false)
+
+	rsLabels := map[string]string{"observability.open-cluster-management.io/managed-by": "analytics-rightsizing"}
+	legacyPolicy := &policyv1.Policy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rs-prom-rules-policy",
+			Namespace: "open-cluster-management-global-set",
+			Labels:    rsLabels,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mco, legacyPolicy).Build()
+	r := &AnalyticsReconciler{Client: c, APIReader: c, Log: ctrl.Log.WithName("test")}
+
+	_, err := r.Reconcile(context.TODO(), ctrl.Request{})
+	require.NoError(t, err)
+	require.True(t, r.migrationDone)
+
+	deletedPolicy := &policyv1.Policy{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: "rs-prom-rules-policy", Namespace: "open-cluster-management-global-set"}, deletedPolicy)
+	require.True(t, apierrors.IsNotFound(err), "legacy Policy should have been deleted by migration via APIReader")
+}

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rightsizing_controller.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rightsizing_controller.go
@@ -20,7 +20,9 @@ var log = logf.Log.WithName("analytics")
 // Uses a two-pass hybrid approach:
 //  1. Label-based: catches all labeled resources across any namespace.
 //  2. Name-based: catches unlabeled resources from pre-2.17 (2.16) installations.
-func CleanupRightSizingResources(ctx context.Context, c client.Client, mco *mcov1beta2.MultiClusterObservability) error {
+//
+// apiReader is used for List operations to avoid starting Informers/watches on Policy, PlacementBinding, and Placement resources, which the operator does not have watch permissions for.
+func CleanupRightSizingResources(ctx context.Context, c client.Client, apiReader client.Reader, mco *mcov1beta2.MultiClusterObservability) error {
 	log.Info("rs - cleaning up all right-sizing resources")
 
 	// Error only occurs for unknown component types, which can't happen with compile-time constants.
@@ -34,7 +36,7 @@ func CleanupRightSizingResources(ctx context.Context, c client.Client, mco *mcov
 	}
 
 	return errors.Join(
-		rsutility.CleanupRSResourcesByLabel(ctx, c),
+		rsutility.CleanupRSResourcesByLabel(ctx, c, apiReader),
 		rsutility.CleanupLegacyPolicyResourcesByName(ctx, c, nsNS, virtNS),
 	)
 }
@@ -42,7 +44,8 @@ func CleanupRightSizingResources(ctx context.Context, c client.Client, mco *mcov
 // CleanupLegacyPolicyResources removes Policy-based right-sizing resources left from pre-GA installations.
 // ConfigMaps are PRESERVED because MCOA reuses them for per-cluster configuration.
 // Uses a two-pass approach: label-based (2.17 resources) + name-based (potentially unlabeled 2.16 resources).
-func CleanupLegacyPolicyResources(ctx context.Context, c client.Client, mco *mcov1beta2.MultiClusterObservability) error {
+// apiReader is used for List operations to avoid starting Informers/watches on Policy, PlacementBinding, and Placement resources, which the operator does not have watch permissions for.
+func CleanupLegacyPolicyResources(ctx context.Context, c client.Client, apiReader client.Reader, mco *mcov1beta2.MultiClusterObservability) error {
 	// Error only occurs for unknown component types, which can't happen with compile-time constants.
 	_, nsNS, _ := rsutility.GetComponentConfig(mco, rsutility.ComponentTypeNamespace)
 	if nsNS == "" {
@@ -57,7 +60,7 @@ func CleanupLegacyPolicyResources(ctx context.Context, c client.Client, mco *mco
 		"nsNamespace", nsNS, "virtNamespace", virtNS)
 
 	return errors.Join(
-		rsutility.CleanupLegacyPolicyResourcesByLabel(ctx, c),
+		rsutility.CleanupLegacyPolicyResourcesByLabel(ctx, c, apiReader),
 		rsutility.CleanupLegacyPolicyResourcesByName(ctx, c, nsNS, virtNS),
 	)
 }

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component.go
@@ -64,15 +64,20 @@ func GetComponentConfig(mco *mcov1beta2.MultiClusterObservability, componentType
 // CleanupRSResourcesByLabel deletes all right-sizing resources across namespaces using the managed-by label.
 // This catches resources that may have been created in a different namespace due to NamespaceBinding changes.
 // ConfigMaps are included — use this only in full deletion (MCO CR deleted).
-func CleanupRSResourcesByLabel(ctx context.Context, c client.Client) error {
+// apiReader is used for List calls to avoid starting Informer watches on Policy, PlacementBinding, and Placement resources, which the operator does not have watch permissions for.
+func CleanupRSResourcesByLabel(ctx context.Context, c client.Client, apiReader client.Reader) error {
 	log.Info("rs - label-based cleanup of all right-sizing resources")
 	labelSelector := client.MatchingLabels{RSManagedByLabel: RSManagedByValue}
+
+	if apiReader == nil {
+		apiReader = c
+	}
 
 	var errs []error
 
 	// Clean up Policies
 	policyList := &policyv1.PolicyList{}
-	if err := c.List(ctx, policyList, labelSelector); err != nil {
+	if err := apiReader.List(ctx, policyList, labelSelector); err != nil {
 		if !meta.IsNoMatchError(err) {
 			errs = append(errs, fmt.Errorf("rs - failed to list policies: %w", err))
 		}
@@ -87,7 +92,7 @@ func CleanupRSResourcesByLabel(ctx context.Context, c client.Client) error {
 
 	// Clean up PlacementBindings
 	pbList := &policyv1.PlacementBindingList{}
-	if err := c.List(ctx, pbList, labelSelector); err != nil {
+	if err := apiReader.List(ctx, pbList, labelSelector); err != nil {
 		if !meta.IsNoMatchError(err) {
 			errs = append(errs, fmt.Errorf("rs - failed to list placementbindings: %w", err))
 		}
@@ -102,7 +107,7 @@ func CleanupRSResourcesByLabel(ctx context.Context, c client.Client) error {
 
 	// Clean up Placements
 	placementList := &clusterv1beta1.PlacementList{}
-	if err := c.List(ctx, placementList, labelSelector); err != nil {
+	if err := apiReader.List(ctx, placementList, labelSelector); err != nil {
 		if !meta.IsNoMatchError(err) {
 			errs = append(errs, fmt.Errorf("rs - failed to list placements: %w", err))
 		}
@@ -117,7 +122,7 @@ func CleanupRSResourcesByLabel(ctx context.Context, c client.Client) error {
 
 	// Clean up ConfigMaps
 	cmList := &corev1.ConfigMapList{}
-	if err := c.List(ctx, cmList, labelSelector); err != nil {
+	if err := apiReader.List(ctx, cmList, labelSelector); err != nil {
 		if !meta.IsNoMatchError(err) {
 			errs = append(errs, fmt.Errorf("rs - failed to list configmaps: %w", err))
 		}
@@ -136,15 +141,20 @@ func CleanupRSResourcesByLabel(ctx context.Context, c client.Client) error {
 // CleanupLegacyPolicyResourcesByLabel deletes labeled Policy, PlacementBinding, and Placement
 // resources created by pre-GA (Policy-based) installations. ConfigMaps are NOT deleted because
 // MCOA reuses them for per-cluster configuration.
-func CleanupLegacyPolicyResourcesByLabel(ctx context.Context, c client.Client) error {
+// apiReader is used for List calls to avoid starting Informer watches on Policy, PlacementBinding, and Placement resources, which the operator does not have watch permissions for.
+func CleanupLegacyPolicyResourcesByLabel(ctx context.Context, c client.Client, apiReader client.Reader) error {
 	log.Info("rs - label-based cleanup of legacy Policy resources (preserving ConfigMaps)")
 	labelSelector := client.MatchingLabels{RSManagedByLabel: RSManagedByValue}
+
+	if apiReader == nil {
+		apiReader = c
+	}
 
 	var errs []error
 
 	// Clean up Policies
 	policyList := &policyv1.PolicyList{}
-	if err := c.List(ctx, policyList, labelSelector); err != nil {
+	if err := apiReader.List(ctx, policyList, labelSelector); err != nil {
 		if !meta.IsNoMatchError(err) {
 			errs = append(errs, fmt.Errorf("rs - failed to list policies: %w", err))
 		}
@@ -161,7 +171,7 @@ func CleanupLegacyPolicyResourcesByLabel(ctx context.Context, c client.Client) e
 
 	// Clean up PlacementBindings
 	pbList := &policyv1.PlacementBindingList{}
-	if err := c.List(ctx, pbList, labelSelector); err != nil {
+	if err := apiReader.List(ctx, pbList, labelSelector); err != nil {
 		if !meta.IsNoMatchError(err) {
 			errs = append(errs, fmt.Errorf("rs - failed to list placementbindings: %w", err))
 		}
@@ -178,7 +188,7 @@ func CleanupLegacyPolicyResourcesByLabel(ctx context.Context, c client.Client) e
 
 	// Clean up Placements
 	placementList := &clusterv1beta1.PlacementList{}
-	if err := c.List(ctx, placementList, labelSelector); err != nil {
+	if err := apiReader.List(ctx, placementList, labelSelector); err != nil {
 		if !meta.IsNoMatchError(err) {
 			errs = append(errs, fmt.Errorf("rs - failed to list placements: %w", err))
 		}

--- a/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component_test.go
+++ b/operators/multiclusterobservability/controllers/analytics/rightsizing/rs-utility/component_test.go
@@ -164,7 +164,7 @@ func TestCleanupLegacyPolicyResourcesByLabel_PreservesConfigMap(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy, pb, placement, cm).Build()
 
-	require.NoError(t, CleanupLegacyPolicyResourcesByLabel(context.TODO(), c))
+	require.NoError(t, CleanupLegacyPolicyResourcesByLabel(context.TODO(), c, c))
 
 	// Policy, PlacementBinding, Placement must be deleted.
 	err := c.Get(context.TODO(), types.NamespacedName{Name: policy.Name, Namespace: ns}, &policyv1.Policy{})
@@ -193,7 +193,7 @@ func TestCleanupRSResourcesByLabel_DeletesConfigMap(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(policy, placement, cm).Build()
 
-	require.NoError(t, CleanupRSResourcesByLabel(context.TODO(), c))
+	require.NoError(t, CleanupRSResourcesByLabel(context.TODO(), c, c))
 
 	// All resources including ConfigMap must be deleted.
 	err := c.Get(context.TODO(), types.NamespacedName{Name: policy.Name, Namespace: ns}, &policyv1.Policy{})

--- a/operators/multiclusterobservability/main.go
+++ b/operators/multiclusterobservability/main.go
@@ -324,8 +324,9 @@ func main() {
 	}
 
 	if err = (&analytics.AnalyticsReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Analytics"),
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Log:       ctrl.Log.WithName("controllers").WithName("Analytics"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Analytics")
 		os.Exit(1)


### PR DESCRIPTION
Partially addresses https://redhat.atlassian.net/browse/ACM-38875. A follow-up PR will address remaining watchers if applicable.

### Problem
When `AnalyticsReconciler` performs legacy migration cleanup (`CleanupLegacyPolicyResources`) or deletion cleanup (`CleanupRightSizingResources`), it invokes `.List(...)` on `Policy`, `PlacementBinding`, and `Placement` resources using `r.Client`.

Because `r.Client` is a cached `controller-runtime` client, calling `.List(...)` dynamically starts background Informers that issue cluster-scoped `WATCH` requests to the Kubernetes API server. However, `mco_role.yaml` intentionally grants only `list` and `delete` permissions (no `watch`) for these legacy governance resources, causing the API server to reject the requests with `403 Forbidden` (`User ... cannot watch resource "policies" ... at the cluster scope`).

### Fix
- Inject `APIReader` (`mgr.GetAPIReader()`) into `AnalyticsReconciler`.
- Pass `apiReader client.Reader` to `CleanupRSResourcesByLabel` and `CleanupLegacyPolicyResourcesByLabel` to perform direct, uncached `List` queries without starting Informer watches.
- Added unit test coverage in `analytics_controller_test.go` and `component_test.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup during analytics migration by ensuring resources are reliably discovered and removed.
  * Enhanced cleanup of legacy policies and right-sizing resources, including labeled resources.

* **Tests**
  * Added coverage verifying successful migration completion and removal of legacy policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->