### PR TITLE
[ACM-27838] fix misleading namespace log

### DIFF
--- a/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
+++ b/operators/multiclusterobservability/controllers/placementrule/placementrule_controller.go
@@ -499,11 +499,6 @@ func createAllRelatedRes(
 			continue
 		}
 
-		log.Info("Reconciling managed cluster resources",
-			"cluster", managedCluster,
-			"openshiftVersion", openshiftVersion,
-			"triggered_by", request.Name,
-			"in_namespace", request.Namespace)
 		var installProm bool
 		namespace := managedCluster
 		switch openshiftVersion {
@@ -515,6 +510,12 @@ func createAllRelatedRes(
 			}
 			namespace = config.GetDefaultNamespace()
 		}
+
+		log.Info("Reconciling managed cluster resources",
+			"cluster", managedCluster,
+			"openshiftVersion", openshiftVersion,
+			"triggered_by", request.Name,
+			"in_namespace", namespace)
 
 		addonDeployCfg, err := createManagedClusterRes(ctx, c, mco, managedCluster, namespace)
 		if err != nil {


### PR DESCRIPTION
**Problem:**
The logs of the multicluster-observability-operator would mention the wrong cluster namespace
**Fix:**
Change from using request.Namespace to using namespace
