### PR TITLE
[ACM-42609] Workaround for removed alertmanager route when alerting disabled

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/hub_info_secret.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_info_secret.go
@@ -26,6 +26,8 @@ func generateHubInfoSecret(client client.Client, obsNamespace string,
 ) (*corev1.Secret, error) {
 	var obsAPIHost string
 	alertmanagerEndpoint := ""
+	var hubAlertsForwardingHost string
+	var hubAlertsForwardingPath string
 	var alertmanagerRouterCA string
 
 	if crdMap[config.IngressControllerCRD] {
@@ -37,9 +39,12 @@ func generateHubInfoSecret(client client.Client, obsNamespace string,
 		}
 		obsAPIHost = obsAPIURL.Host
 
+		hubAlertsForwardingPath = "/api/alertmanager/v2/" + config.GetDefaultTenantName()
+		hubAlertsForwardingHost = obsAPIURL.Host
+
 		// if alerting is disabled, do not set alertmanagerEndpoint
 		if !config.IsAlertingDisabled() {
-			alertmanagerEndpoint = obsAPIURL.JoinPath("/api/alertmanager/v2", config.GetDefaultTenantName()).String()
+			alertmanagerEndpoint = obsAPIURL.JoinPath(hubAlertsForwardingPath).String()
 		}
 
 		// The observatorium-api Route uses TLS passthrough, so the spoke must trust the
@@ -54,10 +59,13 @@ func generateHubInfoSecret(client client.Client, obsNamespace string,
 		// for KinD support, the managedcluster and hub cluster are assumed in the same cluster, the observatorium-api
 		// will be accessed through k8s service FQDN + port
 		obsAPIHost = config.GetOperandNamePrefix() + "observatorium-api" + "." + config.GetDefaultNamespace() + ".svc.cluster.local:8080"
+
+		hubAlertsForwardingHost = config.GetOperandNamePrefix() + "observatorium-api." + config.GetDefaultNamespace() + ".svc.cluster.local:8080"
+		hubAlertsForwardingPath = "/api/alertmanager/v2/" + config.GetDefaultTenantName()
+
 		// if alerting is disabled, do not set alertmanagerEndpoint
 		if !config.IsAlertingDisabled() {
-			alertmanagerEndpoint = config.GetOperandNamePrefix() + "observatorium-api." +
-				config.GetDefaultNamespace() + ".svc.cluster.local:8080/api/alertmanager/v2/" + config.GetDefaultTenantName()
+			alertmanagerEndpoint = "http://" + hubAlertsForwardingHost + hubAlertsForwardingPath
 		}
 		var err error
 		alertmanagerRouterCA, err = config.GetObsAPIServerCA(client)
@@ -100,6 +108,8 @@ func generateHubInfoSecret(client client.Client, obsNamespace string,
 	hubInfo := &operatorconfig.HubInfo{
 		ObservatoriumAPIEndpoint: obsApiURL.String(),
 		AlertmanagerEndpoint:     alertmanagerEndpoint,
+		HubAlertsForwardingHost:  hubAlertsForwardingHost,
+		HubAlertsForwardingPath:  hubAlertsForwardingPath,
 		AlertmanagerRouterCA:     alertmanagerRouterCA,
 		UWMAlertingDisabled:      isUWMAlertingDisabled,
 		HubClusterID:             trimmedClusterID,

--- a/operators/multiclusterobservability/controllers/placementrule/hub_info_secret.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_info_secret.go
@@ -26,8 +26,7 @@ func generateHubInfoSecret(client client.Client, obsNamespace string,
 ) (*corev1.Secret, error) {
 	var obsAPIHost string
 	alertmanagerEndpoint := ""
-	var hubAlertsForwardingHost string
-	var hubAlertsForwardingPath string
+	var hubAlertsForwardingRoute string
 	var alertmanagerRouterCA string
 
 	if crdMap[config.IngressControllerCRD] {
@@ -39,12 +38,12 @@ func generateHubInfoSecret(client client.Client, obsNamespace string,
 		}
 		obsAPIHost = obsAPIURL.Host
 
-		hubAlertsForwardingPath = "/api/alertmanager/v2/" + config.GetDefaultTenantName()
-		hubAlertsForwardingHost = obsAPIURL.Host
+		// workaround for telco, when alerting is disabled but still need endpoint for alertmanager on hub
+		hubAlertsForwardingRoute = obsAPIURL.JoinPath("/api/alertmanager/v2", config.GetDefaultTenantName()).String()
 
 		// if alerting is disabled, do not set alertmanagerEndpoint
 		if !config.IsAlertingDisabled() {
-			alertmanagerEndpoint = obsAPIURL.JoinPath(hubAlertsForwardingPath).String()
+			alertmanagerEndpoint = hubAlertsForwardingRoute
 		}
 
 		// The observatorium-api Route uses TLS passthrough, so the spoke must trust the
@@ -60,12 +59,11 @@ func generateHubInfoSecret(client client.Client, obsNamespace string,
 		// will be accessed through k8s service FQDN + port
 		obsAPIHost = config.GetOperandNamePrefix() + "observatorium-api" + "." + config.GetDefaultNamespace() + ".svc.cluster.local:8080"
 
-		hubAlertsForwardingHost = config.GetOperandNamePrefix() + "observatorium-api." + config.GetDefaultNamespace() + ".svc.cluster.local:8080"
-		hubAlertsForwardingPath = "/api/alertmanager/v2/" + config.GetDefaultTenantName()
-
+		hubAlertsForwardingRoute = config.GetOperandNamePrefix() + "observatorium-api." +
+			config.GetDefaultNamespace() + ".svc.cluster.local:8080/api/alertmanager/v2/" + config.GetDefaultTenantName()
 		// if alerting is disabled, do not set alertmanagerEndpoint
 		if !config.IsAlertingDisabled() {
-			alertmanagerEndpoint = "http://" + hubAlertsForwardingHost + hubAlertsForwardingPath
+			alertmanagerEndpoint = hubAlertsForwardingRoute
 		}
 		var err error
 		alertmanagerRouterCA, err = config.GetObsAPIServerCA(client)
@@ -108,8 +106,7 @@ func generateHubInfoSecret(client client.Client, obsNamespace string,
 	hubInfo := &operatorconfig.HubInfo{
 		ObservatoriumAPIEndpoint: obsApiURL.String(),
 		AlertmanagerEndpoint:     alertmanagerEndpoint,
-		HubAlertsForwardingHost:  hubAlertsForwardingHost,
-		HubAlertsForwardingPath:  hubAlertsForwardingPath,
+		HubAlertsForwardingRoute: hubAlertsForwardingRoute,
 		AlertmanagerRouterCA:     alertmanagerRouterCA,
 		UWMAlertingDisabled:      isUWMAlertingDisabled,
 		HubClusterID:             trimmedClusterID,

--- a/operators/multiclusterobservability/controllers/placementrule/hub_info_secret_test.go
+++ b/operators/multiclusterobservability/controllers/placementrule/hub_info_secret_test.go
@@ -159,10 +159,11 @@ func TestNewSecret(t *testing.T) {
 	}
 	expectedAlertmanagerEndpoint := "https://" + routeHost + "/api/alertmanager/v2/default"
 	if !strings.HasPrefix(hub.ObservatoriumAPIEndpoint, "https://observatorium-api-open-cluster-management-observability.apps.test-host") ||
-		hub.AlertmanagerEndpoint != expectedAlertmanagerEndpoint || hub.AlertmanagerRouterCA != obsServerCA || hub.HubClusterID != "1a9af6dc0801433cb28a200af81" {
+		hub.AlertmanagerEndpoint != expectedAlertmanagerEndpoint || hub.HubAlertsForwardingRoute != expectedAlertmanagerEndpoint ||
+		hub.AlertmanagerRouterCA != obsServerCA || hub.HubClusterID != "1a9af6dc0801433cb28a200af81" {
 		t.Fatalf(
-			"Wrong content in hub info secret: \ngot: "+hub.ObservatoriumAPIEndpoint+" "+hub.AlertmanagerEndpoint+" "+hub.AlertmanagerRouterCA,
-			clusterName+" "+expectedAlertmanagerEndpoint+" "+obsServerCA,
+			"Wrong content in hub info secret: \ngot: "+hub.ObservatoriumAPIEndpoint+" "+hub.AlertmanagerEndpoint+" "+hub.HubAlertsForwardingRoute+" "+hub.AlertmanagerRouterCA,
+			clusterName+" "+expectedAlertmanagerEndpoint+" "+expectedAlertmanagerEndpoint+" "+obsServerCA,
 		)
 	}
 
@@ -241,10 +242,12 @@ func TestNewSecret(t *testing.T) {
 		t.Fatalf("Failed to unmarshal data in hub info secret (%v)", err)
 	}
 	if !strings.HasPrefix(hub.ObservatoriumAPIEndpoint, "https://custom-obs:8080") ||
-		hub.AlertmanagerEndpoint != "https://custom-obs:8080/api/alertmanager/v2/default" || hub.AlertmanagerRouterCA != obsServerCA {
+		hub.AlertmanagerEndpoint != "https://custom-obs:8080/api/alertmanager/v2/default" ||
+		hub.HubAlertsForwardingRoute != "https://custom-obs:8080/api/alertmanager/v2/default" ||
+		hub.AlertmanagerRouterCA != obsServerCA {
 		t.Fatalf(
-			"Wrong content in hub info secret: \ngot: "+hub.ObservatoriumAPIEndpoint+" "+hub.AlertmanagerEndpoint+" "+hub.AlertmanagerRouterCA,
-			clusterName+" "+"https://custom-obs:8080/api/alertmanager/v2/default"+" "+obsServerCA,
+			"Wrong content in hub info secret: \ngot: "+hub.ObservatoriumAPIEndpoint+" "+hub.AlertmanagerEndpoint+" "+hub.HubAlertsForwardingRoute+" "+hub.AlertmanagerRouterCA,
+			clusterName+" "+"https://custom-obs:8080/api/alertmanager/v2/default"+" "+"https://custom-obs:8080/api/alertmanager/v2/default"+" "+obsServerCA,
 		)
 	}
 }
@@ -271,10 +274,11 @@ func TestNewBYOSecret(t *testing.T) {
 	}
 	expectedAlertmanagerEndpoint := "https://" + routeHost + "/api/alertmanager/v2/default"
 	if !strings.HasPrefix(hub.ObservatoriumAPIEndpoint, "https://observatorium-api-open-cluster-management-observability.apps.test-host") ||
-		hub.AlertmanagerEndpoint != expectedAlertmanagerEndpoint || hub.AlertmanagerRouterCA != obsServerCA {
+		hub.AlertmanagerEndpoint != expectedAlertmanagerEndpoint || hub.HubAlertsForwardingRoute != expectedAlertmanagerEndpoint ||
+		hub.AlertmanagerRouterCA != obsServerCA {
 		t.Fatalf(
-			"Wrong content in hub info secret: \ngot: "+hub.ObservatoriumAPIEndpoint+" "+hub.AlertmanagerEndpoint+" "+hub.AlertmanagerRouterCA,
-			clusterName+" "+expectedAlertmanagerEndpoint+" "+obsServerCA,
+			"Wrong content in hub info secret: \ngot: "+hub.ObservatoriumAPIEndpoint+" "+hub.AlertmanagerEndpoint+" "+hub.HubAlertsForwardingRoute+" "+hub.AlertmanagerRouterCA,
+			clusterName+" "+expectedAlertmanagerEndpoint+" "+expectedAlertmanagerEndpoint+" "+obsServerCA,
 		)
 	}
 }

--- a/operators/pkg/config/types.go
+++ b/operators/pkg/config/types.go
@@ -19,10 +19,11 @@ type HubInfo struct {
 	AlertmanagerRouterCA     string `yaml:"alertmanager-router-ca"`
 	UWMAlertingDisabled      bool   `yaml:"uwm-alerting-disabled"`
 	HubClusterID             string `yaml:"hub-cluster-id"`
-	// HubAlertsForwardingHost and HubAlertsForwardingPath provide persistent data for forwarding alerts to the hub,
-	// even when MCO's alerting is disabled. For custom stacks that override custom monitoring config.
-	HubAlertsForwardingHost string `yaml:"hub-alerts-forwarding-host"`
-	HubAlertsForwardingPath string `yaml:"hub-alerts-forwarding-path"`
+	// when alerting is disabled the AlertmanagerEndpoint as to not update cluster-monitoring-config
+	// telco expects above behavior, but needs to know where to send alerts
+	// 	versions before ACM 5.0 = alertmanager
+	//  versions after ACM 5.0 = observatorium-api
+	HubAlertsForwardingRoute string `yaml:"hub-alerts-forwarding-route"`
 }
 
 type RecordingRule struct {

--- a/operators/pkg/config/types.go
+++ b/operators/pkg/config/types.go
@@ -19,6 +19,10 @@ type HubInfo struct {
 	AlertmanagerRouterCA     string `yaml:"alertmanager-router-ca"`
 	UWMAlertingDisabled      bool   `yaml:"uwm-alerting-disabled"`
 	HubClusterID             string `yaml:"hub-cluster-id"`
+	// HubAlertsForwardingHost and HubAlertsForwardingPath provide persistent data for forwarding alerts to the hub,
+	// even when MCO's alerting is disabled. For custom stacks that override custom monitoring config.
+	HubAlertsForwardingHost string `yaml:"hub-alerts-forwarding-host"`
+	HubAlertsForwardingPath string `yaml:"hub-alerts-forwarding-path"`
 }
 
 type RecordingRule struct {


### PR DESCRIPTION
Telco runs own config for alertmanager https://github.com/openshift-kni/telco-reference/pull/916/changes

Because Telco disables alerting, the alertmanager endpoint is not seen
```
// if alerting is disabled, do not set alertmanagerEndpoint
if !config.IsAlertingDisabled() {
	alertmanagerEndpoint = persistentAlertmanagerEndpoint
}
```

Update for alert fanout https://github.com/stolostron/multicluster-observability-operator/pull/2485 was then a breaking api change. Providing workaround by creating alertmanager route in hub info secret that persists even when alerting is disabled. This will allow Telco to look at `HubAlertsForwardingRoute` in hub-info-secret to see where to send alerts. 

**Note:** Keep this change only in ACM 5.0.0, such that policies can be conditional as to whether `HubAlertsForwardingRoute` is present. If present know to send alerts to observatorium-api (route provided) and use observatorium mTLS certs. Otherwise, send directly to hub alertmanager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hub alert-forwarding route information to generated hub configuration.
  * Supports both ingress and service-based deployments, including custom hub URLs and BYO configurations.
  * Preserves the forwarding route when alerting is disabled, while leaving the alert manager endpoint unset.
  * Documented alert destinations for supported telco and ACM deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->