### PR TITLE
First pass of adding RootClusterIssuer,RootIssuer,RootCertificate

### DIFF
--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -49,7 +49,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-09-02T13:10:40Z"
+    createdAt: "2026-09-10T12:53:48Z"
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-observability-operator.v0.1.0
@@ -520,6 +520,17 @@ spec:
           resources:
           - operatorgroups
           - subscriptions
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - issuers
+          - certificates
+          - clusterissuers
           verbs:
           - create
           - get

--- a/operators/multiclusterobservability/config/rbac/mco_role.yaml
+++ b/operators/multiclusterobservability/config/rbac/mco_role.yaml
@@ -443,3 +443,16 @@ rules:
   - get
   - list
   - watch
+# Needed to create the MCOA root CA Issuer/Certificate/ClusterIssuer that MCOA's logging
+# default stack issues its mTLS certs from, once cert-manager's Certificate CRD is present.
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - issuers
+  - certificates
+  - clusterissuers
+  verbs:
+  - create
+  - get
+  - list
+  - watch

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -307,6 +307,13 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 			}
 			return ctrl.Result{RequeueAfter: dependencyOperatorRequeueInterval}, nil
 		}
+
+		// The Certificate CRD (and its sibling Issuer/ClusterIssuer CRDs) are now established,
+		// so it's safe to create the root CA Issuer/Certificate/ClusterIssuer that MCOA's
+		// logging default stack issues its mTLS certs from.
+		if err := dependencies.EnsureMCOARootCertificatesInstalled(ctx, r.Client); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to install MCOA root certificate resources: %w", err)
+		}
 	}
 
 	// Build render options

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -286,6 +286,27 @@ const (
 	// cert-manager is ready. MCOA's logging default stack uses cert-manager Certificate/
 	// Issuer/ClusterIssuer CRs to issue mTLS certs for log collection/storage.
 	CertManagerCertificateCRDName = "certificates.cert-manager.io"
+
+	// CertManagerNamespace is the fixed operand namespace the cert-manager Operator for Red
+	// Hat OpenShift deploys the cert-manager controllers into. It's enforced by the operator
+	// and can't be changed, so the namespaced cert-manager resources MCO manages (the
+	// self-signed Issuer and root CA Certificate below) must live here too.
+	CertManagerNamespace = "cert-manager"
+
+	// MCOARootCAIssuerName is the self-signed Issuer MCO creates to mint the MCOA root CA
+	// Certificate below. It only ever issues that one Certificate, so it's not meant to be
+	// referenced by anything else.
+	MCOARootCAIssuerName = "mcoa-root-ca"
+
+	// MCOARootCertificateName is the root CA Certificate (and the Secret it's written to, same
+	// name) that backs MCOARootClusterIssuerName. It's what actually signs the leaf
+	// certificates MCOA's logging default stack uses for mTLS.
+	MCOARootCertificateName = "mcoa-root-cert"
+
+	// MCOARootClusterIssuerName is the cluster-scoped Issuer, backed by MCOARootCertificateName's
+	// Secret, that MCOA-rendered Certificates request their mTLS leaf certs from for log
+	// collection/storage.
+	MCOARootClusterIssuerName = "mcoa-root-issuer"
 )
 
 var (

--- a/operators/multiclusterobservability/pkg/dependencies/mcoa_root_certificate.go
+++ b/operators/multiclusterobservability/pkg/dependencies/mcoa_root_certificate.go
@@ -1,0 +1,87 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package dependencies
+
+import (
+	"context"
+	"fmt"
+
+	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// certManagerGroupVersion is the API group/version cert-manager registers its CRDs under.
+const certManagerGroupVersion = "cert-manager.io/v1"
+
+// BuildMCOARootCertificateResources returns the self-signed Issuer, root CA Certificate and
+// ClusterIssuer that MCOA's platform log collection capability needs from cert-manager to
+// issue the mTLS certs used for log collection/storage:
+//   - a self-signed Issuer that only ever mints the root CA Certificate below;
+//   - a root CA Certificate, written to a Secret of the same name;
+//   - a ClusterIssuer backed by that Secret, which is what MCOA-rendered Certificates
+//     actually request their leaf certs from.
+//
+// These are built as unstructured objects (rather than importing cert-manager's API package)
+// to avoid adding a new dependency to this operator for three object kinds.
+func BuildMCOARootCertificateResources() []client.Object {
+	issuer := &unstructured.Unstructured{}
+	issuer.SetGroupVersionKind(schema.FromAPIVersionAndKind(certManagerGroupVersion, "Issuer"))
+	issuer.SetName(mcoconfig.MCOARootCAIssuerName)
+	issuer.SetNamespace(mcoconfig.CertManagerNamespace)
+	issuer.Object["spec"] = map[string]any{
+		"selfSigned": map[string]any{},
+	}
+
+	cert := &unstructured.Unstructured{}
+	cert.SetGroupVersionKind(schema.FromAPIVersionAndKind(certManagerGroupVersion, "Certificate"))
+	cert.SetName(mcoconfig.MCOARootCertificateName)
+	cert.SetNamespace(mcoconfig.CertManagerNamespace)
+	cert.Object["spec"] = map[string]any{
+		"isCA":       true,
+		"secretName": mcoconfig.MCOARootCertificateName,
+		"commonName": "MCOA Root Certificate",
+		"privateKey": map[string]any{
+			"algorithm": "RSA",
+			"size":      int64(4096),
+			"encoding":  "PKCS8",
+		},
+		"issuerRef": map[string]any{
+			"kind": "Issuer",
+			"name": mcoconfig.MCOARootCAIssuerName,
+		},
+	}
+
+	clusterIssuer := &unstructured.Unstructured{}
+	clusterIssuer.SetGroupVersionKind(schema.FromAPIVersionAndKind(certManagerGroupVersion, "ClusterIssuer"))
+	clusterIssuer.SetName(mcoconfig.MCOARootClusterIssuerName)
+	// ClusterIssuer is cluster-scoped: no namespace to set. Its "ca.secretName" is still
+	// resolved from CertManagerNamespace, since that's where cert-manager itself runs.
+	clusterIssuer.Object["spec"] = map[string]any{
+		"ca": map[string]any{
+			"secretName": mcoconfig.MCOARootCertificateName,
+		},
+	}
+
+	return []client.Object{issuer, cert, clusterIssuer}
+}
+
+// EnsureMCOARootCertificatesInstalled creates the Issuer, Certificate and ClusterIssuer from
+// BuildMCOARootCertificateResources if they don't already exist. It never updates an existing
+// object, so it won't fight a manual install or overwrite an already-issued root CA.
+//
+// Callers must only invoke this once cert-manager's Certificate CRD (and, transitively, its
+// Issuer/ClusterIssuer CRDs) are known to be established on the cluster; creating these
+// resources any earlier would just fail with a NoKindMatchError.
+func EnsureMCOARootCertificatesInstalled(ctx context.Context, c client.Client) error {
+	for _, obj := range BuildMCOARootCertificateResources() {
+		if err := c.Create(ctx, obj); err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create %s %s/%s: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(), err)
+		}
+	}
+	return nil
+}

--- a/operators/multiclusterobservability/pkg/dependencies/mcoa_root_certificate_test.go
+++ b/operators/multiclusterobservability/pkg/dependencies/mcoa_root_certificate_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package dependencies
+
+import (
+	"testing"
+
+	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestBuildMCOARootCertificateResources(t *testing.T) {
+	objs := BuildMCOARootCertificateResources()
+	require.Len(t, objs, 3)
+
+	issuer, ok := objs[0].(*unstructured.Unstructured)
+	require.True(t, ok, "first object should be an unstructured Issuer")
+	require.Equal(t, "Issuer", issuer.GetKind())
+	require.Equal(t, mcoconfig.MCOARootCAIssuerName, issuer.GetName())
+	require.Equal(t, mcoconfig.CertManagerNamespace, issuer.GetNamespace())
+
+	_, found, err := unstructured.NestedMap(issuer.Object, "spec", "selfSigned")
+	require.NoError(t, err)
+	require.True(t, found, "Issuer should be self-signed")
+
+	cert, ok := objs[1].(*unstructured.Unstructured)
+	require.True(t, ok, "second object should be an unstructured Certificate")
+	require.Equal(t, "Certificate", cert.GetKind())
+	require.Equal(t, mcoconfig.MCOARootCertificateName, cert.GetName())
+	require.Equal(t, mcoconfig.CertManagerNamespace, cert.GetNamespace())
+
+	isCA, found, err := unstructured.NestedBool(cert.Object, "spec", "isCA")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.True(t, isCA)
+
+	secretName, found, err := unstructured.NestedString(cert.Object, "spec", "secretName")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, mcoconfig.MCOARootCertificateName, secretName)
+
+	issuerRefKind, found, err := unstructured.NestedString(cert.Object, "spec", "issuerRef", "kind")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "Issuer", issuerRefKind)
+
+	issuerRefName, found, err := unstructured.NestedString(cert.Object, "spec", "issuerRef", "name")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, mcoconfig.MCOARootCAIssuerName, issuerRefName)
+
+	clusterIssuer, ok := objs[2].(*unstructured.Unstructured)
+	require.True(t, ok, "third object should be an unstructured ClusterIssuer")
+	require.Equal(t, "ClusterIssuer", clusterIssuer.GetKind())
+	require.Equal(t, mcoconfig.MCOARootClusterIssuerName, clusterIssuer.GetName())
+	require.Empty(t, clusterIssuer.GetNamespace(), "ClusterIssuer is cluster-scoped")
+
+	caSecretName, found, err := unstructured.NestedString(clusterIssuer.Object, "spec", "ca", "secretName")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, mcoconfig.MCOARootCertificateName, caSecretName)
+}
+
+func TestEnsureMCOARootCertificatesInstalled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	require.NoError(t, EnsureMCOARootCertificatesInstalled(t.Context(), fakeClient))
+
+	issuer := &unstructured.Unstructured{}
+	issuer.SetGroupVersionKind(schema.FromAPIVersionAndKind(certManagerGroupVersion, "Issuer"))
+	require.NoError(t, fakeClient.Get(t.Context(), types.NamespacedName{
+		Name:      mcoconfig.MCOARootCAIssuerName,
+		Namespace: mcoconfig.CertManagerNamespace,
+	}, issuer))
+
+	// Calling it again should be a no-op (idempotent), not fail with AlreadyExists.
+	require.NoError(t, EnsureMCOARootCertificatesInstalled(t.Context(), fakeClient))
+}
+
+func TestEnsureMCOARootCertificatesInstalled_PropagatesUnexpectedErrors(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	// erroringClient is defined in loki_operator_test.go (same package) and forces every
+	// Create call to fail with a non-AlreadyExists error.
+	fakeClient := &erroringClient{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+
+	err := EnsureMCOARootCertificatesInstalled(t.Context(), fakeClient)
+	require.Error(t, err)
+}


### PR DESCRIPTION
In this MR, I add support for installing a self-signed Issuer, root CA Certificate, and ClusterIssuer when logging is enabled and the certificate CRD is installed. These resources are currently needed by the managed_logstore branch in the MCOA for its self-signed certificates that get distributed to the managed/MCOA created Cluster Log Forwarder. I tested this locally and verified that the resources were created. I also updated the mco_role.yaml file to add these RBAC permissions and regenerated the bundle. I verified that this works end to end on a hub cluster.

` oc get clusterIssuer -A
NAME               READY   AGE
mcoa-root-issuer   True    47s
oc get Issuer -A
NAMESPACE      NAME           READY   AGE
cert-manager   mcoa-root-ca   True    53s
oc get Certificate -A
NAMESPACE      NAME             READY   SECRET           AGE
cert-manager   mcoa-root-cert   True    mcoa-root-cert   57s`