### PR TITLE
fix(remotewrite): preserve agent WriteRelabelConfigs during transpilation

### DIFF
--- a/operators/endpointmetrics/pkg/remotewrite/transpiler.go
+++ b/operators/endpointmetrics/pkg/remotewrite/transpiler.go
@@ -176,6 +176,12 @@ func Transpile(scrapeConfig *monitoringv1alpha1.ScrapeConfig, agent *monitoringv
 			cfg.DeepCopyInto(&relabelConfigsCopy[i])
 		}
 
+		// Append identification relabel configs from the original agent remoteWrite
+		// (e.g. cluster/clusterID label assignments) after our filtering rules.
+		for _, cfg := range agentRw.WriteRelabelConfigs {
+			relabelConfigsCopy = append(relabelConfigsCopy, *cfg.DeepCopy())
+		}
+
 		spec := &monitoringv1.RemoteWriteSpec{
 			WriteRelabelConfigs: relabelConfigsCopy,
 		}

--- a/operators/endpointmetrics/pkg/remotewrite/transpiler_test.go
+++ b/operators/endpointmetrics/pkg/remotewrite/transpiler_test.go
@@ -387,6 +387,67 @@ func TestSharedPointerCacheIsolation(t *testing.T) {
 	}
 }
 
+func TestTranspile_PreservesIdentificationRelabelConfigs(t *testing.T) {
+	scrapeConfig := &monitoringv1alpha1.ScrapeConfig{
+		Spec: monitoringv1alpha1.ScrapeConfigSpec{
+			Params: map[string][]string{
+				"match[]": {"up"},
+			},
+		},
+	}
+
+	agent := &monitoringv1alpha1.PrometheusAgent{
+		Spec: monitoringv1alpha1.PrometheusAgentSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				RemoteWrite: []monitoringv1.RemoteWriteSpec{
+					{
+						Name: ptr.To("acm-observability"),
+						URL:  "https://example.com/write",
+						WriteRelabelConfigs: []monitoringv1.RelabelConfig{
+							{
+								Action:      "replace",
+								Replacement: ptr.To("local-cluster"),
+								TargetLabel: "cluster",
+							},
+							{
+								Action:      "replace",
+								Replacement: ptr.To("cc983d7a-2cd2-4171-b55c-d978e587a978"),
+								TargetLabel: "clusterID",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	gotList, err := Transpile(scrapeConfig, agent)
+	if err != nil {
+		t.Fatalf("Transpile returned error: %v", err)
+	}
+	if len(gotList) != 1 {
+		t.Fatalf("Expected exactly 1 transpiled spec, got %d", len(gotList))
+	}
+	got := gotList[0]
+
+	promCfgs := convertToPromRelabel(got.WriteRelabelConfigs)
+
+	input := labels.FromMap(map[string]string{"__name__": "up", "job": "prometheus"})
+	lb := labels.NewBuilder(input)
+	keep := relabel.ProcessBuilder(lb, promCfgs...)
+	if !keep {
+		t.Fatal("Expected 'up' metric to be kept, but it was dropped")
+	}
+
+	res := lb.Labels()
+	if v := res.Get("cluster"); v != "local-cluster" {
+		t.Errorf("Expected cluster label to be 'local-cluster', got %q", v)
+	}
+	if v := res.Get("clusterID"); v != "cc983d7a-2cd2-4171-b55c-d978e587a978" {
+		t.Errorf("Expected clusterID label to be 'cc983d7a-2cd2-4171-b55c-d978e587a978', got %q", v)
+	}
+}
+
 func TestTranspile_MultipleRemoteWrites(t *testing.T) {
 	scrapeConfig := &monitoringv1alpha1.ScrapeConfig{
 		Spec: monitoringv1alpha1.ScrapeConfigSpec{

--- a/tests/pkg/tests/observability_mcoa_test.go
+++ b/tests/pkg/tests/observability_mcoa_test.go
@@ -901,7 +901,7 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 					}, 120, 5).Should(Succeed())
 				})
 
-				By("Verifying the platform raw metric is queryable on the hub", func() {
+				By("Verifying the platform raw metric is queryable on the hub with cluster identification labels", func() {
 					Eventually(func() error {
 						res, err := utils.QueryGrafana(testOptions, platformMetricName)
 						if err != nil {
@@ -910,11 +910,13 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 						if len(res.Data.Result) == 0 {
 							return fmt.Errorf("No results found for metric %q", platformMetricName)
 						}
-						return nil
+						// Verify cluster label is stamped — raw ScrapeConfigs must preserve WriteRelabelConfigs
+						// carrying cluster/clusterID assignments from the PrometheusAgent remoteWrite entries.
+						return res.CheckMetricFromAllClusters(managedClustersWithHub)
 					}, 300, 5).Should(Not(HaveOccurred()))
 				})
 
-				By("Verifying the uwl raw metric is queryable on the hub", func() {
+				By("Verifying the uwl raw metric is queryable on the hub with cluster identification labels", func() {
 					Eventually(func() error {
 						res, err := utils.QueryGrafana(testOptions, uwlMetricName)
 						if err != nil {
@@ -923,7 +925,9 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 						if len(res.Data.Result) == 0 {
 							return fmt.Errorf("No results found for metric %q", uwlMetricName)
 						}
-						return nil
+						// Verify cluster label is stamped — raw ScrapeConfigs must preserve WriteRelabelConfigs
+						// carrying cluster/clusterID assignments from the PrometheusAgent remoteWrite entries.
+						return res.CheckMetricFromAllClusters(accessibleOCPClusters)
 					}, 300, 5).Should(Not(HaveOccurred()))
 				})
 


### PR DESCRIPTION
## Description

The transpiler was dropping the agent's `WriteRelabelConfigs` when building each `RemoteWriteSpec`, causing raw metrics (DDR `ScrapeConfigs`) to arrive at the hub without `cluster`/`clusterID` labels.

Fix appends the agent's `WriteRelabelConfigs` after the transpiler's own filtering rules. Mirrors the same fix applied to the MCOA transpiler: stolostron/multicluster-observability-addon#605.

Also extends the DDR e2e test to assert the `cluster` label is present on forwarded metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved cluster identification labels, including cluster and cluster ID, when forwarding metrics.
  * Ensured identification relabeling remains applied to generated remote-write configurations.

* **Tests**
  * Added coverage verifying identification labels are retained on forwarded metrics.
  * Updated observability checks to validate cluster labels across platform and user-workload metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->