### PR TITLE
Add Certificates Issuers in MCO For Logging per-cluster mtls

### DIFF
--- a/operators/multiclusterobservability/bundle.Dockerfile
+++ b/operators/multiclusterobservability/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=multicluster-observability-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-unknown
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -49,7 +49,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-08-25T16:00:30Z"
+    createdAt: "2026-09-02T13:10:40Z"
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-observability-operator.v0.1.0
@@ -515,6 +515,16 @@ spec:
           - list
           - watch
           - delete
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - operatorgroups
+          - subscriptions
+          verbs:
+          - create
+          - get
+          - list
+          - watch
         serviceAccountName: multicluster-observability-operator
       deployments:
       - label:

--- a/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
+++ b/operators/multiclusterobservability/bundle/manifests/multicluster-observability-operator.clusterserviceversion.yaml
@@ -49,7 +49,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-09-02T13:10:40Z"
+    createdAt: "2026-09-10T12:53:48Z"
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: multicluster-observability-operator.v0.1.0
@@ -520,6 +520,17 @@ spec:
           resources:
           - operatorgroups
           - subscriptions
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - issuers
+          - certificates
+          - clusterissuers
           verbs:
           - create
           - get

--- a/operators/multiclusterobservability/config/rbac/mco_role.yaml
+++ b/operators/multiclusterobservability/config/rbac/mco_role.yaml
@@ -431,3 +431,15 @@ rules:
   - list
   - watch
   - delete
+# Needed to install Loki Operator (OperatorGroup + Subscription) via OLM when MCOA platform
+# log collection is enabled and its LokiStack CRD isn't already present on the hub.
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - operatorgroups
+  - subscriptions
+  verbs:
+  - create
+  - get
+  - list
+  - watch

--- a/operators/multiclusterobservability/config/rbac/mco_role.yaml
+++ b/operators/multiclusterobservability/config/rbac/mco_role.yaml
@@ -443,3 +443,16 @@ rules:
   - get
   - list
   - watch
+# Needed to create the MCOA root CA Issuer/Certificate/ClusterIssuer that MCOA's logging
+# default stack issues its mTLS certs from, once cert-manager's Certificate CRD is present.
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - issuers
+  - certificates
+  - clusterissuers
+  verbs:
+  - create
+  - get
+  - list
+  - watch

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -66,10 +66,11 @@ const (
 	// deprecated one.
 	certFinalizer              = "observability.open-cluster-management.io/cert-cleanup"
 	mcoaCleanupRequeueInterval = 5 * time.Second
-	// lokiOperatorRequeueInterval controls how often we recheck for the LokiStack CRD while
-	// waiting for Loki Operator's OLM install to complete. TODO: replace this polling with an
-	// event-driven trigger (e.g. a dedicated CRD watch) once the approach is finalized.
-	lokiOperatorRequeueInterval = 10 * time.Second
+	// dependencyOperatorRequeueInterval controls how often we recheck for a dependency
+	// operator's CRD (e.g. LokiStack, cert-manager's Certificate) while waiting for its OLM
+	// install to complete. TODO: replace this polling with an event-driven trigger (e.g. a
+	// dedicated CRD watch) once the approach is finalized.
+	dependencyOperatorRequeueInterval = 10 * time.Second
 )
 
 const (
@@ -267,15 +268,16 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	}
 
 	// MCOA's platform log collection capability relies on Loki Operator's LokiStack CRD as the
-	// default log store. Only install Loki Operator ourselves when MCOA is enabled and that
-	// capability is enabled; otherwise leave any existing/manual Loki Operator install alone.
+	// default log store, and on cert-manager's Certificate/Issuer/ClusterIssuer CRDs to issue
+	// the mTLS certs used for log collection/storage. Only install these ourselves when MCOA is
+	// enabled and that capability is enabled; otherwise leave any existing/manual install alone.
 	// (platformLogsEnabled already implies MCOAEnabled, but we check both explicitly for clarity.)
 	//
-	// If the CRD isn't present yet, requeue immediately rather than rendering/deploying anything
-	// else this pass, and keep requeuing every reconcile until it appears (OLM's install of Loki
-	// Operator is asynchronous and can take a while). This is deliberately simple polling for
-	// now, rather than an event-driven trigger, to keep the change safe/easy to reason about;
-	// can be optimized later.
+	// If a CRD isn't present yet, requeue immediately rather than rendering/deploying anything
+	// else this pass, and keep requeuing every reconcile until it appears (OLM installs are
+	// asynchronous and can take a while). This is deliberately simple polling for now, rather
+	// than an event-driven trigger, to keep the change safe/easy to reason about; can be
+	// optimized later.
 	platformLogsEnabled := instance.Spec.Capabilities != nil &&
 		instance.Spec.Capabilities.Platform != nil &&
 		instance.Spec.Capabilities.Platform.Logs.Collection.Enabled
@@ -290,7 +292,20 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 			if err := dependencies.EnsureLokiOperatorInstalled(ctx, r.Client); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to install Loki Operator: %w", err)
 			}
-			return ctrl.Result{RequeueAfter: lokiOperatorRequeueInterval}, nil
+			return ctrl.Result{RequeueAfter: dependencyOperatorRequeueInterval}, nil
+		}
+
+		certManagerCRD := &apiextensionsv1.CustomResourceDefinition{}
+		err = r.Client.Get(ctx, types.NamespacedName{Name: config.CertManagerCertificateCRDName}, certManagerCRD)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to check for cert-manager Certificate CRD %s: %w", config.CertManagerCertificateCRDName, err)
+		}
+		if apierrors.IsNotFound(err) {
+			reqLogger.Info("cert-manager Certificate CRD not found, installing cert-manager Operator", "crd", config.CertManagerCertificateCRDName)
+			if err := dependencies.EnsureCertManagerOperatorInstalled(ctx, r.Client); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to install cert-manager Operator: %w", err)
+			}
+			return ctrl.Result{RequeueAfter: dependencyOperatorRequeueInterval}, nil
 		}
 	}
 

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -26,6 +26,7 @@ import (
 	placementctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/controllers/placementrule"
 	certctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/certificates"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/dependencies"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/rendering"
 	smctrl "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/servicemonitor"
 	"github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/util"
@@ -65,6 +66,10 @@ const (
 	// deprecated one.
 	certFinalizer              = "observability.open-cluster-management.io/cert-cleanup"
 	mcoaCleanupRequeueInterval = 5 * time.Second
+	// lokiOperatorRequeueInterval controls how often we recheck for the LokiStack CRD while
+	// waiting for Loki Operator's OLM install to complete. TODO: replace this polling with an
+	// event-driven trigger (e.g. a dedicated CRD watch) once the approach is finalized.
+	lokiOperatorRequeueInterval = 10 * time.Second
 )
 
 const (
@@ -259,6 +264,34 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 	obsAPIURL, err := config.GetObsAPIExternalURL(ctx, r.Client, config.GetDefaultNamespace())
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get the Observatorium API URL: %w", err) // Already wrapped
+	}
+
+	// MCOA's platform log collection capability relies on Loki Operator's LokiStack CRD as the
+	// default log store. Only install Loki Operator ourselves when MCOA is enabled and that
+	// capability is enabled; otherwise leave any existing/manual Loki Operator install alone.
+	// (platformLogsEnabled already implies MCOAEnabled, but we check both explicitly for clarity.)
+	//
+	// If the CRD isn't present yet, requeue immediately rather than rendering/deploying anything
+	// else this pass, and keep requeuing every reconcile until it appears (OLM's install of Loki
+	// Operator is asynchronous and can take a while). This is deliberately simple polling for
+	// now, rather than an event-driven trigger, to keep the change safe/easy to reason about;
+	// can be optimized later.
+	platformLogsEnabled := instance.Spec.Capabilities != nil &&
+		instance.Spec.Capabilities.Platform != nil &&
+		instance.Spec.Capabilities.Platform.Logs.Collection.Enabled
+	if rendering.MCOAEnabled(instance) && platformLogsEnabled {
+		lokiStackCRD := &apiextensionsv1.CustomResourceDefinition{}
+		err = r.Client.Get(ctx, types.NamespacedName{Name: config.LokiStackCRDName}, lokiStackCRD)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to check for LokiStack CRD %s: %w", config.LokiStackCRDName, err)
+		}
+		if apierrors.IsNotFound(err) {
+			reqLogger.Info("LokiStack CRD not found, installing Loki Operator", "crd", config.LokiStackCRDName)
+			if err := dependencies.EnsureLokiOperatorInstalled(ctx, r.Client); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to install Loki Operator: %w", err)
+			}
+			return ctrl.Result{RequeueAfter: lokiOperatorRequeueInterval}, nil
+		}
 	}
 
 	// Build render options

--- a/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
+++ b/operators/multiclusterobservability/controllers/multiclusterobservability/multiclusterobservability_controller.go
@@ -307,6 +307,13 @@ func (r *MultiClusterObservabilityReconciler) Reconcile(ctx context.Context, req
 			}
 			return ctrl.Result{RequeueAfter: dependencyOperatorRequeueInterval}, nil
 		}
+
+		// The Certificate CRD (and its sibling Issuer/ClusterIssuer CRDs) are now established,
+		// so it's safe to create the root CA Issuer/Certificate/ClusterIssuer that MCOA's
+		// logging default stack issues its mTLS certs from.
+		if err := dependencies.EnsureMCOARootCertificatesInstalled(ctx, r.Client); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to install MCOA root certificate resources: %w", err)
+		}
 	}
 
 	// Build render options

--- a/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
+++ b/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
@@ -75,6 +75,12 @@
     - apiGroups: ["loki.grafana.com"]
       resources: ["lokistacks"]
       verbs: ["get", "list", "watch"]
+    - apiGroups: ["cert-manager.io"]
+      resources: ["certificates"]
+      verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+    - apiGroups: ["cert-manager.io"]
+      resources: ["certificates/status"]
+      verbs: ["get", "update"]
     # Role for addon to perform opentelemetry specific actions
     - apiGroups: ["opentelemetry.io"]
       resources: ["opentelemetrycollectors", "instrumentations"]

--- a/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
+++ b/operators/multiclusterobservability/manifests/base/multicluster-observability-addon/cluster_role.yaml
@@ -72,6 +72,9 @@
     - apiGroups: ["observability.openshift.io"]
       resources: ["clusterlogforwarders"]
       verbs: ["get", "list", "watch"]
+    - apiGroups: ["loki.grafana.com"]
+      resources: ["lokistacks"]
+      verbs: ["get", "list", "watch"]
     # Role for addon to perform opentelemetry specific actions
     - apiGroups: ["opentelemetry.io"]
       resources: ["opentelemetrycollectors", "instrumentations"]

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -266,6 +266,28 @@ const (
 	LokiStackCRDName = "lokistacks.loki.grafana.com"
 )
 
+const (
+	// CertManagerOperatorNamespace is the namespace the cert-manager Operator for Red Hat
+	// OpenShift is installed into via OLM. It's a global (cluster-scoped) operator, so it
+	// follows the same convention as other Red Hat cluster-scoped operators.
+	CertManagerOperatorNamespace = "cert-manager-operator"
+
+	// CertManagerOperatorPackageName is the OLM package/Subscription name for the cert-manager
+	// Operator for Red Hat OpenShift.
+	CertManagerOperatorPackageName = "openshift-cert-manager-operator"
+
+	// CertManagerOperatorCatalogSource and CertManagerOperatorCatalogSourceNamespace point at
+	// the default Red Hat operator catalog.
+	CertManagerOperatorCatalogSource          = "redhat-operators"
+	CertManagerOperatorCatalogSourceNamespace = "openshift-marketplace"
+
+	// CertManagerCertificateCRDName is one of the CustomResourceDefinitions the cert-manager
+	// Operator registers once installed. MCO waits for this CRD to exist before assuming
+	// cert-manager is ready. MCOA's logging default stack uses cert-manager Certificate/
+	// Issuer/ClusterIssuer CRs to issue mTLS certs for log collection/storage.
+	CertManagerCertificateCRDName = "certificates.cert-manager.io"
+)
+
 var (
 	ErrMultipleMCOInstances = errors.New("more than one MultiClusterObservability CR exists")
 	ErrMCONotFound          = errors.New("MultiClusterObservability CR not found")

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -247,6 +247,25 @@ const (
 	PrometheusRuleCRDName         = "prometheusrules.monitoring.rhobs"
 )
 
+const (
+	// LokiOperatorNamespace is the namespace Loki Operator is installed into via OLM. Loki
+	// Operator is a global (cluster-scoped) operator, so it follows the same convention as
+	// other Red Hat cluster-scoped operators and lives in openshift-operators-redhat.
+	LokiOperatorNamespace = "openshift-operators-redhat"
+
+	// LokiOperatorPackageName is the OLM package/Subscription name for Loki Operator.
+	LokiOperatorPackageName = "loki-operator"
+
+	// LokiOperatorCatalogSource and LokiOperatorCatalogSourceNamespace point at the default
+	// Red Hat operator catalog.
+	LokiOperatorCatalogSource          = "redhat-operators"
+	LokiOperatorCatalogSourceNamespace = "openshift-marketplace"
+
+	// LokiStackCRDName is the CustomResourceDefinition Loki Operator registers once installed.
+	// MCO waits for this CRD to exist before assuming Loki Operator is ready.
+	LokiStackCRDName = "lokistacks.loki.grafana.com"
+)
+
 var (
 	ErrMultipleMCOInstances = errors.New("more than one MultiClusterObservability CR exists")
 	ErrMCONotFound          = errors.New("MultiClusterObservability CR not found")

--- a/operators/multiclusterobservability/pkg/config/config.go
+++ b/operators/multiclusterobservability/pkg/config/config.go
@@ -286,6 +286,27 @@ const (
 	// cert-manager is ready. MCOA's logging default stack uses cert-manager Certificate/
 	// Issuer/ClusterIssuer CRs to issue mTLS certs for log collection/storage.
 	CertManagerCertificateCRDName = "certificates.cert-manager.io"
+
+	// CertManagerNamespace is the fixed operand namespace the cert-manager Operator for Red
+	// Hat OpenShift deploys the cert-manager controllers into. It's enforced by the operator
+	// and can't be changed, so the namespaced cert-manager resources MCO manages (the
+	// self-signed Issuer and root CA Certificate below) must live here too.
+	CertManagerNamespace = "cert-manager"
+
+	// MCOARootCAIssuerName is the self-signed Issuer MCO creates to mint the MCOA root CA
+	// Certificate below. It only ever issues that one Certificate, so it's not meant to be
+	// referenced by anything else.
+	MCOARootCAIssuerName = "mcoa-root-ca"
+
+	// MCOARootCertificateName is the root CA Certificate (and the Secret it's written to, same
+	// name) that backs MCOARootClusterIssuerName. It's what actually signs the leaf
+	// certificates MCOA's logging default stack uses for mTLS.
+	MCOARootCertificateName = "mcoa-root-cert"
+
+	// MCOARootClusterIssuerName is the cluster-scoped Issuer, backed by MCOARootCertificateName's
+	// Secret, that MCOA-rendered Certificates request their mTLS leaf certs from for log
+	// collection/storage.
+	MCOARootClusterIssuerName = "mcoa-root-issuer"
 )
 
 var (

--- a/operators/multiclusterobservability/pkg/dependencies/cert_manager_operator.go
+++ b/operators/multiclusterobservability/pkg/dependencies/cert_manager_operator.go
@@ -1,0 +1,81 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package dependencies
+
+import (
+	"context"
+	"fmt"
+
+	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// BuildCertManagerOperatorResources returns the Namespace, OperatorGroup and Subscription
+// objects required to install the cert-manager Operator for Red Hat OpenShift via OLM on the
+// hub cluster.
+//
+// OperatorGroup/Subscription are built as unstructured objects (rather than importing
+// github.com/operator-framework/api) to avoid adding a new dependency to this operator for
+// three object kinds.
+func BuildCertManagerOperatorResources() []client.Object {
+	ns := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mcoconfig.CertManagerOperatorNamespace,
+		},
+	}
+
+	// No spec.targetNamespaces/spec.selector: this makes it a global OperatorGroup (AllNamespaces
+	// mode), which is the mode Red Hat's cert-manager Operator recommends from v1.15 onward.
+	og := &unstructured.Unstructured{}
+	og.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1",
+		Kind:    "OperatorGroup",
+	})
+	og.SetName(mcoconfig.CertManagerOperatorPackageName)
+	og.SetNamespace(mcoconfig.CertManagerOperatorNamespace)
+
+	sub := &unstructured.Unstructured{}
+	sub.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1alpha1",
+		Kind:    "Subscription",
+	})
+	sub.SetName(mcoconfig.CertManagerOperatorPackageName)
+	sub.SetNamespace(mcoconfig.CertManagerOperatorNamespace)
+	sub.Object["spec"] = map[string]any{
+		// channel is deliberately omitted: it's an optional field on the Subscription CRD, and
+		// leaving it unset tells OLM to track the package's current default channel, so this
+		// doesn't need to be bumped as the operator ships new channels (see loki_operator.go for
+		// the same reasoning).
+		"name":                mcoconfig.CertManagerOperatorPackageName,
+		"source":              mcoconfig.CertManagerOperatorCatalogSource,
+		"sourceNamespace":     mcoconfig.CertManagerOperatorCatalogSourceNamespace,
+		"installPlanApproval": "Automatic",
+	}
+
+	return []client.Object{ns, og, sub}
+}
+
+// EnsureCertManagerOperatorInstalled creates the cert-manager Operator's Namespace,
+// OperatorGroup and Subscription if they don't already exist. It never updates an existing
+// object, so it won't fight a manual install or an in-progress OLM upgrade.
+func EnsureCertManagerOperatorInstalled(ctx context.Context, c client.Client) error {
+	for _, obj := range BuildCertManagerOperatorResources() {
+		if err := c.Create(ctx, obj); err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create %s %s/%s: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(), err)
+		}
+	}
+	return nil
+}

--- a/operators/multiclusterobservability/pkg/dependencies/cert_manager_operator_test.go
+++ b/operators/multiclusterobservability/pkg/dependencies/cert_manager_operator_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package dependencies
+
+import (
+	"testing"
+
+	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestBuildCertManagerOperatorResources(t *testing.T) {
+	objs := BuildCertManagerOperatorResources()
+	require.Len(t, objs, 3)
+
+	ns, ok := objs[0].(*corev1.Namespace)
+	require.True(t, ok, "first object should be a Namespace")
+	require.Equal(t, mcoconfig.CertManagerOperatorNamespace, ns.GetName())
+
+	og, ok := objs[1].(*unstructured.Unstructured)
+	require.True(t, ok, "second object should be an unstructured OperatorGroup")
+	require.Equal(t, "OperatorGroup", og.GetKind())
+	require.Equal(t, mcoconfig.CertManagerOperatorPackageName, og.GetName())
+	require.Equal(t, mcoconfig.CertManagerOperatorNamespace, og.GetNamespace())
+
+	// No spec.targetNamespaces/spec.selector: global OperatorGroup (AllNamespaces mode).
+	_, found, err := unstructured.NestedStringSlice(og.Object, "spec", "targetNamespaces")
+	require.NoError(t, err)
+	require.False(t, found)
+
+	sub, ok := objs[2].(*unstructured.Unstructured)
+	require.True(t, ok, "third object should be an unstructured Subscription")
+	require.Equal(t, "Subscription", sub.GetKind())
+	require.Equal(t, mcoconfig.CertManagerOperatorPackageName, sub.GetName())
+	require.Equal(t, mcoconfig.CertManagerOperatorNamespace, sub.GetNamespace())
+
+	// channel is deliberately left unset so OLM tracks the package's default channel; see the
+	// comment in BuildCertManagerOperatorResources for why.
+	_, found, err = unstructured.NestedString(sub.Object, "spec", "channel")
+	require.NoError(t, err)
+	require.False(t, found)
+
+	name, found, err := unstructured.NestedString(sub.Object, "spec", "name")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, mcoconfig.CertManagerOperatorPackageName, name)
+}
+
+func TestEnsureCertManagerOperatorInstalled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	require.NoError(t, EnsureCertManagerOperatorInstalled(t.Context(), fakeClient))
+	require.NoError(t, fakeClient.Get(t.Context(), types.NamespacedName{Name: mcoconfig.CertManagerOperatorNamespace}, &corev1.Namespace{}))
+
+	// Calling it again should be a no-op (idempotent), not fail with AlreadyExists.
+	require.NoError(t, EnsureCertManagerOperatorInstalled(t.Context(), fakeClient))
+}
+
+func TestEnsureCertManagerOperatorInstalled_PropagatesUnexpectedErrors(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	// erroringClient is defined in loki_operator_test.go (same package) and forces every
+	// Create call to fail with a non-AlreadyExists error.
+	fakeClient := &erroringClient{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+
+	err := EnsureCertManagerOperatorInstalled(t.Context(), fakeClient)
+	require.Error(t, err)
+}

--- a/operators/multiclusterobservability/pkg/dependencies/loki_operator.go
+++ b/operators/multiclusterobservability/pkg/dependencies/loki_operator.go
@@ -1,0 +1,82 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+// Package dependencies installs third-party operators that MCOA capabilities depend on but
+// that MCO does not otherwise own or manage (e.g. Loki Operator, which provides the LokiStack
+// CRD used as the default log store for platform log collection).
+package dependencies
+
+import (
+	"context"
+	"fmt"
+
+	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// BuildLokiOperatorResources returns the Namespace, OperatorGroup and Subscription objects
+// required to install Loki Operator via OLM on the hub cluster.
+//
+// OperatorGroup/Subscription are built as unstructured objects (rather than importing
+// github.com/operator-framework/api) to avoid adding a new dependency to this operator for
+// three object kinds.
+func BuildLokiOperatorResources() []client.Object {
+	ns := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mcoconfig.LokiOperatorNamespace,
+		},
+	}
+
+	og := &unstructured.Unstructured{}
+	og.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1",
+		Kind:    "OperatorGroup",
+	})
+	og.SetName(mcoconfig.LokiOperatorPackageName)
+	og.SetNamespace(mcoconfig.LokiOperatorNamespace)
+
+	sub := &unstructured.Unstructured{}
+	sub.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1alpha1",
+		Kind:    "Subscription",
+	})
+	sub.SetName(mcoconfig.LokiOperatorPackageName)
+	sub.SetNamespace(mcoconfig.LokiOperatorNamespace)
+	sub.Object["spec"] = map[string]any{
+		// channel is deliberately omitted: it's an optional field on the Subscription CRD, and
+		// leaving it unset tells OLM to track the package's current default channel. Loki
+		// Operator's channels are versioned (e.g. stable-6.3, stable-6.5, ...) and old ones get
+		// dropped from the catalog over time, so hardcoding one here would eventually resolve to
+		// nothing (ConstraintsNotSatisfiable) and silently stop installing.
+		"name":                mcoconfig.LokiOperatorPackageName,
+		"source":              mcoconfig.LokiOperatorCatalogSource,
+		"sourceNamespace":     mcoconfig.LokiOperatorCatalogSourceNamespace,
+		"installPlanApproval": "Automatic",
+	}
+
+	return []client.Object{ns, og, sub}
+}
+
+// EnsureLokiOperatorInstalled creates the Loki Operator's Namespace, OperatorGroup and
+// Subscription if they don't already exist. It never updates an existing object, so it won't
+// fight a manual install or an in-progress OLM upgrade.
+func EnsureLokiOperatorInstalled(ctx context.Context, c client.Client) error {
+	for _, obj := range BuildLokiOperatorResources() {
+		if err := c.Create(ctx, obj); err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create %s %s/%s: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(), err)
+		}
+	}
+	return nil
+}

--- a/operators/multiclusterobservability/pkg/dependencies/loki_operator_test.go
+++ b/operators/multiclusterobservability/pkg/dependencies/loki_operator_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package dependencies
+
+import (
+	"context"
+	"testing"
+
+	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestBuildLokiOperatorResources(t *testing.T) {
+	objs := BuildLokiOperatorResources()
+	require.Len(t, objs, 3)
+
+	ns, ok := objs[0].(*corev1.Namespace)
+	require.True(t, ok, "first object should be a Namespace")
+	require.Equal(t, mcoconfig.LokiOperatorNamespace, ns.GetName())
+
+	og, ok := objs[1].(*unstructured.Unstructured)
+	require.True(t, ok, "second object should be an unstructured OperatorGroup")
+	require.Equal(t, "OperatorGroup", og.GetKind())
+	require.Equal(t, mcoconfig.LokiOperatorPackageName, og.GetName())
+	require.Equal(t, mcoconfig.LokiOperatorNamespace, og.GetNamespace())
+
+	sub, ok := objs[2].(*unstructured.Unstructured)
+	require.True(t, ok, "third object should be an unstructured Subscription")
+	require.Equal(t, "Subscription", sub.GetKind())
+	require.Equal(t, mcoconfig.LokiOperatorPackageName, sub.GetName())
+	require.Equal(t, mcoconfig.LokiOperatorNamespace, sub.GetNamespace())
+
+	// channel is deliberately left unset so OLM tracks the package's default channel; see the
+	// comment in BuildLokiOperatorResources for why.
+	_, found, err := unstructured.NestedString(sub.Object, "spec", "channel")
+	require.NoError(t, err)
+	require.False(t, found)
+
+	name, found, err := unstructured.NestedString(sub.Object, "spec", "name")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, mcoconfig.LokiOperatorPackageName, name)
+}
+
+func TestEnsureLokiOperatorInstalled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	require.NoError(t, EnsureLokiOperatorInstalled(t.Context(), fakeClient))
+	require.NoError(t, fakeClient.Get(t.Context(), types.NamespacedName{Name: mcoconfig.LokiOperatorNamespace}, &corev1.Namespace{}))
+
+	// Calling it again should be a no-op (idempotent), not fail with AlreadyExists.
+	require.NoError(t, EnsureLokiOperatorInstalled(t.Context(), fakeClient))
+}
+
+func TestEnsureLokiOperatorInstalled_PropagatesUnexpectedErrors(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	fakeClient := &erroringClient{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+
+	err := EnsureLokiOperatorInstalled(t.Context(), fakeClient)
+	require.Error(t, err)
+}
+
+// erroringClient wraps a client.Client and forces every Create call to fail with a
+// non-AlreadyExists error, so we can assert that EnsureLokiOperatorInstalled propagates it.
+type erroringClient struct {
+	client.Client
+}
+
+func (e *erroringClient) Create(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+	return apierrors.NewBadRequest("boom for " + obj.GetObjectKind().GroupVersionKind().Kind)
+}

--- a/operators/multiclusterobservability/pkg/dependencies/mcoa_root_certificate.go
+++ b/operators/multiclusterobservability/pkg/dependencies/mcoa_root_certificate.go
@@ -1,0 +1,87 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package dependencies
+
+import (
+	"context"
+	"fmt"
+
+	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// certManagerGroupVersion is the API group/version cert-manager registers its CRDs under.
+const certManagerGroupVersion = "cert-manager.io/v1"
+
+// BuildMCOARootCertificateResources returns the self-signed Issuer, root CA Certificate and
+// ClusterIssuer that MCOA's platform log collection capability needs from cert-manager to
+// issue the mTLS certs used for log collection/storage:
+//   - a self-signed Issuer that only ever mints the root CA Certificate below;
+//   - a root CA Certificate, written to a Secret of the same name;
+//   - a ClusterIssuer backed by that Secret, which is what MCOA-rendered Certificates
+//     actually request their leaf certs from.
+//
+// These are built as unstructured objects (rather than importing cert-manager's API package)
+// to avoid adding a new dependency to this operator for three object kinds.
+func BuildMCOARootCertificateResources() []client.Object {
+	issuer := &unstructured.Unstructured{}
+	issuer.SetGroupVersionKind(schema.FromAPIVersionAndKind(certManagerGroupVersion, "Issuer"))
+	issuer.SetName(mcoconfig.MCOARootCAIssuerName)
+	issuer.SetNamespace(mcoconfig.CertManagerNamespace)
+	issuer.Object["spec"] = map[string]any{
+		"selfSigned": map[string]any{},
+	}
+
+	cert := &unstructured.Unstructured{}
+	cert.SetGroupVersionKind(schema.FromAPIVersionAndKind(certManagerGroupVersion, "Certificate"))
+	cert.SetName(mcoconfig.MCOARootCertificateName)
+	cert.SetNamespace(mcoconfig.CertManagerNamespace)
+	cert.Object["spec"] = map[string]any{
+		"isCA":       true,
+		"secretName": mcoconfig.MCOARootCertificateName,
+		"commonName": "MCOA Root Certificate",
+		"privateKey": map[string]any{
+			"algorithm": "RSA",
+			"size":      int64(4096),
+			"encoding":  "PKCS8",
+		},
+		"issuerRef": map[string]any{
+			"kind": "Issuer",
+			"name": mcoconfig.MCOARootCAIssuerName,
+		},
+	}
+
+	clusterIssuer := &unstructured.Unstructured{}
+	clusterIssuer.SetGroupVersionKind(schema.FromAPIVersionAndKind(certManagerGroupVersion, "ClusterIssuer"))
+	clusterIssuer.SetName(mcoconfig.MCOARootClusterIssuerName)
+	// ClusterIssuer is cluster-scoped: no namespace to set. Its "ca.secretName" is still
+	// resolved from CertManagerNamespace, since that's where cert-manager itself runs.
+	clusterIssuer.Object["spec"] = map[string]any{
+		"ca": map[string]any{
+			"secretName": mcoconfig.MCOARootCertificateName,
+		},
+	}
+
+	return []client.Object{issuer, cert, clusterIssuer}
+}
+
+// EnsureMCOARootCertificatesInstalled creates the Issuer, Certificate and ClusterIssuer from
+// BuildMCOARootCertificateResources if they don't already exist. It never updates an existing
+// object, so it won't fight a manual install or overwrite an already-issued root CA.
+//
+// Callers must only invoke this once cert-manager's Certificate CRD (and, transitively, its
+// Issuer/ClusterIssuer CRDs) are known to be established on the cluster; creating these
+// resources any earlier would just fail with a NoKindMatchError.
+func EnsureMCOARootCertificatesInstalled(ctx context.Context, c client.Client) error {
+	for _, obj := range BuildMCOARootCertificateResources() {
+		if err := c.Create(ctx, obj); err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create %s %s/%s: %w", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(), err)
+		}
+	}
+	return nil
+}

--- a/operators/multiclusterobservability/pkg/dependencies/mcoa_root_certificate_test.go
+++ b/operators/multiclusterobservability/pkg/dependencies/mcoa_root_certificate_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package dependencies
+
+import (
+	"testing"
+
+	mcoconfig "github.com/stolostron/multicluster-observability-operator/operators/multiclusterobservability/pkg/config"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestBuildMCOARootCertificateResources(t *testing.T) {
+	objs := BuildMCOARootCertificateResources()
+	require.Len(t, objs, 3)
+
+	issuer, ok := objs[0].(*unstructured.Unstructured)
+	require.True(t, ok, "first object should be an unstructured Issuer")
+	require.Equal(t, "Issuer", issuer.GetKind())
+	require.Equal(t, mcoconfig.MCOARootCAIssuerName, issuer.GetName())
+	require.Equal(t, mcoconfig.CertManagerNamespace, issuer.GetNamespace())
+
+	_, found, err := unstructured.NestedMap(issuer.Object, "spec", "selfSigned")
+	require.NoError(t, err)
+	require.True(t, found, "Issuer should be self-signed")
+
+	cert, ok := objs[1].(*unstructured.Unstructured)
+	require.True(t, ok, "second object should be an unstructured Certificate")
+	require.Equal(t, "Certificate", cert.GetKind())
+	require.Equal(t, mcoconfig.MCOARootCertificateName, cert.GetName())
+	require.Equal(t, mcoconfig.CertManagerNamespace, cert.GetNamespace())
+
+	isCA, found, err := unstructured.NestedBool(cert.Object, "spec", "isCA")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.True(t, isCA)
+
+	secretName, found, err := unstructured.NestedString(cert.Object, "spec", "secretName")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, mcoconfig.MCOARootCertificateName, secretName)
+
+	issuerRefKind, found, err := unstructured.NestedString(cert.Object, "spec", "issuerRef", "kind")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "Issuer", issuerRefKind)
+
+	issuerRefName, found, err := unstructured.NestedString(cert.Object, "spec", "issuerRef", "name")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, mcoconfig.MCOARootCAIssuerName, issuerRefName)
+
+	clusterIssuer, ok := objs[2].(*unstructured.Unstructured)
+	require.True(t, ok, "third object should be an unstructured ClusterIssuer")
+	require.Equal(t, "ClusterIssuer", clusterIssuer.GetKind())
+	require.Equal(t, mcoconfig.MCOARootClusterIssuerName, clusterIssuer.GetName())
+	require.Empty(t, clusterIssuer.GetNamespace(), "ClusterIssuer is cluster-scoped")
+
+	caSecretName, found, err := unstructured.NestedString(clusterIssuer.Object, "spec", "ca", "secretName")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, mcoconfig.MCOARootCertificateName, caSecretName)
+}
+
+func TestEnsureMCOARootCertificatesInstalled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	require.NoError(t, EnsureMCOARootCertificatesInstalled(t.Context(), fakeClient))
+
+	issuer := &unstructured.Unstructured{}
+	issuer.SetGroupVersionKind(schema.FromAPIVersionAndKind(certManagerGroupVersion, "Issuer"))
+	require.NoError(t, fakeClient.Get(t.Context(), types.NamespacedName{
+		Name:      mcoconfig.MCOARootCAIssuerName,
+		Namespace: mcoconfig.CertManagerNamespace,
+	}, issuer))
+
+	// Calling it again should be a no-op (idempotent), not fail with AlreadyExists.
+	require.NoError(t, EnsureMCOARootCertificatesInstalled(t.Context(), fakeClient))
+}
+
+func TestEnsureMCOARootCertificatesInstalled_PropagatesUnexpectedErrors(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	// erroringClient is defined in loki_operator_test.go (same package) and forces every
+	// Create call to fail with a non-AlreadyExists error.
+	fakeClient := &erroringClient{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+
+	err := EnsureMCOARootCertificatesInstalled(t.Context(), fakeClient)
+	require.Error(t, err)
+}


### PR DESCRIPTION
In this MR, I add support for installing a self-signed Issuer, root CA Certificate, and ClusterIssuer when logging is enabled and the certificate CRD is installed. These resources are currently needed by the managed_logstore branch in the MCOA for its self-signed certificates that get distributed to the managed/MCOA created Cluster Log Forwarder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically installs the Loki and cert-manager operators when required for platform log collection.
  * Creates certificate resources for secure communication between observability components.
  * Adds permissions to manage Loki resources, certificates, and operator subscriptions.

* **Bug Fixes**
  * Reconciliation now waits for required resources to become available before proceeding.

* **Tests**
  * Added coverage for dependency installation, certificate setup, idempotency, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->