### PR TITLE
fix(mcoa): synchronize addon teardown and harden e2e install/config tests

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -337,7 +337,7 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 		// and ManifestWorks on spokes. MCOAResources() skips CMA when DisableCMAORender
 		// is set (to preserve user annotations during normal operation), but during cleanup
 		// we must remove it to trigger the full addon lifecycle teardown.
-		requeue, res, err := r.cleanupMCOAManifestWorks(ctx, reqLogger)
+		requeue, res, err := r.waitForMCOATeardown(ctx, reqLogger)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -462,7 +462,7 @@ func (r *MultiClusterObservabilityReconciler) initFinalization(ctx context.Conte
 
 		// Explicitly delete the CMA so the addon framework cleans up ManagedClusterAddons
 		// and ManifestWorks on spokes before we proceed with deleting other resources.
-		requeue, res, err := r.cleanupMCOAManifestWorks(ctx, log)
+		requeue, res, err := r.waitForMCOATeardown(ctx, log)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -1230,21 +1230,17 @@ func (r *MultiClusterObservabilityReconciler) deleteMCOACMA(ctx context.Context)
 	return nil
 }
 
-// hasMCOAManifestWorks checks if there are any remaining ManifestWorks for the MCOA addon on the hub.
-func (r *MultiClusterObservabilityReconciler) hasMCOAManifestWorks(ctx context.Context) ([]string, error) {
-	return util.HasMCOAManifestWorks(ctx, r.Client)
-}
-
-// cleanupMCOAManifestWorks deletes the ClusterManagementAddOn (CMA) and waits for its ManifestWorks to be cleaned up.
+// waitForMCOATeardown deletes the ClusterManagementAddOn (CMA) to trigger addon teardown
+// and waits for all spoke-side ManifestWorks and ManagedClusterAddOns to be fully cleaned up.
 // It returns a boolean indicating whether reconciliation should be requeued, and any error encountered.
-func (r *MultiClusterObservabilityReconciler) cleanupMCOAManifestWorks(ctx context.Context, logger logr.Logger) (bool, ctrl.Result, error) {
+func (r *MultiClusterObservabilityReconciler) waitForMCOATeardown(ctx context.Context, logger logr.Logger) (bool, ctrl.Result, error) {
 	if err := r.deleteMCOACMA(ctx); err != nil {
 		return false, ctrl.Result{}, err
 	}
 
-	blockingClusters, err := r.hasMCOAManifestWorks(ctx)
+	blockingClusters, err := util.HasRemainingMCOAResources(ctx, r.Client)
 	if err != nil {
-		return false, ctrl.Result{}, fmt.Errorf("failed to check for remaining ManifestWorks during MCOA cleanup: %w", err)
+		return false, ctrl.Result{}, fmt.Errorf("failed to check for remaining MCOA resources during cleanup: %w", err)
 	}
 	if len(blockingClusters) > 0 {
 		logClusters := blockingClusters
@@ -1252,7 +1248,7 @@ func (r *MultiClusterObservabilityReconciler) cleanupMCOAManifestWorks(ctx conte
 			logClusters = logClusters[:10:10]
 			logClusters = append(logClusters, fmt.Sprintf("...and %d more", len(blockingClusters)-10))
 		}
-		logger.Info("Waiting for MCOA ManifestWorks to be deleted", "blockingClusters", logClusters)
+		logger.Info("Waiting for MCOA ManifestWorks and ManagedClusterAddOns to be deleted", "blockingClusters", logClusters)
 		return true, ctrl.Result{RequeueAfter: mcoaCleanupRequeueInterval}, nil
 	}
 

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller_test.go
@@ -1847,26 +1847,6 @@ func TestMCOAWaitForManifestWorks(t *testing.T) {
 		},
 	}
 
-	t.Run("hasMCOAManifestWorks helper", func(t *testing.T) {
-		clientWithWork := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mw).Build()
-		r1 := &MultiClusterObservabilityReconciler{
-			Client: clientWithWork,
-			Scheme: s,
-		}
-		blocking, err := r1.hasMCOAManifestWorks(t.Context())
-		assert.NoError(t, err)
-		assert.Contains(t, blocking, "test-ns")
-
-		clientEmpty := fake.NewClientBuilder().WithScheme(s).Build()
-		r2 := &MultiClusterObservabilityReconciler{
-			Client: clientEmpty,
-			Scheme: s,
-		}
-		blocking, err = r2.hasMCOAManifestWorks(t.Context())
-		assert.NoError(t, err)
-		assert.Empty(t, blocking)
-	})
-
 	t.Run("initFinalization delay", func(t *testing.T) {
 		now := metav1.Now()
 		mcoToDelete1 := &mcov1beta2.MultiClusterObservability{

--- a/operators/multiclusterobservability/pkg/util/mcoa_util.go
+++ b/operators/multiclusterobservability/pkg/util/mcoa_util.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 
 	mcov1beta2 "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/api/v1beta2"
@@ -60,13 +61,7 @@ func HasMCOAManifestWorks(ctx context.Context, c client.Client) ([]string, error
 		return nil, fmt.Errorf("failed to list ManagedClusters: %w", err)
 	}
 
-	ignoredNamespaces := make(map[string]struct{})
-	for _, mc := range clusterList.Items {
-		isAvailable := meta.IsStatusConditionTrue(mc.Status.Conditions, clusterv1.ManagedClusterConditionAvailable)
-		if !isAvailable {
-			ignoredNamespaces[mc.Name] = struct{}{}
-		}
-	}
+	ignoredNamespaces := getUnavailableClusterNamespaces(clusterList)
 
 	workList := &workv1.ManifestWorkList{}
 	opts := []client.ListOption{
@@ -92,10 +87,7 @@ func HasMCOAManifestWorks(ctx context.Context, c client.Client) ([]string, error
 		return nil, nil
 	}
 
-	blockingNamespaces := make([]string, 0, len(blockingMap))
-	for ns := range blockingMap {
-		blockingNamespaces = append(blockingNamespaces, ns)
-	}
+	blockingNamespaces := slices.Collect(maps.Keys(blockingMap))
 	slices.Sort(blockingNamespaces)
 
 	return blockingNamespaces, nil
@@ -115,4 +107,79 @@ func containsPrometheusAgent(work workv1.ManifestWork) bool {
 		}
 	}
 	return false
+}
+
+// getUnavailableClusterNamespaces returns a set of cluster namespaces where the ManagedCluster
+// is currently not available/connected.
+func getUnavailableClusterNamespaces(clusterList *clusterv1.ManagedClusterList) map[string]struct{} {
+	ignored := make(map[string]struct{})
+	for _, mc := range clusterList.Items {
+		isAvailable := meta.IsStatusConditionTrue(mc.Status.Conditions, clusterv1.ManagedClusterConditionAvailable)
+		if !isAvailable {
+			ignored[mc.Name] = struct{}{}
+		}
+	}
+	return ignored
+}
+
+// HasRemainingMCOAResources checks for ANY remaining MCOA ManifestWorks or ManagedClusterAddOns
+// on available ManagedClusters.
+//
+// Unlike HasMCOAManifestWorks (which only checks for PrometheusAgent to coordinate legacy
+// metrics collector transitions), this function checks for ANY remaining MCOA ManifestWorks
+// or ManagedClusterAddOns. It is used during MCOA teardown to ensure the MCOA manager
+// deployment is not undeployed prematurely while spokes are still cleaning up resources.
+//
+// Resources on unavailable ManagedClusters are ignored to prevent disconnected spokes
+// from hanging the cleanup process.
+func HasRemainingMCOAResources(ctx context.Context, c client.Client) ([]string, error) {
+	clusterList := &clusterv1.ManagedClusterList{}
+	if err := c.List(ctx, clusterList); err != nil {
+		return nil, fmt.Errorf("failed to list ManagedClusters: %w", err)
+	}
+
+	ignoredNamespaces := getUnavailableClusterNamespaces(clusterList)
+
+	blockingMap := make(map[string]struct{})
+
+	workList := &workv1.ManifestWorkList{}
+	opts := []client.ListOption{
+		client.MatchingLabels{
+			addonv1beta1.AddonLabelKey: config.MultiClusterObservabilityAddon,
+		},
+	}
+	if err := c.List(ctx, workList, opts...); err != nil {
+		return nil, fmt.Errorf("failed to list ManifestWorks: %w", err)
+	}
+
+	for _, work := range workList.Items {
+		if _, ignored := ignoredNamespaces[work.Namespace]; ignored {
+			continue
+		}
+		blockingMap[work.Namespace] = struct{}{}
+	}
+
+	mcaList := &addonv1beta1.ManagedClusterAddOnList{}
+	if err := c.List(ctx, mcaList); err != nil {
+		return nil, fmt.Errorf("failed to list ManagedClusterAddOns: %w", err)
+	}
+
+	for _, mca := range mcaList.Items {
+		if mca.Name != config.MultiClusterObservabilityAddon {
+			continue
+		}
+		if _, ignored := ignoredNamespaces[mca.Namespace]; ignored {
+			continue
+		}
+		blockingMap[mca.Namespace] = struct{}{}
+	}
+
+	if len(blockingMap) == 0 {
+		return nil, nil
+	}
+
+	blockingNamespaces := slices.Collect(maps.Keys(blockingMap))
+	slices.Sort(blockingNamespaces)
+
+	return blockingNamespaces, nil
 }

--- a/operators/multiclusterobservability/pkg/util/mcoa_util_test.go
+++ b/operators/multiclusterobservability/pkg/util/mcoa_util_test.go
@@ -168,3 +168,164 @@ func TestHasMCOAManifestWorks(t *testing.T) {
 		assert.Contains(t, blocking, "test-cluster")
 	})
 }
+
+func TestHasRemainingMCOAResources(t *testing.T) {
+	s := scheme.Scheme
+	_ = addonv1beta1.Install(s)
+	_ = clusterv1.Install(s)
+	_ = workv1.Install(s)
+
+	t.Run("returns blocking namespaces when healthy cluster has ManifestWork with PrometheusAgent", func(t *testing.T) {
+		mw := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "addon-multicluster-observability-addon-deploy-0",
+				Namespace: "healthy-cluster",
+				Labels: map[string]string{
+					addonv1beta1.AddonLabelKey: config.MultiClusterObservabilityAddon,
+				},
+			},
+			Spec: workv1.ManifestWorkSpec{
+				Workload: workv1.ManifestsTemplate{
+					Manifests: []workv1.Manifest{prometheusAgentManifest()},
+				},
+			},
+		}
+		mc := &clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "healthy-cluster",
+			},
+			Status: clusterv1.ManagedClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   clusterv1.ManagedClusterConditionAvailable,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mw, mc).Build()
+		blocking, err := HasRemainingMCOAResources(context.Background(), cl)
+		assert.NoError(t, err)
+		assert.Contains(t, blocking, "healthy-cluster")
+	})
+
+	t.Run("RS-only ManifestWorks (PrometheusRule) block teardown until completely removed", func(t *testing.T) {
+		mw := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "addon-multicluster-observability-addon-deploy-0",
+				Namespace: "healthy-cluster",
+				Labels: map[string]string{
+					addonv1beta1.AddonLabelKey: config.MultiClusterObservabilityAddon,
+				},
+			},
+			Spec: workv1.ManifestWorkSpec{
+				Workload: workv1.ManifestsTemplate{
+					Manifests: []workv1.Manifest{prometheusRuleManifest()},
+				},
+			},
+		}
+		mc := &clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "healthy-cluster",
+			},
+			Status: clusterv1.ManagedClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   clusterv1.ManagedClusterConditionAvailable,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mw, mc).Build()
+		blocking, err := HasRemainingMCOAResources(context.Background(), cl)
+		assert.NoError(t, err)
+		assert.Contains(t, blocking, "healthy-cluster", "RS-only ManifestWorks must block MCOA manager undeployment during cleanup")
+	})
+
+	t.Run("ManagedClusterAddOn blocks teardown even when ManifestWork is deleted", func(t *testing.T) {
+		mca := &addonv1beta1.ManagedClusterAddOn{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      config.MultiClusterObservabilityAddon,
+				Namespace: "healthy-cluster",
+			},
+		}
+		mc := &clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "healthy-cluster",
+			},
+			Status: clusterv1.ManagedClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   clusterv1.ManagedClusterConditionAvailable,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mca, mc).Build()
+		blocking, err := HasRemainingMCOAResources(context.Background(), cl)
+		assert.NoError(t, err)
+		assert.Contains(t, blocking, "healthy-cluster", "ManagedClusterAddOn must block MCOA manager undeployment so pre-delete hooks can finish")
+	})
+
+	t.Run("returns empty slice when ManifestWork and ManagedClusterAddOn are in a disconnected/offline cluster", func(t *testing.T) {
+		mw := &workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "addon-multicluster-observability-addon-deploy-0",
+				Namespace: "offline-cluster",
+				Labels: map[string]string{
+					addonv1beta1.AddonLabelKey: config.MultiClusterObservabilityAddon,
+				},
+			},
+		}
+		mca := &addonv1beta1.ManagedClusterAddOn{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      config.MultiClusterObservabilityAddon,
+				Namespace: "offline-cluster",
+			},
+		}
+		mc := &clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "offline-cluster",
+			},
+			Status: clusterv1.ManagedClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   clusterv1.ManagedClusterConditionAvailable,
+						Status: metav1.ConditionFalse,
+					},
+				},
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mw, mca, mc).Build()
+		blocking, err := HasRemainingMCOAResources(context.Background(), cl)
+		assert.NoError(t, err)
+		assert.Empty(t, blocking)
+	})
+
+	t.Run("returns empty slice when all ManifestWorks and ManagedClusterAddOns are gone", func(t *testing.T) {
+		mc := &clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "healthy-cluster",
+			},
+			Status: clusterv1.ManagedClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   clusterv1.ManagedClusterConditionAvailable,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mc).Build()
+		blocking, err := HasRemainingMCOAResources(context.Background(), cl)
+		assert.NoError(t, err)
+		assert.Empty(t, blocking)
+	})
+}

--- a/tests/pkg/tests/observability_config_test.go
+++ b/tests/pkg/tests/observability_config_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/kustomize"
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 )
 
@@ -406,28 +407,31 @@ var _ = Describe("", func() {
 				return false
 			}, EventuallyTimeoutMinute*2, EventuallyIntervalSecond*10).Should(BeTrue())
 
-			mcoRes, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).
-				Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
-			if err != nil {
-				panic(err.Error())
-			}
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				mcoRes, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+					Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
 
-			// Update the MCO CR to change the log level for thanos-compact
-			spec := mcoRes.Object["spec"].(map[string]any)
-			advancedSpec, _ := spec["advanced"].(map[string]any)
-			if containers, ok := advancedSpec["compact"].(map[string]any)["containers"].([]any); ok {
-				if args, ok := containers[0].(map[string]any)["args"].([]any); ok {
-					for i, arg := range args {
-						if strings.HasPrefix(arg.(string), "--log.level=") {
-							args[i] = "--log.level=info"
-							break
+				// Update the MCO CR to change the log level for thanos-compact
+				spec := mcoRes.Object["spec"].(map[string]any)
+				advancedSpec, _ := spec["advanced"].(map[string]any)
+				if containers, ok := advancedSpec["compact"].(map[string]any)["containers"].([]any); ok {
+					if args, ok := containers[0].(map[string]any)["args"].([]any); ok {
+						for i, arg := range args {
+							if strings.HasPrefix(arg.(string), "--log.level=") {
+								args[i] = "--log.level=info"
+								break
+							}
 						}
 					}
 				}
-			}
 
-			_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
-				Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+				_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+					Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+				return err
+			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Check the value is effect in the sts observability-thanos-compact")
@@ -480,29 +484,34 @@ var _ = Describe("", func() {
 		"ACM-34594: Observability: Verify Thanos Compact debug tuning in MCO CR - [P2][Sev2][Observability][Integration]@ocpInterop @non-ui-post-restore @non-ui-post-release @non-ui-pre-upgrade @non-ui-post-upgrade @post-upgrade @post-restore @e2e @post-release (config/g0)",
 		func() {
 			By("Updating MCO CR with compact debug settings")
-			mcoRes, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).
-				Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				mcoRes, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+					Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
 
-			spec := mcoRes.Object["spec"].(map[string]any)
-			advancedSpec, ok := spec["advanced"].(map[string]any)
-			if !ok {
-				Skip("Skip the case since the MCO CR did not have advanced spec configured")
-			}
-			compactSpec, ok := advancedSpec["compact"].(map[string]any)
-			if !ok {
-				compactSpec = map[string]any{}
-				advancedSpec["compact"] = compactSpec
-			}
-			compactSpec["debug"] = map[string]any{
-				"logLevel":                  "debug",
-				"waitInterval":              "5m",
-				"blockMetaFetchConcurrency": int64(64),
-				"downsampleConcurrency":     int64(4),
-			}
+				spec := mcoRes.Object["spec"].(map[string]any)
+				advancedSpec, ok := spec["advanced"].(map[string]any)
+				if !ok {
+					Skip("Skip the case since the MCO CR did not have advanced spec configured")
+				}
+				compactSpec, ok := advancedSpec["compact"].(map[string]any)
+				if !ok {
+					compactSpec = map[string]any{}
+					advancedSpec["compact"] = compactSpec
+				}
+				compactSpec["debug"] = map[string]any{
+					"logLevel":                  "debug",
+					"waitInterval":              "5m",
+					"blockMetaFetchConcurrency": int64(64),
+					"downsampleConcurrency":     int64(4),
+				}
 
-			_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
-				Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+				_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+					Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+				return err
+			})
 			Expect(err).NotTo(HaveOccurred())
 
 			expectedCompactDebugArgs := []string{
@@ -536,20 +545,25 @@ var _ = Describe("", func() {
 			}, EventuallyTimeoutMinute*2, EventuallyIntervalSecond*10).Should(Succeed())
 
 			By("Updating wait interval above 5m adds web disable flag")
-			mcoRes, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
-				Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				mcoRes, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+					Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
 
-			spec = mcoRes.Object["spec"].(map[string]any)
-			advancedSpec = spec["advanced"].(map[string]any)
-			compactSpec = advancedSpec["compact"].(map[string]any)
-			compactSpec["debug"] = map[string]any{
-				"waitInterval":              "10m",
-				"blockMetaFetchConcurrency": int64(32),
-			}
+				spec := mcoRes.Object["spec"].(map[string]any)
+				advancedSpec := spec["advanced"].(map[string]any)
+				compactSpec := advancedSpec["compact"].(map[string]any)
+				compactSpec["debug"] = map[string]any{
+					"waitInterval":              "10m",
+					"blockMetaFetchConcurrency": int64(32),
+				}
 
-			_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
-				Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+				_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+					Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+				return err
+			})
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func() error {
@@ -581,26 +595,31 @@ var _ = Describe("", func() {
 		"Observability: Verify Thanos Receive debug tuning in MCO CR - [P2][Sev2][Observability][Integration]@ocpInterop @non-ui-post-restore @non-ui-post-release @non-ui-pre-upgrade @non-ui-post-upgrade @post-upgrade @post-restore @e2e @post-release (config/g0)",
 		func() {
 			By("Updating MCO CR with receive debug settings")
-			mcoRes, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).
-				Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				mcoRes, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+					Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
 
-			spec := mcoRes.Object["spec"].(map[string]any)
-			advancedSpec, ok := spec["advanced"].(map[string]any)
-			if !ok {
-				Skip("Skip the case since the MCO CR did not have advanced spec configured")
-			}
-			receiveSpec, ok := advancedSpec["receive"].(map[string]any)
-			if !ok {
-				receiveSpec = map[string]any{}
-				advancedSpec["receive"] = receiveSpec
-			}
-			receiveSpec["debug"] = map[string]any{
-				"logLevel": "debug",
-			}
+				spec := mcoRes.Object["spec"].(map[string]any)
+				advancedSpec, ok := spec["advanced"].(map[string]any)
+				if !ok {
+					Skip("Skip the case since the MCO CR did not have advanced spec configured")
+				}
+				receiveSpec, ok := advancedSpec["receive"].(map[string]any)
+				if !ok {
+					receiveSpec = map[string]any{}
+					advancedSpec["receive"] = receiveSpec
+				}
+				receiveSpec["debug"] = map[string]any{
+					"logLevel": "debug",
+				}
 
-			_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
-				Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+				_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+					Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+				return err
+			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking receive logLevel is set on Observatorium CR")
@@ -629,19 +648,31 @@ var _ = Describe("", func() {
 			}, EventuallyTimeoutMinute*2, EventuallyIntervalSecond*10).Should(Succeed())
 
 			By("Updating receive debug log level to info")
-			mcoRes, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
-				Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				mcoRes, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+					Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
 
-			spec = mcoRes.Object["spec"].(map[string]any)
-			advancedSpec = spec["advanced"].(map[string]any)
-			receiveSpec = advancedSpec["receive"].(map[string]any)
-			receiveSpec["debug"] = map[string]any{
-				"logLevel": "info",
-			}
+				spec := mcoRes.Object["spec"].(map[string]any)
+				advancedSpec, ok := spec["advanced"].(map[string]any)
+				if !ok {
+					return fmt.Errorf("spec.advanced is not a map")
+				}
+				receiveSpec, ok := advancedSpec["receive"].(map[string]any)
+				if !ok {
+					receiveSpec = map[string]any{}
+					advancedSpec["receive"] = receiveSpec
+				}
+				receiveSpec["debug"] = map[string]any{
+					"logLevel": "info",
+				}
 
-			_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
-				Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+				_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+					Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+				return err
+			})
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func() error {
@@ -712,20 +743,25 @@ var _ = Describe("", func() {
 			}, EventuallyTimeoutMinute*1, EventuallyIntervalSecond*10).Should(Succeed())
 
 			By("Setting both queryTimeout and writeTimeout in MCO CR")
-			mcoRes, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).
-				Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				mcoRes, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+					Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
 
-			spec := mcoRes.Object["spec"].(map[string]any)
-			advancedSpec, ok := spec["advanced"].(map[string]any)
-			if !ok {
-				Skip("Skip the case since the MCO CR did not have advanced spec configured")
-			}
-			advancedSpec["queryTimeout"] = "10m"
-			advancedSpec["writeTimeout"] = "15m"
+				spec := mcoRes.Object["spec"].(map[string]any)
+				advancedSpec, ok := spec["advanced"].(map[string]any)
+				if !ok {
+					Skip("Skip the case since the MCO CR did not have advanced spec configured")
+				}
+				advancedSpec["queryTimeout"] = "10m"
+				advancedSpec["writeTimeout"] = "15m"
 
-			_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
-				Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+				_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+					Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+				return err
+			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking Observatorium CR carries both timeout values")
@@ -773,17 +809,23 @@ var _ = Describe("", func() {
 			}, EventuallyTimeoutMinute*2, EventuallyIntervalSecond*10).Should(Succeed())
 
 			By("Reverting MCO CR timeouts to defaults")
-			mcoRes, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
-				Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				mcoRes, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+					Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
 
-			spec = mcoRes.Object["spec"].(map[string]any)
-			advancedSpec = spec["advanced"].(map[string]any)
-			delete(advancedSpec, "queryTimeout")
-			delete(advancedSpec, "writeTimeout")
+				spec := mcoRes.Object["spec"].(map[string]any)
+				if advancedSpec, ok := spec["advanced"].(map[string]any); ok {
+					delete(advancedSpec, "queryTimeout")
+					delete(advancedSpec, "writeTimeout")
+				}
 
-			_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
-				Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+				_, err = dynClient.Resource(utils.NewMCOGVRV1BETA2()).
+					Update(context.TODO(), mcoRes, metav1.UpdateOptions{})
+				return err
+			})
 			Expect(err).NotTo(HaveOccurred())
 		},
 	)

--- a/tests/pkg/tests/observability_install_test.go
+++ b/tests/pkg/tests/observability_install_test.go
@@ -27,7 +27,7 @@ const mcoOperatorCrashLoopThreshold = 5
 // stopIfCrashLooping returns a StopTrying error when any pod in the observability
 // namespace or the MCO operator pod has exceeded the restart threshold, causing Gomega
 // to abort the Eventually immediately instead of waiting for the full install timeout.
-// Transient list errors are ignored so the caller keeps retrying.
+// Kubernetes API errors are returned so the caller's Eventually retries the full check.
 func stopIfCrashLooping(ctx context.Context, hubClient kubernetes.Interface) error {
 	checks := []struct {
 		namespace     string
@@ -41,10 +41,10 @@ func stopIfCrashLooping(ctx context.Context, hubClient kubernetes.Interface) err
 	for _, c := range checks {
 		pods, err := hubClient.CoreV1().Pods(c.namespace).List(ctx, metav1.ListOptions{LabelSelector: c.labelSelector})
 		if err != nil {
-			continue
+			return fmt.Errorf("listing pods in namespace %q with selector %q: %w", c.namespace, c.labelSelector, err)
 		}
 		for _, pod := range pods.Items {
-			for _, cs := range pod.Status.ContainerStatuses {
+			for _, cs := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
 				if cs.RestartCount > mcoOperatorCrashLoopThreshold {
 					return StopTrying(fmt.Sprintf(
 						"pod %s container %s has restarted %d times, aborting install wait",

--- a/tests/pkg/tests/observability_install_test.go
+++ b/tests/pkg/tests/observability_install_test.go
@@ -15,8 +15,47 @@ import (
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/kustomize"
 	"github.com/stolostron/multicluster-observability-operator/tests/pkg/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 )
+
+// mcoOperatorCrashLoopThreshold is how many container restarts we tolerate before
+// declaring the operator permanently broken. A few initial restarts are expected while
+// dependent resources (secrets, CRDs) finish being created.
+const mcoOperatorCrashLoopThreshold = 5
+
+// stopIfCrashLooping returns a StopTrying error when any pod in the observability
+// namespace or the MCO operator pod has exceeded the restart threshold, causing Gomega
+// to abort the Eventually immediately instead of waiting for the full install timeout.
+// Transient list errors are ignored so the caller keeps retrying.
+func stopIfCrashLooping(ctx context.Context, hubClient kubernetes.Interface) error {
+	checks := []struct {
+		namespace     string
+		labelSelector string
+	}{
+		// All stack components (Thanos, Alertmanager, Grafana, …)
+		{MCO_NAMESPACE, ""},
+		// MCO operator itself runs in a different namespace
+		{"", MCO_LABEL},
+	}
+	for _, c := range checks {
+		pods, err := hubClient.CoreV1().Pods(c.namespace).List(ctx, metav1.ListOptions{LabelSelector: c.labelSelector})
+		if err != nil {
+			continue
+		}
+		for _, pod := range pods.Items {
+			for _, cs := range pod.Status.ContainerStatuses {
+				if cs.RestartCount > mcoOperatorCrashLoopThreshold {
+					return StopTrying(fmt.Sprintf(
+						"pod %s container %s has restarted %d times, aborting install wait",
+						pod.Name, cs.Name, cs.RestartCount,
+					))
+				}
+			}
+		}
+	}
+	return nil
+}
 
 func installMCO() {
 	if os.Getenv("SKIP_INSTALL_STEP") == trueStr {
@@ -157,6 +196,9 @@ func installMCO() {
 	}()
 	By("Waiting for MCO ready status")
 	Eventually(func() error {
+		if err := stopIfCrashLooping(context.Background(), hubClient); err != nil {
+			return err
+		}
 		err = utils.CheckMCOStatusCondition(context.Background(), testOptions, "Ready", metav1.ConditionTrue, "Ready")
 		if err != nil {
 			testFailed = true
@@ -167,7 +209,7 @@ func installMCO() {
 		testFailed = false
 		mcoTestFailed = false
 		return nil
-	}, EventuallyTimeoutMinute*15, EventuallyIntervalSecond*20).Should(Succeed())
+	}, EventuallyTimeoutMinute*30, EventuallyIntervalSecond*20).Should(Succeed())
 
 	obaTestFailed := false
 	defer func() {
@@ -180,6 +222,9 @@ func installMCO() {
 	}()
 	By("Check endpoint-operator and metrics-collector pods are ready")
 	Eventually(func() error {
+		if err := stopIfCrashLooping(context.Background(), hubClient); err != nil {
+			return err
+		}
 		err = utils.CheckAllOBAsEnabled(testOptions)
 		if err != nil {
 			obaTestFailed = true
@@ -190,7 +235,7 @@ func installMCO() {
 		obaTestFailed = false
 		testFailed = false
 		return nil
-	}, EventuallyTimeoutMinute*15, EventuallyIntervalSecond*20).Should(Succeed())
+	}, EventuallyTimeoutMinute*30, EventuallyIntervalSecond*20).Should(Succeed())
 
 	By("Check clustermanagementaddon CR is created")
 	Eventually(func() error {

--- a/tests/pkg/tests/observability_install_test.go
+++ b/tests/pkg/tests/observability_install_test.go
@@ -25,8 +25,9 @@ import (
 const mcoOperatorCrashLoopThreshold = 5
 
 // stopIfCrashLooping returns a StopTrying error when any pod in the observability
-// namespace or the MCO operator pod has exceeded the restart threshold, causing Gomega
-// to abort the Eventually immediately instead of waiting for the full install timeout.
+// namespace or the MCO operator pod has exceeded the restart threshold and is not ready
+// or terminated with success, causing Gomega to abort the Eventually immediately instead
+// of waiting for the full install timeout.
 // Kubernetes API errors are returned so the caller's Eventually retries the full check.
 func stopIfCrashLooping(ctx context.Context, hubClient kubernetes.Interface) error {
 	checks := []struct {
@@ -44,7 +45,23 @@ func stopIfCrashLooping(ctx context.Context, hubClient kubernetes.Interface) err
 			return fmt.Errorf("listing pods in namespace %q with selector %q: %w", c.namespace, c.labelSelector, err)
 		}
 		for _, pod := range pods.Items {
-			for _, cs := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+			for _, cs := range pod.Status.InitContainerStatuses {
+				// Skip containers that completed successfully or are currently ready.
+				if (cs.State.Terminated != nil && cs.State.Terminated.ExitCode == 0) || cs.Ready {
+					continue
+				}
+				if cs.RestartCount > mcoOperatorCrashLoopThreshold {
+					return StopTrying(fmt.Sprintf(
+						"pod %s init container %s has restarted %d times, aborting install wait",
+						pod.Name, cs.Name, cs.RestartCount,
+					))
+				}
+			}
+			for _, cs := range pod.Status.ContainerStatuses {
+				// Skip containers that completed successfully or are currently ready.
+				if (cs.State.Terminated != nil && cs.State.Terminated.ExitCode == 0) || cs.Ready {
+					continue
+				}
 				if cs.RestartCount > mcoOperatorCrashLoopThreshold {
 					return StopTrying(fmt.Sprintf(
 						"pod %s container %s has restarted %d times, aborting install wait",

--- a/tests/pkg/tests/observability_mcoa_test.go
+++ b/tests/pkg/tests/observability_mcoa_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 	var accessibleOCPClusters []utils.Cluster
 	// var ocpClustersWithHub []utils.Cluster
 
-	BeforeAll(func() {
+	BeforeAll(func(ctx context.Context) {
 		By("Getting available managed clusters")
 		var err error
 		managedClusters, err = utils.GetAvailableManagedClustersAsClusters(testOptions)
@@ -88,7 +88,7 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 		})
 		By("Deleting COO subscription if it exists and CRDs", func() {
 			utils.DeleteCOOSubscription(accessibleOCPClusters)
-			Expect(utils.DeleteMonitoringCRDs(testOptions, accessibleOCPClusters)).NotTo(HaveOccurred())
+			Expect(utils.DeleteMonitoringCRDs(ctx, accessibleOCPClusters)).NotTo(HaveOccurred())
 		})
 	})
 
@@ -447,7 +447,7 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 	// 		})
 	// 		By("Deleting COO subscription", func() {
 	// 			utils.DeleteCOOSubscription(onlyTheHub)
-	// 			Expect(utils.DeleteMonitoringCRDs(testOptions, onlyTheHub)).NotTo(HaveOccurred())
+	// 			Expect(utils.DeleteMonitoringCRDs(context.Background(), onlyTheHub)).NotTo(HaveOccurred())
 	// 		})
 	// 	})
 	// })
@@ -730,7 +730,7 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 				// 	Expect(utils.CreateCOOSubscription(onlyTheHub)).NotTo(HaveOccurred())
 				// 	DeferCleanup(func(ctx SpecContext) {
 				// 		utils.DeleteCOOSubscription(onlyTheHub)
-				// 		Expect(utils.DeleteMonitoringCRDs(testOptions, onlyTheHub)).NotTo(HaveOccurred())
+				// 		Expect(utils.DeleteMonitoringCRDs(ctx, onlyTheHub)).NotTo(HaveOccurred())
 				// 	})
 				// 	// Wait for COO to be running
 				// 	utils.CheckCOODeployment(onlyTheHub)

--- a/tests/pkg/tests/observability_mcoa_test.go
+++ b/tests/pkg/tests/observability_mcoa_test.go
@@ -85,6 +85,8 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 			// Wait for the MCOA manager to go away so endpoint-operator CRD self-heal
 			// is less likely to race with the explicit CRD cleanup below.
 			utils.CheckDeploymentAvailability(testOptions.HubCluster, mcoaManagerDeploymentName, utils.MCO_NAMESPACE, false)
+			utils.CheckClusterManagementAddonDeleted(testOptions, utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME)
+			utils.CheckManagedClusterAddonDeleted(testOptions, utils.MCOA_CLUSTER_MANAGEMENT_ADDON_NAME)
 		})
 		By("Deleting COO subscription if it exists and CRDs", func() {
 			Expect(utils.DeleteCOOSubscription(accessibleOCPClusters)).NotTo(HaveOccurred())

--- a/tests/pkg/tests/observability_mcoa_test.go
+++ b/tests/pkg/tests/observability_mcoa_test.go
@@ -80,14 +80,14 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 		By(fmt.Sprintf("Running tests against the following OCP managed clusters with API access: %v", accessibleOCPClusterNames))
 
 		By("Disabling MCOA", func() {
-			Expect(utils.SetMCOACapabilities(testOptions, false, false)).NotTo(HaveOccurred())
+			Expect(utils.ResetMCOACapabilities(testOptions)).NotTo(HaveOccurred())
 			utils.CheckStatefulSetAvailabilityOnClusters(managedClustersWithHub, platformPrometheusAgentStatefulSetName, utils.MCO_AGENT_ADDON_NAMESPACE, false)
 			// Wait for the MCOA manager to go away so endpoint-operator CRD self-heal
 			// is less likely to race with the explicit CRD cleanup below.
 			utils.CheckDeploymentAvailability(testOptions.HubCluster, mcoaManagerDeploymentName, utils.MCO_NAMESPACE, false)
 		})
 		By("Deleting COO subscription if it exists and CRDs", func() {
-			utils.DeleteCOOSubscription(accessibleOCPClusters)
+			Expect(utils.DeleteCOOSubscription(accessibleOCPClusters)).NotTo(HaveOccurred())
 			Expect(utils.DeleteMonitoringCRDs(ctx, accessibleOCPClusters)).NotTo(HaveOccurred())
 		})
 	})
@@ -1166,7 +1166,7 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 
 	AfterAll(func() {
 		By("Disabling MCOA", func() {
-			Expect(utils.SetMCOACapabilities(testOptions, false, false)).NotTo(HaveOccurred())
+			Expect(utils.ResetMCOACapabilities(testOptions)).NotTo(HaveOccurred())
 			utils.CheckStatefulSetAvailabilityOnClusters(managedClustersWithHub, platformPrometheusAgentStatefulSetName, utils.MCO_AGENT_ADDON_NAMESPACE, false)
 			utils.CheckDeploymentAvailability(testOptions.HubCluster, mcoaManagerDeploymentName, utils.MCO_NAMESPACE, false)
 

--- a/tests/pkg/utils/clustermanagementaddon.go
+++ b/tests/pkg/utils/clustermanagementaddon.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -303,4 +304,19 @@ func RemoveConfigFromPlacementInClusterManagementAddon(
 
 		return nil
 	})
+}
+
+// CheckClusterManagementAddonDeleted waits for the ClusterManagementAddon to be deleted.
+func CheckClusterManagementAddonDeleted(opt TestOptions, name string) {
+	clientDynamic := GetKubeClientDynamic(opt, true)
+	gomega.Eventually(func() error {
+		_, err := clientDynamic.Resource(clusterManagementAddonGVR).Get(context.TODO(), name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("ClusterManagementAddon %s still exists", name)
+	}, 300, 5).Should(gomega.Succeed())
 }

--- a/tests/pkg/utils/kube_debug.go
+++ b/tests/pkg/utils/kube_debug.go
@@ -580,6 +580,7 @@ func printManifestWorks(client dynamic.Interface) {
 
 		if isLegacy || isMCOA {
 			obj.SetManagedFields(nil)
+			unstructured.RemoveNestedField(obj.Object, "spec", "workload")
 			filtered = append(filtered, obj)
 		}
 	}

--- a/tests/pkg/utils/mco_addon.go
+++ b/tests/pkg/utils/mco_addon.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -85,4 +86,25 @@ func GetManagedClusterAddon(opt TestOptions, name, namespace string) (*addonv1be
 	}
 
 	return mca, nil
+}
+
+// CheckManagedClusterAddonDeleted checks that the ManagedClusterAddon is removed from all managed clusters.
+func CheckManagedClusterAddonDeleted(opt TestOptions, name string) {
+	gomega.Eventually(func() error {
+		managedClusters, err := GetAvailableManagedClusters(opt)
+		if err != nil {
+			return err
+		}
+
+		for _, cluster := range managedClusters {
+			_, err := GetManagedClusterAddon(opt, name, cluster.Name)
+			if err == nil {
+				return fmt.Errorf("ManagedClusterAddon %s on cluster %s still exists", name, cluster.Name)
+			}
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+		return nil
+	}, 300, 5).Should(gomega.Succeed())
 }

--- a/tests/pkg/utils/mco_crd.go
+++ b/tests/pkg/utils/mco_crd.go
@@ -11,6 +11,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
@@ -26,20 +27,55 @@ const (
 func DeleteMonitoringCRDs(opt TestOptions, clusters []Cluster) error {
 	for _, cluster := range clusters {
 		apiExtensionsClient := NewKubeClientAPIExtension(cluster.ClusterServerURL, cluster.KubeConfig, cluster.KubeContext)
+		dynClient := GetKubeClientDynamicWithCluster(cluster)
 
 		crds, err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
 
-		var crdsToDelete []string
 		for _, crd := range crds.Items {
-			if crd.Spec.Group == "monitoring.rhobs" {
-				err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), crd.Name, metav1.DeleteOptions{})
-				if err != nil && !errors.IsNotFound(err) {
-					return err
+			if crd.Spec.Group != "monitoring.rhobs" {
+				continue
+			}
+
+			// Find the storage version to build a valid GVR.
+			version := ""
+			for _, v := range crd.Spec.Versions {
+				if v.Storage {
+					version = v.Name
+					break
 				}
-				crdsToDelete = append(crdsToDelete, crd.Name)
+			}
+			if version == "" {
+				continue
+			}
+
+			gvr := schema.GroupVersionResource{
+				Group:    crd.Spec.Group,
+				Version:  version,
+				Resource: crd.Spec.Names.Plural,
+			}
+
+			// Delete all instances explicitly so that GC does not block CRD deletion.
+			// metav1.NamespaceAll ("") works for both namespaced and cluster-scoped resources.
+			instances, listErr := dynClient.Resource(gvr).Namespace(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+			if listErr != nil && !errors.IsNotFound(listErr) {
+				klog.Warningf("Failed to list instances of %s on cluster %s: %v", crd.Name, cluster.Name, listErr)
+			} else if instances != nil {
+				for i := range instances.Items {
+					inst := &instances.Items[i]
+					klog.Infof("Deleting %s/%s on cluster %s", crd.Name, inst.GetName(), cluster.Name)
+					delErr := dynClient.Resource(gvr).Namespace(inst.GetNamespace()).Delete(context.TODO(), inst.GetName(), metav1.DeleteOptions{})
+					if delErr != nil && !errors.IsNotFound(delErr) {
+						klog.Warningf("Failed to delete %s/%s on cluster %s: %v", crd.Name, inst.GetName(), cluster.Name, delErr)
+					}
+				}
+			}
+
+			klog.Infof("Deleting CRD %s on cluster %s", crd.Name, cluster.Name)
+			if err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), crd.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+				return err
 			}
 		}
 
@@ -65,10 +101,16 @@ func DeleteMonitoringCRDs(opt TestOptions, clusters []Cluster) error {
 					return true, nil
 				}
 				return false, nil
-			})
-			if err != nil {
-				return fmt.Errorf("failed to wait for CRD %s to be deleted on cluster %s: %w", crdName, cluster.Name, err)
 			}
+			for _, crd := range remaining.Items {
+				if crd.Spec.Group == "monitoring.rhobs" {
+					return false, nil
+				}
+			}
+			return true, nil
+		})
+		if err != nil {
+			return fmt.Errorf("timed out waiting for monitoring.rhobs CRDs to be deleted on cluster %s: %w", cluster.Name, err)
 		}
 	}
 

--- a/tests/pkg/utils/mco_crd.go
+++ b/tests/pkg/utils/mco_crd.go
@@ -11,7 +11,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
@@ -27,57 +26,20 @@ const (
 func DeleteMonitoringCRDs(ctx context.Context, clusters []Cluster) error {
 	for _, cluster := range clusters {
 		apiExtensionsClient := NewKubeClientAPIExtension(cluster.ClusterServerURL, cluster.KubeConfig, cluster.KubeContext)
-		dynClient := GetKubeClientDynamicWithCluster(cluster)
 
-		crds, err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
+		crds, err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
 
+		var crdsToDelete []string
 		for _, crd := range crds.Items {
-			if crd.Spec.Group != "monitoring.rhobs" {
-				continue
-			}
-
-			// Find the storage version to build a valid GVR.
-			version := ""
-			for _, v := range crd.Spec.Versions {
-				if v.Storage {
-					version = v.Name
-					break
+			if crd.Spec.Group == "monitoring.rhobs" {
+				err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), crd.Name, metav1.DeleteOptions{})
+				if err != nil && !errors.IsNotFound(err) {
+					return err
 				}
-			}
-			if version == "" {
-				continue
-			}
-
-			gvr := schema.GroupVersionResource{
-				Group:    crd.Spec.Group,
-				Version:  version,
-				Resource: crd.Spec.Names.Plural,
-			}
-
-			// Delete all instances explicitly so that GC does not block CRD deletion.
-			// metav1.NamespaceAll ("") works for both namespaced and cluster-scoped resources.
-			instances, listErr := dynClient.Resource(gvr).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
-			if listErr != nil {
-				if !errors.IsNotFound(listErr) {
-					klog.Warningf("Failed to list instances of %s on cluster %s: %v", crd.Name, cluster.Name, listErr)
-				}
-			} else if instances != nil {
-				for i := range instances.Items {
-					inst := &instances.Items[i]
-					klog.InfoS("Deleting CRD instance", "crd", crd.Name, "instance", inst.GetName(), "cluster", cluster.Name)
-					delErr := dynClient.Resource(gvr).Namespace(inst.GetNamespace()).Delete(ctx, inst.GetName(), metav1.DeleteOptions{})
-					if delErr != nil && !errors.IsNotFound(delErr) {
-						klog.Warningf("Failed to delete %s/%s on cluster %s: %v", crd.Name, inst.GetName(), cluster.Name, delErr)
-					}
-				}
-			}
-
-			klog.InfoS("Deleting CRD", "crd", crd.Name, "cluster", cluster.Name)
-			if err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Delete(ctx, crd.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-				return err
+				crdsToDelete = append(crdsToDelete, crd.Name)
 			}
 		}
 
@@ -103,16 +65,10 @@ func DeleteMonitoringCRDs(ctx context.Context, clusters []Cluster) error {
 					return true, nil
 				}
 				return false, nil
+			})
+			if err != nil {
+				return fmt.Errorf("failed to wait for CRD %s to be deleted on cluster %s: %w", crdName, cluster.Name, err)
 			}
-			for _, crd := range remaining.Items {
-				if crd.Spec.Group == "monitoring.rhobs" {
-					return false, nil
-				}
-			}
-			return true, nil
-		})
-		if err != nil {
-			return fmt.Errorf("timed out waiting for monitoring.rhobs CRDs to be deleted on cluster %s: %w", cluster.Name, err)
 		}
 	}
 

--- a/tests/pkg/utils/mco_crd.go
+++ b/tests/pkg/utils/mco_crd.go
@@ -24,12 +24,12 @@ const (
 	mcoaEndpointManagedByLabelValue = "mcoa-endpoint-operator"
 )
 
-func DeleteMonitoringCRDs(opt TestOptions, clusters []Cluster) error {
+func DeleteMonitoringCRDs(ctx context.Context, clusters []Cluster) error {
 	for _, cluster := range clusters {
 		apiExtensionsClient := NewKubeClientAPIExtension(cluster.ClusterServerURL, cluster.KubeConfig, cluster.KubeContext)
 		dynClient := GetKubeClientDynamicWithCluster(cluster)
 
-		crds, err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{})
+		crds, err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -59,22 +59,24 @@ func DeleteMonitoringCRDs(opt TestOptions, clusters []Cluster) error {
 
 			// Delete all instances explicitly so that GC does not block CRD deletion.
 			// metav1.NamespaceAll ("") works for both namespaced and cluster-scoped resources.
-			instances, listErr := dynClient.Resource(gvr).Namespace(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
-			if listErr != nil && !errors.IsNotFound(listErr) {
-				klog.Warningf("Failed to list instances of %s on cluster %s: %v", crd.Name, cluster.Name, listErr)
+			instances, listErr := dynClient.Resource(gvr).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+			if listErr != nil {
+				if !errors.IsNotFound(listErr) {
+					klog.Warningf("Failed to list instances of %s on cluster %s: %v", crd.Name, cluster.Name, listErr)
+				}
 			} else if instances != nil {
 				for i := range instances.Items {
 					inst := &instances.Items[i]
-					klog.Infof("Deleting %s/%s on cluster %s", crd.Name, inst.GetName(), cluster.Name)
-					delErr := dynClient.Resource(gvr).Namespace(inst.GetNamespace()).Delete(context.TODO(), inst.GetName(), metav1.DeleteOptions{})
+					klog.InfoS("Deleting CRD instance", "crd", crd.Name, "instance", inst.GetName(), "cluster", cluster.Name)
+					delErr := dynClient.Resource(gvr).Namespace(inst.GetNamespace()).Delete(ctx, inst.GetName(), metav1.DeleteOptions{})
 					if delErr != nil && !errors.IsNotFound(delErr) {
 						klog.Warningf("Failed to delete %s/%s on cluster %s: %v", crd.Name, inst.GetName(), cluster.Name, delErr)
 					}
 				}
 			}
 
-			klog.Infof("Deleting CRD %s on cluster %s", crd.Name, cluster.Name)
-			if err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), crd.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			klog.InfoS("Deleting CRD", "crd", crd.Name, "cluster", cluster.Name)
+			if err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Delete(ctx, crd.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
 				return err
 			}
 		}

--- a/tests/pkg/utils/mco_deploy.go
+++ b/tests/pkg/utils/mco_deploy.go
@@ -773,9 +773,10 @@ func SetMCOAAllCapabilities(opt TestOptions, platformMetrics, platformAlerts, us
 	})
 }
 
-// ResetMCOACapabilities completely removes the spec.capabilities block from the MCO CR,
-// ensuring that other capabilities (such as analytics/right-sizing, logs, or traces)
-// do not linger and keep MCOA or the addon manager alive.
+// ResetMCOACapabilities explicitly disables all MCOA capabilities (metrics, alerts,
+// right-sizing/analytics, logs, and traces) in the MCO CR.
+// Setting right-sizing flags to false rather than removing them prevents
+// the analytics controller from re-defaulting them to true (fresh-install behavior).
 func ResetMCOACapabilities(opt TestOptions) error {
 	clientDynamic := NewKubeClientDynamic(
 		opt.HubCluster.ClusterServerURL,
@@ -788,7 +789,36 @@ func ResetMCOACapabilities(opt TestOptions) error {
 			return getErr
 		}
 
-		unstructured.RemoveNestedField(mco.Object, "spec", "capabilities")
+		if err := setRSEnabled(mco, false); err != nil {
+			return err
+		}
+		if err := unstructured.SetNestedField(mco.Object, false, "spec", "capabilities", "platform", "metrics", "default", "enabled"); err != nil {
+			return err
+		}
+		if err := unstructured.SetNestedField(mco.Object, false, "spec", "capabilities", "platform", "metrics", "alerts", "enabled"); err != nil {
+			return err
+		}
+		if err := unstructured.SetNestedField(mco.Object, false, "spec", "capabilities", "platform", "logs", "collection", "enabled"); err != nil {
+			return err
+		}
+		if err := unstructured.SetNestedField(mco.Object, false, "spec", "capabilities", "platform", "analytics", "incidentDetection", "enabled"); err != nil {
+			return err
+		}
+		if err := unstructured.SetNestedField(mco.Object, false, "spec", "capabilities", "userWorkloads", "metrics", "default", "enabled"); err != nil {
+			return err
+		}
+		if err := unstructured.SetNestedField(mco.Object, false, "spec", "capabilities", "userWorkloads", "metrics", "alerts", "enabled"); err != nil {
+			return err
+		}
+		if err := unstructured.SetNestedField(mco.Object, false, "spec", "capabilities", "userWorkloads", "traces", "collection", "collector", "enabled"); err != nil {
+			return err
+		}
+		if err := unstructured.SetNestedField(mco.Object, false, "spec", "capabilities", "userWorkloads", "traces", "collection", "instrumentation", "enabled"); err != nil {
+			return err
+		}
+		if err := unstructured.SetNestedField(mco.Object, false, "spec", "capabilities", "userWorkloads", "logs", "collection", "clusterLogForwarder", "enabled"); err != nil {
+			return err
+		}
 
 		_, updateErr := clientDynamic.Resource(NewMCOGVRV1BETA2()).Update(context.TODO(), mco, metav1.UpdateOptions{})
 		return updateErr

--- a/tests/pkg/utils/mco_deploy.go
+++ b/tests/pkg/utils/mco_deploy.go
@@ -773,6 +773,28 @@ func SetMCOAAllCapabilities(opt TestOptions, platformMetrics, platformAlerts, us
 	})
 }
 
+// ResetMCOACapabilities completely removes the spec.capabilities block from the MCO CR,
+// ensuring that other capabilities (such as analytics/right-sizing, logs, or traces)
+// do not linger and keep MCOA or the addon manager alive.
+func ResetMCOACapabilities(opt TestOptions) error {
+	clientDynamic := NewKubeClientDynamic(
+		opt.HubCluster.ClusterServerURL,
+		opt.KubeConfig,
+		opt.HubCluster.KubeContext)
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		mco, getErr := clientDynamic.Resource(NewMCOGVRV1BETA2()).Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+
+		unstructured.RemoveNestedField(mco.Object, "spec", "capabilities")
+
+		_, updateErr := clientDynamic.Resource(NewMCOGVRV1BETA2()).Update(context.TODO(), mco, metav1.UpdateOptions{})
+		return updateErr
+	})
+}
+
 func SetNetworkPoliciesEnabled(opt TestOptions, enabled bool) error {
 	clientDynamic := NewKubeClientDynamic(
 		opt.HubCluster.ClusterServerURL,

--- a/tests/pkg/utils/mco_deploy.go
+++ b/tests/pkg/utils/mco_deploy.go
@@ -607,25 +607,24 @@ func ModifyMCOCR(opt TestOptions) error {
 		opt.HubCluster.ClusterServerURL,
 		opt.KubeConfig,
 		opt.HubCluster.KubeContext)
-	mco, getErr := clientDynamic.Resource(NewMCOGVRV1BETA2()).Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
-	if getErr != nil {
-		return getErr
-	}
-	spec := mco.Object["spec"].(map[string]any)
-	storageConfig := spec["storageConfig"].(map[string]any)
-	storageConfig["alertmanagerStorageSize"] = "3Gi"
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		mco, getErr := clientDynamic.Resource(NewMCOGVRV1BETA2()).Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		spec := mco.Object["spec"].(map[string]any)
+		storageConfig := spec["storageConfig"].(map[string]any)
+		storageConfig["alertmanagerStorageSize"] = "3Gi"
 
-	advRetentionCon, _ := CheckAdvRetentionConfig(opt)
-	if advRetentionCon {
-		retentionConfig := spec["advanced"].(map[string]any)["retentionConfig"].(map[string]any)
-		retentionConfig["retentionResolutionRaw"] = "3d"
-	}
+		advRetentionCon, _ := CheckAdvRetentionConfig(opt)
+		if advRetentionCon {
+			retentionConfig := spec["advanced"].(map[string]any)["retentionConfig"].(map[string]any)
+			retentionConfig["retentionResolutionRaw"] = "3d"
+		}
 
-	_, updateErr := clientDynamic.Resource(NewMCOGVRV1BETA2()).Update(context.TODO(), mco, metav1.UpdateOptions{})
-	if updateErr != nil {
+		_, updateErr := clientDynamic.Resource(NewMCOGVRV1BETA2()).Update(context.TODO(), mco, metav1.UpdateOptions{})
 		return updateErr
-	}
-	return nil
+	})
 }
 
 // SetLegacyAlertForwardingDisabled sets or clears the mco-disable-alerting annotation on the MCO CR.
@@ -888,19 +887,22 @@ func RevertMCOCRModification(opt TestOptions) error {
 		opt.HubCluster.ClusterServerURL,
 		opt.KubeConfig,
 		opt.HubCluster.KubeContext)
-	mco, getErr := clientDynamic.Resource(NewMCOGVRV1BETA2()).Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
-	if getErr != nil {
-		return getErr
-	}
-	spec := mco.Object["spec"].(map[string]any)
-	advRetentionCon, _ := CheckAdvRetentionConfig(opt)
-	if advRetentionCon {
-		retentionConfig := spec["advanced"].(map[string]any)["retentionConfig"].(map[string]any)
-		retentionConfig["retentionResolutionRaw"] = "6d"
-	}
-	_, updateErr := clientDynamic.Resource(NewMCOGVRV1BETA2()).Update(context.TODO(), mco, metav1.UpdateOptions{})
-	if updateErr != nil {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		mco, getErr := clientDynamic.Resource(NewMCOGVRV1BETA2()).Get(context.TODO(), MCO_CR_NAME, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		spec := mco.Object["spec"].(map[string]any)
+		advRetentionCon, _ := CheckAdvRetentionConfig(opt)
+		if advRetentionCon {
+			retentionConfig := spec["advanced"].(map[string]any)["retentionConfig"].(map[string]any)
+			retentionConfig["retentionResolutionRaw"] = "6d"
+		}
+		_, updateErr := clientDynamic.Resource(NewMCOGVRV1BETA2()).Update(context.TODO(), mco, metav1.UpdateOptions{})
 		return updateErr
+	})
+	if err != nil {
+		return err
 	}
 
 	// we delete the statefulset so it comes up again with the correct size
@@ -908,7 +910,7 @@ func RevertMCOCRModification(opt TestOptions) error {
 		opt.HubCluster.ClusterServerURL,
 		opt.KubeConfig,
 		opt.HubCluster.KubeContext)
-	err := kubeClient.AppsV1().StatefulSets(MCO_NAMESPACE).Delete(context.TODO(), "observability-alertmanager", metav1.DeleteOptions{})
+	err = kubeClient.AppsV1().StatefulSets(MCO_NAMESPACE).Delete(context.TODO(), "observability-alertmanager", metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Fixes MCOA teardown synchronization and hardens E2E test suites against timeouts and flakes:

* **MCOA Teardown Synchronization:** Waits for all spoke-side `ManifestWork`s and `ManagedClusterAddOn`s across available clusters before undeploying the MCOA manager (`HasRemainingMCOAResources`), preventing orphaned spoke resources and stuck finalizers.
* **Install Timeout & Crash-Loop Fast-Fail:** Extends MCO/OBA readiness timeouts to 30 minutes for slow environments (e.g. IBM Power) while adding a `stopIfCrashLooping` guard (>5 container restarts) to abort immediately via Gomega `StopTrying` on real regressions.
* **MCO CR Conflict Retries:** Wraps MCO CR updates in config tests and test helpers in `retry.RetryOnConflict` to resolve optimistic locking conflicts from concurrent reconciliations.
* **Capability Teardown Hardening:** Explicitly sets all MCOA capabilities to `false` on teardown to prevent the analytics controller from re-enabling them, and synchronizes CMA/MCA deletion before removing CRDs.
* **Log Noise Reduction:** Trims `spec.workload` from ManifestWorks in debug log printers.
