### PR TITLE
ACM-42564: add RBAC for thanos operator, routes, and hub-managed resources

### DIFF
--- a/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
+++ b/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
@@ -63,11 +63,28 @@
     - apiGroups: [""]
       resources: ["secrets"]
       verbs: ["get", "list", "watch"]
-    # The addon will need to pull subscriptions to know if certain operators
-    # are installed in the hub cluster
-    - apiGroups: ["operators.coreos.com"]
-      resources: ["subscriptions"]
+    # Role for addon to read routes to discover MCOA obs-api endpoint
+    - apiGroups: ["route.openshift.io"]
+      resources: ["routes"]
       verbs: ["get", "list", "watch"]
+    # Role for addon to perform thanos operator specific actions
+    - apiGroups: ["monitoring.thanos.io"]
+      resources: ["thanosreceives", "thanosqueries", "thanoscompacts", "thanosstores", "thanosrulers"]
+      verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+    # Hub-only resources managed directly by HubResourceReconciler
+    - apiGroups: [""]
+      resources: ["namespaces"]
+      verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+    - apiGroups: ["perses.dev"]
+      resources: ["persesdashboards", "persesdatasources"]
+      verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+    - apiGroups: ["observability.openshift.io"]
+      resources: ["uiplugins"]
+      verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+    # Hub COO operator lifecycle managed by HubResourceReconciler
+    - apiGroups: ["operators.coreos.com"]
+      resources: ["subscriptions", "operatorgroups"]
+      verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
     # Roles for addon to perform logging specific actions
     - apiGroups: ["observability.openshift.io"]
       resources: ["clusterlogforwarders"]


### PR DESCRIPTION
## Summary
- Add cluster role rules for MCOA addon manager to support thanos operator CRs (`monitoring.thanos.io`), route discovery (`route.openshift.io`), and hub-only resources managed by HubResourceReconciler (namespaces, perses dashboards/datasources, uiplugins, COO subscriptions/operatorgroups)
- Replaces the previous read-only `operators.coreos.com/subscriptions` rule with full CRUD to support direct COO management on the hub

## Test plan
- [ ] Verify MCOA addon manager can create/update/delete ThanosStore CRs
- [ ] Verify MCOA addon manager can read routes for obs-api endpoint discovery
- [ ] Verify HubResourceReconciler can manage perses dashboards, datasources, UIPlugin, and COO subscription on the hub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded observability permissions to support OpenShift routes, Thanos resources, dashboards, data sources, UI plugins, and hub namespaces.
  * Added access for managing subscriptions and operator groups to improve integration with platform-installed components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->