### PR TITLE
First pass of adding Cert Manager Operator installation before MCOA Pod is deployed

### DIFF
--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -66,10 +66,11 @@ const (
 	// deprecated one.
 	certFinalizer              = "observability.open-cluster-management.io/cert-cleanup"
 	mcoaCleanupRequeueInterval = 5 * time.Second
-	// lokiOperatorRequeueInterval controls how often we recheck for the LokiStack CRD while
-	// waiting for Loki Operator's OLM install to complete. TODO: replace this polling with an
-	// event-driven trigger (e.g. a dedicated CRD watch) once the approach is finalized.
-	lokiOperatorRequeueInterval = 10 * time.Second
+	// dependencyOperatorRequeueInterval controls how often we recheck for a dependency
+	// operator's CRD (e.g. LokiStack, cert-manager's Certificate) while waiting for its OLM
+	// install to complete. TODO: replace this polling with an event-driven trigger (e.g. a
+	// dedicated CRD watch) once the approach is finalized.
+	dependencyOperatorRequeueInterval = 10 * time.Second
 )
 
 const (
@@ -267,15 +268,16 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	}
 
 	// MCOA's platform log collection capability relies on Loki Operator's LokiStack CRD as the
-	// default log store. Only install Loki Operator ourselves when MCOA is enabled and that
-	// capability is enabled; otherwise leave any existing/manual Loki Operator install alone.
+	// default log store, and on cert-manager's Certificate/Issuer/ClusterIssuer CRDs to issue
+	// the mTLS certs used for log collection/storage. Only install these ourselves when MCOA is
+	// enabled and that capability is enabled; otherwise leave any existing/manual install alone.
 	// (platformLogsEnabled already implies MCOAEnabled, but we check both explicitly for clarity.)
 	//
-	// If the CRD isn't present yet, requeue immediately rather than rendering/deploying anything
-	// else this pass, and keep requeuing every reconcile until it appears (OLM's install of Loki
-	// Operator is asynchronous and can take a while). This is deliberately simple polling for
-	// now, rather than an event-driven trigger, to keep the change safe/easy to reason about;
-	// can be optimized later.
+	// If a CRD isn't present yet, requeue immediately rather than rendering/deploying anything
+	// else this pass, and keep requeuing every reconcile until it appears (OLM installs are
+	// asynchronous and can take a while). This is deliberately simple polling for now, rather
+	// than an event-driven trigger, to keep the change safe/easy to reason about; can be
+	// optimized later.
 	platformLogsEnabled := instance.Spec.Capabilities != nil &&
 		instance.Spec.Capabilities.Platform != nil &&
 		instance.Spec.Capabilities.Platform.Logs.Collection.Enabled
@@ -290,7 +292,20 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 			if err := dependencies.EnsureLokiOperatorInstalled(ctx, r.Client); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to install Loki Operator: %w", err)
 			}
-			return ctrl.Result{RequeueAfter: lokiOperatorRequeueInterval}, nil
+			return ctrl.Result{RequeueAfter: dependencyOperatorRequeueInterval}, nil
+		}
+
+		certManagerCRD := &apiextensionsv1.CustomResourceDefinition{}
+		err = r.Client.Get(ctx, types.NamespacedName{Name: config.CertManagerCertificateCRDName}, certManagerCRD)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to check for cert-manager Certificate CRD %s: %w", config.CertManagerCertificateCRDName, err)
+		}
+		if apierrors.IsNotFound(err) {
+			reqLogger.Info("cert-manager Certificate CRD not found, installing cert-manager Operator", "crd", config.CertManagerCertificateCRDName)
+			if err := dependencies.EnsureCertManagerOperatorInstalled(ctx, r.Client); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to install cert-manager Operator: %w", err)
+			}
+			return ctrl.Result{RequeueAfter: dependencyOperatorRequeueInterval}, nil
 		}
 	}
 

--- a/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
+++ b/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
@@ -75,6 +75,12 @@
     - apiGroups: ["loki.grafana.com"]
       resources: ["lokistacks"]
       verbs: ["get", "list", "watch"]
+    - apiGroups: ["cert-manager.io"]
+      resources: ["certificates"]
+      verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+    - apiGroups: ["cert-manager.io"]
+      resources: ["certificates/status"]
+      verbs: ["get", "update"]
     # Role for addon to perform opentelemetry specific actions
     - apiGroups: ["opentelemetry.io"]
       resources: ["opentelemetrycollectors", "instrumentations"]

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -266,6 +266,28 @@ const (
 	LokiStackCRDName = "lokistacks.loki.grafana.com"
 )
 
+const (
+	// CertManagerOperatorNamespace is the namespace the cert-manager Operator for Red Hat
+	// OpenShift is installed into via OLM. It's a global (cluster-scoped) operator, so it
+	// follows the same convention as other Red Hat cluster-scoped operators.
+	CertManagerOperatorNamespace = "cert-manager-operator"
+
+	// CertManagerOperatorPackageName is the OLM package/Subscription name for the cert-manager
+	// Operator for Red Hat OpenShift.
+	CertManagerOperatorPackageName = "openshift-cert-manager-operator"
+
+	// CertManagerOperatorCatalogSource and CertManagerOperatorCatalogSourceNamespace point at
+	// the default Red Hat operator catalog.
+	CertManagerOperatorCatalogSource          = "redhat-operators"
+	CertManagerOperatorCatalogSourceNamespace = "openshift-marketplace"
+
+	// CertManagerCertificateCRDName is one of the CustomResourceDefinitions the cert-manager
+	// Operator registers once installed. MCO waits for this CRD to exist before assuming
+	// cert-manager is ready. MCOA's logging default stack uses cert-manager Certificate/
+	// Issuer/ClusterIssuer CRs to issue mTLS certs for log collection/storage.
+	CertManagerCertificateCRDName = "certificates.cert-manager.io"
+)
+
 var (
 	ErrMultipleMCOInstances = errors.New("more than one MultiClusterObservability CR exists")
 	ErrMCONotFound          = errors.New("MultiClusterObservability CR not found")

--- a/operators/multiclusterobservability/pkg/dependencies/cert_manager_operator.go
+++ b/operators/multiclusterobservability/pkg/dependencies/cert_manager_operator.go
@@ -1,0 +1,81 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package dependencies
+
+import (
+	"context"
+	"fmt"
+
+	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// BuildCertManagerOperatorResources returns the Namespace, OperatorGroup and Subscription
+// objects required to install the cert-manager Operator for Red Hat OpenShift via OLM on the
+// hub cluster.
+//
+// OperatorGroup/Subscription are built as unstructured objects (rather than importing
+// github.com/operator-framework/api) to avoid adding a new dependency to this operator for
+// three object kinds.
+func BuildCertManagerOperatorResources() []client.Object {
+	ns := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mcoconfig.CertManagerOperatorNamespace,
+		},
+	}
+
+	// No spec.targetNamespaces/spec.selector: this makes it a global OperatorGroup (AllNamespaces
+	// mode), which is the mode Red Hat's cert-manager Operator recommends from v1.15 onward.
+	og := &unstructured.Unstructured{}
+	og.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1",
+		Kind:    "OperatorGroup",
+	})
+	og.SetName(mcoconfig.CertManagerOperatorPackageName)
+	og.SetNamespace(mcoconfig.CertManagerOperatorNamespace)
+
+	sub := &unstructured.Unstructured{}
+	sub.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1alpha1",
+		Kind:    "Subscription",
+	})
+	sub.SetName(mcoconfig.CertManagerOperatorPackageName)
+	sub.SetNamespace(mcoconfig.CertManagerOperatorNamespace)
+	sub.Object["spec"] = map[string]any{
+		// channel is deliberately omitted: it's an optional field on the Subscription CRD, and
+		// leaving it unset tells OLM to track the package's current default channel, so this
+		// doesn't need to be bumped as the operator ships new channels (see loki_operator.go for
+		// the same reasoning).
+		"name":                mcoconfig.CertManagerOperatorPackageName,
+		"source":              mcoconfig.CertManagerOperatorCatalogSource,
+		"sourceNamespace":     mcoconfig.CertManagerOperatorCatalogSourceNamespace,
+		"installPlanApproval": "Automatic",
+	}
+
+	return []client.Object{ns, og, sub}
+}
+
+// EnsureCertManagerOperatorInstalled creates the cert-manager Operator's Namespace,
+// OperatorGroup and Subscription if they don't already exist. It never updates an existing
+// object, so it won't fight a manual install or an in-progress OLM upgrade.
+func EnsureCertManagerOperatorInstalled(ctx context.Context, c client.Client) error {
+	for _, obj := range BuildCertManagerOperatorResources() {
+		if err := c.Create(ctx, obj); err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create %s %s/%s: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(), err)
+		}
+	}
+	return nil
+}

--- a/operators/multiclusterobservability/pkg/dependencies/cert_manager_operator_test.go
+++ b/operators/multiclusterobservability/pkg/dependencies/cert_manager_operator_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package dependencies
+
+import (
+	"testing"
+
+	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestBuildCertManagerOperatorResources(t *testing.T) {
+	objs := BuildCertManagerOperatorResources()
+	require.Len(t, objs, 3)
+
+	ns, ok := objs[0].(*corev1.Namespace)
+	require.True(t, ok, "first object should be a Namespace")
+	require.Equal(t, mcoconfig.CertManagerOperatorNamespace, ns.GetName())
+
+	og, ok := objs[1].(*unstructured.Unstructured)
+	require.True(t, ok, "second object should be an unstructured OperatorGroup")
+	require.Equal(t, "OperatorGroup", og.GetKind())
+	require.Equal(t, mcoconfig.CertManagerOperatorPackageName, og.GetName())
+	require.Equal(t, mcoconfig.CertManagerOperatorNamespace, og.GetNamespace())
+
+	// No spec.targetNamespaces/spec.selector: global OperatorGroup (AllNamespaces mode).
+	_, found, err := unstructured.NestedStringSlice(og.Object, "spec", "targetNamespaces")
+	require.NoError(t, err)
+	require.False(t, found)
+
+	sub, ok := objs[2].(*unstructured.Unstructured)
+	require.True(t, ok, "third object should be an unstructured Subscription")
+	require.Equal(t, "Subscription", sub.GetKind())
+	require.Equal(t, mcoconfig.CertManagerOperatorPackageName, sub.GetName())
+	require.Equal(t, mcoconfig.CertManagerOperatorNamespace, sub.GetNamespace())
+
+	// channel is deliberately left unset so OLM tracks the package's default channel; see the
+	// comment in BuildCertManagerOperatorResources for why.
+	_, found, err = unstructured.NestedString(sub.Object, "spec", "channel")
+	require.NoError(t, err)
+	require.False(t, found)
+
+	name, found, err := unstructured.NestedString(sub.Object, "spec", "name")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, mcoconfig.CertManagerOperatorPackageName, name)
+}
+
+func TestEnsureCertManagerOperatorInstalled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	require.NoError(t, EnsureCertManagerOperatorInstalled(t.Context(), fakeClient))
+	require.NoError(t, fakeClient.Get(t.Context(), types.NamespacedName{Name: mcoconfig.CertManagerOperatorNamespace}, &corev1.Namespace{}))
+
+	// Calling it again should be a no-op (idempotent), not fail with AlreadyExists.
+	require.NoError(t, EnsureCertManagerOperatorInstalled(t.Context(), fakeClient))
+}
+
+func TestEnsureCertManagerOperatorInstalled_PropagatesUnexpectedErrors(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	// erroringClient is defined in loki_operator_test.go (same package) and forces every
+	// Create call to fail with a non-AlreadyExists error.
+	fakeClient := &erroringClient{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+
+	err := EnsureCertManagerOperatorInstalled(t.Context(), fakeClient)
+	require.Error(t, err)
+}


### PR DESCRIPTION
This follows the same pattern as https://github.com/stolostron/multicluster-observability-operator/pull/2709. This is the first pass of adding support for Cert Manager Installation in the MCO. This occurs if logging is enabled and the MCOA will get deployed but the hub, currently does not have the Certificates CRD. It checks this, and if not, it installs the Cert Manager Operator resources into the cluster, which install the CertManager CRD. It also includes adding RBAC permissions to the MCOA Pod for certificates. 