### PR TITLE
fix(grafana): maintain time range when navigating between VM right-si…

### DIFF
--- a/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization-overestimation.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization-overestimation.yaml
@@ -32,8 +32,8 @@ data:
         {
           "asDropdown": false,
           "icon": "dashboard",
-          "includeVars": false,
-          "keepTime": false,
+          "includeVars": true,
+          "keepTime": true,
           "tags": [],
           "targetBlank": false,
           "title": "Back to Main Dashboard",

--- a/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization-underestimation.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization-underestimation.yaml
@@ -32,8 +32,8 @@ data:
         {
           "asDropdown": false,
           "icon": "dashboard",
-          "includeVars": false,
-          "keepTime": false,
+          "includeVars": true,
+          "keepTime": true,
           "tags": [],
           "targetBlank": false,
           "title": "Back to Main Dashboard",


### PR DESCRIPTION
fix(grafana): preserve time range across VM right-sizing dashboard navigation

Enable keepTime and includeVars on the "Back to Main Dashboard" links in the virtualization overestimation and underestimation dashboards so users don't lose their selected time range and variable context when navigating between dashboards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Grafana dashboard links now preserve selected variable values and the current time range when navigating between related dashboards.
  - Updated both right-sizing virtualization overestimation and underestimation dashboards for consistent navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->