### PR TITLE
[ACM-43197] Split right-sizing Grafana profile into CPU profile and memory profile

### DIFF
--- a/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-namespace.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-namespace.yaml
@@ -127,7 +127,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(sum by (cluster)(acm_rs:cluster:cpu_recommendation{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (cluster)(acm_rs:cluster:cpu_recommendation{cluster=\"$cluster\", profile=\"$cpu_profile\"})[$days:])",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -237,7 +237,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "topk(20,\nsum by (namespace) (acm_rs:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\"})\n/\nsum by (namespace) (acm_rs:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\"})\n)",
+              "expr": "topk(20,\nsum by (namespace) (acm_rs:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\"})\n/\nsum by (namespace) (acm_rs:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\"})\n)",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -318,7 +318,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(sum by (cluster)(acm_rs:cluster:cpu_usage{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (cluster)(acm_rs:cluster:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\"})[$days:])",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -409,7 +409,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(sum by (cluster)(acm_rs:cluster:cpu_request{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (cluster)(acm_rs:cluster:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\"})[$days:])",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -508,7 +508,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(sum by (cluster)(acm_rs:cluster:cpu_usage{cluster=\"$cluster\", profile=\"$profile\"})[$days:]) / max_over_time(sum by (cluster)(acm_rs:cluster:cpu_request{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (cluster)(acm_rs:cluster:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\"})[$days:]) / max_over_time(sum by (cluster)(acm_rs:cluster:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\"})[$days:])",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -862,7 +862,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\"})[$days:]) / max_over_time(sum by (namespace) (acm_rs:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\"})[$days:]) / max_over_time(sum by (namespace) (acm_rs:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\"})[$days:])",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -875,7 +875,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\"})[$days:]) ",
+              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\"})[$days:]) ",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -889,7 +889,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\"})[$days:])",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -904,7 +904,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$cpu_profile\"})[$days:])",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -919,7 +919,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:cpu_request_hard{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:cpu_request_hard{cluster=\"$cluster\", profile=\"$cpu_profile\"})[$days:])",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1064,7 +1064,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(sum by (cluster)(acm_rs:cluster:memory_recommendation{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (cluster)(acm_rs:cluster:memory_recommendation{cluster=\"$cluster\", profile=\"$memory_profile\"})[$days:])",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -1172,7 +1172,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "topk(20,\nsum by (namespace) (acm_rs:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\"})\n/\nsum by (namespace) (acm_rs:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\"})\n)",
+              "expr": "topk(20,\nsum by (namespace) (acm_rs:namespace:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\"})\n/\nsum by (namespace) (acm_rs:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\"})\n)",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -1253,7 +1253,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(sum by (cluster)(acm_rs:cluster:memory_usage{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (cluster)(acm_rs:cluster:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\"})[$days:])",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -1343,7 +1343,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(sum by (cluster)(acm_rs:cluster:memory_request{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (cluster)(acm_rs:cluster:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\"})[$days:])",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -1430,7 +1430,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(sum by (cluster)(acm_rs:cluster:memory_usage{cluster=\"$cluster\", profile=\"$profile\"})[$days:]) / max_over_time(sum by (cluster)(acm_rs:cluster:memory_request{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (cluster)(acm_rs:cluster:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\"})[$days:]) / max_over_time(sum by (cluster)(acm_rs:cluster:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\"})[$days:])",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -1782,7 +1782,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\"})[$days:]) / max_over_time(sum by (namespace) (acm_rs:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\"})[$days:]) / max_over_time(sum by (namespace) (acm_rs:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\"})[$days:])",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -1795,7 +1795,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\"})[$days:])",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1809,7 +1809,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\"})[$days:])",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1824,7 +1824,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$memory_profile\"})[$days:])",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1839,7 +1839,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:memory_request_hard{cluster=\"$cluster\", profile=\"$profile\"})[$days:])",
+              "expr": "max_over_time(sum by (namespace) (acm_rs:namespace:memory_request_hard{cluster=\"$cluster\", profile=\"$memory_profile\"})[$days:])",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1949,15 +1949,42 @@ data:
               "type": "prometheus",
               "uid": "${datasource}"
             },
-            "definition": "label_values({__name__=~\"acm_rs:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\"},profile)",
+            "definition": "label_values(acm_rs:namespace:cpu_usage{cluster=\"$cluster\"},profile)",
             "hide": 0,
             "includeAll": false,
-            "label": "Profile",
+            "label": "CPU Profile",
             "multi": false,
-            "name": "profile",
+            "name": "cpu_profile",
             "options": [],
             "query": {
-              "query": "label_values({__name__=~\"acm_rs:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\"},profile)",
+              "query": "label_values(acm_rs:namespace:cpu_usage{cluster=\"$cluster\"},profile)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "Max OverAll",
+              "value": "Max OverAll"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "definition": "label_values(acm_rs:namespace:memory_usage{cluster=\"$cluster\"},profile)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Memory Profile",
+            "multi": false,
+            "name": "memory_profile",
+            "options": [],
+            "query": {
+              "query": "label_values(acm_rs:namespace:memory_usage{cluster=\"$cluster\"},profile)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 2,

--- a/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization-overestimation.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization-overestimation.yaml
@@ -127,7 +127,7 @@ data:
               "datasource": {
                 "uid": "${datasource}"
               },
-              "expr": "floor(max_over_time(acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])-\nmax_over_time(acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:]))",
+              "expr": "floor(max_over_time(acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])-\nmax_over_time(acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:]))",
               "hide": false,
               "instant": true,
               "interval": "",
@@ -240,7 +240,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "(\n  acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"} \n  / \n  acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"} \n)",
+              "expr": "(\n  acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\", name=~\"$vm\"} \n  / \n  acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\", name=~\"$vm\"} \n)",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -320,7 +320,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "max_over_time(acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])",
+              "expr": "max_over_time(acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -410,7 +410,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "max_over_time(acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])",
+              "expr": "max_over_time(acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -503,7 +503,7 @@ data:
               "datasource": {
                 "uid": "${datasource}"
               },
-              "expr": "max_over_time(acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:]) / max_over_time(acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])",
+              "expr": "max_over_time(acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:]) / max_over_time(acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -609,7 +609,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "floor((max_over_time(acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])/ 1073741824) -\n(max_over_time(acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])/ 1073741824))",
+              "expr": "floor((max_over_time(acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])/ 1073741824) -\n(max_over_time(acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])/ 1073741824))",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -719,7 +719,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "(\n  acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"} \n  / \n  acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"} \n)",
+              "expr": "(\n  acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\", name=~\"$vm\"} \n  / \n  acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\", name=~\"$vm\"} \n)",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -800,7 +800,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])/ 1073741824",
+              "expr": "max_over_time(acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])/ 1073741824",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -890,7 +890,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])/ 1073741824",
+              "expr": "max_over_time(acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])/ 1073741824",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -972,7 +972,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:]) / max_over_time(acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])",
+              "expr": "max_over_time(acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:]) / max_over_time(acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -1051,14 +1051,38 @@ data:
               "type": "prometheus",
               "uid": "${datasource}"
             },
-            "definition": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\"},profile)",
-            "description": "Profile Variable",
+            "definition": "label_values(acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\"},profile)",
+            "description": "CPU Profile Variable",
             "includeAll": false,
-            "label": "Profile",
-            "name": "profile",
+            "label": "CPU Profile",
+            "name": "cpu_profile",
             "options": [],
             "query": {
-              "query": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\"},profile)",
+              "query": "label_values(acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\"},profile)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {
+              "text": "Max OverAll",
+              "value": "Max OverAll"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "definition": "label_values(acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\"},profile)",
+            "description": "Memory Profile Variable",
+            "includeAll": false,
+            "label": "Memory Profile",
+            "name": "memory_profile",
+            "options": [],
+            "query": {
+              "query": "label_values(acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\"},profile)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 2,
@@ -1129,14 +1153,14 @@ data:
               "type": "prometheus",
               "uid": "${datasource}"
             },
-            "definition": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$profile\"},namespace)",
+            "definition": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$cpu_profile\"},namespace)",
             "description": "Namespace Variable",
             "includeAll": false,
             "label": "Namespace",
             "name": "namespace",
             "options": [],
             "query": {
-              "query": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$profile\"},namespace)",
+              "query": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$cpu_profile\"},namespace)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 2,
@@ -1152,14 +1176,14 @@ data:
               "type": "prometheus",
               "uid": "${datasource}"
             },
-            "definition": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$profile\",namespace=\"$namespace\"}, name)",
+            "definition": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$cpu_profile\",namespace=\"$namespace\"}, name)",
             "description": "VM Variable",
             "includeAll": false,
             "label": "VM",
             "name": "vm",
             "options": [],
             "query": {
-              "query": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$profile\",namespace=\"$namespace\"}, name)",
+              "query": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$cpu_profile\",namespace=\"$namespace\"}, name)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 2,

--- a/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization-overestimation.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization-overestimation.yaml
@@ -32,8 +32,8 @@ data:
         {
           "asDropdown": false,
           "icon": "dashboard",
-          "includeVars": false,
-          "keepTime": false,
+          "includeVars": true,
+          "keepTime": true,
           "tags": [],
           "targetBlank": false,
           "title": "Back to Main Dashboard",

--- a/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization-underestimation.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization-underestimation.yaml
@@ -32,8 +32,8 @@ data:
         {
           "asDropdown": false,
           "icon": "dashboard",
-          "includeVars": false,
-          "keepTime": false,
+          "includeVars": true,
+          "keepTime": true,
           "tags": [],
           "targetBlank": false,
           "title": "Back to Main Dashboard",

--- a/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization-underestimation.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization-underestimation.yaml
@@ -127,7 +127,7 @@ data:
               "datasource": {
                 "uid": "${datasource}"
               },
-              "expr": "floor(max_over_time(acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])-\nmax_over_time(acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:]))* (-1)",
+              "expr": "floor(max_over_time(acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])-\nmax_over_time(acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:]))* (-1)",
               "hide": false,
               "interval": "",
               "instant": true,
@@ -240,7 +240,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "(\n  acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"} \n  / \n  acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"} \n)",
+              "expr": "(\n  acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\", name=~\"$vm\"} \n  / \n  acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\", name=~\"$vm\"} \n)",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -320,7 +320,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "max_over_time(acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])",
+              "expr": "max_over_time(acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -410,7 +410,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "max_over_time(acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])",
+              "expr": "max_over_time(acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -503,7 +503,7 @@ data:
               "datasource": {
                 "uid": "${datasource}"
               },
-              "expr": "max_over_time(acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:]) / max_over_time(acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])",
+              "expr": "max_over_time(acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:]) / max_over_time(acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -609,7 +609,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "floor((max_over_time(acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])/ 1073741824) -\n(max_over_time(acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])/ 1073741824))* (-1)",
+              "expr": "floor((max_over_time(acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])/ 1073741824) -\n(max_over_time(acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])/ 1073741824))* (-1)",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -719,7 +719,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "(\n  acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"} \n  / \n  acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"} \n)",
+              "expr": "(\n  acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\", name=~\"$vm\"} \n  / \n  acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\", name=~\"$vm\"} \n)",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -800,7 +800,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])/ 1073741824",
+              "expr": "max_over_time(acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])/ 1073741824",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -890,7 +890,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])/ 1073741824",
+              "expr": "max_over_time(acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])/ 1073741824",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -972,7 +972,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "max_over_time(acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:]) / max_over_time(acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])",
+              "expr": "max_over_time(acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:]) / max_over_time(acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\", name=~\"$vm\"}[$days:])",
               "instant": true,
               "interval": "",
               "legendFormat": "",
@@ -1051,14 +1051,38 @@ data:
               "type": "prometheus",
               "uid": "${datasource}"
             },
-            "definition": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\"},profile)",
-            "description": "Profile Variable",
+            "definition": "label_values(acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\"},profile)",
+            "description": "CPU Profile Variable",
             "includeAll": false,
-            "label": "Profile",
-            "name": "profile",
+            "label": "CPU Profile",
+            "name": "cpu_profile",
             "options": [],
             "query": {
-              "query": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\"},profile)",
+              "query": "label_values(acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\"},profile)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {
+              "text": "Max OverAll",
+              "value": "Max OverAll"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "definition": "label_values(acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\"},profile)",
+            "description": "Memory Profile Variable",
+            "includeAll": false,
+            "label": "Memory Profile",
+            "name": "memory_profile",
+            "options": [],
+            "query": {
+              "query": "label_values(acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\"},profile)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 2,
@@ -1129,14 +1153,14 @@ data:
               "type": "prometheus",
               "uid": "${datasource}"
             },
-            "definition": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$profile\"},namespace)",
+            "definition": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$cpu_profile\"},namespace)",
             "description": "Namespace Variable",
             "includeAll": false,
             "label": "Namespace",
             "name": "namespace",
             "options": [],
             "query": {
-              "query": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$profile\"},namespace)",
+              "query": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$cpu_profile\"},namespace)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 2,
@@ -1152,14 +1176,14 @@ data:
               "type": "prometheus",
               "uid": "${datasource}"
             },
-            "definition": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$profile\",namespace=\"$namespace\"}, name)",
+            "definition": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$cpu_profile\",namespace=\"$namespace\"}, name)",
             "description": "VM Variable",
             "includeAll": false,
             "label": "VM",
             "name": "vm",
             "options": [],
             "query": {
-              "query": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$profile\",namespace=\"$namespace\"}, name)",
+              "query": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$cpu_profile\",namespace=\"$namespace\"}, name)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 2,

--- a/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization.yaml
+++ b/operators/multiclusterobservability/manifests/base/grafana/analytics/dash-acm-right-sizing-virtualization.yaml
@@ -92,7 +92,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "sum(\n(floor(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])-\nmax_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])) > 0)\nand on (name, namespace) (max by (name, namespace) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) > 0)\n)",
+              "expr": "sum(\n(floor(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:])-\nmax_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:])) > 0)\nand on (name, namespace) (max by (name, namespace) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) > 0)\n)",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -165,7 +165,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "sum(\n(floor(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])-\nmax_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])) < 0) * (-1)\nand on (name, namespace) (max by (name, namespace) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) > 0)\n)",
+              "expr": "sum(\n(floor(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:])-\nmax_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:])) < 0) * (-1)\nand on (name, namespace) (max by (name, namespace) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) > 0)\n)",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -238,7 +238,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "sum(\n(floor((max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]) / 1073741824)-\n(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]) / 1073741824)) > 0)\nand on (name, namespace) (max by (name, namespace) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) > 0)\n)",
+              "expr": "sum(\n(floor((max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:]) / 1073741824)-\n(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:]) / 1073741824)) > 0)\nand on (name, namespace) (max by (name, namespace) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) > 0)\n)",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -311,7 +311,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "sum(\n(floor((max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]) / 1073741824)-\n(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]) / 1073741824)) < 0) * (-1)\nand on (name, namespace) (max by (name, namespace) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) > 0)\n)",
+              "expr": "sum(\n(floor((max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:]) / 1073741824)-\n(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:]) / 1073741824)) < 0) * (-1)\nand on (name, namespace) (max by (name, namespace) (kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=\"$cluster\", namespace=~\"$namespace\"} > 0) > 0)\n)",
               "format": "time_series",
               "instant": true,
               "interval": "",
@@ -425,7 +425,7 @@ data:
                       {
                         "targetBlank": false,
                         "title": "Show VM or Pod level details",
-                        "url": "/d/bnqQIPySEProdkhgafkdekgfOver/acm-right-sizing-openshift-virtualization-vm-dashboard-overestimation?${__url_time_range}&var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-vm=${__data.fields.name}&var-days=$days"
+                        "url": "/d/bnqQIPySEProdkhgafkdekgfOver/acm-right-sizing-openshift-virtualization-vm-dashboard-overestimation?${__url_time_range}&var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-vm=${__data.fields.name}&var-days=$days&var-cpu_profile=$cpu_profile&var-memory_profile=$memory_profile"
                       }
                     ]
                   },
@@ -555,7 +555,7 @@ data:
                       {
                         "targetBlank": false,
                         "title": "Show VM or Pod level Details",
-                        "url": "/d/bnqQIPySEProdkhgafkdekgfOver/acm-right-sizing-openshift-virtualization-vm-dashboard-overestimation?${__url_time_range}&var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-vm=${__data.fields.name}&var-days=$days"
+                        "url": "/d/bnqQIPySEProdkhgafkdekgfOver/acm-right-sizing-openshift-virtualization-vm-dashboard-overestimation?${__url_time_range}&var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-vm=${__data.fields.name}&var-days=$days&var-cpu_profile=$cpu_profile&var-memory_profile=$memory_profile"
                       }
                     ]
                   },
@@ -764,7 +764,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    (\n        max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]) / max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])\n    ) > 0,\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    (\n        max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:]) / max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:])\n    ) > 0,\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -777,7 +777,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    (max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    (max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:])),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -791,7 +791,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:]),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -805,7 +805,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    ceil(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    ceil(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:])),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -819,7 +819,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n  (\n    acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"} + on(name, namespace) acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"}\n  ),\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n  (\n    acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"} + on(name, namespace) acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"}\n  ),\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": false,
@@ -833,7 +833,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    (\n        floor(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])-\n        max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]))\n    ),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    (\n        floor(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:])-\n        max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:]))\n    ),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1045,7 +1045,7 @@ data:
                       {
                         "targetBlank": false,
                         "title": "Show VM or Pod level details",
-                        "url": "/d/bnqQIPySEProdkekgfunderestimated/acm-right-sizing-openshift-virtualization-vm-dashboard-underestimated?${__url_time_range}&var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-vm=${__data.fields.name}&var-days=$days"
+                        "url": "/d/bnqQIPySEProdkekgfunderestimated/acm-right-sizing-openshift-virtualization-vm-dashboard-underestimated?${__url_time_range}&var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-vm=${__data.fields.name}&var-days=$days&var-cpu_profile=$cpu_profile&var-memory_profile=$memory_profile"
                       }
                     ]
                   },
@@ -1175,7 +1175,7 @@ data:
                       {
                         "targetBlank": false,
                         "title": "Shoe VM or Pod level Details",
-                        "url": "/d/bnqQIPySEProdkekgfunderestimated/acm-right-sizing-openshift-virtualization-vm-dashboard-underestimated?${__url_time_range}&var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-vm=${__data.fields.name}&var-days=$days"
+                        "url": "/d/bnqQIPySEProdkekgfunderestimated/acm-right-sizing-openshift-virtualization-vm-dashboard-underestimated?${__url_time_range}&var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-vm=${__data.fields.name}&var-days=$days&var-cpu_profile=$cpu_profile&var-memory_profile=$memory_profile"
                       }
                     ]
                   },
@@ -1381,7 +1381,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    (\n        max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]) / max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])\n    ) > 0, \n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    (\n        max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:]) / max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:])\n    ) > 0, \n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -1394,7 +1394,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]), \n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:]), \n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1408,7 +1408,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:]),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1422,7 +1422,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    ceil(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    ceil(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:])),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1436,7 +1436,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n  (\n    acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"} + on(name, namespace) acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"}\n  ),\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n  (\n    acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"} + on(name, namespace) acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"}\n  ),\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": false,
@@ -1450,7 +1450,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    (floor(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])- max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])) * (-1)),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    (floor(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_request{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:])- max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:cpu_recommendation{cluster=\"$cluster\", profile=\"$cpu_profile\", namespace=~\"$namespace\"})[$days:])) * (-1)),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1666,7 +1666,7 @@ data:
                       {
                         "targetBlank": false,
                         "title": "Show VM or Pod level Details",
-                        "url": "/d/bnqQIPySEProdkhgafkdekgfOver/acm-right-sizing-openshift-virtualization-vm-dashboard-overestimation?${__url_time_range}&var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-vm=${__data.fields.name}&var-days=$days"
+                        "url": "/d/bnqQIPySEProdkhgafkdekgfOver/acm-right-sizing-openshift-virtualization-vm-dashboard-overestimation?${__url_time_range}&var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-vm=${__data.fields.name}&var-days=$days&var-cpu_profile=$cpu_profile&var-memory_profile=$memory_profile"
                       }
                     ]
                   },
@@ -1796,7 +1796,7 @@ data:
                       {
                         "targetBlank": false,
                         "title": "Show VM or Pod level Details",
-                        "url": "/d/bnqQIPySEProdkhgafkdekgfOver/acm-right-sizing-openshift-virtualization-vm-dashboard-overestimation?${__url_time_range}&var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-vm=${__data.fields.name}&var-days=$days"
+                        "url": "/d/bnqQIPySEProdkhgafkdekgfOver/acm-right-sizing-openshift-virtualization-vm-dashboard-overestimation?${__url_time_range}&var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-vm=${__data.fields.name}&var-days=$days&var-cpu_profile=$cpu_profile&var-memory_profile=$memory_profile"
                       }
                     ]
                   }
@@ -1921,7 +1921,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]) / max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:]) / max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:]),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -1934,7 +1934,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    (max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]) /1073741824),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    (max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:]) /1073741824),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1948,7 +1948,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    (max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])/1073741824),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    (max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:])/1073741824),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1962,7 +1962,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    (ceil(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])/ 1073741824)),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    (ceil(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:])/ 1073741824)),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1976,7 +1976,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n  (\n    acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"} + on(name, namespace) acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"}\n  ),\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n  (\n    acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"} + on(name, namespace) acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"}\n  ),\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": false,
@@ -1990,7 +1990,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    (floor((max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])) / 1073741824 - (max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])) / 1073741824)),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    (floor((max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:])) / 1073741824 - (max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:])) / 1073741824)),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -2192,7 +2192,7 @@ data:
                       {
                         "targetBlank": false,
                         "title": "Show VM or Pod level Details",
-                        "url": "/d/bnqQIPySEProdkekgfunderestimated/acm-right-sizing-openshift-virtualization-vm-dashboard-underestimated?${__url_time_range}&var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-vm=${__data.fields.name}&var-days=$days"
+                        "url": "/d/bnqQIPySEProdkekgfunderestimated/acm-right-sizing-openshift-virtualization-vm-dashboard-underestimated?${__url_time_range}&var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-vm=${__data.fields.name}&var-days=$days&var-cpu_profile=$cpu_profile&var-memory_profile=$memory_profile"
                       }
                     ]
                   },
@@ -2322,7 +2322,7 @@ data:
                       {
                         "targetBlank": false,
                         "title": "Show VM or Pod level Details",
-                        "url": "/d/bnqQIPySEProdkekgfunderestimated/acm-right-sizing-openshift-virtualization-vm-dashboard-underestimated?${__url_time_range}&var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-vm=${__data.fields.name}&var-days=$days"
+                        "url": "/d/bnqQIPySEProdkekgfunderestimated/acm-right-sizing-openshift-virtualization-vm-dashboard-underestimated?${__url_time_range}&var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-vm=${__data.fields.name}&var-days=$days&var-cpu_profile=$cpu_profile&var-memory_profile=$memory_profile"
                       }
                     ]
                   }
@@ -2459,7 +2459,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    (max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:]) / max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    (max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:]) / max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:])),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -2472,7 +2472,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    (max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])/ 1073741824),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    (max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:])/ 1073741824),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -2486,7 +2486,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    (max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])/ 1073741824),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    (max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:])/ 1073741824),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -2500,7 +2500,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    (ceil(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])/ 1073741824)),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    (ceil(max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:])/ 1073741824)),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -2514,7 +2514,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n  (\n    acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"} + on(name, namespace) acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"}\n  ),\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n  (\n    acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"} + on(name, namespace) acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"}\n  ),\n  \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": false,
@@ -2528,7 +2528,7 @@ data:
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "label_join(\n    (floor((max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])) / 1073741824 - (max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$profile\", namespace=~\"$namespace\"})[$days:])) / 1073741824)* (-1)),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
+              "expr": "label_join(\n    (floor((max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_request{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:])) / 1073741824 - (max_over_time(sum by (name, namespace) (acm_rs_vm:namespace:memory_recommendation{cluster=\"$cluster\", profile=\"$memory_profile\", namespace=~\"$namespace\"})[$days:])) / 1073741824)* (-1)),\n    \"name_namespace\", \"-\", \"name\", \"namespace\"\n)",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -2702,14 +2702,38 @@ data:
               "type": "prometheus",
               "uid": "${datasource}"
             },
-            "definition": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\"},profile)",
-            "description": "Profile Variable",
+            "definition": "label_values(acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\"},profile)",
+            "description": "CPU Profile Variable",
             "includeAll": false,
-            "label": "Profile",
-            "name": "profile",
+            "label": "CPU Profile",
+            "name": "cpu_profile",
             "options": [],
             "query": {
-              "query": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\"},profile)",
+              "query": "label_values(acm_rs_vm:namespace:cpu_usage{cluster=\"$cluster\"},profile)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {
+              "text": "Max OverAll",
+              "value": "Max OverAll"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "definition": "label_values(acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\"},profile)",
+            "description": "Memory Profile Variable",
+            "includeAll": false,
+            "label": "Memory Profile",
+            "name": "memory_profile",
+            "options": [],
+            "query": {
+              "query": "label_values(acm_rs_vm:namespace:memory_usage{cluster=\"$cluster\"},profile)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 2,
@@ -2782,7 +2806,7 @@ data:
               "type": "prometheus",
               "uid": "${datasource}"
             },
-            "definition": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$profile\"},namespace)",
+            "definition": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$cpu_profile\"},namespace)",
             "description": "Namespace Variable",
             "includeAll": true,
             "label": "Namespace",
@@ -2790,7 +2814,7 @@ data:
             "name": "namespace",
             "options": [],
             "query": {
-              "query": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$profile\"},namespace)",
+              "query": "label_values({__name__=~\"acm_rs_vm:namespace:(cpu_request|cpu_usage|memory_request|memory_usage)\",cluster=\"$cluster\",profile=\"$cpu_profile\"},namespace)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 2,

--- a/tests/pkg/tests/observability_mcoa_test.go
+++ b/tests/pkg/tests/observability_mcoa_test.go
@@ -82,6 +82,9 @@ var _ = Describe("Observability Addon (MCOA)", Ordered, func() {
 		By("Disabling MCOA", func() {
 			Expect(utils.SetMCOACapabilities(testOptions, false, false)).NotTo(HaveOccurred())
 			utils.CheckStatefulSetAvailabilityOnClusters(managedClustersWithHub, platformPrometheusAgentStatefulSetName, utils.MCO_AGENT_ADDON_NAMESPACE, false)
+			// Wait for the MCOA manager to go away so endpoint-operator CRD self-heal
+			// is less likely to race with the explicit CRD cleanup below.
+			utils.CheckDeploymentAvailability(testOptions.HubCluster, mcoaManagerDeploymentName, utils.MCO_NAMESPACE, false)
 		})
 		By("Deleting COO subscription if it exists and CRDs", func() {
 			utils.DeleteCOOSubscription(accessibleOCPClusters)

--- a/tests/pkg/tests/observability_right_sizing_test.go
+++ b/tests/pkg/tests/observability_right_sizing_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -795,9 +796,14 @@ var _ = Describe("Always-MCOA right-sizing: ADC reflects CR spec state (rightsiz
 	})
 })
 
+// staleGrafanaProfileRef matches leftover Grafana interpolations of the old
+// "profile" variable ($profile or ${profile}) without matching $cpu_profile /
+// $memory_profile.
+var staleGrafanaProfileRef = regexp.MustCompile(`\$\{profile(?::[^}]*)?\}|\$profile([^a-zA-Z0-9_]|$)`)
+
 // validateDashboardProfileVars fetches a Grafana dashboard ConfigMap and verifies that
 // the embedded JSON contains cpu_profile and memory_profile template variables,
-// with no stale "$profile" references.
+// with no stale $profile or ${profile} references.
 func validateDashboardProfileVars(dynClient dynamic.Interface, cmName string) error {
 	configMapGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
 	cm, err := dynClient.Resource(configMapGVR).
@@ -808,7 +814,10 @@ func validateDashboardProfileVars(dynClient dynamic.Interface, cmName string) er
 	}
 
 	data, found, err := unstructured.NestedStringMap(cm.Object, "data")
-	if err != nil || !found {
+	if err != nil {
+		return fmt.Errorf("read ConfigMap %s data: %w", cmName, err)
+	}
+	if !found {
 		return fmt.Errorf("ConfigMap %s has no data field", cmName)
 	}
 
@@ -843,8 +852,8 @@ func validateDashboardProfileVars(dynClient dynamic.Interface, cmName string) er
 			return fmt.Errorf("dashboard %s/%s still has stale 'profile' variable (should be split into cpu_profile/memory_profile)", cmName, key)
 		}
 
-		if strings.Contains(dashJSON, `"$profile"`) {
-			return fmt.Errorf("dashboard %s/%s still references \"$profile\" in queries", cmName, key)
+		if stale := staleGrafanaProfileRef.FindString(dashJSON); stale != "" {
+			return fmt.Errorf("dashboard %s/%s still references %q in queries", cmName, key, stale)
 		}
 	}
 

--- a/tests/pkg/tests/observability_right_sizing_test.go
+++ b/tests/pkg/tests/observability_right_sizing_test.go
@@ -6,8 +6,10 @@ package tests
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -257,6 +259,12 @@ var _ = Describe("RHACM4K-55205: Enable and teardown namespace right-sizing reco
 		)
 	})
 
+	It("Should have cpu_profile and memory_profile variables in the namespace Grafana dashboard", func() {
+		Eventually(func() error {
+			return validateDashboardProfileVars(dynClient, "grafana-dashboard-acm-right-sizing-namespaces")
+		}, 2*time.Minute, 10*time.Second).Should(Succeed())
+	})
+
 	AfterAll(func() {
 		By("Disabling namespace right-sizing recommendation and cleaning up resources")
 
@@ -478,6 +486,22 @@ var _ = Describe("RHACM4K-58751: Enable and teardown virtualization right-sizing
 		}, 2*time.Minute, 10*time.Second).Should(Succeed(),
 			"Expected virtualization dashboard ConfigMaps to exist in namespace 'open-cluster-management-observability'",
 		)
+	})
+
+	It("Should have cpu_profile and memory_profile variables in all virtualization Grafana dashboards", func() {
+		dashboardCMs := []string{
+			"grafana-dashboard-acm-right-sizing-virt-main",
+			"grafana-dashboard-acm-right-sizing-virt-overestimation",
+			"grafana-dashboard-acm-right-sizing-virt-underestimation",
+		}
+		Eventually(func() error {
+			for _, name := range dashboardCMs {
+				if err := validateDashboardProfileVars(dynClient, name); err != nil {
+					return fmt.Errorf("dashboard %s: %w", name, err)
+				}
+			}
+			return nil
+		}, 2*time.Minute, 10*time.Second).Should(Succeed())
 	})
 
 	AfterAll(func() {
@@ -770,3 +794,59 @@ var _ = Describe("Always-MCOA right-sizing: ADC reflects CR spec state (rightsiz
 		}, 2*time.Minute, 10*time.Second).Should(Succeed())
 	})
 })
+
+// validateDashboardProfileVars fetches a Grafana dashboard ConfigMap and verifies that
+// the embedded JSON contains cpu_profile and memory_profile template variables,
+// with no stale "$profile" references.
+func validateDashboardProfileVars(dynClient dynamic.Interface, cmName string) error {
+	configMapGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	cm, err := dynClient.Resource(configMapGVR).
+		Namespace("open-cluster-management-observability").
+		Get(context.TODO(), cmName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get ConfigMap %s: %w", cmName, err)
+	}
+
+	data, found, err := unstructured.NestedStringMap(cm.Object, "data")
+	if err != nil || !found {
+		return fmt.Errorf("ConfigMap %s has no data field", cmName)
+	}
+
+	for key, dashJSON := range data {
+		if !strings.HasSuffix(key, ".json") {
+			continue
+		}
+
+		var dashboard struct {
+			Templating struct {
+				List []struct {
+					Name string `json:"name"`
+				} `json:"list"`
+			} `json:"templating"`
+		}
+		if err := json.Unmarshal([]byte(dashJSON), &dashboard); err != nil {
+			return fmt.Errorf("failed to parse dashboard JSON in %s/%s: %w", cmName, key, err)
+		}
+
+		varNames := make(map[string]bool)
+		for _, v := range dashboard.Templating.List {
+			varNames[v.Name] = true
+		}
+
+		if !varNames["cpu_profile"] {
+			return fmt.Errorf("dashboard %s/%s missing cpu_profile variable", cmName, key)
+		}
+		if !varNames["memory_profile"] {
+			return fmt.Errorf("dashboard %s/%s missing memory_profile variable", cmName, key)
+		}
+		if varNames["profile"] {
+			return fmt.Errorf("dashboard %s/%s still has stale 'profile' variable (should be split into cpu_profile/memory_profile)", cmName, key)
+		}
+
+		if strings.Contains(dashJSON, `"$profile"`) {
+			return fmt.Errorf("dashboard %s/%s still references \"$profile\" in queries", cmName, key)
+		}
+	}
+
+	return nil
+}

--- a/tests/pkg/utils/mco_crd.go
+++ b/tests/pkg/utils/mco_crd.go
@@ -57,8 +57,10 @@ func DeleteMonitoringCRDs(opt TestOptions, clusters []Cluster) error {
 				}
 				// Endpoint operator CRD self-heal (PR #2566) recreates OBO CRDs while the
 				// operator pod is still running. That is expected on the hub / local-cluster
-				// and must not fail e2e setup/teardown.
-				if crd.Labels[mcoaEndpointManagedByLabelKey] == mcoaEndpointManagedByLabelValue {
+				// and must not fail e2e setup/teardown. Only accept a fully restored CRD
+				// (not one still terminating from the delete we just issued).
+				if crd.DeletionTimestamp == nil &&
+					crd.Labels[mcoaEndpointManagedByLabelKey] == mcoaEndpointManagedByLabelValue {
 					klog.Infof("CRD %s was restored by endpoint operator on cluster %s; treating cleanup as successful", crdName, cluster.Name)
 					return true, nil
 				}

--- a/tests/pkg/utils/mco_crd.go
+++ b/tests/pkg/utils/mco_crd.go
@@ -15,6 +15,14 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// Must stay in sync with operators/endpointmetrics/controllers/mcoa.ManagedByLabel*.
+// The endpoint operator self-heals CRDs that carry this label while it is running
+// (see DeployCRDs / CRD Delete watch). E2E cleanup must tolerate that race.
+const (
+	mcoaEndpointManagedByLabelKey   = "app.kubernetes.io/managed-by"
+	mcoaEndpointManagedByLabelValue = "mcoa-endpoint-operator"
+)
+
 func DeleteMonitoringCRDs(opt TestOptions, clusters []Cluster) error {
 	for _, cluster := range clusters {
 		apiExtensionsClient := NewKubeClientAPIExtension(cluster.ClusterServerURL, cluster.KubeConfig, cluster.KubeContext)
@@ -37,14 +45,22 @@ func DeleteMonitoringCRDs(opt TestOptions, clusters []Cluster) error {
 
 		for _, crdName := range crdsToDelete {
 			klog.Infof("Waiting for CRD %s to be deleted on cluster %s", crdName, cluster.Name)
-			err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
-				_, err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crdName, metav1.GetOptions{})
+			err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+				crd, err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crdName, metav1.GetOptions{})
 				if errors.IsNotFound(err) {
 					klog.Infof("CRD %s is deleted on cluster %s", crdName, cluster.Name)
 					return true, nil
 				}
 				if err != nil {
 					klog.Warningf("Error getting CRD %s on cluster %s: %v", crdName, cluster.Name, err)
+					return false, nil
+				}
+				// Endpoint operator CRD self-heal (PR #2566) recreates OBO CRDs while the
+				// operator pod is still running. That is expected on the hub / local-cluster
+				// and must not fail e2e setup/teardown.
+				if crd.Labels[mcoaEndpointManagedByLabelKey] == mcoaEndpointManagedByLabelValue {
+					klog.Infof("CRD %s was restored by endpoint operator on cluster %s; treating cleanup as successful", crdName, cluster.Name)
+					return true, nil
 				}
 				return false, nil
 			})


### PR DESCRIPTION
- Split the single `$profile` Grafana variable into `$cpu_profile` and `$memory_profile` so CPU and memory percentile recommendations can be selected independently on the namespace and virtualization right-sizing dashboards.
- Add e2e coverage that those dashboards expose the new variables and no longer reference `$profile`.