### PR TITLE
First pass of adding Loki Operator Installation before MCOA Pod is deployed

### DIFF
--- a/operators/multiclusterobservability/bundle.Dockerfile
+++ b/operators/multiclusterobservability/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=multicluster-observability-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-unknown
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -49,7 +49,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-08-25T16:00:30Z"
+    createdAt: "2026-09-02T13:10:40Z"
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-observability-operator.v0.1.0
@@ -515,6 +515,16 @@ spec:
           - list
           - watch
           - delete
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - operatorgroups
+          - subscriptions
+          verbs:
+          - create
+          - get
+          - list
+          - watch
         serviceAccountName: multicluster-observability-operator
       deployments:
       - label:

--- a/operators/multiclusterobservability/config/rbac/mco_role.yaml
+++ b/operators/multiclusterobservability/config/rbac/mco_role.yaml
@@ -431,3 +431,15 @@ rules:
   - list
   - watch
   - delete
+# Needed to install Loki Operator (OperatorGroup + Subscription) via OLM when MCOA platform
+# log collection is enabled and its LokiStack CRD isn't already present on the hub.
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - operatorgroups
+  - subscriptions
+  verbs:
+  - create
+  - get
+  - list
+  - watch

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -26,6 +26,7 @@ import (
 	placementctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/placementrule"
 	certctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/certificates"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/dependencies"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/rendering"
 	smctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/servicemonitor"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/util"
@@ -65,6 +66,10 @@ const (
 	// deprecated one.
 	certFinalizer              = "observability.open-cluster-management.io/cert-cleanup"
 	mcoaCleanupRequeueInterval = 5 * time.Second
+	// lokiOperatorRequeueInterval controls how often we recheck for the LokiStack CRD while
+	// waiting for Loki Operator's OLM install to complete. TODO: replace this polling with an
+	// event-driven trigger (e.g. a dedicated CRD watch) once the approach is finalized.
+	lokiOperatorRequeueInterval = 10 * time.Second
 )
 
 const (
@@ -259,6 +264,34 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	obsAPIURL, err := config.GetObsAPIExternalURL(ctx, r.Client, config.GetDefaultNamespace())
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get the Observatorium API URL: %w", err) // Already wrapped
+	}
+
+	// MCOA's platform log collection capability relies on Loki Operator's LokiStack CRD as the
+	// default log store. Only install Loki Operator ourselves when MCOA is enabled and that
+	// capability is enabled; otherwise leave any existing/manual Loki Operator install alone.
+	// (platformLogsEnabled already implies MCOAEnabled, but we check both explicitly for clarity.)
+	//
+	// If the CRD isn't present yet, requeue immediately rather than rendering/deploying anything
+	// else this pass, and keep requeuing every reconcile until it appears (OLM's install of Loki
+	// Operator is asynchronous and can take a while). This is deliberately simple polling for
+	// now, rather than an event-driven trigger, to keep the change safe/easy to reason about;
+	// can be optimized later.
+	platformLogsEnabled := instance.Spec.Capabilities != nil &&
+		instance.Spec.Capabilities.Platform != nil &&
+		instance.Spec.Capabilities.Platform.Logs.Collection.Enabled
+	if rendering.MCOAEnabled(instance) && platformLogsEnabled {
+		lokiStackCRD := &apiextensionsv1.CustomResourceDefinition{}
+		err = r.Client.Get(ctx, types.NamespacedName{Name: config.LokiStackCRDName}, lokiStackCRD)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to check for LokiStack CRD %s: %w", config.LokiStackCRDName, err)
+		}
+		if apierrors.IsNotFound(err) {
+			reqLogger.Info("LokiStack CRD not found, installing Loki Operator", "crd", config.LokiStackCRDName)
+			if err := dependencies.EnsureLokiOperatorInstalled(ctx, r.Client); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to install Loki Operator: %w", err)
+			}
+			return ctrl.Result{RequeueAfter: lokiOperatorRequeueInterval}, nil
+		}
 	}
 
 	// Build render options

--- a/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
+++ b/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
@@ -72,6 +72,9 @@
     - apiGroups: ["observability.openshift.io"]
       resources: ["clusterlogforwarders"]
       verbs: ["get", "list", "watch"]
+    - apiGroups: ["loki.grafana.com"]
+      resources: ["lokistacks"]
+      verbs: ["get", "list", "watch"]
     # Role for addon to perform opentelemetry specific actions
     - apiGroups: ["opentelemetry.io"]
       resources: ["opentelemetrycollectors", "instrumentations"]

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -247,6 +247,28 @@ const (
 	PrometheusRuleCRDName         = "prometheusrules.monitoring.rhobs"
 )
 
+const (
+	// LokiOperatorNamespace is the namespace Loki Operator is installed into via OLM. Loki
+	// Operator is a global (cluster-scoped) operator, so it follows the same convention as
+	// other Red Hat cluster-scoped operators and lives in openshift-operators-redhat.
+	LokiOperatorNamespace = "openshift-operators-redhat"
+
+	// LokiOperatorPackageName is the OLM package/Subscription name for Loki Operator.
+	LokiOperatorPackageName = "loki-operator"
+
+	// LokiOperatorChannel is the default subscription channel used when installing Loki Operator.
+	LokiOperatorChannel = "stable-6.3"
+
+	// LokiOperatorCatalogSource and LokiOperatorCatalogSourceNamespace point at the default
+	// Red Hat operator catalog.
+	LokiOperatorCatalogSource          = "redhat-operators"
+	LokiOperatorCatalogSourceNamespace = "openshift-marketplace"
+
+	// LokiStackCRDName is the CustomResourceDefinition Loki Operator registers once installed.
+	// MCO waits for this CRD to exist before assuming Loki Operator is ready.
+	LokiStackCRDName = "lokistacks.loki.grafana.com"
+)
+
 var (
 	ErrMultipleMCOInstances = errors.New("more than one MultiClusterObservability CR exists")
 	ErrMCONotFound          = errors.New("MultiClusterObservability CR not found")

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -256,9 +256,6 @@ const (
 	// LokiOperatorPackageName is the OLM package/Subscription name for Loki Operator.
 	LokiOperatorPackageName = "loki-operator"
 
-	// LokiOperatorChannel is the default subscription channel used when installing Loki Operator.
-	LokiOperatorChannel = "stable-6.3"
-
 	// LokiOperatorCatalogSource and LokiOperatorCatalogSourceNamespace point at the default
 	// Red Hat operator catalog.
 	LokiOperatorCatalogSource          = "redhat-operators"

--- a/operators/multiclusterobservability/pkg/dependencies/loki_operator.go
+++ b/operators/multiclusterobservability/pkg/dependencies/loki_operator.go
@@ -55,7 +55,11 @@ func BuildLokiOperatorResources() []client.Object {
 	sub.SetName(mcoconfig.LokiOperatorPackageName)
 	sub.SetNamespace(mcoconfig.LokiOperatorNamespace)
 	sub.Object["spec"] = map[string]any{
-		"channel":             mcoconfig.LokiOperatorChannel,
+		// channel is deliberately omitted: it's an optional field on the Subscription CRD, and
+		// leaving it unset tells OLM to track the package's current default channel. Loki
+		// Operator's channels are versioned (e.g. stable-6.3, stable-6.5, ...) and old ones get
+		// dropped from the catalog over time, so hardcoding one here would eventually resolve to
+		// nothing (ConstraintsNotSatisfiable) and silently stop installing.
 		"name":                mcoconfig.LokiOperatorPackageName,
 		"source":              mcoconfig.LokiOperatorCatalogSource,
 		"sourceNamespace":     mcoconfig.LokiOperatorCatalogSourceNamespace,

--- a/operators/multiclusterobservability/pkg/dependencies/loki_operator.go
+++ b/operators/multiclusterobservability/pkg/dependencies/loki_operator.go
@@ -1,0 +1,78 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+// Package dependencies installs third-party operators that MCOA capabilities depend on but
+// that MCO does not otherwise own or manage (e.g. Loki Operator, which provides the LokiStack
+// CRD used as the default log store for platform log collection).
+package dependencies
+
+import (
+	"context"
+	"fmt"
+
+	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// BuildLokiOperatorResources returns the Namespace, OperatorGroup and Subscription objects
+// required to install Loki Operator via OLM on the hub cluster.
+//
+// OperatorGroup/Subscription are built as unstructured objects (rather than importing
+// github.com/operator-framework/api) to avoid adding a new dependency to this operator for
+// three object kinds.
+func BuildLokiOperatorResources() []client.Object {
+	ns := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mcoconfig.LokiOperatorNamespace,
+		},
+	}
+
+	og := &unstructured.Unstructured{}
+	og.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1",
+		Kind:    "OperatorGroup",
+	})
+	og.SetName(mcoconfig.LokiOperatorPackageName)
+	og.SetNamespace(mcoconfig.LokiOperatorNamespace)
+
+	sub := &unstructured.Unstructured{}
+	sub.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1alpha1",
+		Kind:    "Subscription",
+	})
+	sub.SetName(mcoconfig.LokiOperatorPackageName)
+	sub.SetNamespace(mcoconfig.LokiOperatorNamespace)
+	sub.Object["spec"] = map[string]any{
+		"channel":             mcoconfig.LokiOperatorChannel,
+		"name":                mcoconfig.LokiOperatorPackageName,
+		"source":              mcoconfig.LokiOperatorCatalogSource,
+		"sourceNamespace":     mcoconfig.LokiOperatorCatalogSourceNamespace,
+		"installPlanApproval": "Automatic",
+	}
+
+	return []client.Object{ns, og, sub}
+}
+
+// EnsureLokiOperatorInstalled creates the Loki Operator's Namespace, OperatorGroup and
+// Subscription if they don't already exist. It never updates an existing object, so it won't
+// fight a manual install or an in-progress OLM upgrade.
+func EnsureLokiOperatorInstalled(ctx context.Context, c client.Client) error {
+	for _, obj := range BuildLokiOperatorResources() {
+		if err := c.Create(ctx, obj); err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create %s %s/%s: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(), err)
+		}
+	}
+	return nil
+}

--- a/operators/multiclusterobservability/pkg/dependencies/loki_operator_test.go
+++ b/operators/multiclusterobservability/pkg/dependencies/loki_operator_test.go
@@ -39,10 +39,16 @@ func TestBuildLokiOperatorResources(t *testing.T) {
 	require.Equal(t, mcoconfig.LokiOperatorPackageName, sub.GetName())
 	require.Equal(t, mcoconfig.LokiOperatorNamespace, sub.GetNamespace())
 
-	channel, found, err := unstructured.NestedString(sub.Object, "spec", "channel")
+	// channel is deliberately left unset so OLM tracks the package's default channel; see the
+	// comment in BuildLokiOperatorResources for why.
+	_, found, err := unstructured.NestedString(sub.Object, "spec", "channel")
+	require.NoError(t, err)
+	require.False(t, found)
+
+	name, found, err := unstructured.NestedString(sub.Object, "spec", "name")
 	require.NoError(t, err)
 	require.True(t, found)
-	require.Equal(t, mcoconfig.LokiOperatorChannel, channel)
+	require.Equal(t, mcoconfig.LokiOperatorPackageName, name)
 }
 
 func TestEnsureLokiOperatorInstalled(t *testing.T) {

--- a/operators/multiclusterobservability/pkg/dependencies/loki_operator_test.go
+++ b/operators/multiclusterobservability/pkg/dependencies/loki_operator_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package dependencies
+
+import (
+	"context"
+	"testing"
+
+	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestBuildLokiOperatorResources(t *testing.T) {
+	objs := BuildLokiOperatorResources()
+	require.Len(t, objs, 3)
+
+	ns, ok := objs[0].(*corev1.Namespace)
+	require.True(t, ok, "first object should be a Namespace")
+	require.Equal(t, mcoconfig.LokiOperatorNamespace, ns.GetName())
+
+	og, ok := objs[1].(*unstructured.Unstructured)
+	require.True(t, ok, "second object should be an unstructured OperatorGroup")
+	require.Equal(t, "OperatorGroup", og.GetKind())
+	require.Equal(t, mcoconfig.LokiOperatorPackageName, og.GetName())
+	require.Equal(t, mcoconfig.LokiOperatorNamespace, og.GetNamespace())
+
+	sub, ok := objs[2].(*unstructured.Unstructured)
+	require.True(t, ok, "third object should be an unstructured Subscription")
+	require.Equal(t, "Subscription", sub.GetKind())
+	require.Equal(t, mcoconfig.LokiOperatorPackageName, sub.GetName())
+	require.Equal(t, mcoconfig.LokiOperatorNamespace, sub.GetNamespace())
+
+	channel, found, err := unstructured.NestedString(sub.Object, "spec", "channel")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, mcoconfig.LokiOperatorChannel, channel)
+}
+
+func TestEnsureLokiOperatorInstalled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	require.NoError(t, EnsureLokiOperatorInstalled(t.Context(), fakeClient))
+	require.NoError(t, fakeClient.Get(t.Context(), types.NamespacedName{Name: mcoconfig.LokiOperatorNamespace}, &corev1.Namespace{}))
+
+	// Calling it again should be a no-op (idempotent), not fail with AlreadyExists.
+	require.NoError(t, EnsureLokiOperatorInstalled(t.Context(), fakeClient))
+}
+
+func TestEnsureLokiOperatorInstalled_PropagatesUnexpectedErrors(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	fakeClient := &erroringClient{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+
+	err := EnsureLokiOperatorInstalled(t.Context(), fakeClient)
+	require.Error(t, err)
+}
+
+// erroringClient wraps a client.Client and forces every Create call to fail with a
+// non-AlreadyExists error, so we can assert that EnsureLokiOperatorInstalled propagates it.
+type erroringClient struct {
+	client.Client
+}
+
+func (e *erroringClient) Create(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+	return apierrors.NewBadRequest("boom for " + obj.GetObjectKind().GroupVersionKind().Kind)
+}


### PR DESCRIPTION
This is the first pass of adding support for Loki Operator Installation in the MCO. This occurs if logging is enabled and the MCOA will get deployed but the hub, currently does not have the LokiStack CRD. It checks this, and if not, it installs the Loki Operator resources into the cluster, which install the LokiStack CRD. 