### PR TITLE
fix: report COO status via ClusterClaims

### DIFF
--- a/operators/endpointmetrics/controllers/mcoa/coo_status.go
+++ b/operators/endpointmetrics/controllers/mcoa/coo_status.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,24 +32,29 @@ const (
 // WriteCOOStatus checks whether a COO Subscription exists on the spoke and
 // writes the result as ClusterClaims. The OCM registration agent automatically
 // syncs these to ManagedCluster.Status.ClusterClaims on the hub.
-func WriteCOOStatus(ctx context.Context, c client.Client, log logr.Logger) error {
-	installed, managedBy, err := getCOOSubscriptionStatus(ctx, c)
+// On non-OCP clusters (OLMAvailable=false), this is a no-op.
+func (r *MCOAAgentReconciler) WriteCOOStatus(ctx context.Context) error {
+	if !r.OLMAvailable {
+		return nil
+	}
+
+	installed, managedBy, err := getCOOSubscriptionStatus(ctx, r.Client)
 	if err != nil {
 		return fmt.Errorf("failed to check COO subscription: %w", err)
 	}
 
-	if err := ensureClusterClaim(ctx, c, CooInstalledClaimName, installed); err != nil {
+	if err := ensureClusterClaim(ctx, r.Client, CooInstalledClaimName, installed); err != nil {
 		return fmt.Errorf("failed to ensure ClusterClaim %s: %w", CooInstalledClaimName, err)
 	}
 
 	if managedBy == "" {
 		managedBy = "none"
 	}
-	if err := ensureClusterClaim(ctx, c, CooManagedByClaimName, managedBy); err != nil {
+	if err := ensureClusterClaim(ctx, r.Client, CooManagedByClaimName, managedBy); err != nil {
 		return fmt.Errorf("failed to ensure ClusterClaim %s: %w", CooManagedByClaimName, err)
 	}
 
-	log.V(1).Info("COO status ClusterClaims updated", "installed", installed, "managedBy", managedBy)
+	r.Log.V(1).Info("COO status ClusterClaims updated", "installed", installed, "managedBy", managedBy)
 	return nil
 }
 

--- a/operators/endpointmetrics/controllers/mcoa/coo_status.go
+++ b/operators/endpointmetrics/controllers/mcoa/coo_status.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -54,23 +55,14 @@ func WriteCOOStatus(ctx context.Context, c client.Client, log logr.Logger) error
 }
 
 func ensureClusterClaim(ctx context.Context, c client.Client, name, value string) error {
-	claim := &clusterv1alpha1.ClusterClaim{}
-	err := c.Get(ctx, client.ObjectKey{Name: name}, claim)
-	if errors.IsNotFound(err) {
-		claim = &clusterv1alpha1.ClusterClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: name},
-			Spec:       clusterv1alpha1.ClusterClaimSpec{Value: value},
-		}
-		return c.Create(ctx, claim)
+	claim := &clusterv1alpha1.ClusterClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
 	}
-	if err != nil {
-		return err
-	}
-	if claim.Spec.Value != value {
+	_, err := controllerutil.CreateOrUpdate(ctx, c, claim, func() error {
 		claim.Spec.Value = value
-		return c.Update(ctx, claim)
-	}
-	return nil
+		return nil
+	})
+	return err
 }
 
 func getCOOSubscriptionStatus(ctx context.Context, c client.Client) (installed string, managedBy string, err error) {

--- a/operators/endpointmetrics/controllers/mcoa/coo_status.go
+++ b/operators/endpointmetrics/controllers/mcoa/coo_status.go
@@ -22,54 +22,44 @@ const (
 	cooSubscriptionName = "cluster-observability-operator"
 	mcoaReleaseLabel    = "release"
 	mcoaReleaseName     = "multicluster-observability-addon"
-	managedByMCOA       = "mcoa"
-	managedByExternal   = "external"
 
-	CooInstalledClaimName = "coo-installed.observability.open-cluster-management.io"
-	CooManagedByClaimName = "coo-managed-by.observability.open-cluster-management.io"
+	CooStatusClaimName = "coo.observability.open-cluster-management.io"
+
+	CooStatusNotInstalled = "not-installed"
+	CooStatusMCOA         = "mcoa"
+	CooStatusExternal     = "external"
 )
 
 // WriteCOOStatus checks whether a COO Subscription exists on the spoke and
-// writes the result as ClusterClaims. The OCM registration agent automatically
-// syncs these to ManagedCluster.Status.ClusterClaims on the hub.
+// writes the result as a single ClusterClaim. The OCM registration agent
+// automatically syncs it to ManagedCluster.Status.ClusterClaims on the hub.
 // On non-OCP clusters (OLMAvailable=false), this is a no-op.
 func (r *MCOAAgentReconciler) WriteCOOStatus(ctx context.Context) error {
 	if !r.OLMAvailable {
 		return nil
 	}
 
-	installed, managedBy, err := getCOOSubscriptionStatus(ctx, r.Client)
+	status, err := getCOOSubscriptionStatus(ctx, r.Client)
 	if err != nil {
 		return fmt.Errorf("failed to check COO subscription: %w", err)
 	}
 
-	if err := ensureClusterClaim(ctx, r.Client, CooInstalledClaimName, installed); err != nil {
-		return fmt.Errorf("failed to ensure ClusterClaim %s: %w", CooInstalledClaimName, err)
+	claim := &clusterv1alpha1.ClusterClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: CooStatusClaimName},
+	}
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, claim, func() error {
+		claim.Spec.Value = status
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to ensure ClusterClaim %s: %w", CooStatusClaimName, err)
 	}
 
-	if managedBy == "" {
-		managedBy = "none"
-	}
-	if err := ensureClusterClaim(ctx, r.Client, CooManagedByClaimName, managedBy); err != nil {
-		return fmt.Errorf("failed to ensure ClusterClaim %s: %w", CooManagedByClaimName, err)
-	}
-
-	r.Log.V(1).Info("COO status ClusterClaims updated", "installed", installed, "managedBy", managedBy)
+	r.Log.V(1).Info("COO status ClusterClaim updated", "status", status)
 	return nil
 }
 
-func ensureClusterClaim(ctx context.Context, c client.Client, name, value string) error {
-	claim := &clusterv1alpha1.ClusterClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-	}
-	_, err := controllerutil.CreateOrUpdate(ctx, c, claim, func() error {
-		claim.Spec.Value = value
-		return nil
-	})
-	return err
-}
-
-func getCOOSubscriptionStatus(ctx context.Context, c client.Client) (installed string, managedBy string, err error) {
+func getCOOSubscriptionStatus(ctx context.Context, c client.Client) (string, error) {
 	subList := &unstructured.UnstructuredList{}
 	subList.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "operators.coreos.com",
@@ -79,22 +69,30 @@ func getCOOSubscriptionStatus(ctx context.Context, c client.Client) (installed s
 
 	if err := c.List(ctx, subList); err != nil {
 		if errors.IsNotFound(err) || meta.IsNoMatchError(err) {
-			return "false", "", nil
+			return CooStatusNotInstalled, nil
 		}
-		return "", "", fmt.Errorf("failed to list subscriptions: %w", err)
+		return "", fmt.Errorf("failed to list subscriptions: %w", err)
 	}
 
+	allMCOA := true
+	found := false
 	for _, sub := range subList.Items {
 		specName, _, _ := unstructured.NestedString(sub.Object, "spec", "name")
-		if specName == cooSubscriptionName {
-			managedBy := managedByExternal
-			labels := sub.GetLabels()
-			if labels != nil && labels[mcoaReleaseLabel] == mcoaReleaseName {
-				managedBy = managedByMCOA
-			}
-			return "true", managedBy, nil
+		if specName != cooSubscriptionName {
+			continue
+		}
+		found = true
+		labels := sub.GetLabels()
+		if labels == nil || labels[mcoaReleaseLabel] != mcoaReleaseName {
+			allMCOA = false
 		}
 	}
 
-	return "false", "", nil
+	if !found {
+		return CooStatusNotInstalled, nil
+	}
+	if allMCOA {
+		return CooStatusMCOA, nil
+	}
+	return CooStatusExternal, nil
 }

--- a/operators/endpointmetrics/controllers/mcoa/coo_status.go
+++ b/operators/endpointmetrics/controllers/mcoa/coo_status.go
@@ -1,0 +1,104 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package mcoa
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	cooSubscriptionName = "cluster-observability-operator"
+	mcoaReleaseLabel    = "release"
+	mcoaReleaseName     = "multicluster-observability-addon"
+	managedByMCOA       = "mcoa"
+	managedByExternal   = "external"
+
+	CooInstalledClaimName = "coo-installed.observability.open-cluster-management.io"
+	CooManagedByClaimName = "coo-managed-by.observability.open-cluster-management.io"
+)
+
+// WriteCOOStatus checks whether a COO Subscription exists on the spoke and
+// writes the result as ClusterClaims. The OCM registration agent automatically
+// syncs these to ManagedCluster.Status.ClusterClaims on the hub.
+func WriteCOOStatus(ctx context.Context, c client.Client, log logr.Logger) error {
+	installed, managedBy, err := getCOOSubscriptionStatus(ctx, c)
+	if err != nil {
+		return fmt.Errorf("failed to check COO subscription: %w", err)
+	}
+
+	if err := ensureClusterClaim(ctx, c, CooInstalledClaimName, installed); err != nil {
+		return fmt.Errorf("failed to ensure ClusterClaim %s: %w", CooInstalledClaimName, err)
+	}
+
+	if managedBy == "" {
+		managedBy = "none"
+	}
+	if err := ensureClusterClaim(ctx, c, CooManagedByClaimName, managedBy); err != nil {
+		return fmt.Errorf("failed to ensure ClusterClaim %s: %w", CooManagedByClaimName, err)
+	}
+
+	log.V(1).Info("COO status ClusterClaims updated", "installed", installed, "managedBy", managedBy)
+	return nil
+}
+
+func ensureClusterClaim(ctx context.Context, c client.Client, name, value string) error {
+	claim := &clusterv1alpha1.ClusterClaim{}
+	err := c.Get(ctx, client.ObjectKey{Name: name}, claim)
+	if errors.IsNotFound(err) {
+		claim = &clusterv1alpha1.ClusterClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       clusterv1alpha1.ClusterClaimSpec{Value: value},
+		}
+		return c.Create(ctx, claim)
+	}
+	if err != nil {
+		return err
+	}
+	if claim.Spec.Value != value {
+		claim.Spec.Value = value
+		return c.Update(ctx, claim)
+	}
+	return nil
+}
+
+func getCOOSubscriptionStatus(ctx context.Context, c client.Client) (installed string, managedBy string, err error) {
+	subList := &unstructured.UnstructuredList{}
+	subList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1alpha1",
+		Kind:    "Subscription",
+	})
+
+	if err := c.List(ctx, subList); err != nil {
+		if errors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return "false", "", nil
+		}
+		return "", "", fmt.Errorf("failed to list subscriptions: %w", err)
+	}
+
+	for _, sub := range subList.Items {
+		specName, _, _ := unstructured.NestedString(sub.Object, "spec", "name")
+		if specName == cooSubscriptionName {
+			managedBy := managedByExternal
+			labels := sub.GetLabels()
+			if labels != nil && labels[mcoaReleaseLabel] == mcoaReleaseName {
+				managedBy = managedByMCOA
+			}
+			return "true", managedBy, nil
+		}
+	}
+
+	return "false", "", nil
+}

--- a/operators/endpointmetrics/controllers/mcoa/coo_status_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/coo_status_test.go
@@ -1,0 +1,208 @@
+// Copyright (c) Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+// Licensed under the Apache License 2.0
+
+package mcoa
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, clusterv1alpha1.AddToScheme(s))
+	return s
+}
+
+func newCOOSubscription(name, namespace string, labels map[string]string) *unstructured.Unstructured {
+	sub := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "operators.coreos.com/v1alpha1",
+			"kind":       "Subscription",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"name": cooSubscriptionName,
+			},
+		},
+	}
+	if labels != nil {
+		sub.SetLabels(labels)
+	}
+	return sub
+}
+
+func getClaimValue(t *testing.T, c client.Client, name string) string {
+	t.Helper()
+	claim := &clusterv1alpha1.ClusterClaim{}
+	err := c.Get(context.Background(), client.ObjectKey{Name: name}, claim)
+	require.NoError(t, err)
+	return claim.Spec.Value
+}
+
+func TestWriteCOOStatus(t *testing.T) {
+	tests := []struct {
+		name              string
+		olmAvailable      bool
+		objects           []client.Object
+		expectedInstalled string
+		expectedManagedBy string
+		expectNoClaims    bool
+	}{
+		{
+			name:           "OLM not available: no-op",
+			olmAvailable:   false,
+			expectNoClaims: true,
+		},
+		{
+			name:              "no subscriptions: COO not installed",
+			olmAvailable:      true,
+			expectedInstalled: "false",
+			expectedManagedBy: "none",
+		},
+		{
+			name:         "COO installed by external party",
+			olmAvailable: true,
+			objects: []client.Object{
+				newCOOSubscription("my-coo", "openshift-operators", nil),
+			},
+			expectedInstalled: "true",
+			expectedManagedBy: "external",
+		},
+		{
+			name:         "COO installed by MCOA",
+			olmAvailable: true,
+			objects: []client.Object{
+				newCOOSubscription("coo", "openshift-operators", map[string]string{
+					mcoaReleaseLabel: mcoaReleaseName,
+				}),
+			},
+			expectedInstalled: "true",
+			expectedManagedBy: "mcoa",
+		},
+		{
+			name:         "unrelated subscription: COO not installed",
+			olmAvailable: true,
+			objects: []client.Object{
+				func() *unstructured.Unstructured {
+					sub := &unstructured.Unstructured{
+						Object: map[string]any{
+							"apiVersion": "operators.coreos.com/v1alpha1",
+							"kind":       "Subscription",
+							"metadata": map[string]any{
+								"name":      "some-other-operator",
+								"namespace": "openshift-operators",
+							},
+							"spec": map[string]any{
+								"name": "some-other-operator",
+							},
+						},
+					}
+					return sub
+				}(),
+			},
+			expectedInstalled: "false",
+			expectedManagedBy: "none",
+		},
+		{
+			name:         "updates existing claims",
+			olmAvailable: true,
+			objects: []client.Object{
+				&clusterv1alpha1.ClusterClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: CooInstalledClaimName},
+					Spec:       clusterv1alpha1.ClusterClaimSpec{Value: "true"},
+				},
+				&clusterv1alpha1.ClusterClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: CooManagedByClaimName},
+					Spec:       clusterv1alpha1.ClusterClaimSpec{Value: "mcoa"},
+				},
+			},
+			expectedInstalled: "false",
+			expectedManagedBy: "none",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestScheme(t)
+			c := fake.NewClientBuilder().WithScheme(s).WithObjects(tc.objects...).Build()
+
+			r := &MCOAAgentReconciler{
+				Client:       c,
+				Log:          ctrl.Log.WithName("test"),
+				OLMAvailable: tc.olmAvailable,
+			}
+
+			err := r.WriteCOOStatus(context.Background())
+			require.NoError(t, err)
+
+			if tc.expectNoClaims {
+				claim := &clusterv1alpha1.ClusterClaim{}
+				assert.Error(t, c.Get(context.Background(), client.ObjectKey{Name: CooInstalledClaimName}, claim))
+				return
+			}
+
+			assert.Equal(t, tc.expectedInstalled, getClaimValue(t, c, CooInstalledClaimName))
+			assert.Equal(t, tc.expectedManagedBy, getClaimValue(t, c, CooManagedByClaimName))
+		})
+	}
+}
+
+func TestGetCOOSubscriptionStatus(t *testing.T) {
+	tests := []struct {
+		name              string
+		objects           []client.Object
+		expectedInstalled string
+		expectedManagedBy string
+	}{
+		{
+			name:              "no subscriptions",
+			expectedInstalled: "false",
+			expectedManagedBy: "",
+		},
+		{
+			name: "COO subscription without MCOA label",
+			objects: []client.Object{
+				newCOOSubscription("coo", "openshift-operators", nil),
+			},
+			expectedInstalled: "true",
+			expectedManagedBy: "external",
+		},
+		{
+			name: "COO subscription with MCOA label",
+			objects: []client.Object{
+				newCOOSubscription("coo", "openshift-operators", map[string]string{
+					mcoaReleaseLabel: mcoaReleaseName,
+				}),
+			},
+			expectedInstalled: "true",
+			expectedManagedBy: "mcoa",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestScheme(t)
+			c := fake.NewClientBuilder().WithScheme(s).WithObjects(tc.objects...).Build()
+
+			installed, managedBy, err := getCOOSubscriptionStatus(context.Background(), c)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedInstalled, installed)
+			assert.Equal(t, tc.expectedManagedBy, managedBy)
+		})
+	}
+}

--- a/operators/endpointmetrics/controllers/mcoa/coo_status_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/coo_status_test.go
@@ -56,23 +56,21 @@ func getClaimValue(t *testing.T, c client.Client, name string) string {
 
 func TestWriteCOOStatus(t *testing.T) {
 	tests := []struct {
-		name              string
-		olmAvailable      bool
-		objects           []client.Object
-		expectedInstalled string
-		expectedManagedBy string
-		expectNoClaims    bool
+		name           string
+		olmAvailable   bool
+		objects        []client.Object
+		expectedStatus string
+		expectNoClaim  bool
 	}{
 		{
-			name:           "OLM not available: no-op",
-			olmAvailable:   false,
-			expectNoClaims: true,
+			name:          "OLM not available: no-op",
+			olmAvailable:  false,
+			expectNoClaim: true,
 		},
 		{
-			name:              "no subscriptions: COO not installed",
-			olmAvailable:      true,
-			expectedInstalled: "false",
-			expectedManagedBy: "none",
+			name:           "no subscriptions: not installed",
+			olmAvailable:   true,
+			expectedStatus: CooStatusNotInstalled,
 		},
 		{
 			name:         "COO installed by external party",
@@ -80,8 +78,7 @@ func TestWriteCOOStatus(t *testing.T) {
 			objects: []client.Object{
 				newCOOSubscription("my-coo", "openshift-operators", nil),
 			},
-			expectedInstalled: "true",
-			expectedManagedBy: "external",
+			expectedStatus: CooStatusExternal,
 		},
 		{
 			name:         "COO installed by MCOA",
@@ -91,15 +88,14 @@ func TestWriteCOOStatus(t *testing.T) {
 					mcoaReleaseLabel: mcoaReleaseName,
 				}),
 			},
-			expectedInstalled: "true",
-			expectedManagedBy: "mcoa",
+			expectedStatus: CooStatusMCOA,
 		},
 		{
-			name:         "unrelated subscription: COO not installed",
+			name:         "unrelated subscription: not installed",
 			olmAvailable: true,
 			objects: []client.Object{
 				func() *unstructured.Unstructured {
-					sub := &unstructured.Unstructured{
+					return &unstructured.Unstructured{
 						Object: map[string]any{
 							"apiVersion": "operators.coreos.com/v1alpha1",
 							"kind":       "Subscription",
@@ -112,27 +108,31 @@ func TestWriteCOOStatus(t *testing.T) {
 							},
 						},
 					}
-					return sub
 				}(),
 			},
-			expectedInstalled: "false",
-			expectedManagedBy: "none",
+			expectedStatus: CooStatusNotInstalled,
 		},
 		{
-			name:         "updates existing claims",
+			name:         "updates existing claim",
 			olmAvailable: true,
 			objects: []client.Object{
 				&clusterv1alpha1.ClusterClaim{
-					ObjectMeta: metav1.ObjectMeta{Name: CooInstalledClaimName},
-					Spec:       clusterv1alpha1.ClusterClaimSpec{Value: "true"},
-				},
-				&clusterv1alpha1.ClusterClaim{
-					ObjectMeta: metav1.ObjectMeta{Name: CooManagedByClaimName},
-					Spec:       clusterv1alpha1.ClusterClaimSpec{Value: "mcoa"},
+					ObjectMeta: metav1.ObjectMeta{Name: CooStatusClaimName},
+					Spec:       clusterv1alpha1.ClusterClaimSpec{Value: CooStatusMCOA},
 				},
 			},
-			expectedInstalled: "false",
-			expectedManagedBy: "none",
+			expectedStatus: CooStatusNotInstalled,
+		},
+		{
+			name:         "multiple subscriptions with one external: external wins",
+			olmAvailable: true,
+			objects: []client.Object{
+				newCOOSubscription("coo-mcoa", "openshift-operators", map[string]string{
+					mcoaReleaseLabel: mcoaReleaseName,
+				}),
+				newCOOSubscription("coo-admin", "other-namespace", nil),
+			},
+			expectedStatus: CooStatusExternal,
 		},
 	}
 
@@ -150,37 +150,33 @@ func TestWriteCOOStatus(t *testing.T) {
 			err := r.WriteCOOStatus(context.Background())
 			require.NoError(t, err)
 
-			if tc.expectNoClaims {
+			if tc.expectNoClaim {
 				claim := &clusterv1alpha1.ClusterClaim{}
-				assert.Error(t, c.Get(context.Background(), client.ObjectKey{Name: CooInstalledClaimName}, claim))
+				assert.Error(t, c.Get(context.Background(), client.ObjectKey{Name: CooStatusClaimName}, claim))
 				return
 			}
 
-			assert.Equal(t, tc.expectedInstalled, getClaimValue(t, c, CooInstalledClaimName))
-			assert.Equal(t, tc.expectedManagedBy, getClaimValue(t, c, CooManagedByClaimName))
+			assert.Equal(t, tc.expectedStatus, getClaimValue(t, c, CooStatusClaimName))
 		})
 	}
 }
 
 func TestGetCOOSubscriptionStatus(t *testing.T) {
 	tests := []struct {
-		name              string
-		objects           []client.Object
-		expectedInstalled string
-		expectedManagedBy string
+		name           string
+		objects        []client.Object
+		expectedStatus string
 	}{
 		{
-			name:              "no subscriptions",
-			expectedInstalled: "false",
-			expectedManagedBy: "",
+			name:           "no subscriptions",
+			expectedStatus: CooStatusNotInstalled,
 		},
 		{
 			name: "COO subscription without MCOA label",
 			objects: []client.Object{
 				newCOOSubscription("coo", "openshift-operators", nil),
 			},
-			expectedInstalled: "true",
-			expectedManagedBy: "external",
+			expectedStatus: CooStatusExternal,
 		},
 		{
 			name: "COO subscription with MCOA label",
@@ -189,8 +185,23 @@ func TestGetCOOSubscriptionStatus(t *testing.T) {
 					mcoaReleaseLabel: mcoaReleaseName,
 				}),
 			},
-			expectedInstalled: "true",
-			expectedManagedBy: "mcoa",
+			expectedStatus: CooStatusMCOA,
+		},
+		{
+			name: "multiple COO subscriptions all MCOA",
+			objects: []client.Object{
+				newCOOSubscription("coo-1", "ns-1", map[string]string{mcoaReleaseLabel: mcoaReleaseName}),
+				newCOOSubscription("coo-2", "ns-2", map[string]string{mcoaReleaseLabel: mcoaReleaseName}),
+			},
+			expectedStatus: CooStatusMCOA,
+		},
+		{
+			name: "multiple COO subscriptions one external",
+			objects: []client.Object{
+				newCOOSubscription("coo-mcoa", "ns-1", map[string]string{mcoaReleaseLabel: mcoaReleaseName}),
+				newCOOSubscription("coo-admin", "ns-2", nil),
+			},
+			expectedStatus: CooStatusExternal,
 		},
 	}
 
@@ -199,10 +210,9 @@ func TestGetCOOSubscriptionStatus(t *testing.T) {
 			s := newTestScheme(t)
 			c := fake.NewClientBuilder().WithScheme(s).WithObjects(tc.objects...).Build()
 
-			installed, managedBy, err := getCOOSubscriptionStatus(context.Background(), c)
+			status, err := getCOOSubscriptionStatus(context.Background(), c)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedInstalled, installed)
-			assert.Equal(t, tc.expectedManagedBy, managedBy)
+			assert.Equal(t, tc.expectedStatus, status)
 		})
 	}
 }

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
@@ -99,7 +99,7 @@ func (r *MCOAAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, fmt.Errorf("failed to restore OBO CRDs after event on %s: %w", req.Name, err)
 		}
 
-	case req.Name == CooInstalledClaimName:
+	case req.Name == CooStatusClaimName:
 		if err := r.WriteCOOStatus(ctx); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update COO status ClusterClaims: %w", err)
 		}
@@ -151,7 +151,7 @@ func (r *MCOAAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			subscriptionUnstructured(),
 			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, _ client.Object) []reconcile.Request {
 				return []reconcile.Request{{NamespacedName: client.ObjectKey{
-					Name:      CooInstalledClaimName,
+					Name:      CooStatusClaimName,
 					Namespace: "",
 				}}}
 			}),

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
@@ -83,11 +83,6 @@ func NewMCOAAgentReconciler(
 func (r *MCOAAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Log.V(1).Info("Reconciling MCOA Agent", "name", req.Name, "namespace", req.Namespace)
 
-	cooStatusErr := r.WriteCOOStatus(ctx)
-	if cooStatusErr != nil {
-		r.Log.Error(cooStatusErr, "failed to update COO status ClusterClaims")
-	}
-
 	switch {
 	case req.Name == operatorconfig.OCPClusterMonitoringConfigMapName && req.Namespace == operatorconfig.OCPClusterMonitoringNamespace:
 		if err := r.ReconcileCMOPlatformConfig(ctx); err != nil {
@@ -104,13 +99,15 @@ func (r *MCOAAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, fmt.Errorf("failed to restore OBO CRDs after event on %s: %w", req.Name, err)
 		}
 
+	case req.Name == CooInstalledClaimName:
+		if err := r.WriteCOOStatus(ctx); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to update COO status ClusterClaims: %w", err)
+		}
+
 	default:
 		r.Log.V(1).Info("Ignoring event for unmanaged resource", "name", req.Name, "namespace", req.Namespace)
 	}
 
-	if cooStatusErr != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to update COO status ClusterClaims: %w", cooStatusErr)
-	}
 	return ctrl.Result{}, nil
 }
 

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
@@ -83,12 +83,9 @@ func NewMCOAAgentReconciler(
 func (r *MCOAAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Log.V(1).Info("Reconciling MCOA Agent", "name", req.Name, "namespace", req.Namespace)
 
-	var cooStatusErr error
-	if r.OLMAvailable {
-		cooStatusErr = WriteCOOStatus(ctx, r.Client, r.Log)
-		if cooStatusErr != nil {
-			r.Log.Error(cooStatusErr, "failed to update COO status ClusterClaims")
-		}
+	cooStatusErr := r.WriteCOOStatus(ctx)
+	if cooStatusErr != nil {
+		r.Log.Error(cooStatusErr, "failed to update COO status ClusterClaims")
 	}
 
 	switch {

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller.go
@@ -14,7 +14,9 @@ import (
 	operatorconfig "github.com/stolostron/multicluster-observability-operator/operators/pkg/config"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
@@ -40,6 +42,7 @@ type MCOAAgentReconciler struct {
 	AccessorSecret                string
 	EnablePlatformAlertForwarding bool
 	EnableUWLAlertForwarding      bool
+	OLMAvailable                  bool
 }
 
 // NewMCOAAgentReconciler creates a new MCOAAgentReconciler.
@@ -57,6 +60,7 @@ func NewMCOAAgentReconciler(
 	accessorSecret string,
 	enablePlatformAlertForwarding bool,
 	enableUWLAlertForwarding bool,
+	olmAvailable bool,
 ) *MCOAAgentReconciler {
 	return &MCOAAgentReconciler{
 		Client:                        client,
@@ -72,50 +76,51 @@ func NewMCOAAgentReconciler(
 		AccessorSecret:                accessorSecret,
 		EnablePlatformAlertForwarding: enablePlatformAlertForwarding,
 		EnableUWLAlertForwarding:      enableUWLAlertForwarding,
+		OLMAvailable:                  olmAvailable,
 	}
 }
 
 func (r *MCOAAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Log.V(1).Info("Reconciling MCOA Agent", "name", req.Name, "namespace", req.Namespace)
 
+	var cooStatusErr error
+	if r.OLMAvailable {
+		cooStatusErr = WriteCOOStatus(ctx, r.Client, r.Log)
+		if cooStatusErr != nil {
+			r.Log.Error(cooStatusErr, "failed to update COO status ClusterClaims")
+		}
+	}
+
 	switch {
 	case req.Name == operatorconfig.OCPClusterMonitoringConfigMapName && req.Namespace == operatorconfig.OCPClusterMonitoringNamespace:
 		if err := r.ReconcileCMOPlatformConfig(ctx); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile CMO config: %w", err)
 		}
-		return ctrl.Result{}, nil
 	case req.Name == operatorconfig.OCPUserWorkloadMonitoringConfigMap && req.Namespace == operatorconfig.OCPUserWorkloadMonitoringNamespace:
 		if err := r.ReconcileCMOUWLConfig(ctx); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile UWL config: %w", err)
 		}
-		return ctrl.Result{}, nil
 
 	case isManagedCRDName(req.Name) && req.Namespace == "":
-		// The predicate already filters by name; the empty-namespace guard here
-		// disambiguates from any future watch source that might use the same name
-		// with a namespace (e.g. a ConfigMap named like a CRD).
 		r.Log.Info("OBO CRD event, re-applying all managed CRDs", "crd", req.Name)
 		if err := DeployCRDs(ctx, r.Client); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to restore OBO CRDs after event on %s: %w", req.Name, err)
 		}
-		return ctrl.Result{}, nil
 
 	default:
 		r.Log.V(1).Info("Ignoring event for unmanaged resource", "name", req.Name, "namespace", req.Namespace)
-		return ctrl.Result{}, nil
 	}
+
+	if cooStatusErr != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update COO status ClusterClaims: %w", cooStatusErr)
+	}
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *MCOAAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		// Watch ConfigMaps we manage across multiple namespaces.
-		// The cache FieldSelectors already limit this to exactly the CMs we need.
+	b := ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.ConfigMap{}, ctrlbuilder.WithPredicates(observabilityendpoint.ConfigMapDataChangedPredicate("", ""))).
-		// Watch OBO CRDs with metadata-only to avoid caching large OpenAPI validation schemas.
-		// CRDs are cluster-scoped so EnqueueRequestForObject produces the correct name-only key.
-		// Only Delete events are relevant: Create/Update events from DeployCRDs's own SSA calls
-		// would otherwise feed back into the reconciler and cause an O(N²) event storm.
 		WatchesMetadata(
 			&apiextensionsv1.CustomResourceDefinition{},
 			&handler.EnqueueRequestForObject{},
@@ -144,8 +149,34 @@ func (r *MCOAAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				platformMetricsCollectorComponent,
 				userWorkloadMetricsCollectorComponent,
 			)),
-		).
-		Complete(r)
+		)
+
+	if r.OLMAvailable {
+		r.Log.Info("OLM detected, watching Subscriptions for COO status")
+		b = b.Watches(
+			subscriptionUnstructured(),
+			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, _ client.Object) []reconcile.Request {
+				return []reconcile.Request{{NamespacedName: client.ObjectKey{
+					Name:      CooInstalledClaimName,
+					Namespace: "",
+				}}}
+			}),
+			ctrlbuilder.WithPredicates(predicate.Funcs{
+				CreateFunc: func(e event.CreateEvent) bool {
+					return isCOOSubscriptionObject(e.Object)
+				},
+				DeleteFunc: func(e event.DeleteEvent) bool {
+					return isCOOSubscriptionObject(e.Object)
+				},
+				UpdateFunc:  func(_ event.UpdateEvent) bool { return false },
+				GenericFunc: func(_ event.GenericEvent) bool { return false },
+			}),
+		)
+	} else {
+		r.Log.Info("OLM not detected, skipping Subscription watch for COO status")
+	}
+
+	return b.Complete(r)
 }
 
 func (r *MCOAAgentReconciler) mapComponentLabelToRequests(
@@ -182,4 +213,26 @@ func (r *MCOAAgentReconciler) mapComponentLabelToRequests(
 		}
 		return nil
 	}
+}
+
+func subscriptionUnstructured() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1alpha1",
+		Kind:    "Subscription",
+	})
+	return obj
+}
+
+func isCOOSubscriptionObject(obj client.Object) bool {
+	if obj == nil {
+		return false
+	}
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return obj.GetName() == cooSubscriptionName
+	}
+	specName, _, _ := unstructured.NestedString(u.Object, "spec", "name")
+	return specName == cooSubscriptionName
 }

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -36,6 +37,7 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 	s := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(s))
 	require.NoError(t, ocinfrav1.AddToScheme(s))
+	require.NoError(t, clusterv1alpha1.AddToScheme(s))
 
 	// Register ScrapeConfig for the custom monitoring.rhobs/v1alpha1 API Group
 	addRhobsToScheme(t, s)
@@ -318,6 +320,7 @@ func TestMCOAAgentReconciler_Reconcile(t *testing.T) {
 				"observability-alertmanager-accessor",
 				tt.alertmanagerEndpoint != "", // enablePlatformAlertForwarding
 				!tt.disableUWLAlertForwarding,
+				true, // olmAvailable
 			)
 
 			result, err := r.Reconcile(context.Background(), tt.req)

--- a/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
+++ b/operators/endpointmetrics/controllers/mcoa/mcoa_agent_integration_test.go
@@ -32,6 +32,7 @@ import (
 	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
+	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/config"
@@ -56,6 +57,8 @@ func TestMain(m *testing.M) {
 
 	cvCRD := readCRDFiles(
 		filepath.Join("..", "observabilityendpoint", "testdata", "crd", "clusterversions-crd.yaml"),
+		filepath.Join("..", "observabilityendpoint", "testdata", "crd", "clusterclaims-crd.yaml"),
+		filepath.Join("..", "observabilityendpoint", "testdata", "crd", "operators.coreos.com_subscriptions.yaml"),
 		filepath.Join("crds", "monitoring.rhobs_scrapeconfigs.yaml"),
 		filepath.Join("crds", "monitoring.rhobs_prometheusagents.yaml"),
 	)
@@ -109,6 +112,7 @@ func TestMCOAAgentIntegration(t *testing.T) {
 	require.NoError(t, kubescheme.AddToScheme(s))
 	require.NoError(t, ocinfrav1.AddToScheme(s))
 	require.NoError(t, apiextensionsv1.AddToScheme(s))
+	require.NoError(t, clusterv1alpha1.AddToScheme(s))
 
 	// Register ScrapeConfig for the custom monitoring.rhobs/v1alpha1 API Group
 	addRhobsToScheme(t, s)
@@ -145,6 +149,7 @@ func TestMCOAAgentIntegration(t *testing.T) {
 		"observability-alertmanager-accessor",
 		true, // enablePlatformAlertForwarding
 		true, // enableUWLAlertForwarding
+		true, // olmAvailable
 	)
 	err = reconciler.SetupWithManager(mgr)
 	require.NoError(t, err)
@@ -341,6 +346,7 @@ func TestMCOAAgentIntegration(t *testing.T) {
 			"observability-alertmanager-accessor",
 			false, // enablePlatformAlertForwarding
 			false, // enableUWLAlertForwarding
+			true,  // olmAvailable
 		)
 
 		// Trigger reconcile by directly calling the Reconcile method on this private reconciler
@@ -393,6 +399,7 @@ func TestMCOAAgentIntegration(t *testing.T) {
 			"observability-alertmanager-accessor",
 			true,  // enablePlatformAlertForwarding
 			false, // disabled UWL alert forwarding
+			true,  // olmAvailable
 		)
 
 		// Trigger reconcile by directly calling the Reconcile method on this private reconciler
@@ -443,6 +450,7 @@ func TestMCOAAgentIntegration(t *testing.T) {
 		"observability-alertmanager-accessor",
 		true, // enablePlatformAlertForwarding
 		true, // enableUWLAlertForwarding
+		true, // olmAvailable
 	).SetupWithManager(mgr2))
 	go func() {
 		if err := mgr2.Start(ctx); err != nil && ctx.Err() == nil {

--- a/operators/endpointmetrics/controllers/observabilityendpoint/testdata/crd/clusterclaims-crd.yaml
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/testdata/crd/clusterclaims-crd.yaml
@@ -1,0 +1,26 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterclaims.cluster.open-cluster-management.io
+spec:
+  group: cluster.open-cluster-management.io
+  names:
+    kind: ClusterClaim
+    listKind: ClusterClaimList
+    plural: clusterclaims
+    singular: clusterclaim
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                value:
+                  type: string
+                  maxLength: 1024

--- a/operators/endpointmetrics/controllers/observabilityendpoint/testdata/crd/operators.coreos.com_subscriptions.yaml
+++ b/operators/endpointmetrics/controllers/observabilityendpoint/testdata/crd/operators.coreos.com_subscriptions.yaml
@@ -1,0 +1,25 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: subscriptions.operators.coreos.com
+spec:
+  group: operators.coreos.com
+  names:
+    kind: Subscription
+    listKind: SubscriptionList
+    plural: subscriptions
+    singular: subscription
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string

--- a/operators/endpointmetrics/main.go
+++ b/operators/endpointmetrics/main.go
@@ -47,6 +47,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/klog/v2"
+	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -67,6 +68,7 @@ func init() {
 	utilruntime.Must(prometheusv1.AddToScheme(scheme))
 	utilruntime.Must(hyperv1.AddToScheme(scheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+	utilruntime.Must(clusterv1alpha1.Install(scheme))
 
 	// Register ScrapeConfig and PrometheusAgent for the custom monitoring.rhobs/v1alpha1 API Group used by MCOA on spoke clusters
 	rhobsGroupVersion := schema.GroupVersion{Group: "monitoring.rhobs", Version: "v1alpha1"}
@@ -171,6 +173,7 @@ func doCleanup(args []string) error {
 		"",
 		false, // false forces Platform Alertmanager config removal
 		false, // false forces UWL Alertmanager config removal
+		false, // OLM not needed during cleanup
 	)
 
 	var wg sync.WaitGroup
@@ -352,6 +355,15 @@ func runMCOA(args []string) {
 		os.Exit(1)
 	}
 
+	_, olmErr := mgr.GetRESTMapper().RESTMapping(
+		schema.GroupKind{Group: "operators.coreos.com", Kind: "Subscription"},
+		"v1alpha1",
+	)
+	olmAvailable := olmErr == nil
+	if !olmAvailable {
+		setupLog.Info("OLM not detected, skipping COO status reporting")
+	}
+
 	if err = mcoa.NewMCOAAgentReconciler(
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName("mcoa-endpoint-controller"),
@@ -366,6 +378,7 @@ func runMCOA(args []string) {
 		hubAmAccessorSecret,
 		enablePlatformAlertForwarding,
 		enableUWLAlertForwarding,
+		olmAvailable,
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "mcoa-endpoint-controller")
 		os.Exit(1)


### PR DESCRIPTION
## Summary

The endpoint-monitoring-operator now writes COO install status as a single ClusterClaim `coo.observability.open-cluster-management.io` with values: `not-installed`, `mcoa`, `external`. ClusterClaims are automatically synced to ManagedCluster.Status on the hub by the OCM registration agent, so MCOA can read them directly without ManifestWork feedback.

Handles multiple concurrent COO Subscriptions by treating any non-MCOA subscription as external. Skips COO detection on non-OCP clusters where OLM is unavailable.

**Depends on:** stolostron/multicluster-observability-addon#654 (hub reads the ClusterClaim + grants RBAC)

## Changes
- Added `WriteCOOStatus()` method on `MCOAAgentReconciler` — creates/updates a single ClusterClaim
- Added OLM Subscription watch to trigger COO status updates on install/uninstall
- Added `OLMAvailable` field set at instantiation, gating COO detection on non-OCP clusters
- Used `controllerutil.CreateOrUpdate` for ClusterClaim management
- Registered `clusterv1alpha1` scheme for ClusterClaim types
- Added unit tests for `WriteCOOStatus` and `getCOOSubscriptionStatus`
- Added ClusterClaim and Subscription CRD stubs for envtest

## Test plan
- [ ] Deploy both images (addon + endpoint operator)
- [ ] Verify single ClusterClaim created on spoke after endpoint operator starts
- [ ] Install COO manually → claim value `external`
- [ ] Install COO via MCOA → claim value `mcoa`
- [ ] Uninstall COO → claim value `not-installed`
- [ ] Non-OCP spoke → no ClusterClaim created, no crash