### PR TITLE
[ACM-38875]: fix(mcoa): support asymmetric alertmanager cleanup and non-destructive external labels

### DIFF
--- a/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
+++ b/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
@@ -122,13 +122,11 @@ func (r *MCOAAgentReconciler) ReconcileCMOPlatformConfig(ctx context.Context) er
 		}
 
 		// 2. Reconcile External Labels
-		// Check if any alert forwarding stanza for this hub exists (either MCOA's or legacy's).
-		// If so, retain external labels (_id, cluster). If no alert forwarding exists for this hub,
-		// clean up external labels.
-		hasHubAlertmanager := slices.ContainsFunc(parsed.PrometheusK8sConfig.AlertmanagerConfigs, func(am cmomanifests.AdditionalAlertmanagerConfig) bool {
-			return r.isOwnedAlertmanagerConfig(am, true)
-		})
-		if r.reconcileExternalLabels(parsed.PrometheusK8sConfig, hasHubAlertmanager) {
+		// If MCOA alert forwarding is enabled, ensure MCOA external labels are present.
+		// If MCOA alert forwarding was just disabled (MCOA config removed), clean up MCOA external labels once.
+		// If forwarding is disabled and no MCOA config was removed, do not touch external labels
+		// (allows legacy operator and user-defined policies to manage labels without interference).
+		if r.reconcileExternalLabels(parsed.PrometheusK8sConfig, modifiedAm) {
 			modified = true
 		}
 
@@ -294,13 +292,16 @@ func (r *MCOAAgentReconciler) fetchCMOConfigMap(
 	return cm, false, nil
 }
 
-func (r *MCOAAgentReconciler) reconcileExternalLabels(cfg *cmomanifests.PrometheusK8sConfig, retainLabels bool) bool {
+func (r *MCOAAgentReconciler) reconcileExternalLabels(cfg *cmomanifests.PrometheusK8sConfig, amRemoved bool) bool {
 	if cfg == nil {
 		return false
 	}
-	if !retainLabels {
-		// When no alert forwarding configurations for this hub exist, clean up external labels.
-		if cfg.ExternalLabels == nil {
+	if !r.EnablePlatformAlertForwarding {
+		// When MCOA alert forwarding is disabled:
+		// Only clean up external labels if MCOA's Alertmanager configuration was just stripped during this reconcile.
+		// If no MCOA Alertmanager configuration was removed (amRemoved == false), do not touch external labels
+		// to allow coexistence with legacy operators and user-defined policies.
+		if !amRemoved || cfg.ExternalLabels == nil {
 			return false
 		}
 		modified := false
@@ -318,6 +319,7 @@ func (r *MCOAAgentReconciler) reconcileExternalLabels(cfg *cmomanifests.Promethe
 		return modified
 	}
 
+	// When MCOA alert forwarding is ENABLED:
 	modified := false
 	if cfg.ExternalLabels == nil {
 		cfg.ExternalLabels = make(map[string]string)

--- a/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
+++ b/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler.go
@@ -103,13 +103,7 @@ func (r *MCOAAgentReconciler) ReconcileCMOPlatformConfig(ctx context.Context) er
 	}
 
 	if parsed.PrometheusK8sConfig != nil {
-		// 1. Reconcile External Labels (only when alert forwarding is enabled)
-		hasAlertForwarding := alertmanagerURL != "" && r.EnablePlatformAlertForwarding
-		if r.reconcileExternalLabels(parsed.PrometheusK8sConfig, hasAlertForwarding) {
-			modified = true
-		}
-
-		// 2. Reconcile Alertmanager Configurations
+		// 1. Reconcile Alertmanager Configurations
 		cleanAm, modifiedAm := r.reconcileAlertmanagerConfigs(parsed.PrometheusK8sConfig.AlertmanagerConfigs, alertmanagerURL, r.EnablePlatformAlertForwarding)
 		if modifiedAm {
 			parsed.PrometheusK8sConfig.AlertmanagerConfigs = cleanAm
@@ -125,6 +119,17 @@ func (r *MCOAAgentReconciler) ReconcileCMOPlatformConfig(ctx context.Context) er
 				}
 				r.Log.Info("Detected conflict in Alertmanager configuration, re-applying", "name", cm.Name, "namespace", cm.Namespace)
 			}
+		}
+
+		// 2. Reconcile External Labels
+		// Check if any alert forwarding stanza for this hub exists (either MCOA's or legacy's).
+		// If so, retain external labels (_id, cluster). If no alert forwarding exists for this hub,
+		// clean up external labels.
+		hasHubAlertmanager := slices.ContainsFunc(parsed.PrometheusK8sConfig.AlertmanagerConfigs, func(am cmomanifests.AdditionalAlertmanagerConfig) bool {
+			return r.isOwnedAlertmanagerConfig(am, true)
+		})
+		if r.reconcileExternalLabels(parsed.PrometheusK8sConfig, hasHubAlertmanager) {
+			modified = true
 		}
 
 		// 3. Reconcile Remote Writes
@@ -294,6 +299,7 @@ func (r *MCOAAgentReconciler) reconcileExternalLabels(cfg *cmomanifests.Promethe
 		return false
 	}
 	if !retainLabels {
+		// When no alert forwarding configurations for this hub exist, clean up external labels.
 		if cfg.ExternalLabels == nil {
 			return false
 		}
@@ -305,6 +311,9 @@ func (r *MCOAAgentReconciler) reconcileExternalLabels(cfg *cmomanifests.Promethe
 		if _, exists := cfg.ExternalLabels[operatorconfig.ClusterNameLabelKeyForAlerts]; exists {
 			delete(cfg.ExternalLabels, operatorconfig.ClusterNameLabelKeyForAlerts)
 			modified = true
+		}
+		if len(cfg.ExternalLabels) == 0 && modified {
+			cfg.ExternalLabels = nil
 		}
 		return modified
 	}
@@ -336,8 +345,17 @@ func (r *MCOAAgentReconciler) reconcileAlertmanagerConfigs(
 	endpoint string,
 	enable bool,
 ) ([]cmomanifests.AdditionalAlertmanagerConfig, bool) {
-	cleaned := slices.DeleteFunc(slices.Clone(existing), r.isOwnedAlertmanagerConfig)
-	if endpoint != "" && enable {
+	shouldEnable := endpoint != "" && enable
+
+	// When enabling alert forwarding, perform aggressive cleanup (matching all hub-ID suffixes)
+	// to clean up legacy stanzas during transition. When disabling, only clean MCOA's exact CA secret
+	// so that concurrently running legacy endpoint operators are not interfered with.
+	filterFunc := func(am cmomanifests.AdditionalAlertmanagerConfig) bool {
+		return r.isOwnedAlertmanagerConfig(am, shouldEnable)
+	}
+
+	cleaned := slices.DeleteFunc(slices.Clone(existing), filterFunc)
+	if shouldEnable {
 		cleaned = append(cleaned, r.newAdditionalAlertmanagerConfig(endpoint))
 	}
 	sortAlertmanagerConfigs(cleaned)
@@ -413,24 +431,30 @@ func (r *MCOAAgentReconciler) newAdditionalAlertmanagerConfig(endpoint string) c
 	return config
 }
 
-func (r *MCOAAgentReconciler) isOwnedAlertmanagerConfig(am cmomanifests.AdditionalAlertmanagerConfig) bool {
+func (r *MCOAAgentReconciler) isOwnedAlertmanagerConfig(am cmomanifests.AdditionalAlertmanagerConfig, aggressiveClean bool) bool {
 	if r.CASecret == "" || am.TLSConfig.CA == nil {
 		return false
 	}
+	// Exact match: always match MCOA's own CA secret (e.g. hub-mtls-ca-<hubID>).
 	if am.TLSConfig.CA.Name == r.CASecret {
 		return true
 	}
-	// Suffix-based fallback: the hub may rename the CA secret prefix across upgrades while
-	// keeping the hub-ID suffix (e.g. "-465e377c…") stable. The accessor secret has a stable
-	// base name, so stripping it from r.AccessorSecret yields the hub-ID suffix we can match on.
-	// This also makes MCOA e2e tests more resilient: if the legacy stack leaves behind an entry
-	// with a different CA prefix (e.g. obs-alertmanager-mtls-ca-<hubID>), MCOA can still
-	// identify and clean it up rather than leaving a stale forwarding config.
-	hubIDSuffix := strings.TrimPrefix(r.AccessorSecret, observabilityendpoint.HubAmAccessorSecretName)
-	if len(hubIDSuffix) <= 1 {
-		return false
+	// Suffix-based matching for transition/migration:
+	// When MCOA is actively enabling alert forwarding (aggressiveClean == true), we also match
+	// any Alertmanager stanza whose CA secret ends with the hub-ID suffix (e.g. obs-alertmanager-mtls-ca-<hubID>
+	// or hub-alertmanager-router-ca-<hubID>). This ensures that legacy stanzas left behind by
+	// previous operator versions or imperfect uninstallers are cleanly replaced by MCOA's configuration.
+	//
+	// However, when MCOA alert forwarding is disabled (aggressiveClean == false), we do NOT use suffix
+	// matching. This allows the legacy endpoint operator to manage its own alert forwarding stanzas
+	// without MCOA stripping them during coexistence (e.g., when MCOA is only deployed for Right-Sizing).
+	if aggressiveClean {
+		hubIDSuffix := strings.TrimPrefix(r.AccessorSecret, observabilityendpoint.HubAmAccessorSecretName)
+		if len(hubIDSuffix) > 1 && strings.HasSuffix(am.TLSConfig.CA.Name, hubIDSuffix) {
+			return true
+		}
 	}
-	return strings.HasSuffix(am.TLSConfig.CA.Name, hubIDSuffix)
+	return false
 }
 
 func (r *MCOAAgentReconciler) listScrapeConfigsByComponent(ctx context.Context, component string) ([]prometheusv1alpha1.ScrapeConfig, error) {

--- a/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler_test.go
@@ -597,43 +597,62 @@ func TestCMOConfigReconciler_reconcileRemoteWrites_Sorting(t *testing.T) {
 func TestCMOConfigReconciler_reconcileExternalLabels(t *testing.T) {
 	t.Parallel()
 
-	r := &MCOAAgentReconciler{
-		Log:         ctrl.Log.WithName("test"),
-		ClusterID:   "my-cluster-id",
-		ClusterName: "my-cluster-name",
+	rDisabled := &MCOAAgentReconciler{
+		Log:                           ctrl.Log.WithName("test"),
+		ClusterID:                     "my-cluster-id",
+		ClusterName:                   "my-cluster-name",
+		EnablePlatformAlertForwarding: false,
 	}
 
-	// Case 1: no hub alertmanager present (retainLabels = false) -> remove external labels
+	// Case 1: disabled forwarding, amRemoved = true -> remove external labels
 	cfg1 := &cmomanifests.PrometheusK8sConfig{
 		ExternalLabels: map[string]string{
 			operatorconfig.ClusterLabelKeyForAlerts:     "old-id",
 			operatorconfig.ClusterNameLabelKeyForAlerts: "old-name",
 		},
 	}
-	modified := r.reconcileExternalLabels(cfg1, false)
-	assert.True(t, modified, "external labels must be removed when no hub alertmanager is present")
+	modified := rDisabled.reconcileExternalLabels(cfg1, true)
+	assert.True(t, modified, "external labels must be removed when am was removed")
 	assert.Empty(t, cfg1.ExternalLabels)
 
-	// Case 2: forwarding enabled / hub alertmanager present (retainLabels = true) -> preserve and reconcile external labels
+	// Case 2: disabled forwarding, amRemoved = false -> do not touch external labels
 	cfg2 := &cmomanifests.PrometheusK8sConfig{
+		ExternalLabels: map[string]string{
+			operatorconfig.ClusterLabelKeyForAlerts:     "user-or-legacy-id",
+			operatorconfig.ClusterNameLabelKeyForAlerts: "user-or-legacy-name",
+		},
+	}
+	modified = rDisabled.reconcileExternalLabels(cfg2, false)
+	assert.False(t, modified, "must not modify external labels when am was not removed")
+	assert.Equal(t, "user-or-legacy-id", cfg2.ExternalLabels[operatorconfig.ClusterLabelKeyForAlerts])
+	assert.Equal(t, "user-or-legacy-name", cfg2.ExternalLabels[operatorconfig.ClusterNameLabelKeyForAlerts])
+
+	// Case 3: enabled forwarding -> enforce cluster ID and cluster name
+	rEnabled := &MCOAAgentReconciler{
+		Log:                           ctrl.Log.WithName("test"),
+		ClusterID:                     "my-cluster-id",
+		ClusterName:                   "my-cluster-name",
+		EnablePlatformAlertForwarding: true,
+	}
+	cfg3 := &cmomanifests.PrometheusK8sConfig{
 		ExternalLabels: map[string]string{
 			operatorconfig.ClusterLabelKeyForAlerts:     "old-id",
 			operatorconfig.ClusterNameLabelKeyForAlerts: "old-name",
 		},
 	}
-	modified = r.reconcileExternalLabels(cfg2, true)
+	modified = rEnabled.reconcileExternalLabels(cfg3, false)
 	assert.True(t, modified)
-	assert.Equal(t, "my-cluster-id", cfg2.ExternalLabels[operatorconfig.ClusterLabelKeyForAlerts])
-	assert.Equal(t, "my-cluster-name", cfg2.ExternalLabels[operatorconfig.ClusterNameLabelKeyForAlerts])
+	assert.Equal(t, "my-cluster-id", cfg3.ExternalLabels[operatorconfig.ClusterLabelKeyForAlerts])
+	assert.Equal(t, "my-cluster-name", cfg3.ExternalLabels[operatorconfig.ClusterNameLabelKeyForAlerts])
 
-	// Case 3: forwarding enabled / hub alertmanager present, labels already correct -> no modification
-	cfg3 := &cmomanifests.PrometheusK8sConfig{
+	// Case 4: enabled forwarding, labels already correct -> no modification
+	cfg4 := &cmomanifests.PrometheusK8sConfig{
 		ExternalLabels: map[string]string{
 			operatorconfig.ClusterLabelKeyForAlerts:     "my-cluster-id",
 			operatorconfig.ClusterNameLabelKeyForAlerts: "my-cluster-name",
 		},
 	}
-	modified = r.reconcileExternalLabels(cfg3, true)
+	modified = rEnabled.reconcileExternalLabels(cfg4, false)
 	assert.False(t, modified)
 }
 
@@ -646,8 +665,8 @@ func TestCMOConfigReconciler_reconcileExternalLabels_DisabledForwarding(t *testi
 	namespace := "test-namespace"
 	const hubID = "465e377c1ecd4cc29c7"
 
-	// Sub-test 1: Coexistence - Legacy alertmanager config is present, MCOA alert forwarding disabled
-	// External labels must be retained to avoid breaking legacy alert forwarding.
+	// Sub-test 1: Coexistence - Legacy alertmanager config is present, MCOA alert forwarding disabled (no MCOA config stripped)
+	// External labels must be retained without modification by MCOA.
 	t.Run("Coexistence_LegacyAlertmanagerPresent_RetainsLabels", func(t *testing.T) {
 		cfgWithLegacy := cmomanifests.ClusterMonitoringConfiguration{
 			PrometheusK8sConfig: &cmomanifests.PrometheusK8sConfig{
@@ -709,23 +728,37 @@ func TestCMOConfigReconciler_reconcileExternalLabels_DisabledForwarding(t *testi
 		require.NoError(t, err)
 
 		platformYAML := updatedCM.Data[observabilityendpoint.ClusterMonitoringConfigDataKey]
-		// Legacy Alertmanager config is still active, so external labels must NOT be stripped
+		// Legacy Alertmanager config is active and no MCOA config was removed, so external labels must NOT be stripped by MCOA
 		assert.Contains(t, platformYAML, "my-cluster-id")
 		assert.Contains(t, platformYAML, "my-cluster-name")
 	})
 
-	// Sub-test 2: Complete cleanup - No alertmanager config for hub present, MCOA alert forwarding disabled
-	// External labels must be cleaned up.
-	t.Run("Cleanup_NoHubAlertmanagerPresent_CleansLabels", func(t *testing.T) {
-		cfgWithoutAm := cmomanifests.ClusterMonitoringConfiguration{
+	// Sub-test 2: Complete cleanup - MCOA alertmanager config was present and gets stripped
+	// External labels must be cleaned up on transition.
+	t.Run("Cleanup_MCOAAlertmanagerPresent_CleansLabelsOnDisable", func(t *testing.T) {
+		cfgWithMcoa := cmomanifests.ClusterMonitoringConfiguration{
 			PrometheusK8sConfig: &cmomanifests.PrometheusK8sConfig{
 				ExternalLabels: map[string]string{
 					operatorconfig.ClusterLabelKeyForAlerts:     "my-cluster-id",
 					operatorconfig.ClusterNameLabelKeyForAlerts: "my-cluster-name",
 				},
+				AlertmanagerConfigs: []cmomanifests.AdditionalAlertmanagerConfig{
+					{
+						Scheme:     "https",
+						APIVersion: "v2",
+						TLSConfig: cmomanifests.TLSConfig{
+							CA: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "hub-mtls-ca-" + hubID,
+								},
+								Key: "ca.crt",
+							},
+						},
+					},
+				},
 			},
 		}
-		rawYAML, err := yaml.Marshal(cfgWithoutAm)
+		rawYAML, err := yaml.Marshal(cfgWithMcoa)
 		require.NoError(t, err)
 
 		cmPlatform := &corev1.ConfigMap{
@@ -763,7 +796,7 @@ func TestCMOConfigReconciler_reconcileExternalLabels_DisabledForwarding(t *testi
 		require.NoError(t, err)
 
 		platformYAML := updatedCM.Data[observabilityendpoint.ClusterMonitoringConfigDataKey]
-		// No Alertmanager config is active, so external labels must be cleaned up
+		// MCOA Alertmanager config was removed and no other hub AM config exists, so external labels must be cleaned up
 		assert.NotContains(t, platformYAML, "my-cluster-id")
 		assert.NotContains(t, platformYAML, "my-cluster-name")
 	})

--- a/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/cmo_config_reconciler_test.go
@@ -61,24 +61,22 @@ func TestCMOConfigReconciler_reconcileAlertmanagerConfigs(t *testing.T) {
 	assert.Equal(t, "observability-alertmanager-accessor-465e377c1ecd4cc29c7", am.BearerToken.Name)
 }
 
-// TestCMOConfigReconciler_reconcileAlertmanagerConfigs_RenamedCASecret tests that when the
-// hub renames the CA secret prefix across upgrades (e.g. obs-alertmanager-mtls-ca → hub-mtls-ca),
-// the old configmap entry is still recognized as owned and removed when forwarding is disabled.
-func TestCMOConfigReconciler_reconcileAlertmanagerConfigs_RenamedCASecret(t *testing.T) {
+// TestCMOConfigReconciler_reconcileAlertmanagerConfigs_TransitionFromLegacy tests that when
+// MCOA enables alert forwarding, any old legacy entry (e.g. obs-alertmanager-mtls-ca-<hubID>)
+// is recognized via suffix matching and replaced by MCOA's new config.
+func TestCMOConfigReconciler_reconcileAlertmanagerConfigs_TransitionFromLegacy(t *testing.T) {
 	t.Parallel()
 
 	const hubID = "465e377c1ecd4cc29c7"
-	// Simulate a hub that renamed the CA secret from "obs-alertmanager-mtls-ca-<hubID>"
-	// to "hub-mtls-ca-<hubID>" across an upgrade.
 	r := &MCOAAgentReconciler{
 		Log:            ctrl.Log.WithName("test"),
-		CASecret:       "hub-mtls-ca-" + hubID,   // new prefix after hub rename
-		CertSecret:     "hub-mtls-cert-" + hubID, // new prefix after hub rename
+		CASecret:       "hub-mtls-ca-" + hubID,
+		CertSecret:     "hub-mtls-cert-" + hubID,
 		AccessorSecret: "observability-alertmanager-accessor-" + hubID,
 	}
 
-	// Existing config was written with the old CA name (before the hub renamed it).
-	oldCfg := cmomanifests.AdditionalAlertmanagerConfig{
+	// Existing config was written by legacy operator with old CA name prefix
+	oldLegacyCfg := cmomanifests.AdditionalAlertmanagerConfig{
 		Scheme:     "https",
 		APIVersion: "v2",
 		TLSConfig: cmomanifests.TLSConfig{
@@ -91,12 +89,82 @@ func TestCMOConfigReconciler_reconcileAlertmanagerConfigs_RenamedCASecret(t *tes
 		},
 	}
 
-	// With UWL alert forwarding disabled, the old entry must be removed even though
-	// its CA name doesn't exactly match r.CASecret.
+	// With alert forwarding enabled, the legacy entry must be replaced with MCOA's new entry.
 	endpoint := "https://observatorium-api.example.com"
-	configs, modified := r.reconcileAlertmanagerConfigs([]cmomanifests.AdditionalAlertmanagerConfig{oldCfg}, endpoint, false)
-	require.True(t, modified, "should be modified: old entry must be cleaned up")
-	assert.Empty(t, configs, "old alertmanager config with renamed CA should be removed")
+	configs, modified := r.reconcileAlertmanagerConfigs([]cmomanifests.AdditionalAlertmanagerConfig{oldLegacyCfg}, endpoint, true)
+	require.True(t, modified, "should be modified: legacy entry must be replaced by new MCOA config")
+	require.Len(t, configs, 1)
+	assert.Equal(t, "hub-mtls-ca-"+hubID, configs[0].TLSConfig.CA.Name)
+}
+
+// TestCMOConfigReconciler_reconcileAlertmanagerConfigs_CoexistenceWithLegacy tests that when
+// MCOA has alert forwarding disabled, it does NOT remove legacy alertmanager configs (obs-alertmanager-mtls-ca-<hubID>)
+// so that a concurrently running legacy endpoint operator can manage them without thrashing.
+func TestCMOConfigReconciler_reconcileAlertmanagerConfigs_CoexistenceWithLegacy(t *testing.T) {
+	t.Parallel()
+
+	const hubID = "465e377c1ecd4cc29c7"
+	r := &MCOAAgentReconciler{
+		Log:            ctrl.Log.WithName("test"),
+		CASecret:       "hub-mtls-ca-" + hubID,
+		CertSecret:     "hub-mtls-cert-" + hubID,
+		AccessorSecret: "observability-alertmanager-accessor-" + hubID,
+	}
+
+	// Legacy config present in ConfigMap
+	legacyCfg := cmomanifests.AdditionalAlertmanagerConfig{
+		Scheme:     "https",
+		APIVersion: "v2",
+		TLSConfig: cmomanifests.TLSConfig{
+			CA: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "obs-alertmanager-mtls-ca-" + hubID,
+				},
+				Key: "ca.crt",
+			},
+		},
+	}
+
+	// With alert forwarding disabled, MCOA must NOT touch the legacy config.
+	endpoint := "https://observatorium-api.example.com"
+	configs, modified := r.reconcileAlertmanagerConfigs([]cmomanifests.AdditionalAlertmanagerConfig{legacyCfg}, endpoint, false)
+	assert.False(t, modified, "must not be modified: legacy config should remain untouched when MCOA forwarding is disabled")
+	require.Len(t, configs, 1)
+	assert.Equal(t, "obs-alertmanager-mtls-ca-"+hubID, configs[0].TLSConfig.CA.Name)
+}
+
+// TestCMOConfigReconciler_reconcileAlertmanagerConfigs_DisabledCleansOwnConfig tests that when
+// MCOA has alert forwarding disabled and MCOA's own config is present, MCOA removes its own config.
+func TestCMOConfigReconciler_reconcileAlertmanagerConfigs_DisabledCleansOwnConfig(t *testing.T) {
+	t.Parallel()
+
+	const hubID = "465e377c1ecd4cc29c7"
+	r := &MCOAAgentReconciler{
+		Log:            ctrl.Log.WithName("test"),
+		CASecret:       "hub-mtls-ca-" + hubID,
+		CertSecret:     "hub-mtls-cert-" + hubID,
+		AccessorSecret: "observability-alertmanager-accessor-" + hubID,
+	}
+
+	// MCOA config present in ConfigMap
+	mcoaCfg := cmomanifests.AdditionalAlertmanagerConfig{
+		Scheme:     "https",
+		APIVersion: "v2",
+		TLSConfig: cmomanifests.TLSConfig{
+			CA: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "hub-mtls-ca-" + hubID,
+				},
+				Key: "ca.crt",
+			},
+		},
+	}
+
+	// With alert forwarding disabled, MCOA's own config must be removed.
+	endpoint := "https://observatorium-api.example.com"
+	configs, modified := r.reconcileAlertmanagerConfigs([]cmomanifests.AdditionalAlertmanagerConfig{mcoaCfg}, endpoint, false)
+	assert.True(t, modified, "must be modified: MCOA's own config should be removed")
+	assert.Empty(t, configs)
 }
 
 // TestCMOConfigReconciler_reconcileAlertmanagerConfigs_OrderStable verifies that a reorder
@@ -535,7 +603,7 @@ func TestCMOConfigReconciler_reconcileExternalLabels(t *testing.T) {
 		ClusterName: "my-cluster-name",
 	}
 
-	// Case 1: neither agent present nor forwarding enabled -> remove external labels
+	// Case 1: no hub alertmanager present (retainLabels = false) -> remove external labels
 	cfg1 := &cmomanifests.PrometheusK8sConfig{
 		ExternalLabels: map[string]string{
 			operatorconfig.ClusterLabelKeyForAlerts:     "old-id",
@@ -543,10 +611,10 @@ func TestCMOConfigReconciler_reconcileExternalLabels(t *testing.T) {
 		},
 	}
 	modified := r.reconcileExternalLabels(cfg1, false)
-	assert.True(t, modified)
+	assert.True(t, modified, "external labels must be removed when no hub alertmanager is present")
 	assert.Empty(t, cfg1.ExternalLabels)
 
-	// Case 2: forwarding enabled with NO agent (retainLabels = true) -> preserve and reconcile external labels
+	// Case 2: forwarding enabled / hub alertmanager present (retainLabels = true) -> preserve and reconcile external labels
 	cfg2 := &cmomanifests.PrometheusK8sConfig{
 		ExternalLabels: map[string]string{
 			operatorconfig.ClusterLabelKeyForAlerts:     "old-id",
@@ -558,7 +626,7 @@ func TestCMOConfigReconciler_reconcileExternalLabels(t *testing.T) {
 	assert.Equal(t, "my-cluster-id", cfg2.ExternalLabels[operatorconfig.ClusterLabelKeyForAlerts])
 	assert.Equal(t, "my-cluster-name", cfg2.ExternalLabels[operatorconfig.ClusterNameLabelKeyForAlerts])
 
-	// Case 3: forwarding enabled with NO agent, labels already correct -> no modification
+	// Case 3: forwarding enabled / hub alertmanager present, labels already correct -> no modification
 	cfg3 := &cmomanifests.PrometheusK8sConfig{
 		ExternalLabels: map[string]string{
 			operatorconfig.ClusterLabelKeyForAlerts:     "my-cluster-id",
@@ -576,58 +644,129 @@ func TestCMOConfigReconciler_reconcileExternalLabels_DisabledForwarding(t *testi
 
 	ctx := context.Background()
 	namespace := "test-namespace"
+	const hubID = "465e377c1ecd4cc29c7"
 
-	// Existing config map containing old externalLabels
-	oldCfg := cmomanifests.ClusterMonitoringConfiguration{
-		PrometheusK8sConfig: &cmomanifests.PrometheusK8sConfig{
-			ExternalLabels: map[string]string{
-				operatorconfig.ClusterLabelKeyForAlerts:     "my-cluster-id",
-				operatorconfig.ClusterNameLabelKeyForAlerts: "my-cluster-name",
+	// Sub-test 1: Coexistence - Legacy alertmanager config is present, MCOA alert forwarding disabled
+	// External labels must be retained to avoid breaking legacy alert forwarding.
+	t.Run("Coexistence_LegacyAlertmanagerPresent_RetainsLabels", func(t *testing.T) {
+		cfgWithLegacy := cmomanifests.ClusterMonitoringConfiguration{
+			PrometheusK8sConfig: &cmomanifests.PrometheusK8sConfig{
+				ExternalLabels: map[string]string{
+					operatorconfig.ClusterLabelKeyForAlerts:     "my-cluster-id",
+					operatorconfig.ClusterNameLabelKeyForAlerts: "my-cluster-name",
+				},
+				AlertmanagerConfigs: []cmomanifests.AdditionalAlertmanagerConfig{
+					{
+						Scheme:     "https",
+						APIVersion: "v2",
+						TLSConfig: cmomanifests.TLSConfig{
+							CA: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "obs-alertmanager-mtls-ca-" + hubID,
+								},
+								Key: "ca.crt",
+							},
+						},
+					},
+				},
 			},
-		},
-	}
-	oldYAML, err := yaml.Marshal(oldCfg)
-	require.NoError(t, err)
+		}
+		rawYAML, err := yaml.Marshal(cfgWithLegacy)
+		require.NoError(t, err)
 
-	cmPlatform := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
+		cmPlatform := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+			},
+			Data: map[string]string{
+				observabilityendpoint.ClusterMonitoringConfigDataKey: string(rawYAML),
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cmPlatform).Build()
+		rPlatform := &MCOAAgentReconciler{
+			Client:                        cl,
+			Log:                           ctrl.Log.WithName("test-controller"),
+			Namespace:                     namespace,
+			ClusterID:                     "my-cluster-id",
+			ClusterName:                   "my-cluster-name",
+			HubAlertmanagerURL:            "https://new-hub.com",
+			CASecret:                      "hub-mtls-ca-" + hubID,
+			CertSecret:                    "hub-mtls-cert-" + hubID,
+			AccessorSecret:                "observability-alertmanager-accessor-" + hubID,
+			EnablePlatformAlertForwarding: false,
+		}
+
+		err = rPlatform.ReconcileCMOPlatformConfig(ctx)
+		require.NoError(t, err)
+
+		updatedCM := &corev1.ConfigMap{}
+		err = cl.Get(ctx, client.ObjectKey{
 			Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
 			Namespace: operatorconfig.OCPClusterMonitoringNamespace,
-		},
-		Data: map[string]string{
-			observabilityendpoint.ClusterMonitoringConfigDataKey: string(oldYAML),
-		},
-	}
+		}, updatedCM)
+		require.NoError(t, err)
 
-	clPlatform := fake.NewClientBuilder().WithScheme(s).WithObjects(cmPlatform).Build()
+		platformYAML := updatedCM.Data[observabilityendpoint.ClusterMonitoringConfigDataKey]
+		// Legacy Alertmanager config is still active, so external labels must NOT be stripped
+		assert.Contains(t, platformYAML, "my-cluster-id")
+		assert.Contains(t, platformYAML, "my-cluster-name")
+	})
 
-	// Platform alert forwarding disabled (EnablePlatformAlertForwarding: false)
-	rPlatform := &MCOAAgentReconciler{
-		Client:                        clPlatform,
-		Log:                           ctrl.Log.WithName("test-controller"),
-		Namespace:                     namespace,
-		ClusterID:                     "my-cluster-id",
-		ClusterName:                   "my-cluster-name",
-		HubAlertmanagerURL:            "https://new-hub.com",
-		CASecret:                      "test-ca-secret",
-		CertSecret:                    "test-cert-secret",
-		EnablePlatformAlertForwarding: false,
-	}
+	// Sub-test 2: Complete cleanup - No alertmanager config for hub present, MCOA alert forwarding disabled
+	// External labels must be cleaned up.
+	t.Run("Cleanup_NoHubAlertmanagerPresent_CleansLabels", func(t *testing.T) {
+		cfgWithoutAm := cmomanifests.ClusterMonitoringConfiguration{
+			PrometheusK8sConfig: &cmomanifests.PrometheusK8sConfig{
+				ExternalLabels: map[string]string{
+					operatorconfig.ClusterLabelKeyForAlerts:     "my-cluster-id",
+					operatorconfig.ClusterNameLabelKeyForAlerts: "my-cluster-name",
+				},
+			},
+		}
+		rawYAML, err := yaml.Marshal(cfgWithoutAm)
+		require.NoError(t, err)
 
-	err = rPlatform.ReconcileCMOPlatformConfig(ctx)
-	require.NoError(t, err)
+		cmPlatform := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+				Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+			},
+			Data: map[string]string{
+				observabilityendpoint.ClusterMonitoringConfigDataKey: string(rawYAML),
+			},
+		}
 
-	updatedCMPlatform := &corev1.ConfigMap{}
-	err = clPlatform.Get(ctx, client.ObjectKey{
-		Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
-		Namespace: operatorconfig.OCPClusterMonitoringNamespace,
-	}, updatedCMPlatform)
-	require.NoError(t, err)
+		cl := fake.NewClientBuilder().WithScheme(s).WithObjects(cmPlatform).Build()
+		rPlatform := &MCOAAgentReconciler{
+			Client:                        cl,
+			Log:                           ctrl.Log.WithName("test-controller"),
+			Namespace:                     namespace,
+			ClusterID:                     "my-cluster-id",
+			ClusterName:                   "my-cluster-name",
+			HubAlertmanagerURL:            "https://new-hub.com",
+			CASecret:                      "hub-mtls-ca-" + hubID,
+			CertSecret:                    "hub-mtls-cert-" + hubID,
+			AccessorSecret:                "observability-alertmanager-accessor-" + hubID,
+			EnablePlatformAlertForwarding: false,
+		}
 
-	platformYAML := updatedCMPlatform.Data[observabilityendpoint.ClusterMonitoringConfigDataKey]
-	// Since alert forwarding was disabled, external labels must be removed!
-	assert.NotContains(t, platformYAML, "my-cluster-id")
-	assert.NotContains(t, platformYAML, "my-cluster-name")
+		err = rPlatform.ReconcileCMOPlatformConfig(ctx)
+		require.NoError(t, err)
+
+		updatedCM := &corev1.ConfigMap{}
+		err = cl.Get(ctx, client.ObjectKey{
+			Name:      operatorconfig.OCPClusterMonitoringConfigMapName,
+			Namespace: operatorconfig.OCPClusterMonitoringNamespace,
+		}, updatedCM)
+		require.NoError(t, err)
+
+		platformYAML := updatedCM.Data[observabilityendpoint.ClusterMonitoringConfigDataKey]
+		// No Alertmanager config is active, so external labels must be cleaned up
+		assert.NotContains(t, platformYAML, "my-cluster-id")
+		assert.NotContains(t, platformYAML, "my-cluster-name")
+	})
 }
 
 func TestCMOConfigReconciler_fetchCMOConfigMap_Gating(t *testing.T) {

--- a/operators/endpointmetrics/main.go
+++ b/operators/endpointmetrics/main.go
@@ -321,8 +321,7 @@ func runMCOA(args []string) {
 		Scheme: scheme,
 		Metrics: server.Options{
 			BindAddress:   metricsAddr,
-			TLSOpts:       []func(*tls.Config){tlsConfig},
-			SecureServing: true,
+			SecureServing: false,
 		},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,


### PR DESCRIPTION
### Summary
Resolves [ACM-38875](https://issues.redhat.com/browse/ACM-38875) (complementary to MCOA [multicluster-observability-addon#598](https://github.com/stolostron/multicluster-observability-addon/pull/598)).

### Context & Problem
With MCOA PR #598, the endpoint monitoring operator is now deployed on managed clusters even when platform metrics is disabled (e.g., when Right-Sizing is active). When platform metrics is disabled, MCOA and legacy endpoint operators may run concurrently. Previously, MCOA aggressively stripped Alertmanager configs and external labels on every reconcile, causing continuous update conflicts on CMO's `cluster-monitoring-config`.

### Changes
1. **Asymmetric Alertmanager Cleanup (`isOwnedAlertmanagerConfig`)**:
   - **Enabled**: Uses suffix matching (`-<hub-id>`) to migrate/replace older legacy Alertmanager stanzas.
   - **Disabled**: Matches only MCOA's exact CA secret (`r.CASecret`), leaving legacy Alertmanager stanzas untouched during coexistence.
2. **Deterministic External Labels Lifecycle (`reconcileExternalLabels`)**:
   - Cleans external labels only once when MCOA's Alertmanager config is stripped (`modifiedAm == true`).
   - When disabled and no MCOA config was removed (`modifiedAm == false`), MCOA leaves external labels untouched, preventing reconcile fighting with the legacy controller and preserving user-defined policies.
3. **Metrics Server TLS Fix (Embedded / Unrelated)**:
   - Sets `SecureServing: false` on `metricsserver.Options` so the operator serves plaintext HTTP on `127.0.0.1:8080`, allowing `kube-rbac-proxy` to act as the TLS/RBAC termination proxy without metrics scraping failures.
4. **Unit Tests**:
   - Added test cases covering transition replacement, legacy coexistence, and external label lifecycle handling.

[ACM-38875]: https://issues.redhat.com/browse/ACM-38875