### PR TITLE
[ACM-42815] test: populate clusterServerURL in options.yaml with validation and fallback

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,10 +97,16 @@ pipeline {
                     cp resources/options.yaml.template resources/options.yaml
                     /usr/local/bin/yq e -i '.options.hub.name="'"\$HUB_CLUSTER_NAME"'"' resources/options.yaml
                     /usr/local/bin/yq e -i '.options.hub.baseDomain="'"\$BASE_DOMAIN"'"' resources/options.yaml
-                    if [[ -n "$MANAGED_CLUSTER_NAME" ]]; then
-                    /usr/local/bin/yq e -i '.options.clusters[0].name="'"\$MANAGED_CLUSTER_NAME"'"' resources/options.yaml
-                    /usr/local/bin/yq e -i '.options.clusters[0].baseDomain="'"\$MANAGED_CLUSTER_BASE_DOMAIN"'"' resources/options.yaml
-                    /usr/local/bin/yq e -i '.options.clusters[0].kubeconfig="'"\$MAKUBECONFIG"'"' resources/options.yaml
+                    if [[ -n "\$OC_HUB_CLUSTER_API_URL" ]]; then
+                      /usr/local/bin/yq e -i '.options.hub.clusterServerURL="'"\$OC_HUB_CLUSTER_API_URL"'"' resources/options.yaml
+                    fi
+                    if [[ -n "\$MANAGED_CLUSTER_NAME" ]]; then
+                      /usr/local/bin/yq e -i '.options.clusters[0].name="'"\$MANAGED_CLUSTER_NAME"'"' resources/options.yaml
+                      /usr/local/bin/yq e -i '.options.clusters[0].baseDomain="'"\$MANAGED_CLUSTER_BASE_DOMAIN"'"' resources/options.yaml
+                      /usr/local/bin/yq e -i '.options.clusters[0].kubeconfig="'"\$MAKUBECONFIG"'"' resources/options.yaml
+                      if [[ -n "\$MANAGED_CLUSTER_API_URL" ]]; then
+                        /usr/local/bin/yq e -i '.options.clusters[0].clusterServerURL="'"\$MANAGED_CLUSTER_API_URL"'"' resources/options.yaml
+                      fi
                     fi
                     cat resources/options.yaml
                     if [[ -n "${params.TAGGING}" ]]; then

--- a/execute_obs_interop_commands.sh
+++ b/execute_obs_interop_commands.sh
@@ -73,9 +73,17 @@ else
   cp resources/options.yaml.template resources/options.yaml
   /usr/local/bin/yq e -i '.options.hub.name="'"$HUB_CLUSTER_NAME"'"' resources/options.yaml
   /usr/local/bin/yq e -i '.options.hub.baseDomain="'"$BASE_DOMAIN"'"' resources/options.yaml
-  /usr/local/bin/yq e -i '.options.clusters.name="'"$MANAGED_CLUSTER_NAME"'"' resources/options.yaml
-  /usr/local/bin/yq e -i '.options.clusters.baseDomain="'"$MANAGED_CLUSTER_BASE_DOMAIN"'"' resources/options.yaml
-  /usr/local/bin/yq e -i '.options.clusters.kubeconfig="'"$MAKUBECONFIG"'"' resources/options.yaml
+  if [[ -n $OC_HUB_CLUSTER_API_URL ]]; then
+    /usr/local/bin/yq e -i '.options.hub.clusterServerURL="'"$OC_HUB_CLUSTER_API_URL"'"' resources/options.yaml
+  fi
+  if [[ -n $MANAGED_CLUSTER_NAME ]]; then
+    /usr/local/bin/yq e -i '.options.clusters[0].name="'"$MANAGED_CLUSTER_NAME"'"' resources/options.yaml
+    /usr/local/bin/yq e -i '.options.clusters[0].baseDomain="'"$MANAGED_CLUSTER_BASE_DOMAIN"'"' resources/options.yaml
+    /usr/local/bin/yq e -i '.options.clusters[0].kubeconfig="'"$MAKUBECONFIG"'"' resources/options.yaml
+    if [[ -n $MANAGED_CLUSTER_API_URL ]]; then
+      /usr/local/bin/yq e -i '.options.clusters[0].clusterServerURL="'"$MANAGED_CLUSTER_API_URL"'"' resources/options.yaml
+    fi
+  fi
   cat resources/options.yaml
   ginkgo --focus=$TAGGING -v pkg/tests/ -- -options=../../resources/options.yaml -v=5
 fi

--- a/tests/pkg/tests/observability-e2e-test_suite_test.go
+++ b/tests/pkg/tests/observability-e2e-test_suite_test.go
@@ -235,6 +235,14 @@ func initVars() {
 	substring1 := "rosa"
 	substring2 := "hcp"
 	substring3 := "rhov" // Format of rhov api url is https://<baseDomain>:6443
+
+	if testOptions.HubCluster.ClusterServerURL != "" {
+		if err := utils.ValidateClusterServerURL(testOptions.HubCluster.ClusterServerURL); err != nil {
+			klog.Warningf("Provided hub clusterServerURL %q is invalid (%v), clearing it to fall back to baseDomain heuristics", testOptions.HubCluster.ClusterServerURL, err)
+			testOptions.HubCluster.ClusterServerURL = ""
+		}
+	}
+
 	if testOptions.HubCluster.BaseDomain != "" {
 		baseDomain = testOptions.HubCluster.BaseDomain
 		if testOptions.HubCluster.ClusterServerURL == "" {
@@ -258,11 +266,11 @@ func initVars() {
 	} else {
 		Expect(baseDomain).NotTo(BeEmpty(), "The `baseDomain` is required.")
 		testOptions.HubCluster.BaseDomain = baseDomain
-		testOptions.HubCluster.ClusterServerURL = fmt.Sprintf("https://api.%s:6443", baseDomain)
-		if strings.Contains(cloudProvider, substring1) && strings.Contains(cloudProvider, substring2) {
-			testOptions.HubCluster.ClusterServerURL = fmt.Sprintf("https://api.%s:443", baseDomain)
-		} else {
+		if testOptions.HubCluster.ClusterServerURL == "" {
 			testOptions.HubCluster.ClusterServerURL = fmt.Sprintf("https://api.%s:6443", baseDomain)
+			if strings.Contains(cloudProvider, substring1) && strings.Contains(cloudProvider, substring2) {
+				testOptions.HubCluster.ClusterServerURL = fmt.Sprintf("https://api.%s:443", baseDomain)
+			}
 		}
 	}
 
@@ -281,7 +289,13 @@ func initVars() {
 
 	if testOptions.ManagedClusters != nil && len(testOptions.ManagedClusters) > 0 {
 		for i, mc := range testOptions.ManagedClusters {
-			if mc.ClusterServerURL == "" {
+			if mc.ClusterServerURL != "" {
+				if err := utils.ValidateClusterServerURL(mc.ClusterServerURL); err != nil {
+					klog.Warningf("Provided managed cluster %s clusterServerURL %q is invalid (%v), clearing it to fall back to baseDomain heuristics", mc.Name, mc.ClusterServerURL, err)
+					testOptions.ManagedClusters[i].ClusterServerURL = ""
+				}
+			}
+			if testOptions.ManagedClusters[i].ClusterServerURL == "" {
 				testOptions.ManagedClusters[i].ClusterServerURL = fmt.Sprintf("https://api.%s:6443", mc.BaseDomain)
 			}
 			if mc.KubeConfig == "" {

--- a/tests/pkg/tests/observability-e2e-test_suite_test.go
+++ b/tests/pkg/tests/observability-e2e-test_suite_test.go
@@ -232,9 +232,6 @@ func initVars() {
 	}
 
 	cloudProvider := strings.ToLower(os.Getenv("CLOUD_PROVIDER"))
-	substring1 := "rosa"
-	substring2 := "hcp"
-	substring3 := "rhov" // Format of rhov api url is https://<baseDomain>:6443
 
 	if testOptions.HubCluster.ClusterServerURL != "" {
 		if err := utils.ValidateClusterServerURL(testOptions.HubCluster.ClusterServerURL); err != nil {
@@ -246,31 +243,13 @@ func initVars() {
 	if testOptions.HubCluster.BaseDomain != "" {
 		baseDomain = testOptions.HubCluster.BaseDomain
 		if testOptions.HubCluster.ClusterServerURL == "" {
-			if strings.Contains(cloudProvider, substring1) && strings.Contains(cloudProvider, substring2) {
-				testOptions.HubCluster.ClusterServerURL = fmt.Sprintf(
-					"https://api.%s:443",
-					testOptions.HubCluster.BaseDomain,
-				)
-			} else if strings.Contains(cloudProvider, substring3) {
-				testOptions.HubCluster.ClusterServerURL = fmt.Sprintf(
-					"https://%s:6443",
-					testOptions.HubCluster.BaseDomain,
-				)
-			} else {
-				testOptions.HubCluster.ClusterServerURL = fmt.Sprintf(
-					"https://api.%s:6443",
-					testOptions.HubCluster.BaseDomain,
-				)
-			}
+			testOptions.HubCluster.ClusterServerURL = utils.DefaultClusterServerURL(testOptions.HubCluster.BaseDomain, cloudProvider)
 		}
 	} else {
 		Expect(baseDomain).NotTo(BeEmpty(), "The `baseDomain` is required.")
 		testOptions.HubCluster.BaseDomain = baseDomain
 		if testOptions.HubCluster.ClusterServerURL == "" {
-			testOptions.HubCluster.ClusterServerURL = fmt.Sprintf("https://api.%s:6443", baseDomain)
-			if strings.Contains(cloudProvider, substring1) && strings.Contains(cloudProvider, substring2) {
-				testOptions.HubCluster.ClusterServerURL = fmt.Sprintf("https://api.%s:443", baseDomain)
-			}
+			testOptions.HubCluster.ClusterServerURL = utils.DefaultClusterServerURL(baseDomain, cloudProvider)
 		}
 	}
 
@@ -296,7 +275,7 @@ func initVars() {
 				}
 			}
 			if testOptions.ManagedClusters[i].ClusterServerURL == "" {
-				testOptions.ManagedClusters[i].ClusterServerURL = fmt.Sprintf("https://api.%s:6443", mc.BaseDomain)
+				testOptions.ManagedClusters[i].ClusterServerURL = utils.DefaultClusterServerURL(mc.BaseDomain, cloudProvider)
 			}
 			if mc.KubeConfig == "" {
 				testOptions.ManagedClusters[i].KubeConfig = os.Getenv("IMPORT_KUBECONFIG")

--- a/tests/pkg/tests/observability_install_test.go
+++ b/tests/pkg/tests/observability_install_test.go
@@ -51,8 +51,8 @@ func installMCO() {
 
 	By("Checking MCO operator is started up and running")
 	podList, err := hubClient.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{LabelSelector: MCO_LABEL})
-	Expect(len(podList.Items)).To(Equal(1))
 	Expect(err).NotTo(HaveOccurred())
+	Expect(len(podList.Items)).To(Equal(1))
 	var (
 		mcoPod = ""
 		mcoNs  = ""

--- a/tests/pkg/utils/options.go
+++ b/tests/pkg/utils/options.go
@@ -4,6 +4,42 @@
 
 package utils
 
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// ValidateClusterServerURL ensures that a clusterServerURL contains a valid scheme, host, and optional port.
+func ValidateClusterServerURL(rawURL string) error {
+	if rawURL == "" {
+		return errors.New("clusterServerURL cannot be empty")
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse clusterServerURL %q: %w", rawURL, err)
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("invalid clusterServerURL %q: scheme must be 'http' or 'https', got %q", rawURL, u.Scheme)
+	}
+
+	if u.Hostname() == "" {
+		return fmt.Errorf("invalid clusterServerURL %q: missing host/domain", rawURL)
+	}
+
+	if portStr := u.Port(); portStr != "" {
+		port, err := strconv.Atoi(portStr)
+		if err != nil || port < 1 || port > 65535 {
+			return fmt.Errorf("invalid clusterServerURL %q: port %q is out of range (1-65535)", rawURL, portStr)
+		}
+	}
+
+	return nil
+}
+
 type TestOptionsContainer struct {
 	Options TestOptions `yaml:"options"`
 }

--- a/tests/pkg/utils/options.go
+++ b/tests/pkg/utils/options.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 // ValidateClusterServerURL ensures that a clusterServerURL contains a valid scheme, host, and optional port.
@@ -38,6 +39,21 @@ func ValidateClusterServerURL(rawURL string) error {
 	}
 
 	return nil
+}
+
+// DefaultClusterServerURL resolves the default cluster API URL from baseDomain and cloudProvider heuristics.
+func DefaultClusterServerURL(baseDomain, cloudProvider string) string {
+	cloudProvider = strings.ToLower(cloudProvider)
+	substring1 := "rosa"
+	substring2 := "hcp"
+	substring3 := "rhov" // Format of rhov api url is https://<baseDomain>:6443
+
+	if strings.Contains(cloudProvider, substring1) && strings.Contains(cloudProvider, substring2) {
+		return fmt.Sprintf("https://api.%s:443", baseDomain)
+	} else if strings.Contains(cloudProvider, substring3) {
+		return fmt.Sprintf("https://%s:6443", baseDomain)
+	}
+	return fmt.Sprintf("https://api.%s:6443", baseDomain)
 }
 
 type TestOptionsContainer struct {

--- a/tests/pkg/utils/options_test.go
+++ b/tests/pkg/utils/options_test.go
@@ -80,3 +80,53 @@ func TestValidateClusterServerURL(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultClusterServerURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		baseDomain    string
+		cloudProvider string
+		want          string
+	}{
+		{
+			name:          "rosa hcp lowercase",
+			baseDomain:    "example.com",
+			cloudProvider: "rosa-hcp",
+			want:          "https://api.example.com:443",
+		},
+		{
+			name:          "rosa hcp mixed case",
+			baseDomain:    "example.com",
+			cloudProvider: "ROSA_HCP",
+			want:          "https://api.example.com:443",
+		},
+		{
+			name:          "rhov provider",
+			baseDomain:    "apps.rhov.example.com",
+			cloudProvider: "rhov",
+			want:          "https://apps.rhov.example.com:6443",
+		},
+		{
+			name:          "standard aws provider",
+			baseDomain:    "example.com",
+			cloudProvider: "aws",
+			want:          "https://api.example.com:6443",
+		},
+		{
+			name:          "empty cloud provider default",
+			baseDomain:    "example.com",
+			cloudProvider: "",
+			want:          "https://api.example.com:6443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DefaultClusterServerURL(tt.baseDomain, tt.cloudProvider)
+			if got != tt.want {
+				t.Errorf("DefaultClusterServerURL(%q, %q) = %q, want %q", tt.baseDomain, tt.cloudProvider, got, tt.want)
+			}
+		})
+	}
+}
+

--- a/tests/pkg/utils/options_test.go
+++ b/tests/pkg/utils/options_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package utils
+
+import (
+	"testing"
+)
+
+func TestValidateClusterServerURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawURL  string
+		wantErr bool
+	}{
+		{
+			name:    "valid standard openshift https URL with port 6443",
+			rawURL:  "https://api.ci-rosa-50-fi.498a.p1.openshiftapps.com:6443",
+			wantErr: false,
+		},
+		{
+			name:    "valid rosa hcp https URL with port 443",
+			rawURL:  "https://api.ci-rosa-50-fi.498a.p1.openshiftapps.com:443",
+			wantErr: false,
+		},
+		{
+			name:    "valid https URL without explicit port",
+			rawURL:  "https://api.ci-rosa-50-fi.498a.p1.openshiftapps.com",
+			wantErr: false,
+		},
+		{
+			name:    "valid http URL for local testing",
+			rawURL:  "http://localhost:8080",
+			wantErr: false,
+		},
+		{
+			name:    "valid IP address server URL",
+			rawURL:  "https://127.0.0.1:6443",
+			wantErr: false,
+		},
+		{
+			name:    "empty URL",
+			rawURL:  "",
+			wantErr: true,
+		},
+		{
+			name:    "missing scheme",
+			rawURL:  "api.ci-rosa-50-fi.498a.p1.openshiftapps.com:6443",
+			wantErr: true,
+		},
+		{
+			name:    "unsupported scheme ftp",
+			rawURL:  "ftp://api.ci-rosa-50-fi.498a.p1.openshiftapps.com:6443",
+			wantErr: true,
+		},
+		{
+			name:    "missing host",
+			rawURL:  "https://:6443",
+			wantErr: true,
+		},
+		{
+			name:    "invalid port out of range",
+			rawURL:  "https://api.ci-rosa-50-fi.498a.p1.openshiftapps.com:99999",
+			wantErr: true,
+		},
+		{
+			name:    "invalid non-numeric port",
+			rawURL:  "https://api.ci-rosa-50-fi.498a.p1.openshiftapps.com:port",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateClusterServerURL(tt.rawURL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateClusterServerURL(%q) error = %v, wantErr %v", tt.rawURL, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/tests/pkg/utils/options_test.go
+++ b/tests/pkg/utils/options_test.go
@@ -129,4 +129,3 @@ func TestDefaultClusterServerURL(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
### Description
Fixes an issue where observability e2e tests fail against AWS Classic ROSA Hub clusters when `CLOUD_PROVIDER` is set to `rosa-hcp` (e.g. in hybrid ROSA HCP spoke / Classic ROSA hub test topologies).

### Root Cause
In `tests/pkg/tests/observability-e2e-test_suite_test.go`, when `testOptions.HubCluster.ClusterServerURL` was omitted in `options.yaml`, the suite guessed the server URL based on `CLOUD_PROVIDER`. If `CLOUD_PROVIDER` contained `rosa` and `hcp`, it forced port `443` (`https://api.<baseDomain>:443`), causing connection timeouts (`context deadline exceeded`) against Classic ROSA clusters whose API listens on port `6443`.

### Changes
1. **CI Script Updates (`Jenkinsfile`, `execute_obs_interop_commands.sh`)**:
   - Write explicit `clusterServerURL` into `resources/options.yaml` for both hub (`$OC_HUB_CLUSTER_API_URL`) and managed clusters (`$MANAGED_CLUSTER_API_URL`).
   - Fix Groovy escaping in `Jenkinsfile` for `\$MANAGED_CLUSTER_NAME` to prevent premature interpolation on the controller.
2. **URL Validation & Fallback (`tests/pkg/utils/options.go`, `tests/pkg/tests/observability-e2e-test_suite_test.go`)**:
   - Added `ValidateClusterServerURL` helper to validate scheme (`http`/`https`), host, and port ranges.
   - If `clusterServerURL` in `options.yaml` is invalid, the suite logs a warning and gracefully falls back to `baseDomain` heuristics.
3. **Unit Tests (`tests/pkg/utils/options_test.go`)**:
   - Added unit test suite covering valid/invalid URL formats, port ranges, and edge cases.
4. **Assertion Order (`tests/pkg/tests/observability_install_test.go`)**:
   - Assert `err` before asserting slice length to ensure API connection failures are reported accurately.

### Jira Issue
[ACM-42815](https://redhat.atlassian.net/browse/ACM-42815)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of hub and managed cluster server URLs during test and installation workflows.
  - Invalid or unavailable URLs are now safely regenerated from cluster and provider information.
  - Valid configured URLs are preserved, while incomplete cluster settings are not written.
  - Improved support for ROSA/HCP and RHOV endpoint formats.

- **Tests**
  - Added coverage for URL validation and provider-specific URL generation.
  - Improved validation of installation errors and operator pod checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ACM-42815]: https://redhat.atlassian.net/browse/ACM-42815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ